### PR TITLE
feat(statusline): show Agentic QE version + regroup footer divider

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,10 +187,10 @@ When set up with this kit, a two-line footer is appended **below** ruflo's own s
 
 ```
 ▊ RuFlo V3.10.5 ● you  │  ⏇ main  │  Opus 4.x        ┐
-🏗️  DDD Domains … 🤖 Swarm … 🔧 Architecture …       ├ ruflo's own lines (unchanged)
-📊 AgentDB …                                          ┘
-────────────────────────────────────────────         ← the kit's appended footer ↓
-🧠 SONA  [●●●●●]  50 patterns · 55 traj · Δ1.32 LoRA · ⚡ HNSW      🛡 aidefence on
+🏗️  DDD Domains … 🤖 Swarm … 🔧 Architecture …       │ ruflo's own lines + the kit's
+📊 AgentDB …                                          │ SONA/aidefence line (all ruflo)
+🧠 SONA  [●●●●●]  50 patterns · 55 traj · Δ1.32 LoRA · ⚡ HNSW      🛡 aidefence on  ┘
+─────────────────────────────────────────────────────  ← divider (matches ruflo's header rule)
 🎓 Agentic QE V3.10.1  🎓 23 patterns · 🧭 114 traj · 🧬 543 vec⚡ · 💾 16MB
 ```
 

--- a/README.md
+++ b/README.md
@@ -191,13 +191,13 @@ When set up with this kit, a two-line footer is appended **below** ruflo's own s
 📊 AgentDB …                                          ┘
 ────────────────────────────────────────────         ← the kit's appended footer ↓
 🧠 SONA  [●●●●●]  50 patterns · 55 traj · Δ1.32 LoRA · ⚡ HNSW      🛡 aidefence on
