### PR TITLE
fix(natives): resolve better-sqlite3 by fresh fs walk, not cached resolver

### DIFF
--- a/src/lib/natives.mjs
+++ b/src/lib/natives.mjs
@@ -5,7 +5,6 @@
 // `security defend` needs (dropped from the 3.28 tree — ruvnet/ruflo#2670).
 import fs from 'node:fs';
 import path from 'node:path';
-import { createRequire } from 'node:module';
 import { rufloNodeModules, aqeRoot } from './paths.mjs';
 
 /** agentdb locations under the global ruflo tree (mirrors ruflo-patch-native). */
@@ -16,15 +15,21 @@ export function agentdbLocations() {
     .filter((p) => fs.existsSync(p));
 }
 
-/** Package root of better-sqlite3 as resolved from `fromDir` (real Node
- *  resolution), or null if not resolvable. */
+/** Package root of better-sqlite3 as resolved from `fromDir`, or null if not
+ *  found. Walks up the node_modules chain reading disk fresh on every call —
+ *  the node resolution equivalent, but WITHOUT createRequire().resolve(), whose
+ *  process-wide cache (Module._pathCache/_realpathCache) goes stale after an
+ *  in-process `npm install` reshapes the tree. That staleness made `sync`'s
+ *  final convergence proof report a false WASM fallback on a location the
+ *  earlier heal (and a fresh process) both saw as native. */
 export function bsq3Root(fromDir) {
-  try {
-    const req = createRequire(path.join(fromDir, 'noop.js'));
-    const entry = req.resolve('better-sqlite3'); // …/better-sqlite3/lib/index.js
-    return path.join(entry.slice(0, entry.lastIndexOf(`${path.sep}better-sqlite3${path.sep}`)), 'better-sqlite3');
-  } catch {
-    return null;
+  let dir = path.resolve(fromDir);
+  for (;;) {
+    const cand = path.join(dir, 'node_modules', 'better-sqlite3');
+    if (fs.existsSync(path.join(cand, 'package.json'))) return cand;
+    const parent = path.dirname(dir);
+    if (parent === dir) return null; // reached filesystem root
+    dir = parent;
   }
 }
 

--- a/tests/kit/natives.test.mjs
+++ b/tests/kit/natives.test.mjs
@@ -45,3 +45,35 @@ test('bsq3IsNative is false for a WASM-fallback install (no binding file)', () =
   assert.equal(bsq3IsNative(dir), false);
   fs.rmSync(dir, { recursive: true, force: true });
 });
+
+test('bsq3Root finds better-sqlite3 hoisted up the node_modules chain', () => {
+  // Real layout: ruflo/node_modules/agentdb resolves better-sqlite3 from the
+  // hoisted ruflo/node_modules/better-sqlite3 — walk up, don't only look nested.
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ak-natives-hoist-'));
+  const fromDir = path.join(root, 'node_modules', 'agentdb');
+  const hoisted = path.join(root, 'node_modules', 'better-sqlite3');
+  fs.mkdirSync(fromDir, { recursive: true });
+  fs.mkdirSync(hoisted, { recursive: true });
+  fs.writeFileSync(path.join(hoisted, 'package.json'), JSON.stringify({ name: 'better-sqlite3' }));
+  assert.equal(bsq3Root(fromDir), hoisted);
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+test('bsq3Root follows a nested→hoisted move in-process (sync convergence bug)', () => {
+  // The false-negative: healNatives resolves better-sqlite3 to a NESTED copy,
+  // then an in-process `npm install` (aidefence) dedupes it away, leaving only a
+  // HOISTED copy. The final proof must resolve to the hoisted copy — reading disk
+  // fresh — not a stale cached root pointing at the removed nested path.
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ak-natives-move-'));
+  const fromDir = path.join(root, 'node_modules', 'agentdb');
+  const nested = path.join(fromDir, 'node_modules', 'better-sqlite3');
+  const hoisted = path.join(root, 'node_modules', 'better-sqlite3');
+  for (const p of [nested, hoisted]) {
+    fs.mkdirSync(p, { recursive: true });
+    fs.writeFileSync(path.join(p, 'package.json'), JSON.stringify({ name: 'better-sqlite3' }));
+  }
+  assert.equal(bsq3Root(fromDir), nested, 'prefers the nested copy while it exists');
+  fs.rmSync(nested, { recursive: true, force: true }); // simulate npm dedupe mid-sync
+  assert.equal(bsq3Root(fromDir), hoisted, 'resolves to the hoisted copy after the move');
+  fs.rmSync(root, { recursive: true, force: true });
+});


### PR DESCRIPTION
## Problem

`ak sync` could end with a **false** failure even when everything was actually healthy:

```
✓ natives: …/ruflo/node_modules/agentdb: native installed; …/agentic-flow/node_modules/agentdb: native built…; agentic-qe: native installed
…
✗ still failing: [natives] 1/1 agentdb location(s) on WASM fallback (data-loss writes)
```

The heal step reported the location **native**, yet the final convergence proof reported **WASM fallback** — and a fresh `node` process confirmed the on-disk state was native and healthy. So the end state was fine; the proof lied.

## Root cause

`bsq3Root()` resolved better-sqlite3 via `createRequire().resolve()`. Node's resolution cache (`Module._pathCache` / `_realpathCache`) is **process-wide** and goes stale after an in-process `npm install` reshapes `node_modules`. During one `sync`:

1. `healNatives()` resolves + builds native better-sqlite3 (priming the cache; the tree has a **nested** `agentic-flow/node_modules/agentdb`).
2. `healAidefence()` runs `npm install @claude-flow/aidefence` into the ruflo tree → **dedupes** the nested agentdb away.
3. The convergence proof calls `bsq3Root()` again → gets the **cached** root pointing at the now-deleted nested path → binding check fails → false WASM.

`agentdbLocations()` uses plain `fs.existsSync` and correctly saw the tree shrink 2→1; only the resolver-backed lookup was stale.

## Fix

`bsq3Root()` now walks up the `node_modules` chain with `fs.existsSync` on every call — the Node-resolution equivalent, but reading disk fresh, so it's immune to in-process tree mutation (matching how `agentdbLocations()` already reads).

- Identical behavior for the resolvable / not-resolvable / native / WASM cases (existing tests unchanged).
- Adds coverage for **hoisted** resolution (the real `ruflo/node_modules/agentdb` → `ruflo/node_modules/better-sqlite3` layout) and the **nested→hoisted** mid-process move that triggered the bug.

## Verification

`npm run check` green (exit 0): typecheck, eslint, markdownlint, build, 76 kit + 20 statusline tests. Verified live on the reporting machine: `ak status` shows `✓ natives native better-sqlite3 in 1 agentdb location(s)` and `ak sync` now reports `✓ converged — no failing subsystems`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)