### PR TITLE
fix(setup): inject statusline footer last so it can't silently miss

### DIFF
--- a/src/commands/setup.mjs
+++ b/src/commands/setup.mjs
@@ -99,9 +99,10 @@ export async function run_project({ flags, cfg }) {
   (init.code === 0 ? ok : fail)('ruflo init --full');
   if (init.code !== 0) return false;
 
-  // 2. statusline heal (footer + fallback version + legacy repoint)
-  const sl = fixStatusline(root);
-  (sl.applied ? ok : info)(`statusline: ${sl.applied ? 'footer injected' : sl.reason ?? 'in sync'}`);
+  // 2. statusline heal is DEFERRED to the end of project setup (see step 10):
+  //    fixStatusline is a no-op until ruflo/aqe have finished writing
+  //    .claude/helpers/statusline.cjs, so injecting the footer here can silently
+  //    miss (helper not settled) — running it last guarantees convergence.
 
   // 3. strip committed MCP cruft (keep any agentic-qe entry)
   const mcpJson = path.join(root, '.mcp.json');
@@ -172,6 +173,14 @@ export async function run_project({ flags, cfg }) {
     const aqe = await runCmd('aqe', ['init', '--auto'], { cwd: root, timeout: 300_000 });
     (aqe.code === 0 ? ok : warn)('agentic-qe initialized');
   }
+
+  // 10. statusline footer — LAST, after ruflo + aqe have settled the helper.
+  //     A still-missing footer is a WARN (not silent info): it means the AQE /
+  //     SONA segments won't render and `ak sync` is needed to heal it.
+  const sl = fixStatusline(root);
+  if (sl.applied) ok(`statusline: footer injected (v${sl.version})`);
+  else if (sl.reason) warn(`statusline: ${sl.reason} — run \`ak sync\` to re-inject`);
+  else ok('statusline: footer in sync');
   return true;
 }
 


### PR DESCRIPTION
## Problem

`ak setup` (project scope) ran `fixStatusline` at **step 2**, right after `ruflo init`. But `fixStatusline` early-returns `applied:false` when `.claude/helpers/statusline.cjs` isn't settled yet (`statusline.mjs:23`), and setup logged that outcome as **`info`, not a warning** (`setup.mjs:104`).

Result: on a real repo, the footer injection silently no-op'd, so the statusline rendered **without the Agentic QE / SONA segments** — and nobody was told. Only the reactive net (`ak sync` detecting "footer missing") healed it later; setup itself never converged.

## Root cause (verified, not assumed)

- Reproduced that `aqe init --auto` (step 9) **preserves** an already-injected footer — so nothing was clobbering it. Step 2 simply missed a not-yet-settled helper file.
- Confirmed `fixStatusline` is idempotent and injects cleanly once the helper exists.

## Fix

- Move the statusline heal to the **final project step (step 10)**, after both `ruflo init` and `aqe init` have written the helper.
- A still-missing footer is now a **`warn`** pointing at `ak sync`, never silent `info`.

## Verification

- `node --check src/commands/setup.mjs` passes
- `node tests/statusline-segments.test.cjs` → 20 passed, 0 failed
- Applied the equivalent heal to a live repo via `ak sync`; the `🎓 Agentic QE` segment now renders