### PR TITLE
feat: registry-driven conditional CLAUDE.md blocks + superpowers house-rules block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,13 @@
 test-*.log
 .swarm/
 .claude-flow/
+
+# Dogfooding artifacts — running ruflo init / aqe init / ruflo-onboard against THIS
+# repo writes these. They are NOT source (see CLAUDE.md "Dogfooding artifacts are not
+# source"); never commit them.
+.agentic-qe/
+.claude/
+ruvector.db
+*.db
+CLAUDE.md.backup
+CLAUDE.md.pre-ruflo

--- a/README.md
+++ b/README.md
@@ -265,10 +265,13 @@ ruflo-machine-ref/
 ├── shell/
 │   └── ruflo-functions.sh     # ruflo-resync, ruflo-onboard, ruflo-setup-project, ruflo-setup-aqe, …
 ├── claude/
-│   └── ruflo-reference.md     # the machine-wide CLAUDE.md ruflo block (CLI-first)
+│   ├── ruflo-reference.md         # the machine-wide CLAUDE.md ruflo block (always on, CLI-first)
+│   ├── aqe-reference.md           # conditional block — present only when agentic-qe is installed
+│   └── superpowers-reference.md   # conditional block — house rules so superpowers + ruflo coexist
 └── docs/
     ├── BACKGROUND.md          # the full root-cause story (memory + learning + aqe + security)
     ├── TROUBLESHOOTING.md     # symptom → diagnosis → fix
