### PR TITLE
fix(heal): harden healNatives against stale locations and opaque failures

### DIFF
--- a/src/lib/heal.mjs
+++ b/src/lib/heal.mjs
@@ -31,13 +31,21 @@ async function npmInstallInto(dir, spec) {
 export async function healNatives() {
   const details = [];
   for (const dir of agentdbLocations()) {
+    // Re-check right before installing: an upgrade earlier in the same sync
+    // can remove a location (e.g. agentic-flow/node_modules/agentdb, gone in
+    // the 3.29.0 tree) between enumeration and heal.
+    if (!fs.existsSync(dir)) continue;
     if (bsq3IsNative(dir)) continue;
     const r = await npmInstallInto(dir, 'better-sqlite3@^12');
-    details.push(`${dir}: ${r.code === 0 && bsq3IsNative(dir) ? 'native installed' : 'FAILED'}`);
+    details.push(`${dir}: ${r.code === 0 && bsq3IsNative(dir)
+      ? 'native installed'
+      : `FAILED (${(r.stderr || `exit ${r.code}`).trim().split('\n').slice(-2).join(' ').slice(0, 200)})`}`);
   }
   if (fs.existsSync(aqeRoot()) && !bsq3IsNative(aqeRoot())) {
     const r = await npmInstallInto(aqeRoot(), 'better-sqlite3@^12');
-    details.push(`agentic-qe: ${r.code === 0 && bsq3IsNative(aqeRoot()) ? 'native installed' : 'FAILED'}`);
+    details.push(`agentic-qe: ${r.code === 0 && bsq3IsNative(aqeRoot())
+      ? 'native installed'
+      : `FAILED (${(r.stderr || `exit ${r.code}`).trim().split('\n').slice(-2).join(' ').slice(0, 200)})`}`);
   }
   return { ok: !details.some((d) => d.includes('FAILED')), detail: details.join('; ') || 'already native everywhere' };
 }


### PR DESCRIPTION
## What

Two hardening changes to `healNatives()` in `src/lib/heal.mjs`, prompted by a live `ak sync` incident during the ruflo 3.28.0 → 3.29.0 upgrade:

1. **Stale-location guard** — each agentdb location is re-checked with `fs.existsSync` immediately before installing. The upgrade step earlier in the same sync can remove a location between enumeration and heal (`agentic-flow/node_modules/agentdb` no longer exists in the 3.29.0 tree), which previously produced a spurious sticky `FAILED … (data-loss writes)` against a phantom path.

2. **Diagnosable failures** — `FAILED` details now include the last two lines of npm's stderr (capped at 200 chars, exit-code fallback), for both agentdb locations and the agentic-qe root. The bare `FAILED` made the original incident undiagnosable from sync output alone.

## Verification

- `node --check` + module import pass
- `node tests/statusline-segments.test.cjs` — 20/20 pass
- Live `healNatives()` run on the healed machine returns `{"ok":true,"detail":"already native everywhere"}` (idempotence preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)