### PR TITLE
fix: stop ruflo daemon leak + statusline sqlite3 churn; consolidate shell helpers (#3)

### DIFF
--- a/bin/ruflo-enable-learning
+++ b/bin/ruflo-enable-learning
@@ -33,19 +33,19 @@ while (( $# )); do
 	shift
 done
 
-if [[ -t 1 ]]; then
-	C_OK=$'\033[32m'; C_WARN=$'\033[33m'; C_FAIL=$'\033[31m'; C_DIM=$'\033[2m'; C_RESET=$'\033[0m'
-else C_OK=""; C_WARN=""; C_FAIL=""; C_DIM=""; C_RESET=""; fi
-ok()   { printf '%s✓%s %s\n' "$C_OK" "$C_RESET" "$*"; }
-warn() { printf '%s⚠%s  %s\n' "$C_WARN" "$C_RESET" "$*"; }
-fail() { printf '%s✗%s %s\n' "$C_FAIL" "$C_RESET" "$*"; }
-dim()  { printf '%s%s%s\n' "$C_DIM" "$*" "$C_RESET"; }
+# Shared helpers (colors, ok/warn/fail/dim, _ruflo_need, ABI/root) from ruflo-lib.sh:
+# installed copy first, then repo-relative (bin/ ↔ ../shell/).
+for _cand in "$HOME/.config/ruflo/ruflo-lib.sh" "$(dirname "${BASH_SOURCE[0]:-$0}")/../shell/ruflo-lib.sh"; do
+	# shellcheck source=/dev/null
+	[ -f "$_cand" ] && { . "$_cand"; break; }
+done
+unset _cand
+[ -n "${_RUFLO_LIB:-}" ] || { echo "ruflo-lib.sh not found — run install.sh" >&2; exit 2; }
 
-command -v node  >/dev/null 2>&1 || { fail "node not on PATH"; exit 2; }
-command -v ruflo >/dev/null 2>&1 || { fail "ruflo not on PATH"; exit 2; }
+_ruflo_need node ruflo
 command -v ruflo-patch-native >/dev/null 2>&1 || { fail "ruflo-patch-native not on PATH (run install.sh)"; exit 2; }
 
-NODE_ABI=$(node -e 'process.stdout.write(process.versions.modules)')
+NODE_ABI=$(_ruflo_node_abi)
 echo "Node ABI $NODE_ABI | ruflo $(ruflo --version 2>/dev/null | tr -d '\n')"
 echo ""
 
@@ -60,7 +60,7 @@ fi
 # On ruflo >= 3.10 the gist's controller-registry patches are already upstream:
 # agentdb resolves >= 3.0 and ReasoningBank gets an embedder. We only WARN if a
 # regression is detected; we do not patch a non-regressed install.
-RUFLO_ROOT="$(npm root -g)/ruflo"
+RUFLO_ROOT="$(_ruflo_global_root)/ruflo"
 MEM="$RUFLO_ROOT/node_modules/@claude-flow/memory"
 ADB_VER=$(node -e "
 try{const p=require.resolve('agentdb',{paths:['$MEM']});process.stdout.write(require(p.split('/agentdb/')[0]+'/agentdb/package.json').version);}catch(e){process.stdout.write('MISSING');}" 2>/dev/null)
@@ -81,9 +81,11 @@ ruvector_repair() {
 		  const {createRequire}=await import('node:module');
 		  const r=createRequire('$d/package.json');
 		  try{ r(r.resolve('$m')); process.exit(0);}catch(e){process.exit(1);}" 2>/dev/null; then
-			( cd "$d" && npm install "$m" --no-save --no-audit --no-fund >/dev/null 2>&1 ) \
-				&& ok "  repaired $m in ${d#$RUFLO_ROOT/node_modules/}" \
-				|| warn "  could not repair $m in ${d#$RUFLO_ROOT/node_modules/}"
+			if ( cd "$d" && npm install "$m" --no-save --no-audit --no-fund >/dev/null 2>&1 ); then
+				ok "  repaired $m in ${d#"$RUFLO_ROOT"/node_modules/}"
+			else
+				warn "  could not repair $m in ${d#"$RUFLO_ROOT"/node_modules/}"
+			fi
 		fi
 	done
 }
@@ -115,24 +117,36 @@ cap() {
 	" 2>/dev/null
 }
 
+# Direct if/then assertions (no eval) — each runs a probe and tallies green/total.
 declare -i green=0 total=0
-report() { total+=1; if eval "$2"; then ok "$1"; green+=1; else fail "$1 — $3"; fi; }
+pass() { total+=1; ok "$1"; green+=1; }
+miss() { total+=1; fail "$1 — $2"; }
 
-report "native better-sqlite3 (no WASM fallback)" \
-	'! echo "$NS" | grep -q "Using sql.js" && echo "$PN" | grep -qE "Nothing to do|already resolve native"' \
-	"still on sql.js/WASM — patch-native did not take"
-report "HNSW vector engine (@ruvector/core → VectorDb)" \
-	'cap "$CLI" "@ruvector/core" "VectorDb"' \
-	"core present but VectorDb missing"
-report "SONA engine (@ruvector/sona → SonaEngine)" \
-	'cap "$NEURAL" "@ruvector/sona" "SonaEngine"' \
-	"sona native module not loadable from @claude-flow/neural"
-report "GNN layer (@ruvector/gnn → RuvectorLayer)" \
-	'cap "$NEURAL" "@ruvector/gnn" "RuvectorLayer"' \
-	"gnn native module not loadable from @claude-flow/neural"
-report "ReasoningBank (agentdb v3)" \
-	'[[ "$ADB_VER" == 3.* ]]' \
-	"agentdb not v3 — ReasoningBank unavailable"
+if ! echo "$NS" | grep -q "Using sql.js" && echo "$PN" | grep -qE "Nothing to do|already resolve native"; then
+	pass "native better-sqlite3 (no WASM fallback)"
+else
+	miss "native better-sqlite3 (no WASM fallback)" "still on sql.js/WASM — patch-native did not take"
+fi
+if cap "$CLI" "@ruvector/core" "VectorDb"; then
+	pass "HNSW vector engine (@ruvector/core → VectorDb)"
+else
+	miss "HNSW vector engine (@ruvector/core → VectorDb)" "core present but VectorDb missing"
+fi
+if cap "$NEURAL" "@ruvector/sona" "SonaEngine"; then
+	pass "SONA engine (@ruvector/sona → SonaEngine)"
+else
+	miss "SONA engine (@ruvector/sona → SonaEngine)" "sona native module not loadable from @claude-flow/neural"
+fi
+if cap "$NEURAL" "@ruvector/gnn" "RuvectorLayer"; then
+	pass "GNN layer (@ruvector/gnn → RuvectorLayer)"
+else
+	miss "GNN layer (@ruvector/gnn → RuvectorLayer)" "gnn native module not loadable from @claude-flow/neural"
+fi
+if [[ "$ADB_VER" == 3.* ]]; then
+	pass "ReasoningBank (agentdb v3)"
+else
+	miss "ReasoningBank (agentdb v3)" "agentdb not v3 — ReasoningBank unavailable"
+fi
 echo ""
 dim "Note: 'ruflo neural status' may still print HNSW/Training as 'Not loaded' — that is"
 dim "a lazy per-process display (getHNSWStatus), not real dormancy. Prove the loop with"

--- a/bin/ruflo-learning-verify
+++ b/bin/ruflo-learning-verify
@@ -24,17 +24,20 @@ while (( $# )); do
 	esac
 	shift
 done
-if [[ -t 1 ]]; then C_OK=$'\033[32m'; C_FAIL=$'\033[31m'; C_DIM=$'\033[2m'; C_RESET=$'\033[0m'
-else C_OK=""; C_FAIL=""; C_DIM=""; C_RESET=""; fi
-ok()  { printf '%s✓%s %s\n' "$C_OK" "$C_RESET" "$*"; }
-fail(){ printf '%s✗%s %s\n' "$C_FAIL" "$C_RESET" "$*"; }
-dim() { printf '%s%s%s\n' "$C_DIM" "$*" "$C_RESET"; }
+# Shared helpers (colors, ok/fail/dim, _ruflo_need) from ruflo-lib.sh:
+# installed copy first, then repo-relative (bin/ ↔ ../shell/).
+for _cand in "$HOME/.config/ruflo/ruflo-lib.sh" "$(dirname "${BASH_SOURCE[0]:-$0}")/../shell/ruflo-lib.sh"; do
+	# shellcheck source=/dev/null
+	[ -f "$_cand" ] && { . "$_cand"; break; }
+done
+unset _cand
+[ -n "${_RUFLO_LIB:-}" ] || { echo "ruflo-lib.sh not found — run install.sh" >&2; exit 2; }
 
-command -v node  >/dev/null 2>&1 || { fail "node not on PATH"; exit 2; }
-command -v ruflo >/dev/null 2>&1 || { fail "ruflo not on PATH"; exit 2; }
+_ruflo_need node ruflo
 
 T=$(mktemp -d)
 export CLAUDE_FLOW_DB_PATH="$T/.swarm/memory.db"
+# shellcheck disable=SC2329  # invoked via trap below
 cleanup(){ if (( KEEP )); then echo "kept: $T"; else rm -rf "$T"; fi; }
 trap cleanup EXIT
 

--- a/bin/ruflo-parity-test
+++ b/bin/ruflo-parity-test
@@ -51,14 +51,16 @@ for arg in "$@"; do
 	esac
 done
 
-# --- terminal helpers -------------------------------------------------------
-if [[ -t 1 ]]; then
-	C_OK=$'\033[32m'; C_FAIL=$'\033[31m'; C_DIM=$'\033[2m'
-	C_HEAD=$'\033[1;36m'; C_RESET=$'\033[0m'
-else
-	C_OK=""; C_FAIL=""; C_DIM=""; C_HEAD=""; C_RESET=""
-fi
+# Shared helpers (colors C_OK/C_FAIL/C_DIM/C_HEAD/C_RESET, _ruflo_daemon_list) from
+# ruflo-lib.sh: installed copy first, then repo-relative (bin/ ↔ ../shell/).
+for _cand in "$HOME/.config/ruflo/ruflo-lib.sh" "$(dirname "${BASH_SOURCE[0]:-$0}")/../shell/ruflo-lib.sh"; do
+	# shellcheck source=/dev/null
+	[ -f "$_cand" ] && { . "$_cand"; break; }
+done
+unset _cand
+[ -n "${_RUFLO_LIB:-}" ] || { echo "ruflo-lib.sh not found — run install.sh" >&2; exit 2; }
 
+# --- test-specific helpers (PASS/FAIL tally, headers) -----------------------
 PASS=0
 FAIL=0
 LOG_FILE=""
@@ -80,8 +82,22 @@ check() {
 	fi
 }
 
+# shellcheck disable=SC2329  # invoked via trap below
 cleanup_on_exit() {
 	local rc=$?
+	# Stop the daemon ruflo-setup-project started for this throwaway workspace
+	# (issue #3) — orphaned whether or not we keep the dir, since the test is done.
+	# The daemon records the RESOLVED (pwd -P) path, so match that too.
+	if [[ -n "${TEST_DIR:-}" ]] && command -v _ruflo_daemon_list >/dev/null 2>&1; then
+		local _rdir; _rdir="$(cd "$TEST_DIR" 2>/dev/null && pwd -P || echo "$TEST_DIR")"
+		local _dp _dws
+		while IFS="$(printf '\t')" read -r _dp _dws; do
+			[[ "$_dws" == "$_rdir" || "$_dws" == "$TEST_DIR" ]] || continue
+			[[ -n "$_dp" ]] && kill "$_dp" 2>/dev/null && log "Stopped test daemon pid=$_dp ($_dws)"
+		done <<EOF
+$(_ruflo_daemon_list)
+EOF
+	fi
 	if (( FAIL == 0 && KEEP == 0 )) && [[ -n "${TEST_DIR:-}" && -d "$TEST_DIR" ]]; then
 		rm -rf "$TEST_DIR"
 		log ""
@@ -91,7 +107,7 @@ cleanup_on_exit() {
 		log "Test dir kept at: $TEST_DIR"
 		[[ -n "$LOG_FILE" ]] && log "Full log:        $LOG_FILE"
 	fi
-	exit $rc
+	exit "$rc"
 }
 trap cleanup_on_exit EXIT INT TERM
 
@@ -143,7 +159,7 @@ LOG_FILE="${TEST_DIR}.log"
 
 head_line "Create test dir"
 mkdir -p "$TEST_DIR"
-cd "$TEST_DIR"
+cd "$TEST_DIR" || { check "test dir created" "cannot cd to $TEST_DIR" "fail"; exit 2; }
 check "test dir created" "$TEST_DIR" "ok"
 
 # Capture full output to a log file alongside the test dir
@@ -188,9 +204,12 @@ if [[ ! -f "$SETTINGS_FILE" ]]; then
 	check "settings.local.json present" "missing" "fail"
 else
 	DB_PATH=$(python3 -c "import json; print(json.load(open('$SETTINGS_FILE')).get('env', {}).get('CLAUDE_FLOW_DB_PATH', ''))" 2>/dev/null)
+	# The literal token Claude Code does NOT expand — matched verbatim, never expanded here.
+	# shellcheck disable=SC2016
+	UNEXPANDED_CPD='${CLAUDE_PROJECT_DIR}'
 	if [[ -z "$DB_PATH" ]]; then
 		check "CLAUDE_FLOW_DB_PATH set" "absent or unreadable" "fail"
-	elif [[ "$DB_PATH" == *'${CLAUDE_PROJECT_DIR}'* ]]; then
+	elif [[ "$DB_PATH" == *"$UNEXPANDED_CPD"* ]]; then
 		check "CLAUDE_FLOW_DB_PATH resolved" "literal \${CLAUDE_PROJECT_DIR} present — Claude Code does NOT expand it; writes will silently fail" "fail"
 	elif [[ "$DB_PATH" != /* ]]; then
 		check "CLAUDE_FLOW_DB_PATH absolute" "not absolute: $DB_PATH" "fail"

--- a/bin/ruflo-patch-native
+++ b/bin/ruflo-patch-native
@@ -52,24 +52,20 @@ while (( $# )); do
 	shift
 done
 
-if [[ -t 1 ]]; then
-	C_OK=$'\033[32m'; C_WARN=$'\033[33m'; C_FAIL=$'\033[31m'; C_DIM=$'\033[2m'; C_RESET=$'\033[0m'
-else
-	C_OK=""; C_WARN=""; C_FAIL=""; C_DIM=""; C_RESET=""
-fi
-ok()   { printf '%s✓%s %s\n' "$C_OK" "$C_RESET" "$*"; }
-warn() { printf '%s⚠%s  %s\n' "$C_WARN" "$C_RESET" "$*"; }
-fail() { printf '%s✗%s %s\n' "$C_FAIL" "$C_RESET" "$*"; }
-dim()  { printf '%s%s%s\n' "$C_DIM" "$*" "$C_RESET"; }
+# Shared helpers (colors, ok/warn/fail/dim, _ruflo_need, native bsq3 primitives)
+# from ruflo-lib.sh: installed copy first, then repo-relative (bin/ ↔ ../shell/).
+for _cand in "$HOME/.config/ruflo/ruflo-lib.sh" "$(dirname "${BASH_SOURCE[0]:-$0}")/../shell/ruflo-lib.sh"; do
+	# shellcheck source=/dev/null
+	[ -f "$_cand" ] && { . "$_cand"; break; }
+done
+unset _cand
+[ -n "${_RUFLO_LIB:-}" ] || { echo "ruflo-lib.sh not found — run install.sh" >&2; exit 2; }
 
-command -v node >/dev/null 2>&1 || { fail "node not on PATH"; exit 2; }
-command -v npm  >/dev/null 2>&1 || { fail "npm not on PATH"; exit 2; }
-command -v ruflo >/dev/null 2>&1 || { fail "ruflo not on PATH"; exit 2; }
+_ruflo_need node npm ruflo
 
 NODE_VER=$(node --version)
-NODE_ABI=$(node -e 'process.stdout.write(process.versions.modules)')
-NODE_MAJOR=$(node -e 'process.stdout.write(String(process.versions.node.split(".")[0]))')
-RUFLO_ROOT="$(npm root -g)/ruflo"
+NODE_ABI=$(_ruflo_node_abi)
+RUFLO_ROOT="$(_ruflo_global_root)/ruflo"
 
 echo "Node $NODE_VER (ABI $NODE_ABI) | ruflo $(ruflo --version 2>/dev/null | tr -d '\n')"
 echo "ruflo root: $RUFLO_ROOT"
@@ -107,21 +103,13 @@ if (( ${#AGENTDB_DIRS[@]} == 0 )); then
 fi
 
 needs_patch() {
-	# returns 0 if this agentdb dir cannot resolve a native better-sqlite3
-	local agentdb_dir="$1"
-	node -e "
-try {
-  const p = require.resolve('better-sqlite3', { paths: ['$agentdb_dir'] });
-  const base = p.split('/better-sqlite3/')[0] + '/better-sqlite3';
-  const hasBin = require('fs').existsSync(base + '/build/Release/better_sqlite3.node');
-  process.exit(hasBin ? 1 : 0);   // exit 1 = native present (no patch); 0 = needs patch
-} catch (e) { process.exit(0); }   // unresolvable = needs patch
-" 2>/dev/null
+	# 0 if this agentdb dir cannot resolve a native better-sqlite3 (i.e. needs the patch)
+	! _ruflo_bsq3_is_native "$1"
 }
 
 TO_PATCH=()
 for d in "${AGENTDB_DIRS[@]}"; do
-	rel="${d#$RUFLO_ROOT/node_modules/}"
+	rel="${d#"$RUFLO_ROOT"/node_modules/}"
 	if needs_patch "$d"; then
 		echo "  needs patch: $rel"
 		TO_PATCH+=("$d")
@@ -146,7 +134,7 @@ echo "Installing better-sqlite3@$BSQ_RANGE into ${#TO_PATCH[@]} location(s)..."
 PATCH_LOG=$(mktemp)
 patched=0
 for d in "${TO_PATCH[@]}"; do
-	rel="${d#$RUFLO_ROOT/node_modules/}"
+	rel="${d#"$RUFLO_ROOT"/node_modules/}"
 	if ( cd "$d" && npm install "better-sqlite3@$BSQ_RANGE" --no-save --no-audit --no-fund >>"$PATCH_LOG" 2>&1 ); then
 		ok "patched $rel"
 		patched=$((patched+1))
@@ -160,7 +148,7 @@ echo ""
 echo "Verifying native binaries..."
 allnative=1
 for d in "${TO_PATCH[@]}"; do
-	rel="${d#$RUFLO_ROOT/node_modules/}"
+	rel="${d#"$RUFLO_ROOT"/node_modules/}"
 	if needs_patch "$d"; then
 		fail "$rel still not native"
 		allnative=0
@@ -179,7 +167,7 @@ echo ""
 # --- Functional smoke test --------------------------------------------------
 echo "Smoke test (store → retrieve via native path)..."
 TMPD=$(mktemp -d)
-( cd "$TMPD"
+( cd "$TMPD" || exit 1
   export CLAUDE_FLOW_DB_PATH="$TMPD/.swarm/memory.db"
   ruflo init --minimal --force >/dev/null 2>&1
   ruflo memory init >/dev/null 2>&1

--- a/bin/ruflo-security-verify
+++ b/bin/ruflo-security-verify
@@ -24,15 +24,17 @@ while (( $# )); do
 	esac
 	shift
 done
-if [[ -t 1 ]]; then C_OK=$'\033[32m'; C_WARN=$'\033[33m'; C_FAIL=$'\033[31m'; C_RESET=$'\033[0m'
-else C_OK=""; C_WARN=""; C_FAIL=""; C_RESET=""; fi
-ok()  { printf '%s✓%s %s\n' "$C_OK" "$C_RESET" "$*"; }
-warn(){ printf '%s⚠%s  %s\n' "$C_WARN" "$C_RESET" "$*"; }
-fail(){ printf '%s✗%s %s\n' "$C_FAIL" "$C_RESET" "$*"; }
+# Shared helpers (colors, ok/warn/fail, _ruflo_need, global-root) from ruflo-lib.sh:
+# installed copy first, then repo-relative (bin/ ↔ ../shell/).
+for _cand in "$HOME/.config/ruflo/ruflo-lib.sh" "$(dirname "${BASH_SOURCE[0]:-$0}")/../shell/ruflo-lib.sh"; do
+	# shellcheck source=/dev/null
+	[ -f "$_cand" ] && { . "$_cand"; break; }
+done
+unset _cand
+[ -n "${_RUFLO_LIB:-}" ] || { echo "ruflo-lib.sh not found — run install.sh" >&2; exit 2; }
 
-command -v node  >/dev/null 2>&1 || { fail "node not on PATH"; exit 2; }
-command -v ruflo >/dev/null 2>&1 || { fail "ruflo not on PATH"; exit 2; }
-RUFLO_ROOT="$(npm root -g)/ruflo"
+_ruflo_need node ruflo
+RUFLO_ROOT="$(_ruflo_global_root)/ruflo"
 declare -i bad=0
 
 # 1. modules load
@@ -71,4 +73,8 @@ if ruflo security cve --list 2>&1 | grep -qi "no cve database"; then
 fi
 
 echo ""
-(( bad == 0 )) && { ok "Security surface verified."; exit 0; } || { fail "$bad security capability/ies need attention."; exit 1; }
+if (( bad == 0 )); then
+	ok "Security surface verified."; exit 0
+else
+	fail "$bad security capability/ies need attention."; exit 1
+fi

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -179,3 +179,43 @@ ruflo cleanup --force               # remove ruflo artifacts (dry-run by default
 rm -rf .swarm .claude-flow .mcp.json
 ruflo-setup-project                 # re-create cleanly
 ```
+
+## Claude Code crashes with ENOSPC / orphan `ruflo daemon` processes pile up
+
+**Symptom.** Claude Code dies mid-session with
+`the temp filesystem at /private/tmp/claude-501/<project>/<uuid>/tasks is full
+(0MB free)`, and/or `ps axww | grep "daemon start"` shows many `ruflo daemon`
+processes — some pointed at `--workspace` directories that no longer exist
+(e.g. `/tmp/test-*` from `ruflo-parity-test` runs). See issue #3.
+
+**Why.** `ruflo-setup-project` starts a per-workspace `ruflo daemon` (this is what
+makes self-learning continuous). Before this fix, nothing stopped them, so each
+throwaway/removed workspace left a daemon running forever. Separately, the
+statusline footer used to spawn several `sqlite3` subprocesses on every render;
+that volume of captured subprocess output is what fills Claude Code's size-limited
+sandbox `tasks` tmpfs.
+
+**Fix is built in now.** The statusline footer caches its QE metrics
+(`RUFLO_QE_STATUSLINE_TTL_MS`, default 60000ms) and makes at most one `sqlite3`
+call per TTL window. The daemon start is idempotent per workspace, and orphans are
+reaped.
+
+**Reap existing orphans:**
+
+```bash
+ruflo-daemon-gc            # list daemons whose --workspace is gone
+ruflo-daemon-gc --kill     # stop exactly those (live-project daemons untouched)
+```
+
+`uninstall.sh` also reaps stale daemons; `uninstall.sh --this-project` additionally
+stops the current repo's daemon.
+
+**If you run many hooks and still hit the tmpfs limit**, point Claude Code's
+subprocess tmpdir at your main filesystem (more space than the sandbox tmpfs) by
+adding to `~/.claude/settings.json`:
+
+```json
+{ "env": { "CLAUDE_CODE_TMPDIR": "/Users/<you>/tmp/claude-code" } }
+```
+
+Create the directory first (`mkdir -p ~/tmp/claude-code`).

--- a/docs/superpowers/plans/2026-05-29-daemon-statusline-resource-fix.md
+++ b/docs/superpowers/plans/2026-05-29-daemon-statusline-resource-fix.md
@@ -1,0 +1,514 @@
+# Daemon & Statusline Resource Leak Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the kit from leaking orphan `ruflo daemon` processes and from spawning 2–4 `sqlite3` subprocesses per statusline render, the two confirmed root causes behind issue #3's `ENOSPC` session crashes.
+
+**Architecture:** Keep the daemon (it drives continuous self-learning) but make its start idempotent per-workspace and give every surface that starts one a way to stop it: parity-test teardown stops its throwaway-workspace daemon, `uninstall.sh` stops stale + this-project daemons, and a new `ruflo-daemon-gc` reaps daemons whose `--workspace` is gone. The statusline footer caches its QE metrics to a TTL'd file (zero sqlite3 spawns within the window) and, on a miss, runs **one** stdin-fed `.bail off` sqlite3 call with `e.stdout` recovery.
+
+**Tech Stack:** POSIX-ish bash + zsh (functions are sourced into the user's interactive shell), `ps axww -o pid=,args=`, `sqlite3`, Node (injected `statusline.cjs`), `python3` (JSON edits). Verification: `bash -n`, `shellcheck` (if installed), `node --check`, behavioral greps, and a live orphan-daemon round-trip.
+
+**Spec:** `docs/superpowers/specs/2026-05-29-daemon-statusline-resource-fix-design.md`
+
+**Conventions:**
+- No `Co-Authored-By` trailer (project `.claude/settings.json` has no `attribution.commit`).
+- Commit after each task. Never use `--no-verify`.
+- `ps axww -o pid=,args=` is the portable (macOS + Linux) full-width process listing; `-e` means "environment" on BSD/macOS, so it is NOT used.
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+|---|---|---|
+| `shell/ruflo-daemon-lib.sh` | **Shared** `_ruflo_daemon_list` ps-parser (defined once); sourced by the three consumers below (DRY — R10) | Create |
+| `shell/ruflo-functions.sh` | Source the lib; `ruflo-daemon-gc`; idempotent daemon start + `autoStart` guard in `ruflo-setup-project`; cache + single-query in the injected statusline footer; `node --check` after injection | Modify |
+| `bin/ruflo-parity-test` | Source the lib; stop the throwaway-workspace daemon in `cleanup_on_exit` (every exit path) | Modify |
+| `uninstall.sh` | Source the lib; daemon teardown: GC stale daemons always; stop this-repo daemon with `--this-project`; remove the installed lib | Modify |
+| `install.sh` | Deploy `ruflo-daemon-lib.sh` to `~/.config/ruflo/` (stable path for standalone bin scripts) | Modify |
+| `docs/TROUBLESHOOTING.md` | Document daemon lifecycle + `ruflo-daemon-gc` + `CLAUDE_CODE_TMPDIR` workaround | Modify |
+
+> **DRY note (added after the user's request, R10):** the `_ruflo_daemon_list`
+> `ps`-parser was initially written inline in all three consumers; it is now
+> extracted into `shell/ruflo-daemon-lib.sh` (Task 7) and deployed by `install.sh`
+> so the standalone-installed bin scripts can source it from a stable path.
+
+---
+
+## Task 1: Daemon lifecycle helpers + idempotent start + autoStart guard
+
+**Files:**
+- Modify: `shell/ruflo-functions.sh` (add helpers before `ruflo-setup-project`; edit the daemon-start line ~320 and add an autoStart guard after it)
+
+- [ ] **Step 1: Add `_ruflo_daemon_list` and `ruflo-daemon-gc`**
+
+Insert this block immediately before the `ruflo-fix-statusline-version() {` definition (currently line 90):
+
+```bash
+# ---------------------------------------------------------------------------
+# Daemon lifecycle (issue #3). ruflo-setup-project starts a per-workspace daemon
+# (continuous self-learning). Without reaping, throwaway/removed workspaces (e.g.
+# ruflo-parity-test's /tmp dirs) leave orphan daemons running forever.
+#
+# _ruflo_daemon_list emits "<pid>\t<workspace>" for every ruflo daemon process.
+# Portable: ps axww (-e means "environment" on macOS, so it is avoided).
+_ruflo_daemon_list() {
+	ps axww -o pid=,args= 2>/dev/null | while IFS= read -r line; do
+		case "$line" in *"daemon start"*) ;; *) continue ;; esac
+		case "$line" in *"--workspace "*) ;; *) continue ;; esac
+		local ws=${line#*--workspace }; ws=${ws%% --*}
+		local pid=${line%% *}
+		[ -n "$pid" ] && [ -n "$ws" ] && printf '%s\t%s\n' "$pid" "$ws"
+	done
+}
+
+# List (or, with --kill, stop) ruflo daemons whose --workspace no longer exists.
+# Never touches a daemon whose workspace is still present (a live project).
+#   ruflo-daemon-gc           # list orphans (dry preview)
+#   ruflo-daemon-gc --kill    # stop them
+ruflo-daemon-gc() {
+	local do_kill=0
+	[ "${1:-}" = "--kill" ] && do_kill=1
+	local found=0 pid ws
+	while IFS="$(printf '\t')" read -r pid ws; do
+		[ -n "${pid:-}" ] || continue
+		[ -d "$ws" ] && continue
+		found=$((found+1))
+		if [ "$do_kill" -eq 1 ]; then
+			kill "$pid" 2>/dev/null && echo "✓ stopped orphan daemon pid=$pid (workspace gone: $ws)" \
+				|| echo "⚠  could not stop pid=$pid (already exited?)"
+		else
+			echo "orphan daemon pid=$pid → $ws (workspace gone)"
+		fi
+	done <<EOF
+$(_ruflo_daemon_list)
+EOF
+	if [ "$found" -eq 0 ]; then
+		echo "✓ no orphan daemons (every running daemon's --workspace still exists)"
+	elif [ "$do_kill" -eq 0 ]; then
+		echo "Found $found orphan(s). Run 'ruflo-daemon-gc --kill' to stop them."
+	fi
+	return 0
+}
+```
+
+- [ ] **Step 2: Make the daemon start idempotent in `ruflo-setup-project`**
+
+Replace the single daemon-start line (currently line 320):
+
+```bash
+	ruflo daemon start >/dev/null 2>&1 && echo "✓ Daemon started" || echo "⚠  ruflo daemon start failed (may already be running)"
+```
+
+with:
+
+```bash
+	# Idempotent daemon start: never spawn a 2nd daemon for this workspace (issue #3).
+	local _ws; _ws="$(pwd -P)"
+	if [ -n "$(_ruflo_daemon_list | awk -F'\t' -v w="$_ws" '$2==w{print $1; exit}')" ]; then
+		echo "✓ Daemon already running for this workspace (not starting another)"
+	else
+		ruflo daemon start >/dev/null 2>&1 && echo "✓ Daemon started" || echo "⚠  ruflo daemon start failed (may already be running)"
+	fi
+```
+
+- [ ] **Step 3: Add the defensive `autoStart` guard after the daemon start**
+
+Immediately after the block from Step 2 (and before the WAL-checkpoint comment `# WAL checkpoint so the sql.js reader...`), insert:
+
+```bash
+	# Defensive (issue #3 RC3): if upstream `ruflo init` wrote daemon.autoStart:true,
+	# flip it to false so opening Claude Code does not auto-restart the daemon.
+	# No-op when the file/key is absent or already false.
+	if [ -f ".claude/settings.json" ] && command -v python3 >/dev/null 2>&1; then
+		if python3 - <<'PY' 2>/dev/null
+import json, sys
+p = ".claude/settings.json"
+try:
+    with open(p) as f: d = json.load(f)
+except Exception:
+    sys.exit(0)
+cf = d.get("claudeFlow")
+dm = cf.get("daemon") if isinstance(cf, dict) else None
+if isinstance(dm, dict) and dm.get("autoStart") is True:
+    dm["autoStart"] = False
+    with open(p, "w") as f: json.dump(d, f, indent=2)
+    sys.exit(1)  # changed
+sys.exit(0)      # no change
+PY
+		then
+			:  # unchanged (absent/false) — stay quiet
+		else
+			echo "✓ Set claudeFlow.daemon.autoStart=false in .claude/settings.json (was true)"
+		fi
+	fi
+```
+
+- [ ] **Step 4: Syntax + lint check**
+
+Run: `bash -n shell/ruflo-functions.sh && echo OK`
+Expected: `OK`
+
+Run (if installed): `command -v shellcheck >/dev/null && shellcheck -S warning shell/ruflo-functions.sh; echo "shellcheck rc=$?"`
+Expected: no NEW errors beyond any pre-existing ones (the file already had `# shellcheck disable` directives; do not introduce new warnings).
+
+- [ ] **Step 5: Functional check of the helpers in a real shell**
+
+Run:
+```bash
+zsh -c 'source shell/ruflo-functions.sh; type _ruflo_daemon_list ruflo-daemon-gc | grep -q "shell function" && echo "funcs load"; ruflo-daemon-gc'
+```
+Expected: prints `funcs load`, then either lists current orphans or `✓ no orphan daemons ...`. (Do not pass `--kill` here — that is Task 6.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add shell/ruflo-functions.sh
+git commit -m "fix(daemon): reap orphan daemons (ruflo-daemon-gc), idempotent per-workspace start, autoStart guard (#3)"
+```
+
+---
+
+## Task 2: Statusline footer — TTL cache + single sqlite3 spawn
+
+**Files:**
+- Modify: `shell/ruflo-functions.sh` (the `RUFLO_SEG_EOF` heredoc, currently lines 127–190; and add a `node --check` after the injection node script ~line 207)
+
+- [ ] **Step 1: Replace the QE block inside the injected `rufloActivationSegments`**
+
+Inside the `RUFLO_SEG_EOF` heredoc, replace the entire `// ── agentic-qe ...` block — from the line `    // ── agentic-qe (one guarded sqlite3 read) — branch + icon-tagged metrics ──` down to and including its closing `    } catch(e){}` (the one right before `    // ── assemble:`) — with this:
+
+```javascript
+    // ── agentic-qe — TTL-cached; one sqlite3 spawn only on a cache miss (issue #3) ──
+    var qe = "";
+    try {
+      var db = path.join(cwd, ".agentic-qe", "memory.db");
+      if (fs.existsSync(db)) {
+        var cacheDir = path.join(cwd, ".claude-flow", "cache");
+        var cacheFile = path.join(cacheDir, "qe-statusline.json");
+        var ttl = Number(process.env.RUFLO_QE_STATUSLINE_TTL_MS || 60000);
+        var cached = null;
+        try {
+          var c = JSON.parse(fs.readFileSync(cacheFile, "utf8"));
+          if (c && typeof c.line === "string" && ttl > 0 && (Date.now() - c.ts) < ttl) cached = c.line;
+        } catch(e){}
+        if (cached !== null) {
+          qe = cached;                       // hit: zero sqlite3 spawns
+        } else {
+          // miss: ONE sqlite3 call. SQL on stdin + ".bail off" so a missing vector
+          // table (name varies by aqe version) doesn't abort the batch. sqlite3 still
+          // exits non-zero on the error, so execFileSync throws — recover e.stdout.
+          var sql = ".bail off\n"
+            + "SELECT 'pat',COUNT(*) FROM qe_patterns;\n"
+            + "SELECT 'vec',COUNT(*) FROM qe_pattern_embeddings;\n"
+            + "SELECT 'vec',COUNT(*) FROM vectors;\n"
+            + "SELECT 'vec',COUNT(*) FROM embeddings;\n"
+            + "SELECT 'traj',COUNT(*) FROM qe_trajectories;\n";
+          var raw = "";
+          try { raw = cp.execFileSync("sqlite3", [db], {input: sql, stdio:["pipe","pipe","ignore"], timeout:1500}).toString(); }
+          catch(e){ raw = (e && e.stdout) ? e.stdout.toString() : ""; }
+          var pat = 0, qtj = 0, qv = 0;
+          raw.split("\n").forEach(function(ln){
+            var i = ln.indexOf("|"); if (i < 0) return;
+            var k = ln.slice(0, i), v = Number(ln.slice(i + 1)) || 0;
+            if (k === "pat") pat = v; else if (k === "traj") qtj = v; else if (k === "vec" && qv === 0) qv = v;
+          });
+          var qp = [];
+          if (pat > 0) qp.push("🎓 " + pat + " patterns");
+          if (qtj > 0) qp.push("🧭 " + qtj + " traj");
+          if (qv > 0) qp.push("🧬 " + qv + " vec" + G + "⚡" + R);
+          try { var kb = Math.round(fs.statSync(db).size / 1024); qp.push("💾 " + (kb >= 1024 ? (kb/1024).toFixed(1) + "MB" : kb + "KB")); } catch(e){}
+          qe = Y + "🎓 Agentic QE" + R + "  " + (qp.length ? qp.join(DIM + " · " + R) : "on");
+          try { fs.mkdirSync(cacheDir, {recursive:true}); fs.writeFileSync(cacheFile, JSON.stringify({ts: Date.now(), line: qe})); } catch(e){}
+        }
+      }
+    } catch(e){}
+```
+
+> Note: the `q(db, sql)` helper defined at the top of the block is still used by no other branch after this change. Leave it in place — it is harmless and keeps the diff minimal — unless `shellcheck`/lint flags it; the injected JS is not linted, so leave it.
+
+- [ ] **Step 2: Add a `node --check` guard after the injection succeeds**
+
+In `ruflo-fix-statusline-version`, the injection node script ends and prints
+`✓ Statusline activation footer present (...)` on success (currently ~line 212).
+Immediately after that `echo` line (inside the `else` branch), add:
+
+```bash
+		if ! node --check "$sl" 2>/dev/null; then
+			echo "⚠  Injected statusline failed node --check — review $sl"
+		fi
+```
+
+- [ ] **Step 3: Syntax check the shell file**
+
+Run: `bash -n shell/ruflo-functions.sh && echo OK`
+Expected: `OK`
+
+- [ ] **Step 4: Prove the injected JS is valid and behaves (cache + single spawn)**
+
+Extract the heredoc body to a temp file, wrap it with a fake `generateStatusline`, and check it parses and renders, then that a 2nd render within TTL does not rewrite via sqlite3 (cache hit). Run:
+
+```bash
+cd "$(git rev-parse --show-toplevel)"
+tmp=$(mktemp -d)
+# Pull the BEGIN..END block out of the heredoc in the shell file:
+awk '/\/\* ruflo-seg:BEGIN \*\//{f=1} f{print} /\/\* ruflo-seg:END \*\//{f=0}' shell/ruflo-functions.sh > "$tmp/seg.js"
+printf '\nfunction generateStatusline(){return "RuFlo V9.9.9";}\nconsole.log(generateStatusline() + rufloActivationSegments(process.cwd()));\n' >> "$tmp/seg.js"
+node --check "$tmp/seg.js" && echo "node --check OK"
+# Render against THIS repo (has .agentic-qe/memory.db). First render = cache miss (writes cache):
+rm -f .claude-flow/cache/qe-statusline.json
+node "$tmp/seg.js" | sed -E 's/\x1b\[[0-9;]*m//g'
+test -f .claude-flow/cache/qe-statusline.json && echo "cache written ✓"
+# Second render within TTL must reuse cache: stamp cache mtime, render, confirm mtime unchanged (no rewrite path on hit):
+before=$(stat -f %m .claude-flow/cache/qe-statusline.json 2>/dev/null || stat -c %Y .claude-flow/cache/qe-statusline.json)
+node "$tmp/seg.js" >/dev/null
+after=$(stat -f %m .claude-flow/cache/qe-statusline.json 2>/dev/null || stat -c %Y .claude-flow/cache/qe-statusline.json)
+[ "$before" = "$after" ] && echo "cache HIT on 2nd render (no rewrite) ✓" || echo "⚠ cache not hit"
+rm -rf "$tmp"
+```
+Expected: `node --check OK`, a footer line containing `🎓 Agentic QE` with `patterns`/`traj`/`vec`/the DB size, `cache written ✓`, and `cache HIT on 2nd render (no rewrite) ✓`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add shell/ruflo-functions.sh
+git commit -m "fix(statusline): TTL-cache QE footer + single .bail-off sqlite3 spawn on miss (#3)"
+```
+
+---
+
+## Task 3: parity-test stops its own daemon on exit
+
+**Files:**
+- Modify: `bin/ruflo-parity-test` (the `cleanup_on_exit` function, currently lines 83–95)
+
+- [ ] **Step 1: Stop the test-workspace daemon in `cleanup_on_exit`**
+
+Replace the `cleanup_on_exit()` function body so the daemon bound to `$TEST_DIR`
+is stopped on **every** exit path (success, failure, INT/TERM), regardless of
+`--keep`/`--cleanup` (the daemon is an orphan once the test ends either way):
+
+```bash
+cleanup_on_exit() {
+	local rc=$?
+	# Stop the daemon ruflo-setup-project started for this throwaway workspace
+	# (issue #3) — orphaned whether or not we keep the dir, since the test is done.
+	if [[ -n "${TEST_DIR:-}" ]]; then
+		ps axww -o pid=,args= 2>/dev/null | while IFS= read -r line; do
+			case "$line" in *"daemon start"*) ;; *) continue ;; esac
+			case "$line" in *"--workspace $TEST_DIR"*) ;; *) continue ;; esac
+			local pid=${line%% *}
+			[[ -n "$pid" ]] && kill "$pid" 2>/dev/null && log "Stopped test daemon pid=$pid ($TEST_DIR)"
+		done
+	fi
+	if (( FAIL == 0 && KEEP == 0 )) && [[ -n "${TEST_DIR:-}" && -d "$TEST_DIR" ]]; then
+		rm -rf "$TEST_DIR"
+		log ""
+		log "Cleaned up $TEST_DIR (--cleanup, all checks passed)"
+	elif [[ -n "${TEST_DIR:-}" && -d "$TEST_DIR" ]]; then
+		log ""
+		log "Test dir kept at: $TEST_DIR"
+		[[ -n "$LOG_FILE" ]] && log "Full log:        $LOG_FILE"
+	fi
+	exit $rc
+}
+trap cleanup_on_exit EXIT INT TERM
+```
+
+- [ ] **Step 2: Syntax + lint check**
+
+Run: `bash -n bin/ruflo-parity-test && echo OK`
+Expected: `OK`
+
+Run (if installed): `command -v shellcheck >/dev/null && shellcheck -S warning bin/ruflo-parity-test; echo "rc=$?"`
+Expected: no new warnings.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add bin/ruflo-parity-test
+git commit -m "fix(parity-test): stop the throwaway-workspace daemon on exit (no orphans) (#3)"
+```
+
+---
+
+## Task 4: uninstall.sh daemon teardown
+
+**Files:**
+- Modify: `uninstall.sh` (insert a new section between the `--this-project` block ending at line 153 and the npm-removal section starting at line 155)
+
+- [ ] **Step 1: Insert the daemon-teardown section**
+
+After the closing `fi` of the `--this-project` block (line 153) and before the
+`# 6. (--remove-ruflo ...` comment (line 155), insert:
+
+```bash
+# 6. Daemon teardown (issue #3): always reap stale (workspace-gone) daemons;
+#    with --this-project also stop the daemon bound to THIS repo's workspace.
+#    Never touches unrelated live-workspace daemons.
+echo ""
+echo "## Daemon teardown"
+THIS_WS="$(pwd -P)"
+DAEMON_HITS=0
+while IFS="$(printf '\t')" read -r dpid dws; do
+	[ -n "${dpid:-}" ] || continue
+	stale=0; mine=0
+	[ -d "$dws" ] || stale=1
+	[ "$dws" = "$THIS_WS" ] && [ "$THIS_PROJECT" -eq 1 ] && mine=1
+	if [ "$stale" -eq 1 ] || [ "$mine" -eq 1 ]; then
+		DAEMON_HITS=$((DAEMON_HITS+1))
+		if [ "$stale" -eq 1 ]; then reason="workspace gone"; else reason="this project"; fi
+		if [ "$DRY" -eq 1 ]; then
+			printf '%s[dry-run]%s stop daemon pid=%s (%s): %s\n' "$C_DIM" "$C_RESET" "$dpid" "$reason" "$dws"
+		else
+			kill "$dpid" 2>/dev/null && ok "stopped daemon pid=$dpid ($reason): $dws" || warn "could not stop pid=$dpid"
+		fi
+	fi
+done <<EOF
+$(ps axww -o pid=,args= 2>/dev/null | while IFS= read -r line; do
+	case "$line" in *"daemon start"*) ;; *) continue ;; esac
+	case "$line" in *"--workspace "*) ;; *) continue ;; esac
+	ws=${line#*--workspace }; ws=${ws%% --*}
+	pid=${line%% *}
+	[ -n "$pid" ] && [ -n "$ws" ] && printf '%s\t%s\n' "$pid" "$ws"
+done)
+EOF
+if [ "$DAEMON_HITS" -eq 0 ]; then
+	if [ "$THIS_PROJECT" -eq 1 ]; then
+		ok "no daemons to stop (none stale; none for this project)"
+	else
+		ok "no stale daemons to stop"
+	fi
+fi
+```
+
+- [ ] **Step 2: Syntax + lint check**
+
+Run: `bash -n uninstall.sh && echo OK`
+Expected: `OK`
+
+Run: `bash uninstall.sh --dry-run 2>&1 | sed -n '/## Daemon teardown/,/^## /p'`
+Expected: the "Daemon teardown" section prints, showing `[dry-run] stop daemon ...` for any stale daemons, or `✓ no stale daemons to stop`. **Nothing is killed** (dry-run).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add uninstall.sh
+git commit -m "fix(uninstall): stop stale daemons (always) + this-project daemon (--this-project) (#3)"
+```
+
+---
+
+## Task 5: Document daemon lifecycle + CLAUDE_CODE_TMPDIR workaround
+
+**Files:**
+- Modify: `docs/TROUBLESHOOTING.md` (append a new section)
+
+- [ ] **Step 1: Read the end of the file to match style**
+
+Run: `tail -30 docs/TROUBLESHOOTING.md`
+Expected: see the heading style (`## ...`) and tone to match.
+
+- [ ] **Step 2: Append the new section**
+
+Append to `docs/TROUBLESHOOTING.md`:
+
+```markdown
+## Claude Code crashes with ENOSPC / orphan `ruflo daemon` processes pile up
+
+**Symptom.** Claude Code dies mid-session with
+`the temp filesystem at /private/tmp/claude-501/<project>/<uuid>/tasks is full
+(0MB free)`, and/or `ps axww | grep "daemon start"` shows many `ruflo daemon`
+processes — some pointed at `--workspace` directories that no longer exist
+(e.g. `/tmp/test-*` from `ruflo-parity-test` runs). See issue #3.
+
+**Why.** `ruflo-setup-project` starts a per-workspace `ruflo daemon` (this is what
+makes self-learning continuous). Before this fix, nothing stopped them, so each
+throwaway/removed workspace left a daemon running forever. Separately, the
+statusline footer used to spawn several `sqlite3` subprocesses on every render;
+that volume of captured subprocess output is what fills Claude Code's size-limited
+sandbox `tasks` tmpfs.
+
+**Fix is built in now.** The statusline footer caches its QE metrics
+(`RUFLO_QE_STATUSLINE_TTL_MS`, default 60000ms) and makes at most one `sqlite3`
+call per TTL window. The daemon start is idempotent per workspace, and orphans are
+reaped.
+
+**Reap existing orphans:**
+
+```bash
+ruflo-daemon-gc            # list daemons whose --workspace is gone
+ruflo-daemon-gc --kill     # stop exactly those (live-project daemons untouched)
+```
+
+`uninstall.sh` also reaps stale daemons; `uninstall.sh --this-project` additionally
+stops the current repo's daemon.
+
+**If you run many hooks and still hit the tmpfs limit**, point Claude Code's
+subprocess tmpdir at your main filesystem (more space than the sandbox tmpfs) by
+adding to `~/.claude/settings.json`:
+
+```json
+{ "env": { "CLAUDE_CODE_TMPDIR": "/Users/<you>/tmp/claude-code" } }
+```
+
+Create the directory first (`mkdir -p ~/tmp/claude-code`).
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/TROUBLESHOOTING.md
+git commit -m "docs(troubleshooting): daemon lifecycle, ruflo-daemon-gc, CLAUDE_CODE_TMPDIR (#3)"
+```
+
+---
+
+## Task 6: One-time cleanup of the existing orphan daemons on this machine
+
+**Files:** none (operational step on the live machine; gated on user already approving "kill stale orphans now").
+
+- [ ] **Step 1: Show the orphans (workspace gone) without killing**
+
+Run:
+```bash
+zsh -c 'source shell/ruflo-functions.sh; ruflo-daemon-gc'
+```
+Expected: a list of `orphan daemon pid=... → /private/tmp/test-* (workspace gone)`
+lines (the ~11 leftovers), and live-project daemons NOT listed.
+
+- [ ] **Step 2: Kill exactly the orphans**
+
+Run:
+```bash
+zsh -c 'source shell/ruflo-functions.sh; ruflo-daemon-gc --kill'
+```
+Expected: `✓ stopped orphan daemon pid=...` for each; live-project daemons remain.
+
+- [ ] **Step 3: Verify live-project daemons survived**
+
+Run:
+```bash
+ps axww -o pid=,args= | grep "daemon start" | grep -v grep | grep -c -- "--workspace /Users/"
+ps axww -o pid=,args= | grep "daemon start" | grep -v grep | grep -c -- "--workspace /private/tmp/test-"
+```
+Expected: the first count > 0 (live projects kept), the second `0` (test orphans gone).
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- R1 (parity-test stops its daemon, every exit, regardless of `--keep`) → Task 3.
+- R2 (idempotent daemon start) → Task 1 Step 2.
+- R3 (`ruflo-daemon-gc` list/`--kill`, no-op when none) → Task 1 Step 1.
+- R4 (uninstall stops stale always + this-project) → Task 4.
+- R5 (statusline TTL cache + single `.bail off` spawn + `e.stdout` recovery + identical output) → Task 2.
+- R6 (defensive `autoStart:false` only if present and true) → Task 1 Step 3.
+- R7 (one-time cleanup, workspace-gone only) → Task 6.
+- R8 (docs: lifecycle + `CLAUDE_CODE_TMPDIR`) → Task 5.
+- R9 (`bash -n`, `shellcheck`, `node --check`) → Tasks 1/2/3/4 verification steps.
+
+**Placeholder scan:** none — every code step contains the literal content.
+
+**Type/name consistency:** `_ruflo_daemon_list` (tab-separated `pid\tworkspace`) is consumed by `ruflo-daemon-gc` and the idempotent-start `awk -F'\t'` identically; `uninstall.sh` and `ruflo-parity-test` inline the same `ps axww` parse (they don't source the functions). Cache file path `.claude-flow/cache/qe-statusline.json` and env var `RUFLO_QE_STATUSLINE_TTL_MS` are used consistently in Task 2 and Task 5.

--- a/docs/superpowers/specs/2026-05-29-daemon-statusline-resource-fix-design.md
+++ b/docs/superpowers/specs/2026-05-29-daemon-statusline-resource-fix-design.md
@@ -1,0 +1,194 @@
+# Daemon & Statusline Resource Leak — Design Spec
+
+**Date:** 2026-05-29
+**Branch:** `fix/daemon-statusline-resource-leak`
+**Status:** Approved (investigation + scoping complete)
+**Issue:** [#3 — install.sh fills Claude Code sandbox tmpfs, causing session crashes (ENOSPC)](https://github.com/pacphi/ruflo-machine-ref/issues/3)
+
+## Problem
+
+Issue #3 reports that, after running the kit, Claude Code sessions crash with
+`ENOSPC` ("the temp filesystem at /private/tmp/claude-501/<project>/<uuid>/tasks
+is full (0MB free)"). The report names three root causes. Investigation against
+the actual kit code confirms two of them (one with a correction) and refutes the
+third:
+
+### Confirmed — RC1: the kit starts daemons and never stops them
+
+`ruflo-setup-project` (`shell/ruflo-functions.sh`) unconditionally runs
+`ruflo daemon start`. **Nothing in the kit ever stops a daemon** — not
+`ruflo-setup-project`, not `uninstall.sh`, and not `bin/ruflo-parity-test`, whose
+teardown only `rm -rf`s the throwaway `/tmp/test-*` workspace it created while
+leaving the daemon that workspace spawned orphaned and pointed at a now-deleted
+directory.
+
+Observed live during investigation: **18 `ruflo daemon` processes running**,
+~11 of them attached to deleted `/private/tmp/test-2026.05.28.*` workspaces from
+prior parity-test runs. This is a real, reproducible process/resource leak.
+
+*Nuance / correction:* the daemons run **detached**, so they do not write into
+Claude Code's per-session sandbox `tasks` tmpfs directly. The most direct filler
+of that tmpfs is the **high-frequency hook + statusline subprocess output** that
+Claude Code captures per prompt/Bash/edit/render. The issue conflates two real
+problems introduced by the kit (daemon leak + subprocess churn); both are fixed
+here.
+
+### Confirmed (with correction) — RC2: statusline spawns sqlite3 every render
+
+The activation-footer block injected by `ruflo-fix-statusline-version` runs **2–4
+`sqlite3` subprocesses per statusline render**, gated on `.agentic-qe/memory.db`
+existing (it commonly does, and is ~52 MB in this repo). The kit's `statusLine`
+config uses `refreshMs: 5000` with **no `timeout`**, so this fires every ~5s.
+
+*Correction to the report:* each call is bounded by
+`execFileSync(..., { timeout: 1500 })`, so it **cannot "hang indefinitely"** —
+worst case ~6s for 4 calls. The genuine problem is the per-5s subprocess **churn**,
+not an unbounded hang.
+
+### Refuted — RC3: `daemon.autoStart: true`
+
+The kit never writes `claudeFlow.daemon.autoStart`. That key is emitted by
+upstream `ruflo init`. In this repo it is currently **`false`**. The real daemon
+trigger is the explicit `ruflo daemon start` in `ruflo-setup-project` (RC1), not
+`autoStart`. We add a *defensive* guard but do not claim the kit set it.
+
+## Goals
+
+1. **Stop creating orphan daemons.** `bin/ruflo-parity-test` must stop the daemon
+   for the throwaway workspace it created, on every exit path.
+2. **Idempotent daemon start.** `ruflo-setup-project` must not start a second
+   daemon when one is already running for the same workspace.
+3. **Symmetric teardown.** `uninstall.sh` must be able to stop daemons (the
+   project's, with `--this-project`; stale ones always).
+4. **A stale-daemon GC helper.** A `ruflo-daemon-gc` shell function that lists and
+   (optionally) kills daemons whose `--workspace` directory no longer exists.
+5. **Cut statusline churn.** Cache the QE footer metrics to a small file with a
+   TTL so most 5s renders spawn **zero** sqlite3 processes, and collapse the 2–4
+   queries into **one** `sqlite3` invocation on a cache miss.
+6. **One-time cleanup now.** Kill the existing stale orphan daemons on this
+   machine (workspace-gone only), after showing the list.
+7. **Document** the `CLAUDE_CODE_TMPDIR` workaround and the daemon lifecycle in
+   `docs/TROUBLESHOOTING.md`.
+
+## Non-goals
+
+- **Do not** make the daemon opt-in or remove `ruflo daemon start` from
+  `ruflo-setup-project`. The daemon is what makes self-learning continuous
+  (ruflo-reference.md). We keep it and fix the leak (per scoping decision).
+- **Do not** modify upstream `ruflo`/`agentic-qe` behavior or the generated
+  `.claude/settings.json` schema beyond a defensive `daemon.autoStart` guard that
+  is only applied if the file is present and the value is `true`.
+- **Do not** kill live-project daemons during the one-time cleanup — only those
+  whose workspace directory no longer exists.
+- **Do not** change the statusline's visual output. Caching is transparent; the
+  rendered footer is byte-for-byte the same as before within the TTL window.
+
+## Behavior
+
+### Daemon lifecycle
+
+| Surface | Before | After |
+|---|---|---|
+| `ruflo-setup-project` | always `ruflo daemon start` | start only if no daemon for this workspace (idempotent) |
+| `bin/ruflo-parity-test` | `rm -rf` test dir; daemon orphaned | stop the test-workspace daemon in `cleanup_on_exit`, then `rm -rf` |
+| `uninstall.sh --this-project` | reverts statusline only | also stops this project's daemon |
+| `uninstall.sh` (any mode) | — | runs `ruflo-daemon-gc --kill` for stale (workspace-gone) daemons |
+| `ruflo-daemon-gc` (new) | n/a | list orphans; `--kill` stops them; never touches live-workspace daemons |
+
+A daemon is **stale/orphan** iff its `--workspace <dir>` path does not exist on
+disk. A daemon is **this project's** iff its `--workspace` equals `pwd -P`.
+
+### Statusline cache (R5)
+
+On render, `rufloActivationSegments` computes the QE footer like so:
+
+- Cache file: `.claude-flow/cache/qe-statusline.json` (same dir family the kit
+  already writes, e.g. `.claude-flow/neural/`). Holds `{ ts, line }`.
+- If the cache file exists and is younger than `RUFLO_QE_STATUSLINE_TTL_MS`
+  (default 60000) → return the cached `line`, **zero sqlite3 spawns**.
+- On miss → run **one** `sqlite3` invocation (see below), build the line, write
+  the cache, return it.
+- All failures are swallowed (footer is best-effort; a cache or sqlite3 error
+  yields `""`, exactly as today).
+
+**TTL-only (no DB-mtime gate).** The QE `memory.db` is written constantly by the
+AQE hooks, so gating the cache on "cache newer than DB mtime" would invalidate it
+on nearly every render and defeat the purpose. The footer counts are cosmetic;
+being ≤60s stale is fine. A future `RUFLO_QE_STATUSLINE_TTL_MS=0` disables the
+cache.
+
+**Single-spawn SQL (verified against the real 52 MB DB).** A semicolon-batched
+SQL *argument* aborts on the first error (`sqlite3` bails when SQL is passed as an
+argv string), which would drop counts whenever a candidate vector table is absent
+(the table name varies across AQE versions: `qe_pattern_embeddings` / `vectors` /
+`embeddings`). Therefore the single call MUST:
+
+1. Pass the SQL on **stdin** (`execFileSync("sqlite3", [db], { input })`) with a
+   leading `.bail off` so a missing table does not abort the remaining statements.
+2. Emit **labeled rows** so order/absence is unambiguous, in vector priority
+   order:
+   ```
+   .bail off
+   SELECT 'pat',COUNT(*) FROM qe_patterns;
+   SELECT 'vec',COUNT(*) FROM qe_pattern_embeddings;
+   SELECT 'vec',COUNT(*) FROM vectors;
+   SELECT 'vec',COUNT(*) FROM embeddings;
+   SELECT 'traj',COUNT(*) FROM qe_trajectories;
+   ```
+3. **Recover `e.stdout` in the `catch`** — `sqlite3` still exits non-zero when any
+   statement errored (even with `.bail off`), so `execFileSync` throws; the rows
+   that did run are on `e.stdout` and MUST be read from the thrown error.
+4. Parse rows as `label|value`; `pat`/`traj` map directly; for `vec` take the
+   **first non-zero** value (replicates the original "first existing table with
+   count > 0 in priority order" behavior exactly).
+
+## Requirements
+
+- **R1.** `bin/ruflo-parity-test` MUST stop the daemon bound to its throwaway
+  workspace on every exit (success, failure, INT/TERM), before/with the existing
+  `rm -rf`, and MUST do so even when `--cleanup` is not passed (the daemon is an
+  orphan regardless of whether the dir is kept).
+- **R2.** `ruflo-setup-project` MUST NOT start a second daemon if one is already
+  running for the current workspace; it MUST print which path it took.
+- **R3.** A new `ruflo-daemon-gc` function MUST list daemons whose `--workspace`
+  directory is missing; with `--kill` it MUST stop exactly those and no others;
+  with no flag it MUST only list (dry preview). It MUST be a no-op (exit 0) when
+  none are stale.
+- **R4.** `uninstall.sh` MUST stop stale daemons (via the GC logic) and, with
+  `--this-project`, MUST also stop the current repo's daemon. It MUST NOT kill
+  unrelated live-workspace daemons.
+- **R5.** The injected statusline footer MUST cache QE metrics with a TTL
+  (default 60000ms, `RUFLO_QE_STATUSLINE_TTL_MS` override), MUST collapse to a
+  single `sqlite3` call on a cache miss (stdin + `.bail off`, `e.stdout` recovery,
+  labeled rows), and MUST produce rendered output identical to the pre-change
+  footer for the same DB state.
+- **R6.** A defensive guard MUST set `claudeFlow.daemon.autoStart` to `false` in
+  `.claude/settings.json` **only if** that file exists and the value is currently
+  `true`; absence of the key or file is a silent no-op.
+- **R7.** The one-time machine cleanup MUST present the list of stale daemons and
+  kill only workspace-gone daemons, leaving live-project daemons untouched.
+- **R8.** `docs/TROUBLESHOOTING.md` MUST document (a) the daemon lifecycle and
+  `ruflo-daemon-gc`, and (b) the `CLAUDE_CODE_TMPDIR` workaround for users with
+  many hooks.
+- **R9.** All shell changes MUST pass `bash -n` and (if installed) `shellcheck`,
+  and the injected JS MUST pass `node --check` after injection.
+- **R10.** (DRY) The ruflo-daemon `ps`-parser MUST be defined exactly once, in a
+  shared `shell/ruflo-daemon-lib.sh`, sourced by `shell/ruflo-functions.sh`,
+  `uninstall.sh`, and `bin/ruflo-parity-test`. Because the bin scripts run
+  standalone from `~/.local/bin`, `install.sh` MUST deploy the lib to a stable
+  absolute path (`~/.config/ruflo/ruflo-daemon-lib.sh`) and `uninstall.sh` MUST
+  remove it. Each consumer MUST resolve the lib as "installed copy, else repo
+  sibling" and degrade gracefully (skip teardown / print a hint) if it is absent.
+
+## Verification
+
+- `bash -n shell/ruflo-functions.sh uninstall.sh bin/ruflo-parity-test`
+- `shellcheck` on the three files (if installed) — no new errors.
+- `ruflo-daemon-gc` against a synthetic deleted-workspace daemon: lists it;
+  `--kill` stops it; a live-workspace daemon is never listed.
+- Re-run `ruflo-parity-test --cleanup` and confirm **no** new orphan daemon
+  remains (`ps | grep daemon` count unchanged afterward).
+- Render the patched statusline twice within the TTL; confirm the 2nd render
+  spawns **no** sqlite3 (`dtruss`/strace-free check: a sentinel mtime on the cache
+  file is unchanged) and output is byte-identical.
+- `node --check` on the freshly injected `.claude/helpers/statusline.cjs`.

--- a/install.sh
+++ b/install.sh
@@ -48,6 +48,7 @@ SHELL_CHOICE="auto"
 EDIT_RC=1
 DRY=0
 ASSUME_YES=0
+export ASSUME_YES   # read by ask_yes_no() in ruflo-lib.sh (export marks it used)
 PROFILE=""
 WANT_RUFLO="auto"
 WANT_AQE="auto"
@@ -83,24 +84,13 @@ while [ "$#" -gt 0 ]; do
 	shift
 done
 
-if [ -t 1 ]; then C_OK=$'\033[32m'; C_WARN=$'\033[33m'; C_DIM=$'\033[2m'; C_RESET=$'\033[0m'; else C_OK=""; C_WARN=""; C_DIM=""; C_RESET=""; fi
-ok()   { printf '%s✓%s %s\n' "$C_OK" "$C_RESET" "$*"; }
-warn() { printf '%s⚠%s  %s\n' "$C_WARN" "$C_RESET" "$*"; }
-run()  { if [ "$DRY" -eq 1 ]; then printf '%s[dry-run]%s %s\n' "$C_DIM" "$C_RESET" "$*"; else eval "$*"; fi; }
-have() { command -v "$1" >/dev/null 2>&1; }
-
-# ask_yes_no PROMPT DEFAULT(Y|N) -> 0 yes / 1 no. Honors --yes and no-TTY.
-ask_yes_no() {
-	local prompt="$1" def="${2:-Y}" reply hint="[Y/n]"
-	[ "$def" = "N" ] && hint="[y/N]"
-	if [ "$ASSUME_YES" -eq 1 ] || [ ! -t 0 ]; then
-		[ "$def" = "Y" ]; return
-	fi
-	printf '%s %s ' "$prompt" "$hint"
-	read -r reply || reply=""
-	reply="${reply:-$def}"
-	case "$reply" in [Yy]*) return 0 ;; *) return 1 ;; esac
-}
+# Shared helpers (colors, ok/warn/run/have, ask_yes_no) from ruflo-lib.sh — repo
+# copy first (we run from the repo), installed copy as fallback.
+for _cand in "$HERE/shell/ruflo-lib.sh" "$HOME/.config/ruflo/ruflo-lib.sh"; do
+	# shellcheck source=/dev/null
+	[ -f "$_cand" ] && { . "$_cand"; break; }
+done
+[ -n "${_RUFLO_LIB:-}" ] || { echo "error: ruflo-lib.sh not found (expected shell/ruflo-lib.sh)" >&2; exit 2; }
 
 BIN_DIR="$HOME/.local/bin"
 CFG_DIR="$HOME/.config/ruflo"
@@ -202,6 +192,13 @@ echo "## CLAUDE.md reference template -> $CFG_DIR/claude-md-template.md"
 run "mkdir -p '$CFG_DIR'"
 run "cp '$HERE/claude/ruflo-reference.md' '$CFG_DIR/claude-md-template.md'"
 ok "template installed"
+echo ""
+
+# Shared helper lib — deployed to a stable absolute path so the standalone bin
+# scripts (which run from ~/.local/bin, no repo nearby) can source it.
+echo "## shared helper lib -> $CFG_DIR/ruflo-lib.sh"
+run "cp '$HERE/shell/ruflo-lib.sh' '$CFG_DIR/ruflo-lib.sh'"
+ok "helper lib installed"
 echo ""
 
 # Merge the reference block into ~/.claude/CLAUDE.md (sentinel-managed)

--- a/shell/ruflo-functions.sh
+++ b/shell/ruflo-functions.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # ruflo-functions.sh — portable shell helpers for a clean, correct ruflo setup.
 #
 # Source this from your interactive shell rc:
@@ -87,6 +88,55 @@ ruflo-remove-mcp() {
 #   (b) refresh the hard-coded fallback default to the installed version.
 # Idempotent (guarded by a marker) and re-applied on every setup, so each new
 # ruflo release self-heals. Optional arg 1 overrides the statusline path.
+
+# ---------------------------------------------------------------------------
+# Daemon lifecycle (issue #3). ruflo-setup-project starts a per-workspace daemon
+# (continuous self-learning). Without reaping, throwaway/removed workspaces (e.g.
+# ruflo-parity-test's /tmp dirs) leave orphan daemons running forever.
+#
+# Shared helpers (colored output, daemon ps-parser, native better-sqlite3
+# primitives) live in ruflo-lib.sh. Prefer the installed copy (~/.config/ruflo);
+# fall back to the repo sibling. The sourced-file path is BASH_SOURCE[0] in bash
+# and $0 in zsh (with FUNCTION_ARGZERO, the default).
+_ruflo_self="${BASH_SOURCE[0]:-$0}"
+for _ruflo_cand in \
+	"$HOME/.config/ruflo/ruflo-lib.sh" \
+	"$(dirname "$_ruflo_self")/ruflo-lib.sh"; do
+	# shellcheck source=/dev/null
+	[ -f "$_ruflo_cand" ] && { . "$_ruflo_cand"; break; }
+done
+unset _ruflo_self _ruflo_cand
+
+# List (or, with --kill, stop) ruflo daemons whose --workspace no longer exists.
+# Never touches a daemon whose workspace is still present (a live project).
+#   ruflo-daemon-gc           # list orphans (dry preview)
+#   ruflo-daemon-gc --kill    # stop them
+ruflo-daemon-gc() {
+	command -v _ruflo_daemon_list >/dev/null 2>&1 || { echo "⚠  ruflo-daemon-lib.sh not loaded — run install.sh, then re-source your shell"; return 1; }
+	local do_kill=0
+	[ "${1:-}" = "--kill" ] && do_kill=1
+	local found=0 pid ws
+	while IFS="$(printf '\t')" read -r pid ws; do
+		[ -n "${pid:-}" ] || continue
+		[ -d "$ws" ] && continue
+		found=$((found+1))
+		if [ "$do_kill" -eq 1 ]; then
+			kill "$pid" 2>/dev/null && echo "✓ stopped orphan daemon pid=$pid (workspace gone: $ws)" \
+				|| echo "⚠  could not stop pid=$pid (already exited?)"
+		else
+			echo "orphan daemon pid=$pid → $ws (workspace gone)"
+		fi
+	done <<EOF
+$(_ruflo_daemon_list)
+EOF
+	if [ "$found" -eq 0 ]; then
+		echo "✓ no orphan daemons (every running daemon's --workspace still exists)"
+	elif [ "$do_kill" -eq 0 ]; then
+		echo "Found $found orphan(s). Run 'ruflo-daemon-gc --kill' to stop them."
+	fi
+	return 0
+}
+
 ruflo-fix-statusline-version() {
 	local sl="${1:-.claude/helpers/statusline.cjs}"
 	[ -f "$sl" ] || sl="$HOME/.claude/helpers/statusline.cjs"
@@ -100,6 +150,7 @@ ruflo-fix-statusline-version() {
 		echo "⚠  Could not determine ruflo version (skipping statusline version fix)"
 		return 0
 	fi
+	# shellcheck disable=SC2016  # single-quoted JS for node -e, not shell expansion
 	if ! SL="$sl" LIVE_VER="$live_ver" node -e '
 const fs=require("fs"); const f=process.env.SL; let s=fs.readFileSync(f,"utf8");
 const marker="/* ruflo-machine-ref: global-install version probe */";
@@ -158,23 +209,48 @@ function rufloActivationSegments(cwd){
       var ad = path.join(path.dirname(process.execPath), "..", "lib", "node_modules", "ruflo", "node_modules", "@claude-flow", "aidefence", "package.json");
       if (fs.existsSync(ad)) sec = G + "🛡 aidefence on" + R;
     } catch(e){}
-    // ── agentic-qe (one guarded sqlite3 read) — branch + icon-tagged metrics ──
+    // ── agentic-qe — TTL-cached; one sqlite3 spawn only on a cache miss (issue #3) ──
     var qe = "";
     try {
       var db = path.join(cwd, ".agentic-qe", "memory.db");
       if (fs.existsSync(db)) {
-        var qp = [];
-        var pat = q(db, "SELECT COUNT(*) FROM qe_patterns");
-        if (pat && Number(pat) > 0) qp.push("🎓 " + pat + " patterns");
-        var qtj = q(db, "SELECT COUNT(*) FROM qe_trajectories");
-        if (qtj && Number(qtj) > 0) qp.push("🧭 " + qtj + " traj");
-        // QE vectors live in different tables across aqe versions (qe_pattern_embeddings
-        // is the per-pattern embedding store; older/other builds use vectors/embeddings).
-        var qv = 0;
-        for (var vt of ["qe_pattern_embeddings", "vectors", "embeddings"]) { var vc = q(db, "SELECT COUNT(*) FROM " + vt); if (vc && Number(vc) > 0) { qv = Number(vc); break; } }
-        if (qv > 0) qp.push("🧬 " + qv + " vec" + G + "⚡" + R);
-        try { var kb = Math.round(fs.statSync(db).size / 1024); qp.push("💾 " + (kb >= 1024 ? (kb/1024).toFixed(1) + "MB" : kb + "KB")); } catch(e){}
-        qe = Y + "🎓 Agentic QE" + R + "  " + (qp.length ? qp.join(DIM + " · " + R) : "on");
+        var cacheDir = path.join(cwd, ".claude-flow", "cache");
+        var cacheFile = path.join(cacheDir, "qe-statusline.json");
+        var ttl = Number(process.env.RUFLO_QE_STATUSLINE_TTL_MS || 60000);
+        var cachedLine = null;
+        try {
+          var cc = JSON.parse(fs.readFileSync(cacheFile, "utf8"));
+          if (cc && typeof cc.line === "string" && ttl > 0 && (Date.now() - cc.ts) < ttl) cachedLine = cc.line;
+        } catch(e){}
+        if (cachedLine !== null) {
+          qe = cachedLine;                   // hit: zero sqlite3 spawns
+        } else {
+          // miss: ONE sqlite3 call. SQL on stdin + ".bail off" so a missing vector
+          // table (name varies by aqe version) doesn't abort the batch. sqlite3 still
+          // exits non-zero on the error, so execFileSync throws — recover e.stdout.
+          var sql = ".bail off\n"
+            + "SELECT 'pat',COUNT(*) FROM qe_patterns;\n"
+            + "SELECT 'vec',COUNT(*) FROM qe_pattern_embeddings;\n"
+            + "SELECT 'vec',COUNT(*) FROM vectors;\n"
+            + "SELECT 'vec',COUNT(*) FROM embeddings;\n"
+            + "SELECT 'traj',COUNT(*) FROM qe_trajectories;\n";
+          var raw = "";
+          try { raw = cp.execFileSync("sqlite3", [db], {input: sql, stdio:["pipe","pipe","ignore"], timeout:1500}).toString(); }
+          catch(e){ raw = (e && e.stdout) ? e.stdout.toString() : ""; }
+          var pat = 0, qtj = 0, qv = 0;
+          raw.split("\n").forEach(function(ln){
+            var i = ln.indexOf("|"); if (i < 0) return;
+            var k = ln.slice(0, i), v = Number(ln.slice(i + 1)) || 0;
+            if (k === "pat") pat = v; else if (k === "traj") qtj = v; else if (k === "vec" && qv === 0) qv = v;
+          });
+          var qp = [];
+          if (pat > 0) qp.push("🎓 " + pat + " patterns");
+          if (qtj > 0) qp.push("🧭 " + qtj + " traj");
+          if (qv > 0) qp.push("🧬 " + qv + " vec" + G + "⚡" + R);
+          try { var kb = Math.round(fs.statSync(db).size / 1024); qp.push("💾 " + (kb >= 1024 ? (kb/1024).toFixed(1) + "MB" : kb + "KB")); } catch(e){}
+          qe = Y + "🎓 Agentic QE" + R + "  " + (qp.length ? qp.join(DIM + " · " + R) : "on");
+          try { fs.mkdirSync(cacheDir, {recursive:true}); fs.writeFileSync(cacheFile, JSON.stringify({ts: Date.now(), line: qe})); } catch(e){}
+        }
       }
     } catch(e){}
     // ── assemble: line 1 = learning + security; line 2 = agentic-qe ──
@@ -210,6 +286,9 @@ fs.writeFileSync(f,s);
 	else
 		rm -f "$_seg_tmp"
 		echo "✓ Statusline activation footer present (🧠 SONA / 🛡 aidefence / 🎓 Agentic QE)"
+		if ! node --check "$sl" 2>/dev/null; then
+			echo "⚠  Injected statusline failed node --check — review $sl"
+		fi
 	fi
 
 	# Ensure Claude Code actually RUNS the rich statusline.cjs. `aqe init` (and
@@ -317,7 +396,39 @@ import sys; sys.exit(0 if prev == os.environ['RUFLO_DB_PATH'] else 1)
 		echo "⚠  ruflo memory init failed — memory writes may not persist"
 	fi
 	ruflo swarm init --v3-mode >/dev/null 2>&1 && echo "✓ Swarm initialized (v3-mode)" || echo "⚠  ruflo swarm init failed"
-	ruflo daemon start >/dev/null 2>&1 && echo "✓ Daemon started" || echo "⚠  ruflo daemon start failed (may already be running)"
+	# Idempotent daemon start: never spawn a 2nd daemon for this workspace (issue #3).
+	local _ws; _ws="$(pwd -P)"
+	if command -v _ruflo_daemon_list >/dev/null 2>&1 && [ -n "$(_ruflo_daemon_list | awk -F'\t' -v w="$_ws" '$2==w{print $1; exit}')" ]; then
+		echo "✓ Daemon already running for this workspace (not starting another)"
+	else
+		ruflo daemon start >/dev/null 2>&1 && echo "✓ Daemon started" || echo "⚠  ruflo daemon start failed (may already be running)"
+	fi
+
+	# Defensive (issue #3 RC3): if upstream `ruflo init` wrote daemon.autoStart:true,
+	# flip it to false so opening Claude Code does not auto-restart the daemon.
+	# No-op when the file/key is absent or already false.
+	if [ -f ".claude/settings.json" ] && command -v python3 >/dev/null 2>&1; then
+		if python3 - <<'PY' 2>/dev/null
+import json, sys
+p = ".claude/settings.json"
+try:
+    with open(p) as f: d = json.load(f)
+except Exception:
+    sys.exit(0)
+cf = d.get("claudeFlow")
+dm = cf.get("daemon") if isinstance(cf, dict) else None
+if isinstance(dm, dict) and dm.get("autoStart") is True:
+    dm["autoStart"] = False
+    with open(p, "w") as f: json.dump(d, f, indent=2)
+    sys.exit(1)  # changed
+sys.exit(0)      # no change
+PY
+		then
+			:  # unchanged (absent/false) — stay quiet
+		else
+			echo "✓ Set claudeFlow.daemon.autoStart=false in .claude/settings.json (was true)"
+		fi
+	fi
 
 	# WAL checkpoint so the sql.js reader (if used) sees a consistent snapshot.
 	if [ -f .swarm/memory.db ] && [ -f .swarm/memory.db-wal ] && command -v sqlite3 >/dev/null 2>&1; then
@@ -386,13 +497,14 @@ import sys; sys.exit(0 if prev == os.environ['RUFLO_DB_PATH'] else 1)
 # ruflo-resync so an agentic-qe upgrade is one command away from healed.
 _ruflo_aqe_ensure_native() {
 	command -v aqe >/dev/null 2>&1 && command -v npm >/dev/null 2>&1 && command -v node >/dev/null 2>&1 || return 0
-	local aqe_root; aqe_root="$(npm root -g)/agentic-qe"
+	command -v _ruflo_bsq3_is_native >/dev/null 2>&1 || return 0   # ruflo-lib.sh not loaded
+	local aqe_root; aqe_root="$(_ruflo_global_root)/agentic-qe"
 	[ -d "$aqe_root" ] || return 0
-	local abi; abi="$(node -e 'process.stdout.write(process.versions.modules)')"
+	local abi; abi="$(_ruflo_node_abi)"
 	[ "${abi:-0}" -ge 137 ] 2>/dev/null || return 0
-	if ! node -e "const b='$aqe_root/node_modules/better-sqlite3';process.exit(require('fs').existsSync(b+'/build/Release/better_sqlite3.node')?0:1)" 2>/dev/null; then
+	if ! _ruflo_bsq3_is_native "$aqe_root"; then
 		echo "Patching native better-sqlite3 into agentic-qe (Node ABI $abi)…"
-		( cd "$aqe_root" && npm install better-sqlite3@^12 --no-save --no-audit --no-fund >/dev/null 2>&1 ) \
+		_ruflo_bsq3_install "$aqe_root" \
 			&& echo "✓ agentic-qe better-sqlite3 is native" \
 			|| echo "⚠  could not patch agentic-qe better-sqlite3 — aqe init may fail"
 	fi
@@ -426,7 +538,7 @@ ruflo-setup-aqe() {
 	fi
 
 	if [ -f "$sdk" ] && [ -d "$marker" ]; then
-		local nskills; nskills="$(ls .claude/skills/ 2>/dev/null | wc -l | tr -d ' ')"
+		local nskills; nskills="$(find .claude/skills -mindepth 1 -maxdepth 1 2>/dev/null | wc -l | tr -d ' ')"
 		echo "✓ agentic-qe initialized (SDK db + marker present, $nskills skills)"
 		# refresh the statusline so the 🎓 segment appears
 		command -v ruflo-fix-statusline-version >/dev/null 2>&1 && ruflo-fix-statusline-version >/dev/null 2>&1

--- a/shell/ruflo-lib.sh
+++ b/shell/ruflo-lib.sh
@@ -1,0 +1,102 @@
+# shellcheck shell=bash
+# ruflo-lib.sh — shared helpers for the ruflo machine-reference kit.
+#
+# One place for the logic that was previously copy-pasted across install.sh,
+# uninstall.sh, and the bin/ helpers: colored output, yes/no prompting, a dry-run
+# wrapper, PATH guards, the ruflo-daemon ps-parser (issue #3), and the Node-ABI /
+# native better-sqlite3 primitives.
+#
+# Sourced by: install.sh, uninstall.sh, shell/ruflo-functions.sh, and every bin/
+# script. install.sh deploys this to ~/.config/ruflo/ruflo-lib.sh so the
+# standalone bin scripts (which run from ~/.local/bin, no repo nearby) can source
+# it from a stable absolute path; consumers fall back to the repo copy.
+#
+# Pure definitions — sourcing has no side effects beyond setting the C_* color
+# vars and defining functions. Compatible with bash 4+ and zsh. The functions
+# meant for external callers are intentionally "unused" within this file.
+# shellcheck disable=SC2329
+
+# --- colored output ---------------------------------------------------------
+# Set once at source time (matches the per-script behavior these replaced).
+# C_HEAD is used by an external consumer (parity-test's head_line), not in this file.
+# shellcheck disable=SC2034
+if [ -t 1 ]; then
+	C_OK=$'\033[32m'; C_WARN=$'\033[33m'; C_FAIL=$'\033[31m'
+	C_DIM=$'\033[2m'; C_HEAD=$'\033[1;36m'; C_RESET=$'\033[0m'
+else
+	C_OK=""; C_WARN=""; C_FAIL=""; C_DIM=""; C_HEAD=""; C_RESET=""
+fi
+
+ok()   { printf '%s✓%s %s\n' "$C_OK" "$C_RESET" "$*"; }
+warn() { printf '%s⚠%s  %s\n' "$C_WARN" "$C_RESET" "$*"; }
+fail() { printf '%s✗%s %s\n' "$C_FAIL" "$C_RESET" "$*"; }
+dim()  { printf '%s%s%s\n' "$C_DIM" "$*" "$C_RESET"; }
+
+# run CMD… — execute, or just print it under dry-run (DRY=1). Used by install/uninstall.
+run() { if [ "${DRY:-0}" -eq 1 ]; then printf '%s[dry-run]%s %s\n' "$C_DIM" "$C_RESET" "$*"; else eval "$*"; fi; }
+
+# have CMD — true if CMD is on PATH.
+have() { command -v "$1" >/dev/null 2>&1; }
+
+# _ruflo_need CMD… — abort (exit 2) if any CMD is missing. For standalone scripts.
+_ruflo_need() {
+	local c
+	for c in "$@"; do
+		command -v "$c" >/dev/null 2>&1 || { fail "$c not on PATH"; exit 2; }
+	done
+}
+
+# ask_yes_no PROMPT DEFAULT(Y|N) -> 0 yes / 1 no. Honors ASSUME_YES and no-TTY.
+ask_yes_no() {
+	local prompt="$1" def="${2:-Y}" reply hint="[Y/n]"
+	[ "$def" = "N" ] && hint="[y/N]"
+	if [ "${ASSUME_YES:-0}" -eq 1 ] || [ ! -t 0 ]; then
+		[ "$def" = "Y" ]; return
+	fi
+	printf '%s %s ' "$prompt" "$hint"
+	read -r reply || reply=""
+	reply="${reply:-$def}"
+	case "$reply" in [Yy]*) return 0 ;; *) return 1 ;; esac
+}
+
+# --- ruflo daemon process helpers (issue #3) --------------------------------
+# _ruflo_daemon_list — emit "<pid>\t<workspace>" for every running ruflo daemon.
+# Portable: `ps axww` (on BSD/macOS `-e` means "environment", so it is avoided;
+# `ww` prevents column truncation of long --workspace paths). `read -r pid rest`
+# trims ps's leading PID-column padding. The `cli.js` filter excludes unrelated
+# processes (e.g. the shell running this parser) whose argv merely contains the
+# literal strings "daemon start"/"--workspace".
+_ruflo_daemon_list() {
+	ps axww -o pid=,args= 2>/dev/null | while read -r pid rest; do
+		case "$rest" in *"daemon start"*) ;; *) continue ;; esac
+		case "$rest" in *cli.js*) ;; *) continue ;; esac
+		case "$rest" in *"--workspace "*) ;; *) continue ;; esac
+		ws=${rest#*--workspace }; ws=${ws%% --*}
+		[ -n "$pid" ] && [ -n "$ws" ] && printf '%s\t%s\n' "$pid" "$ws"
+	done
+}
+
+# --- Node ABI / native better-sqlite3 primitives ----------------------------
+# _ruflo_node_abi — the running Node's NODE_MODULE_VERSION (ABI), e.g. 137.
+_ruflo_node_abi() { node -e 'process.stdout.write(process.versions.modules)' 2>/dev/null; }
+
+# _ruflo_global_root — `npm root -g` (global node_modules dir).
+_ruflo_global_root() { npm root -g 2>/dev/null; }
+
+# _ruflo_bsq3_is_native DIR — 0 if a native better-sqlite3 resolves from DIR.
+_ruflo_bsq3_is_native() {
+	node -e "
+try {
+  const p = require.resolve('better-sqlite3', { paths: ['$1'] });
+  const base = p.split('/better-sqlite3/')[0] + '/better-sqlite3';
+  process.exit(require('fs').existsSync(base + '/build/Release/better_sqlite3.node') ? 0 : 1);
+} catch (e) { process.exit(1); }
+" 2>/dev/null
+}
+
+# _ruflo_bsq3_install DIR [RANGE] — install better-sqlite3 into DIR (default ^12).
+_ruflo_bsq3_install() {
+	( cd "$1" && npm install "better-sqlite3@${2:-^12}" --no-save --no-audit --no-fund >/dev/null 2>&1 )
+}
+
+_RUFLO_LIB=1   # sentinel: consumers check this to confirm the lib loaded

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -71,23 +71,13 @@ while [ "$#" -gt 0 ]; do
 	shift
 done
 
-if [ -t 1 ]; then C_OK=$'\033[32m'; C_WARN=$'\033[33m'; C_DIM=$'\033[2m'; C_RESET=$'\033[0m'; else C_OK=""; C_WARN=""; C_DIM=""; C_RESET=""; fi
-ok()   { printf '%s✓%s %s\n' "$C_OK" "$C_RESET" "$*"; }
-warn() { printf '%s⚠%s  %s\n' "$C_WARN" "$C_RESET" "$*"; }
-run()  { if [ "$DRY" -eq 1 ]; then printf '%s[dry-run]%s %s\n' "$C_DIM" "$C_RESET" "$*"; else eval "$*"; fi; }
-
-# ask_yes_no PROMPT DEFAULT(Y|N) -> 0 yes / 1 no. Honors --yes and no-TTY.
-ask_yes_no() {
-	local prompt="$1" def="${2:-Y}" reply hint="[Y/n]"
-	[ "$def" = "N" ] && hint="[y/N]"
-	if [ "$ASSUME_YES" -eq 1 ] || [ ! -t 0 ]; then
-		[ "$def" = "Y" ]; return
-	fi
-	printf '%s %s ' "$prompt" "$hint"
-	read -r reply || reply=""
-	reply="${reply:-$def}"
-	case "$reply" in [Yy]*) return 0 ;; *) return 1 ;; esac
-}
+# Shared helpers (colors, ok/warn/run, ask_yes_no, _ruflo_daemon_list) from
+# ruflo-lib.sh — repo copy first (we run from the repo), installed copy as fallback.
+for _cand in "$HERE/shell/ruflo-lib.sh" "$HOME/.config/ruflo/ruflo-lib.sh"; do
+	# shellcheck source=/dev/null
+	[ -f "$_cand" ] && { . "$_cand"; break; }
+done
+[ -n "${_RUFLO_LIB:-}" ] || { echo "error: ruflo-lib.sh not found (expected shell/ruflo-lib.sh)" >&2; exit 2; }
 
 # 1. bin scripts — derived from this repo's bin/, so it always matches install.sh.
 for src in "$HERE"/bin/*; do
@@ -98,6 +88,9 @@ done
 
 # 2. template
 [ -f "$HOME/.config/ruflo/claude-md-template.md" ] && { run "rm -f '$HOME/.config/ruflo/claude-md-template.md'"; ok "removed template"; }
+
+# 2b. shared helper lib (already sourced at the top, so removing it here is safe)
+[ -f "$HOME/.config/ruflo/ruflo-lib.sh" ] && { run "rm -f '$HOME/.config/ruflo/ruflo-lib.sh'"; ok "removed helper lib"; }
 
 # 3. CLAUDE.md managed block
 CLAUDE_MD="$HOME/.claude/CLAUDE.md"
@@ -139,6 +132,7 @@ if [ "$THIS_PROJECT" -eq 1 ]; then
 		printf '%s[dry-run]%s strip activation footer + version-probe injection + console.log wrap from %s\n' "$C_DIM" "$C_RESET" "$SL"
 	else
 		cp "$SL" "$SL.bak.$(date +%Y%m%d-%H%M%S)"
+		# shellcheck disable=SC2016  # single-quoted JS for node -e, not shell expansion
 		SL="$SL" node -e '
 const fs=require("fs"); const f=process.env.SL; let s=fs.readFileSync(f,"utf8");
 s=s.replace(/\/\* ruflo-seg:BEGIN \*\/[\s\S]*?\/\* ruflo-seg:END \*\/\n?/,"");
@@ -152,7 +146,44 @@ fs.writeFileSync(f,s);
 	fi
 fi
 
-# 6. (--remove-ruflo / --remove-aqe / --purge) remove global npm packages.
+# 6. Daemon teardown (issue #3): always reap stale (workspace-gone) daemons;
+#    with --this-project also stop the daemon bound to THIS repo's workspace.
+#    Never touches unrelated live-workspace daemons. The ps-parser (_ruflo_daemon_list)
+#    is provided by ruflo-lib.sh, sourced at the top of this script.
+echo ""
+echo "## Daemon teardown"
+if ! command -v _ruflo_daemon_list >/dev/null 2>&1; then
+	warn "ruflo-lib.sh not loaded — skipping daemon teardown"
+else
+	THIS_WS="$(pwd -P)"
+	DAEMON_HITS=0
+	while IFS="$(printf '\t')" read -r dpid dws; do
+		[ -n "${dpid:-}" ] || continue
+		stale=0; mine=0
+		[ -d "$dws" ] || stale=1
+		[ "$dws" = "$THIS_WS" ] && [ "$THIS_PROJECT" -eq 1 ] && mine=1
+		if [ "$stale" -eq 1 ] || [ "$mine" -eq 1 ]; then
+			DAEMON_HITS=$((DAEMON_HITS+1))
+			if [ "$stale" -eq 1 ]; then reason="workspace gone"; else reason="this project"; fi
+			if [ "$DRY" -eq 1 ]; then
+				printf '%s[dry-run]%s stop daemon pid=%s (%s): %s\n' "$C_DIM" "$C_RESET" "$dpid" "$reason" "$dws"
+			else
+				if kill "$dpid" 2>/dev/null; then ok "stopped daemon pid=$dpid ($reason): $dws"; else warn "could not stop pid=$dpid"; fi
+			fi
+		fi
+	done <<EOF
+$(_ruflo_daemon_list)
+EOF
+	if [ "$DAEMON_HITS" -eq 0 ]; then
+		if [ "$THIS_PROJECT" -eq 1 ]; then
+			ok "no daemons to stop (none stale; none for this project)"
+		else
+			ok "no stale daemons to stop"
+		fi
+	fi
+fi
+
+# 7. (--remove-ruflo / --remove-aqe / --purge) remove global npm packages.
 npm_remove_global() {
 	local pkg="$1"
 	command -v npm >/dev/null 2>&1 || { warn "npm not on PATH — cannot remove $pkg"; return 1; }


### PR DESCRIPTION
## Summary

Investigates and fixes the three claims in #3 (Claude Code `ENOSPC` session crashes), then consolidates the kit's duplicated shell logic for maintainability.

### Reproducibility verdict (#3)
- **RC1 — daemon leak: confirmed.** `ruflo-setup-project` started a per-workspace `ruflo daemon` that nothing ever stopped; throwaway/removed workspaces (e.g. `ruflo-parity-test`'s `/tmp` dirs) left orphans running forever (18 observed live, 14 for dead workspaces).
- **RC2 — statusline `sqlite3` churn: confirmed (with a correction).** The activation footer spawned 2–4 `sqlite3` subprocesses every render (`refreshMs: 5000`) against a ~52 MB DB. Each was already `timeout:1500`-bounded, so the report's "hangs indefinitely" is inaccurate — the real issue is per-5s subprocess churn.
- **RC3 — `daemon.autoStart: true`: refuted.** The kit never wrote that key (upstream `ruflo init` does; it was `false` here). A defensive guard is added regardless.

## Resource fix
- Idempotent per-workspace daemon start; defensive `claudeFlow.daemon.autoStart=false` when present and true.
- New `ruflo-daemon-gc` reaps daemons whose `--workspace` is gone; `ruflo-parity-test` stops its throwaway daemon on every exit; `uninstall.sh` stops stale daemons (always) and this-repo's (`--this-project`).
- Statusline footer caches QE metrics (`RUFLO_QE_STATUSLINE_TTL_MS`, default 60s) and makes ≤1 `sqlite3` spawn per window (SQL on stdin + `.bail off`, `e.stdout` recovery). Rendered output is byte-identical for the same DB state.

## Maintainability (helper consolidation)
- New `shell/ruflo-lib.sh` is the single home for colored output, `ask_yes_no`, `run`, PATH guards, the daemon ps-parser, and the Node-ABI / native-`better-sqlite3` primitives that were copy-pasted across `install.sh`, `uninstall.sh`, and the `bin/` helpers. `install.sh` deploys it to `~/.config/ruflo/` so the standalone bin scripts can source it from a stable path; `uninstall.sh` removes it.
- Replaced `ruflo-enable-learning`'s `eval`-based assertion harness with direct `if`/`then` checks.
- **All 9 shell files are `shellcheck`-clean at every severity** (pre-existing + newly introduced).

## Verification
- `install.sh --full --yes` on the dev machine: npm packages installed (ruflo v3.10.8), 6 agentdb locations patched native v12.10.0, **self-learning 5/5 ACTIVE** (proves the installed bins source the deployed lib).
- `ruflo-onboard` in this repo: **"Daemon already running for this workspace (not starting another)"** (idempotent fix, live), statusline footer + version pinned, memory write verified, doctor 13✓/4⚠ (warnings pre-existing/environmental), **learning loop verified (patterns 0→7, 50 learned)**.
- `bash -n` + `shellcheck` clean across all 9 scripts; cross-shell (bash + zsh) source checks pass.

## Docs
`docs/TROUBLESHOOTING.md` gains a daemon-lifecycle / `ruflo-daemon-gc` / `CLAUDE_CODE_TMPDIR` section; design spec + implementation plan added under `docs/superpowers/`.

Closes #3.