+    ├── CONDITIONAL-BLOCKS.md  # how the per-tool CLAUDE.md blocks work + how to add one
     └── superpowers/           # the design spec + implementation plan
 ```
 
@@ -299,6 +302,7 @@ ruflo/agentic-qe data alone — use `ruflo cleanup --force` for per-project data
 
 - 📖 [docs/BACKGROUND.md](docs/BACKGROUND.md) — the full root-cause investigation (Node/ABI/WASM, why self-learning looked dormant, the agentic-qe variant, the security surface)
 - 🔧 [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md) — symptom → diagnosis → fix runbook
+- 🧩 [docs/CONDITIONAL-BLOCKS.md](docs/CONDITIONAL-BLOCKS.md) — how the per-tool CLAUDE.md blocks work (agentic-qe, superpowers), why superpowers needs "house rules," and how to add support for a new tool
 - 🧱 [docs/superpowers/](docs/superpowers/) — the design spec and implementation plan behind the self-learning work
 
 ---

--- a/claude/superpowers-reference.md
+++ b/claude/superpowers-reference.md
@@ -1,0 +1,40 @@
+<!-- BEGIN ruflo-superpowers-reference -->
+<!-- ruflo-superpowers-reference: merged into ~/.claude/CLAUDE.md ONLY when the superpowers
+     plugin is installed. Managed by install.sh / ruflo-reference-refresh — stripped
+     automatically when superpowers is absent. Source of truth: claude/superpowers-reference.md
+     in the ruflo-machine-ref kit. See docs/CONDITIONAL-BLOCKS.md for the why. -->
+
+## Superpowers + ruflo — house rules (coordination)
+
+> Applies when the **superpowers** plugin is installed alongside ruflo. Superpowers
+> self-injects an aggressive "if there's even a 1% chance a skill applies, you MUST use
+> it" preamble at session start, so it tends to grab every task before ruflo is even
+> considered. These house rules say how the two share the work so ruflo's capabilities
+> actually get used. **Per superpowers' own precedence rule, this CLAUDE.md guidance
+> OUTRANKS superpowers skills** — it is the sanctioned channel for directing the split,
+> not a fight with the plugin.
+
+### The split — who owns what
+- **Superpowers owns *choreography* (HOW work flows):** brainstorming, writing/executing
+  plans, TDD discipline, systematic debugging, git-worktree workflow, requesting/receiving
+  code review, verification-before-completion. Use these to *structure* the work.
+- **ruflo owns *capability* (WHAT the work runs on):** persistent cross-session memory,
+  specialist agents, code analysis (AST / boundaries / diff-risk), security scan +
+  AI-defense, task→agent routing, topology-aware swarms.
+- **agentic-qe owns *quality capability* (when installed):** test generation, coverage,
+  quality gates. (See the ruflo-aqe-reference block for its operating guidance.)
+
+### The tiebreaker (overlap zone)
+Where both could act — parallel agents, debugging, code review, TDD — let superpowers
+*structure the workflow* and ruflo / agentic-qe *provide the substance*. Concretely:
+- Superpowers' `dispatching-parallel-agents` *pattern* → spawn ruflo's specialist agent
+  types and persist findings with `ruflo memory store`.
+- Superpowers' `systematic-debugging` *process* → gather evidence with `ruflo analyze`.
+- Superpowers' planning skills → recall prior decisions with `ruflo memory search --smart`
+  before writing the plan.
+- Superpowers' `verification-before-completion` → still the gate before any "done" claim.
+
+**Rule of thumb:** a superpowers skill telling you *how* to proceed does **not** mean skip
+ruflo. Run the superpowers process; do the actual work with ruflo (and agentic-qe)
+capability. Both come to the party.
+<!-- END ruflo-superpowers-reference -->

--- a/docs/CONDITIONAL-BLOCKS.md
+++ b/docs/CONDITIONAL-BLOCKS.md
@@ -1,0 +1,181 @@
+# Conditional CLAUDE.md blocks — design & how to add one
+
+This kit's job is to give every repo on the machine a **common Claude experience** by
+merging managed text into the global `~/.claude/CLAUDE.md`. Some of that text should appear
+only when a companion tool is installed. This doc explains how that works, why it's built the
+way it is, and how to add support for a new tool (a CLI, a plugin, a skill-set) so it *plays
+nicely with the others* instead of fighting them.
+
+If you've never touched this machinery, read the "mental model" first — the rest is reference.
+
+---
+
+## The mental model: three layers, not three rivals
+
+When you sit down to work, three different kinds of thing can show up:
+
+- **ruflo** is the **workshop** — the power tools, the persistent memory, a crew of specialist
+  agents, the security scanner. It's *what work gets done with*. This kit exists to install
+  and heal it.
+- **agentic-qe** is a **specialist QE crew** you add on top — test generation, coverage,
+  quality gates. More unique capability, same workshop.
+- **superpowers** is a **disciplined project manager** — it insists on a process (brainstorm →
+  plan → TDD → verify). It's *how the work flows*. It ships **zero** CLIs, agents, or memory.
+
+The trap people hit: superpowers fires a loud "you MUST use a skill for everything" announcement
+at session start, while ruflo and agentic-qe sit quietly in a reference doc. **Loud-and-first
+beats quiet-and-waiting**, so superpowers grabs every task and ruflo never comes to the party —
+even though they're different layers (capability vs. choreography) that should *stack*, not
+collide.
+
+The fix is **house rules** posted where Claude reads them first: superpowers runs the meetings,
+ruflo/agentic-qe do the actual work. Crucially, superpowers' own rules say *the user's CLAUDE.md
+outranks superpowers skills* — so a rule written into CLAUDE.md is the **sanctioned** way to
+direct the split, not a fight with the plugin. That house-rules text is the
+`ruflo-superpowers-reference` block.
+
+---
+
+## What a "block" is, in source
+
+Strip away the prose and a managed block is **three things**:
+
+1. **A template file** in `claude/` — markdown wrapped in two HTML-comment markers:
+   ```
+   <!-- BEGIN ruflo-aqe-reference -->
+   …content Claude reads…
+   <!-- END ruflo-aqe-reference -->
+   ```
+   The markers are the whole trick: they let the kit find and replace *only this region* of
+   `~/.claude/CLAUDE.md`, leaving your hand-written notes and every other block untouched. The
+   generic `_ruflo_block_upsert` / `_ruflo_block_strip` primitives in `shell/ruflo-lib.sh` do
+   the surgical replace; they were always block-agnostic.
+
+2. **A detector** — a yes/no command: *"is this tool installed?"* `have aqe` checks PATH;
+   `have_superpowers` checks for the plugin directory on disk.
+
+3. **Gate logic** that ties them together:
+   > detector says yes → drop the template between its markers (upsert); says no → cut that
+   > region out (strip).
+
+Parts 1 and 2 are *data*. Part 3 is the only *logic* — and it's identical for every block.
+
+---
+
+## The registry: one list, not copy-pasted gates
+
+Because the gate logic is the same for every block, it lives in **one place** and loops over a
+**registry** of blocks. The registry is `_ruflo_cond_blocks` in `shell/ruflo-lib.sh`:
+
+```sh
+# <slug> | <source file in claude/> | <staged template in ~/.config/ruflo/> | <detector>
+_ruflo_cond_blocks() {
+	cat <<'EOF'
+ruflo-aqe-reference|aqe-reference.md|aqe-md-template.md|have aqe
+ruflo-superpowers-reference|superpowers-reference.md|superpowers-md-template.md|have_superpowers
+EOF
+}
+```
+
+Each field maps to the three things a block *is*:
+
+| Field | Meaning |
+|-------|---------|
+| `slug` | doubles as the sentinel name — `<!-- BEGIN <slug> -->` … `<!-- END <slug> -->` |
+| source file | the authored markdown in `claude/`, staged at install time |
+| staged template | where it lands under `~/.config/ruflo/` (so resync works with no repo nearby) |
+| detector | any command; **exit 0 = "tool present, include the block"** |
+
+Because the detector is "just a command that exits 0 or 1," the registry doesn't care *how* a
+tool is detected — `have aqe` (PATH) and `have_superpowers` (plugin dir) coexist cleanly. Each
+row brings its own test.
+
+Every consumer **loops the registry** instead of hardcoding a tool:
+
+| Consumer | What it does with the registry |
+|----------|--------------------------------|
+| `install.sh` | stages each template, then upserts/strips each block per its detector |
+| `_ruflo_sync_cond_blocks` (lib) | the shared reconcile loop — used by install and resync |
+| `ruflo-resync` / `ruflo-reference-refresh --sync-blocks` | re-asserts every block after an upgrade |
+| `ruflo-reference-refresh status` | reports each block: present / missing / stale |
+| `uninstall.sh` | removes each staged template and strips each block |
+
+`_ruflo_sync_aqe_block` in `shell/ruflo-functions.sh` is kept as a thin back-compat shim that
+calls `_ruflo_sync_cond_blocks` (so the older `--sync-aqe` flag still works); it now reconciles
+**every** block, not just agentic-qe.
+
+---
+
+## Adding support for a new tool
+
+Two steps. No new logic, ever.
+
+1. **Write the template** — `claude/<name>-reference.md`, wrapped in
+   `<!-- BEGIN ruflo-<name>-reference -->` … `<!-- END ruflo-<name>-reference -->`. Keep the
+   `ruflo-` sentinel prefix — `uninstall.sh` keys off it.
+2. **Add one registry row** to `_ruflo_cond_blocks` in `shell/ruflo-lib.sh`:
+   ```
+   ruflo-<name>-reference|<name>-reference.md|<name>-md-template.md|<detector>
+   ```
+   If the detector isn't a simple `have <binary>`, add a small `have_<name>` function next to
+   `have_superpowers` in the same file.
+
+Install, resync, status, and uninstall pick it up automatically.
+
+### Where "play nicely with others" comes from
+
+This is the key distinction: **the registry decides *presence* (is the block in the file);
+the template's *content* decides *behavior* (how the tool coordinates with the rest).** They're
+independent concerns — which is exactly why this scales: the machinery never changes, you only
+ever author markdown.
+
+So the convention is: **every conditional block's template includes a short "how this
+coordinates with the others" section.** Skeleton:
+
+```markdown
+<!-- BEGIN ruflo-foobar-reference -->
+## Foobar — operating guidance
+> Applies when **foobar** is installed.
+
+### How this coordinates with the others        ← the "play nice" part
+- foobar owns <its lane>; defer to ruflo for memory/agents/security.
+- In overlap with superpowers' process skills, let superpowers choreograph and foobar/ruflo execute.
+
+### Capabilities / how to drive it
+…tool-specific notes…
+<!-- END ruflo-foobar-reference -->
+```
+
+Note the two emphases this kit already ships:
+- **`ruflo-aqe-reference`** is mostly a *capability* block — it teaches Claude about a CLI/MCP
+  it wouldn't otherwise know to use.
+- **`ruflo-superpowers-reference`** is the *opposite* — Claude already knows superpowers (too
+  well, because it self-injects), so that block is almost entirely *arbitration*: the house
+  rules that keep superpowers from crowding ruflo out. Same machinery slot, opposite purpose.
+
+---
+
+## Detection notes & caveats
+
+- **`have_superpowers`** tests presence-on-disk at
+  `~/.claude/plugins/cache/<marketplace>/superpowers/<version>/`. That mirrors how `have aqe`
+  means "installed," **not** "provably active this session" (a plugin could be installed but
+  disabled). On-disk presence is the right gate for a CLAUDE.md block.
+- We deliberately **do not** touch superpowers' own `SessionStart` hook. Mutating a
+  third-party plugin's files is fragile and outside this kit's "merge a managed block into
+  CLAUDE.md" charter. The arbitration block achieves the same outcome through the sanctioned
+  channel (CLAUDE.md precedence).
+
+---
+
+## Verifying a change
+
+```bash
+bash -n install.sh uninstall.sh shell/ruflo-lib.sh shell/ruflo-functions.sh   # syntax
+./install.sh --dry-run            # preview staging + per-block upsert/strip decisions
+```
+
+For an end-to-end check, stage the templates into a scratch `cfg/` dir, point a throwaway
+`CLAUDE.md` at it, stub the detectors, and call `_ruflo_sync_cond_blocks "$REF" "$CFG"` —
+asserting that present→added, absent→stripped, surrounding content is preserved, and re-running
+doesn't duplicate. (This is the same shape as `bin/ruflo-parity-test`'s isolated-dir approach.)

--- a/install.sh
+++ b/install.sh
@@ -187,12 +187,17 @@ case ":$PATH:" in
 esac
 echo ""
 
-# CLAUDE.md reference template (+ the conditional agentic-qe sub-block template)
-echo "## CLAUDE.md reference template -> $CFG_DIR/claude-md-template.md"
+# CLAUDE.md reference templates: the always-on ruflo-reference base + every conditional
+# sub-block template from the registry in ruflo-lib.sh (agentic-qe, superpowers, …).
+# Staging is registry-driven — adding a tool there auto-stages its template, no edit here.
+echo "## CLAUDE.md reference templates -> $CFG_DIR/"
 run "mkdir -p '$CFG_DIR'"
 run "cp '$HERE/claude/ruflo-reference.md' '$CFG_DIR/claude-md-template.md'"
-run "cp '$HERE/claude/aqe-reference.md' '$CFG_DIR/aqe-md-template.md'"
-ok "templates installed (ruflo-reference + conditional aqe-reference)"
+_ruflo_cond_blocks | while IFS='|' read -r _slug _src _tmpl _detector; do
+	[ -n "$_slug" ] || continue
+	run "cp '$HERE/claude/$_src' '$CFG_DIR/$_tmpl'"
+done
+ok "templates installed (ruflo-reference + $(_ruflo_cond_blocks | grep -c .) conditional blocks)"
 echo ""
 
 # Shared helper lib — deployed to a stable absolute path so the standalone bin
@@ -225,23 +230,22 @@ else
 fi
 echo ""
 
-# Conditional agentic-qe operating block: present in ~/.claude/CLAUDE.md ONLY when agentic-qe
-# is installed; stripped otherwise (self-healing on uninstall). Idempotent.
-echo "## ruflo-aqe-reference block (conditional on agentic-qe) -> $CLAUDE_MD"
-AQE_BEGIN='<!-- BEGIN ruflo-aqe-reference -->'; AQE_END='<!-- END ruflo-aqe-reference -->'
+# Conditional operating blocks (agentic-qe, superpowers, …): each present in
+# ~/.claude/CLAUDE.md ONLY when its tool is detected; stripped otherwise (self-healing on
+# uninstall). Driven by the registry in ruflo-lib.sh — see docs/CONDITIONAL-BLOCKS.md.
+echo "## conditional CLAUDE.md blocks (per detected tool) -> $CLAUDE_MD"
 if [ "$DRY" -eq 1 ]; then
-	if have aqe; then printf '%s[dry-run]%s upsert ruflo-aqe-reference block (aqe present)\n' "$C_DIM" "$C_RESET"
-	else printf '%s[dry-run]%s strip ruflo-aqe-reference block (aqe absent)\n' "$C_DIM" "$C_RESET"; fi
-elif have aqe; then
-	_ruflo_block_upsert "$CLAUDE_MD" "$AQE_BEGIN" "$AQE_END" "$HERE/claude/aqe-reference.md" \
-		&& ok "agentic-qe present — merged ruflo-aqe-reference block" \
-		|| warn "could not merge ruflo-aqe-reference block (aqe-reference.md unreadable)"
+	_ruflo_cond_blocks | while IFS='|' read -r _slug _src _tmpl _detector; do
+		[ -n "$_slug" ] || continue
+		if eval "$_detector" >/dev/null 2>&1; then
+			printf '%s[dry-run]%s upsert %s (detector matched)\n' "$C_DIM" "$C_RESET" "$_slug"
+		else
+			printf '%s[dry-run]%s strip %s (detector did not match)\n' "$C_DIM" "$C_RESET" "$_slug"
+		fi
+	done
 else
-	if [ -f "$CLAUDE_MD" ] && grep -qF "$AQE_BEGIN" "$CLAUDE_MD"; then
-		_ruflo_block_strip "$CLAUDE_MD" "$AQE_BEGIN" "$AQE_END"; ok "agentic-qe absent — stripped stale ruflo-aqe-reference block"
-	else
-		dim "agentic-qe absent — no ruflo-aqe-reference block to manage"
-	fi
+	_ruflo_sync_cond_blocks "$CLAUDE_MD" "$CFG_DIR"
+	ok "conditional blocks synced to detected tools"
 fi
 echo ""
 

--- a/shell/ruflo-functions.sh
+++ b/shell/ruflo-functions.sh
@@ -651,23 +651,15 @@ ruflo-neural-train() {
 #
 #   ruflo-resync           # re-apply learning + statusline (recommended after upgrade)
 #   ruflo-resync --aqe     # also refresh agentic-qe skills in this repo
-# Sync the conditional agentic-qe sub-block in ~/.claude/CLAUDE.md: present iff `aqe` is
-# installed (upsert from the staged template), stripped otherwise (self-healing on uninstall).
-# Quiet unless the block's presence actually changes. Needs ruflo-lib.sh (_ruflo_block_*).
+# Sync ALL conditional reference sub-blocks in ~/.claude/CLAUDE.md (agentic-qe,
+# superpowers, …) against their detectors: present when the tool is installed, stripped
+# otherwise. The registry and the upsert/strip logic live in ruflo-lib.sh
+# (_ruflo_cond_blocks, _ruflo_sync_cond_blocks); see docs/CONDITIONAL-BLOCKS.md. The name
+# is kept for back-compat with existing callers and the `--sync-aqe` flag that predate the
+# registry — it now reconciles every block, not just agentic-qe.
 _ruflo_sync_aqe_block() {
-	local ref="$HOME/.claude/CLAUDE.md"
-	local tmpl="$HOME/.config/ruflo/aqe-md-template.md"
-	local b='<!-- BEGIN ruflo-aqe-reference -->' e='<!-- END ruflo-aqe-reference -->'
-	command -v _ruflo_block_upsert >/dev/null 2>&1 || return 0
-	[ -f "$ref" ] || return 0
-	if command -v aqe >/dev/null 2>&1; then
-		[ -f "$tmpl" ] || return 0
-		grep -qF "$b" "$ref" || echo "  + agentic-qe present → adding ruflo-aqe-reference block to $ref"
-		_ruflo_block_upsert "$ref" "$b" "$e" "$tmpl"
-	elif grep -qF "$b" "$ref" 2>/dev/null; then
-		echo "  - agentic-qe absent → stripping stale ruflo-aqe-reference block from $ref"
-		_ruflo_block_strip "$ref" "$b" "$e"
-	fi
+	command -v _ruflo_sync_cond_blocks >/dev/null 2>&1 || return 0
+	_ruflo_sync_cond_blocks "$HOME/.claude/CLAUDE.md" "$HOME/.config/ruflo"
 }
 
 ruflo-resync() {
@@ -687,8 +679,8 @@ ruflo-resync() {
 	echo ""; echo "## 3/4 statusline (version + activation footer) for this project"
 	ruflo-fix-statusline-version
 
-	echo ""; echo "## machine-wide ~/.claude/CLAUDE.md: conditional agentic-qe reference block"
-	_ruflo_sync_aqe_block && echo "✓ ruflo-aqe-reference block in sync with agentic-qe install state"
+	echo ""; echo "## machine-wide ~/.claude/CLAUDE.md: conditional reference blocks (agentic-qe, superpowers, …)"
+	_ruflo_sync_aqe_block && echo "✓ conditional blocks in sync with detected tools"
 
 	if [ "$do_aqe" -eq 1 ]; then
 		echo ""; echo "## 4/4 refresh agentic-qe skills (--aqe)"
@@ -711,6 +703,8 @@ ruflo-resync() {
 #   ruflo-reference-refresh --regenerate replace managed block (preserves content
 #                                        outside the BEGIN/END sentinels)
 #   ruflo-reference-refresh --regenerate -y   skip the y/n prompt
+#   ruflo-reference-refresh --sync-blocks reconcile conditional blocks (aqe, superpowers,
+#                                        …) with detected tools (--sync-aqe is an alias)
 ruflo-reference-refresh() {
 	local ref="$HOME/.claude/CLAUDE.md"
 	local template="$HOME/.config/ruflo/claude-md-template.md"
@@ -719,31 +713,37 @@ ruflo-reference-refresh() {
 		case "$1" in
 			--diff) mode="diff" ;;
 			--regenerate) mode="regenerate" ;;
-			--sync-aqe) mode="sync-aqe" ;;
+			--sync-aqe|--sync-blocks) mode="sync-blocks" ;;
 			-y|--yes) yes=1 ;;
-			-h|--help) echo "Usage: ruflo-reference-refresh [--diff|--regenerate [-y]|--sync-aqe]"; return 0 ;;
+			-h|--help) echo "Usage: ruflo-reference-refresh [--diff|--regenerate [-y]|--sync-blocks]"; return 0 ;;
 			*) echo "Unknown flag: $1"; return 2 ;;
 		esac
 		shift
 	done
-	# --sync-aqe only touches the conditional agentic-qe block; no ruflo template needed.
-	if [ "$mode" = "sync-aqe" ]; then _ruflo_sync_aqe_block; return 0; fi
+	# --sync-blocks (a.k.a. --sync-aqe) only reconciles the conditional blocks; no ruflo template needed.
+	if [ "$mode" = "sync-blocks" ]; then _ruflo_sync_aqe_block; return 0; fi
 	if [ ! -f "$template" ]; then
 		echo "No template at $template (run install.sh, or extract from $ref)."
 		return 1
 	fi
-	local aqe_begin='<!-- BEGIN ruflo-aqe-reference -->'
 	case "$mode" in
 		status)
 			echo "ruflo: $(ruflo --version 2>/dev/null || echo 'not installed')"
 			echo "installed sentinel: $(grep -E 'ruflo-version' "$ref" 2>/dev/null || echo 'none')"
 			echo "template  sentinel: $(grep -E 'ruflo-version' "$template" 2>/dev/null || echo 'none')"
-			if command -v aqe >/dev/null 2>&1; then
-				grep -qF "$aqe_begin" "$ref" 2>/dev/null && echo "agentic-qe: installed — aqe block present" || echo "agentic-qe: installed — aqe block MISSING (run --sync-aqe)"
-			else
-				grep -qF "$aqe_begin" "$ref" 2>/dev/null && echo "agentic-qe: absent — aqe block STALE (run --sync-aqe to strip)" || echo "agentic-qe: absent — aqe block correctly absent"
+			# Reconcile every conditional block (agentic-qe, superpowers, …) against its detector.
+			if command -v _ruflo_cond_blocks >/dev/null 2>&1; then
+				_ruflo_cond_blocks | while IFS='|' read -r _slug _src _tmpl _detector; do
+					[ -n "$_slug" ] || continue
+					_present=no; eval "$_detector" >/dev/null 2>&1 && _present=yes
+					_inref=no; grep -qF "<!-- BEGIN $_slug -->" "$ref" 2>/dev/null && _inref=yes
+					if   [ "$_present" = yes ] && [ "$_inref" = yes ]; then echo "$_slug: tool present — block present ✓"
+					elif [ "$_present" = yes ] && [ "$_inref" = no  ]; then echo "$_slug: tool present — block MISSING (run --sync-blocks)"
+					elif [ "$_present" = no  ] && [ "$_inref" = yes ]; then echo "$_slug: tool absent — block STALE (run --sync-blocks to strip)"
+					else echo "$_slug: tool absent — block correctly absent"; fi
+				done
 			fi
-			echo "Use --diff to compare, --regenerate to rebuild, --sync-aqe to fix the agentic-qe block."
+			echo "Use --diff to compare, --regenerate to rebuild, --sync-blocks to fix conditional blocks."
 			;;
 		diff)
 			local blk; blk=$(mktemp)

--- a/shell/ruflo-lib.sh
+++ b/shell/ruflo-lib.sh
@@ -100,10 +100,10 @@ _ruflo_bsq3_install() {
 }
 
 # --- sentinel-delimited block management (CLAUDE.md sub-blocks) -------------
-# Manage a `<!-- BEGIN x -->`…`<!-- END x -->` block in a file. Used for the
-# conditional ruflo-aqe-reference block in ~/.claude/CLAUDE.md (present only when
-# agentic-qe is installed). Idempotent; preserves everything outside the markers.
-# Markers are matched as fixed substrings (awk index()).
+# Manage a `<!-- BEGIN x -->`…`<!-- END x -->` block in a file. These are the generic
+# primitives behind every conditional block in ~/.claude/CLAUDE.md (see the
+# conditional-block registry below). Idempotent; preserve everything outside the
+# markers. Markers are matched as fixed substrings (awk index()).
 
 # _ruflo_block_upsert FILE BEGIN END SRC — replace the BEGIN..END block in FILE with
 # the contents of SRC (which must itself contain the markers); append if the block is
@@ -137,6 +137,57 @@ _ruflo_block_strip() {
 		index($0,e){skip=0}
 	' "$file" > "$new"
 	cat "$new" > "$file"; rm -f "$new"
+}
+
+# --- conditional-block registry --------------------------------------------
+# Some CLAUDE.md sub-blocks belong in ~/.claude/CLAUDE.md only when a companion
+# tool is installed (the agentic-qe fleet, the superpowers plugin, …). Rather than
+# hand-code the present/absent gate for each one across install.sh, uninstall.sh,
+# and ruflo-reference-refresh, every conditional block is listed here ONCE. Adding a
+# tool = ship claude/<name>-reference.md and add a single row below; install, resync,
+# status, and uninstall all pick it up with no further edits. See
+# docs/CONDITIONAL-BLOCKS.md for the design and how to author a new block's content.
+#
+# Row format (pipe-separated, one block per line):
+#   <slug> | <source file in claude/> | <staged template in ~/.config/ruflo/> | <detector>
+# - <slug>     doubles as the sentinel name: <!-- BEGIN <slug> --> … <!-- END <slug> -->
+# - <detector> is any command; exit 0 means "tool present → include the block".
+_ruflo_cond_blocks() {
+	cat <<'EOF'
+ruflo-aqe-reference|aqe-reference.md|aqe-md-template.md|have aqe
+ruflo-superpowers-reference|superpowers-reference.md|superpowers-md-template.md|have_superpowers
+EOF
+}
+
+# have_superpowers — true if the superpowers plugin is installed on disk at
+# ~/.claude/plugins/cache/<marketplace>/superpowers/<version>/. This is
+# presence-on-disk, mirroring how `have aqe` means "installed" (not "provably active
+# this session"). `find … -quit` returns on the first match; empty output if none, and
+# a missing cache dir is swallowed by 2>/dev/null. Works in both bash and zsh.
+have_superpowers() {
+	[ -n "$(find "$HOME/.claude/plugins/cache" -maxdepth 4 -type d -name superpowers -print -quit 2>/dev/null)" ]
+}
+
+# _ruflo_sync_cond_blocks REF CFG — reconcile every registry block against its detector:
+# upsert from CFG/<staged template> when the detector passes, strip the block otherwise.
+# Idempotent; prints a line only when a block is actually added or removed. No-op if REF
+# is missing or the block primitives are not loaded. Shared by install.sh and ruflo-resync.
+_ruflo_sync_cond_blocks() {
+	local ref="$1" cfg="$2" slug src tmpl detector b e
+	[ -f "$ref" ] || return 0
+	command -v _ruflo_block_upsert >/dev/null 2>&1 || return 0
+	_ruflo_cond_blocks | while IFS='|' read -r slug src tmpl detector; do
+		[ -n "$slug" ] || continue
+		b="<!-- BEGIN $slug -->"; e="<!-- END $slug -->"
+		if eval "$detector" >/dev/null 2>&1; then
+			[ -f "$cfg/$tmpl" ] || continue
+			grep -qF "$b" "$ref" 2>/dev/null || echo "  + $slug → tool present, adding block"
+			_ruflo_block_upsert "$ref" "$b" "$e" "$cfg/$tmpl"
+		elif grep -qF "$b" "$ref" 2>/dev/null; then
+			echo "  - $slug → tool absent, stripping stale block"
+			_ruflo_block_strip "$ref" "$b" "$e"
+		fi
+	done
 }
 
 _RUFLO_LIB=1   # sentinel: consumers check this to confirm the lib loaded

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -4,9 +4,10 @@
 #
 # By default removes ONLY the kit's own footprint:
 #   - every helper this repo ships in bin/ from ~/.local/bin/ (derived from bin/)
-#   - ~/.config/ruflo/{claude-md-template,aqe-md-template}.md
-#   - the BEGIN/END ruflo-reference AND ruflo-aqe-reference blocks from
-#     ~/.claude/CLAUDE.md (content outside the sentinels is preserved)
+#   - ~/.config/ruflo/claude-md-template.md + every staged conditional template
+#     (aqe-md-template.md, superpowers-md-template.md, … — per the registry)
+#   - the BEGIN/END ruflo-reference block AND every conditional block (ruflo-aqe-reference,
+#     ruflo-superpowers-reference, …) from ~/.claude/CLAUDE.md (content outside is preserved)
 #   - the source line from ~/.zshrc / ~/.bashrc
 #
 # Leaves your ruflo install, memory DBs, and project files untouched. Per-project
@@ -86,24 +87,33 @@ for src in "$HERE"/bin/*; do
 	[ -f "$f" ] && { run "rm -f '$f'"; ok "removed $f"; }
 done
 
-# 2. templates (ruflo-reference + conditional agentic-qe block)
+# 2. templates (ruflo-reference base + every conditional sub-block, per the registry in ruflo-lib.sh)
 [ -f "$HOME/.config/ruflo/claude-md-template.md" ] && { run "rm -f '$HOME/.config/ruflo/claude-md-template.md'"; ok "removed template"; }
-[ -f "$HOME/.config/ruflo/aqe-md-template.md" ] && { run "rm -f '$HOME/.config/ruflo/aqe-md-template.md'"; ok "removed agentic-qe template"; }
+_ruflo_cond_blocks | while IFS='|' read -r _slug _src _tmpl _detector; do
+	[ -n "$_slug" ] || continue
+	[ -f "$HOME/.config/ruflo/$_tmpl" ] && { run "rm -f '$HOME/.config/ruflo/$_tmpl'"; ok "removed $_slug template"; }
+done
 
 # 2b. shared helper lib (already sourced at the top, so removing it here is safe)
 [ -f "$HOME/.config/ruflo/ruflo-lib.sh" ] && { run "rm -f '$HOME/.config/ruflo/ruflo-lib.sh'"; ok "removed helper lib"; }
 
-# 3. CLAUDE.md managed blocks (ruflo-reference + the conditional ruflo-aqe-reference)
+# 3. CLAUDE.md managed blocks: the ruflo-reference base + every conditional block (registry-driven,
+#    so any block added to ruflo-lib.sh is cleaned here too). Content outside the sentinels is preserved.
 CLAUDE_MD="$HOME/.claude/CLAUDE.md"
-if [ -f "$CLAUDE_MD" ] && grep -qE '<!-- BEGIN ruflo-(reference|aqe-reference) -->' "$CLAUDE_MD"; then
+# All managed blocks share the "ruflo-" sentinel prefix (ruflo-reference, ruflo-aqe-reference,
+# ruflo-superpowers-reference, …), so one substring check covers the base block and every
+# registry block without enumerating them here.
+if [ -f "$CLAUDE_MD" ] && grep -qF "<!-- BEGIN ruflo-" "$CLAUDE_MD" 2>/dev/null; then
 	if [ "$DRY" -eq 1 ]; then
-		printf '%s[dry-run]%s strip ruflo-reference + ruflo-aqe-reference blocks from %s\n' "$C_DIM" "$C_RESET" "$CLAUDE_MD"
+		printf '%s[dry-run]%s strip ruflo-reference + conditional blocks from %s\n' "$C_DIM" "$C_RESET" "$CLAUDE_MD"
 	else
 		cp "$CLAUDE_MD" "$CLAUDE_MD.bak.$(date +%Y%m%d-%H%M%S)"
-		new=$(mktemp)
-		awk '/<!-- BEGIN ruflo-reference -->/{skip=1} /<!-- BEGIN ruflo-aqe-reference -->/{skip=1} /<!-- END ruflo-reference -->/{skip=0; next} /<!-- END ruflo-aqe-reference -->/{skip=0; next} !skip' "$CLAUDE_MD" > "$new"
-		mv "$new" "$CLAUDE_MD"
-		ok "stripped ruflo-reference + ruflo-aqe-reference blocks (backup saved; rest of file preserved)"
+		_ruflo_block_strip "$CLAUDE_MD" "<!-- BEGIN ruflo-reference -->" "<!-- END ruflo-reference -->"
+		_ruflo_cond_blocks | while IFS='|' read -r _slug _src _tmpl _detector; do
+			[ -n "$_slug" ] || continue
+			_ruflo_block_strip "$CLAUDE_MD" "<!-- BEGIN $_slug -->" "<!-- END $_slug -->"
+		done
+		ok "stripped ruflo-reference + conditional blocks (backup saved; rest of file preserved)"
 	fi
 fi
 


### PR DESCRIPTION
## Why

Adding a conditional `~/.claude/CLAUDE.md` block per companion tool (agentic-qe today, superpowers next) meant **copy-pasting the present/absent gate** into `install.sh`, `uninstall.sh`, and `ruflo-reference-refresh`. This generalizes that into a small **registry** so a new tool is one row + one template — no new logic.

It also fixes a real UX problem: the **superpowers** plugin self-injects an aggressive *"if there's even a 1% chance a skill applies, you MUST use it"* preamble at session start, so it grabs every task and **ruflo never comes to the party**. They aren't actually rivals — superpowers is *choreography* (process), ruflo/agentic-qe are *capability*. The new block posts "house rules" via CLAUDE.md, which is the channel **superpowers' own precedence rule already honors** (user CLAUDE.md > superpowers skills).

## What changed

- **`shell/ruflo-lib.sh`** — `_ruflo_cond_blocks` registry (`slug | source | staged template | detector`), `have_superpowers` on-disk detector, and the generic `_ruflo_sync_cond_blocks` upsert/strip loop.
- **`install.sh` / `uninstall.sh`** — loop the registry for template staging, sync, and teardown (no hardcoded aqe gate).
- **`shell/ruflo-functions.sh`** — `_ruflo_sync_aqe_block` is now a back-compat shim over the generic sync; `ruflo-reference-refresh status` reports every block; adds `--sync-blocks` (`--sync-aqe` kept as alias).
- **`claude/superpowers-reference.md`** — the house-rules template (arbitration, not a capability clone — superpowers self-describes).
- **`docs/CONDITIONAL-BLOCKS.md`** — design + mental model + how to add a tool; linked from README.
- **`.gitignore`** — ignore dogfooding artifacts (`.agentic-qe/`, `.claude/`, `*.db`, …) that `CLAUDE.md` says must never be committed but weren't actually ignored.

**agentic-qe behavior is unchanged** — it's now row 1 of the registry.

## To add the next tool

1. Write `claude/<name>-reference.md` (with `<!-- BEGIN/END ruflo-<name>-reference -->` markers + a "how this coordinates" section).
2. Add one row to `_ruflo_cond_blocks` (and a `have_<name>` if the detector isn't a simple `have <binary>`).

Install, resync, status, and uninstall pick it up automatically.

## Verification

- `bash -n` clean on all four shell files
- `install.sh --dry-run` exits 0; shows both blocks resolving via detectors
- Isolated scratch-dir test: present→added / absent→stripped / surrounding content preserved / no duplication across re-runs — for **both** blocks
- `ruflo-reference-refresh status` correctly reports present-tool/missing-block as `MISSING (run --sync-blocks)` and self-strips a stale block

🤖 Generated with [Claude Code](https://claude.com/claude-code)