-🎓 Agentic QE  🎓 23 patterns · 🧭 114 traj · 🧬 543 vec⚡ · 💾 16MB
+🎓 Agentic QE V3.10.1  🎓 23 patterns · 🧭 114 traj · 🧬 543 vec⚡ · 💾 16MB
 ```
 
 Every field renders only when its data is actually present (numbers above are illustrative):
 - 🧠 **SONA** — `[bar]` is a volume gauge (~10 patterns/dot); `patterns`/`traj` from `.claude-flow/neural/stats.json`; `Δ LoRA` is shown only after you run `ruflo-neural-train` (it caches the transient MicroLoRA delta, which ruflo doesn't persist); `⚡ HNSW` only when a vector index exists.
 - 🛡️ **aidefence on** — proactive prompt-injection/PII defense is loaded (ruflo's native line already shows the `CVE n/m` count, so this signals the *other* half).
-- 🎓 **Agentic QE** — `🎓 patterns` / `🧭 traj` / `🧬 vec` / `💾 size` from a few guarded `sqlite3` reads of `.agentic-qe/memory.db` (the `vec` count comes from `qe_pattern_embeddings`, falling back to `vectors`/`embeddings` across aqe versions). The branch is already in ruflo's header line, so it's not repeated here.
+- 🎓 **Agentic QE** — `V<version>` is the installed `agentic-qe` package version (read from its `package.json`, mirroring `RuFlo V<x>` in ruflo's header); `🎓 patterns` / `🧭 traj` / `🧬 vec` / `💾 size` from a few guarded `sqlite3` reads of `.agentic-qe/memory.db` (the `vec` count comes from `qe_pattern_embeddings`, falling back to `vectors`/`embeddings` across aqe versions). The branch is already in ruflo's header line, so it's not repeated here.
 
 ---
 

--- a/shell/ruflo-functions.sh
+++ b/shell/ruflo-functions.sh
@@ -263,13 +263,18 @@ function rufloActivationSegments(cwd){
         }
       }
     } catch(e){}
-    // ── assemble: line 1 = learning + security; line 2 = agentic-qe ──
+    // ── assemble: line 1 = learning + security (ruflo features); line 2 = agentic-qe ──
+    // No rule above the SONA line — SONA + aidefence are ruflo features and sit flush
+    // under ruflo's native lines. The divider goes BETWEEN the ruflo block and the
+    // agentic-qe line, matching ruflo's native header divider width ('─'.repeat(53) in
+    // statusline.cjs) so the two rules line up.
     var l1 = []; if (learn) l1.push(learn); if (sec) l1.push(sec);
     var out = [];
     if (l1.length) out.push(l1.join("      "));
+    if (out.length && qe) out.push(DIM + "─".repeat(53) + R);
     if (qe) out.push(qe);
     if (!out.length) return "";
-    return "\n" + DIM + "─".repeat(44) + R + "\n" + out.join("\n");
+    return "\n" + out.join("\n");
   } catch(e){ return ""; }
 }
 /* ruflo-seg:END */

--- a/shell/ruflo-functions.sh
+++ b/shell/ruflo-functions.sh
@@ -168,7 +168,7 @@ fs.writeFileSync(f,s);
 	# Activation footer: append (below ruflo's native render) a two-line footer that
 	# shows ONLY the features genuinely active in this project:
 	#   🧠 SONA  <patterns> · <traj> [· ⚡ HNSW]        🛡 aidefence on
-	#   🎓 Agentic QE  <patterns> [· <traj>] [· <vec>] · <size>
+	#   🎓 Agentic QE V<version>  <patterns> [· <traj>] [· <vec>] · <size>
 	# Append-only: never rewrites ruflo's own lines, so it can't break on a ruflo
 	# template change. self-learning + security are fs-only; the agentic-qe line uses
 	# one guarded sqlite3 call only when .agentic-qe/memory.db exists. The injector is
@@ -248,7 +248,17 @@ function rufloActivationSegments(cwd){
           if (qtj > 0) qp.push("🧭 " + qtj + " traj");
           if (qv > 0) qp.push("🧬 " + qv + " vec" + G + "⚡" + R);
           try { var kb = Math.round(fs.statSync(db).size / 1024); qp.push("💾 " + (kb >= 1024 ? (kb/1024).toFixed(1) + "MB" : kb + "KB")); } catch(e){}
-          qe = Y + "🎓 Agentic QE" + R + "  " + (qp.length ? qp.join(DIM + " · " + R) : "on");
+          // Installed agentic-qe version — shown next to the label, mirroring "RuFlo V<x>"
+          // in ruflo's native header. Prefer the global install (matches the aidefence
+          // probe above); fall back to a project-local node_modules copy.
+          var qver = "";
+          try {
+            var qpkg = path.join(path.dirname(process.execPath), "..", "lib", "node_modules", "agentic-qe", "package.json");
+            if (!fs.existsSync(qpkg)) qpkg = path.join(cwd, "node_modules", "agentic-qe", "package.json");
+            var qv2 = JSON.parse(fs.readFileSync(qpkg, "utf8")).version;
+            if (qv2) qver = " V" + qv2;
+          } catch(e){}
+          qe = Y + "🎓 Agentic QE" + qver + R + "  " + (qp.length ? qp.join(DIM + " · " + R) : "on");
           try { fs.mkdirSync(cacheDir, {recursive:true}); fs.writeFileSync(cacheFile, JSON.stringify({ts: Date.now(), line: qe})); } catch(e){}
         }
       }


### PR DESCRIPTION
## What

Two refinements to the kit's append-only status-line footer:

1. **Show the installed Agentic QE version** on the `🎓 Agentic QE` line, mirroring how ruflo's native header shows `RuFlo V<x>`:

   ```
   🎓 Agentic QE V3.10.1  🎓 21 patterns · 🧭 58 traj · 🧬 21 vec⚡ · 💾 53.6MB
   ```

   Version is read from `agentic-qe/package.json` — preferring the global install (same path style as the existing aidefence probe), falling back to a project-local `node_modules` copy. Guarded by try/catch, so a missing package.json leaves the line unchanged. It rides the existing TTL cache, adding only one `fs.readFileSync` (zero extra process spawns).

2. **Regroup the footer divider.** Previously a 44-char rule sat *above* the SONA line, splitting ruflo's native block from the footer. Since SONA + aidefence are ruflo features, that rule was placed awkwardly. Now:
   - No rule above SONA — it sits flush under ruflo's native lines (all ruflo features/metrics grouped together).
   - The divider is drawn **between** the SONA/aidefence line and the Agentic QE line.
   - Widened 44→53 to match ruflo's native header divider (`'─'.repeat(53)`), so the two rules line up.

   ```
   📊 AgentDB    Vectors ●0  │  Size 0KB  │  Tests ●0 (~0 cases)  │  ● none
   🧠 SONA  [●●●●●]  50 patterns · 110 traj · Δ0.00 LoRA      🛡 aidefence on
   ─────────────────────────────────────────────────────
   🎓 Agentic QE V3.10.1  🎓 21 patterns · 🧭 58 traj · 🧬 21 vec⚡ · 💾 53.6MB
   ```

## Where

Single source of truth: `rufloActivationSegments()` in `shell/ruflo-functions.sh` (the injector that `ruflo-fix-statusline-version` / `ruflo-resync` use to regenerate `statusline.cjs`). README example + field descriptions updated to match.

## Verification

- `bash -n shell/ruflo-functions.sh` ✓
- `node --check` on the regenerated `statusline.cjs` ✓
- Live render confirmed both changes (version shown; dividers equal length, correctly placed)