### PR TITLE
docs: install from npm registry instead of GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **One npm package that makes [ruflo](https://github.com/ruvnet/ruflo) (claude-flow) and [agentic-qe](https://github.com/proffesor-for-testing/agentic-qe) actually work — installed, healed, and *proven* — on macOS, Linux, and Windows.**
 
 ```bash
-npm install -g github:pacphi/agentic-kit
+npm install -g @pacphi/agentic-kit@next   # alpha channel until 4.0.0 GA
 ak setup        # once per machine; run it inside a repo to set that project up too
 ```
 


### PR DESCRIPTION
The package is live on npmjs.org (published 2026-07-14 with provenance) — the README's install line predated the publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)