### PR TITLE
feat(status): surface codex MCP registration + close #36 Phase 4

### DIFF
--- a/src/commands/dual.mjs
+++ b/src/commands/dual.mjs
@@ -82,13 +82,13 @@ function runSwarm(configUrl, task, flags) {
   if (flags.parallel) args.push('--parallel-workers');
   if (flags['max-concurrent']) args.push('--max-concurrent', flags['max-concurrent']);
   if (flags.timeout) args.push('--timeout', flags.timeout);
-  // WORKAROUND (upstream @claude-flow/codex, github.com/ruvnet/ruflo): the
-  // orchestrator bootstraps shared memory via `npx ruflo@alpha memory init`, whose
-  // default DB path differs from where the spawned workers read it → the whole run
-  // dies with "Database not initialized". Pinning CLAUDE_FLOW_DB_PATH makes the init
-  // and the workers share ONE db (verified: "✓ Shared memory initialized"). We only
-  // set it when the user hasn't, and the adapter inherits it via its own spawn env.
-  // Remove once the adapter uses the local ruflo / a consistent path upstream.
+  // WORKAROUND (upstream @claude-flow/codex, ruvnet/ruflo#2766): the orchestrator
+  // bootstraps shared memory via `npx ruflo@alpha memory init`, whose default DB path
+  // differs from where the spawned workers read it → the whole run dies with "Database
+  // not initialized". Pinning CLAUDE_FLOW_DB_PATH makes the init and the workers share
+  // ONE db (verified: "✓ Shared memory initialized"). We only set it when the user
+  // hasn't, and the adapter inherits it via its own spawn env. Remove once #2766 ships
+  // (the adapter uses the local ruflo / a consistent path) — then re-verify a live run.
   const dbPath = process.env.CLAUDE_FLOW_DB_PATH ?? path.join(process.cwd(), '.claude-flow', 'dual-run-memory.db');
   fs.mkdirSync(path.dirname(dbPath), { recursive: true });
   return new Promise((resolve) => {
@@ -161,7 +161,7 @@ async function doRun({ positionals, flags }) {
   if (code === 0) { ok('dual run complete'); return 0; }
   fail(`dual run failed (exit ${code})`);
   // ak already pins CLAUDE_FLOW_DB_PATH to neutralize the upstream @claude-flow/codex
-  // shared-memory bootstrap bug, so a failure here is usually a worker (auth, sandbox,
+  // shared-memory bootstrap bug (ruvnet/ruflo#2766), so a failure here is usually a worker (auth, sandbox,
   // or model access) — not routing. The materialized config + host/model assignment
   // are ak's part and are correct.
   info('workers run as `claude -p` / `codex exec`; a failure here is typically host auth/sandbox/model access, not your routing. Re-run a single step with --route to isolate.');

--- a/src/commands/status.mjs
+++ b/src/commands/status.mjs
@@ -8,7 +8,7 @@ import { loadRing, detectRegression } from '../lib/health-history.mjs';
 import * as paths from '../lib/paths.mjs';
 import { nativesStatus, aidefencePresent, securityPresent } from '../lib/natives.mjs';
 import { scanNpxStale } from '../lib/npx.mjs';
-import { registrationStatus } from '../lib/mcp.mjs';
+import { registrationStatus, codexMcpStatus } from '../lib/mcp.mjs';
 import { listDaemons, staleDaemons } from '../lib/daemons.mjs';
 import { scanRvf } from '../lib/rvf.mjs';
 import { registry, syncBlocks } from '../lib/blocks.mjs';
@@ -224,6 +224,28 @@ export async function collect({ pkgRoot, cwd = process.cwd() }) {
   }
   if (mcp.legacyRuflo) {
     rows.push(row('mcp', 'warn', "legacy 'ruflo'-keyed MCP registration present", 'sync migrates it to claude-flow'));
+  }
+
+  // codex MCP backend (mcp__codex__codex) — the dual-host swarm's inline Claude→Codex
+  // path (ADR-0001 projection #3). Only surfaces when the codex host is enabled;
+  // setup/sync register it project-scoped via ensureCodexMcp. Spawn-free: reads the
+  // project .mcp.json (== `claude mcp get codex`) plus the kit.json ownership marker.
+  if (cfg.providers?.hosts?.codex) {
+    try {
+      const { registered, owned } = codexMcpStatus(cfg, cwd);
+      if (registered) {
+        rows.push(row('codex-mcp', 'ok',
+          `codex MCP registered (mcp__codex__codex)${owned ? '' : ' — pre-existing (not ak-managed)'}`));
+      } else if (await have('codex')) {
+        rows.push(row('codex-mcp', 'warn', 'codex enabled but codex MCP not registered',
+          'sync registers the codex MCP server'));
+      } else {
+        rows.push(row('codex-mcp', 'warn', 'codex enabled but codex CLI not installed',
+          'sync installs codex, then registers the codex MCP'));
+      }
+    } catch (e) {
+      rows.push(row('codex-mcp', 'warn', `codex MCP check unavailable: ${e.message}`));
+    }
   }
 
   // hosts (install-if-missing) — cheap: file read + `which`, no network.

--- a/src/lib/dashboard-server.mjs
+++ b/src/lib/dashboard-server.mjs
@@ -597,7 +597,7 @@ const JS = `
 
   // severity rank for rollups + triage sort; preferred order breaks ties.
   var RANK={fail:3,warn:2,ok:1,info:0,unknown:0};
-  var PREF=["versions","self","natives","security","learning","providers","hosts","routing","mcp","ruvnet-brain","ruvnet-brain-nightly","aqe","daemons","blocks","statusline","npx"];
+  var PREF=["versions","self","natives","security","learning","providers","hosts","routing","mcp","codex-mcp","ruvnet-brain","ruvnet-brain-nightly","aqe","daemons","blocks","statusline","npx"];
 
   // Collapse rows into one group per subsystem (kills repeated labels); the
   // group's level is the worst of its rows. Sort worst-first, then by PREF.

--- a/src/lib/mcp.mjs
+++ b/src/lib/mcp.mjs
@@ -4,7 +4,7 @@
 // Registration key is `claude-flow` (#2206), user scope.
 import fs from 'node:fs';
 import path from 'node:path';
-import { rufloNodeModules, claudeUserMcpPath, claudeSettingsPath } from './paths.mjs';
+import { rufloNodeModules, claudeUserMcpPath, claudeSettingsPath, repoRoot } from './paths.mjs';
 import { run } from './exec.mjs';
 import { readJson, addDenyRules, removeDenyRules } from './settings.mjs';
 
@@ -39,6 +39,21 @@ export function registrationStatus() {
     denyCount: (readJson(claudeSettingsPath(), {})?.permissions?.deny ?? [])
       .filter((r) => r.startsWith('mcp__claude-flow__')).length,
   };
+}
+
+/**
+ * Project-scoped codex MCP (mcp__codex__codex) registration state. `ensureCodexMcp`
+ * registers it via `claude mcp add codex -s project`, which persists to `.mcp.json`
+ * at the repo root — so reading that file is the spawn-free equivalent of
+ * `claude mcp get codex` (deterministic + testable, matching `registrationStatus`'s
+ * file-read approach). `owned` reflects kit.json's ak-ownership marker
+ * (`providers.codexMcp === 'ak'`), which gates teardown.
+ * @returns {{ registered: boolean, owned: boolean }}
+ */
+export function codexMcpStatus(cfg, cwd = process.cwd()) {
+  const root = repoRoot(cwd) ?? cwd;
+  const servers = readJson(path.join(root, '.mcp.json'), {})?.mcpServers ?? {};
+  return { registered: 'codex' in servers, owned: cfg?.providers?.codexMcp === 'ak' };
 }
 
 export async function register() {

--- a/tests/kit/codex-mcp.test.mjs
+++ b/tests/kit/codex-mcp.test.mjs
@@ -1,0 +1,67 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { codexMcpStatus } from '../../src/lib/mcp.mjs';
+
+// A tmp dir with a .git marker → repoRoot() resolves to it, so codexMcpStatus reads
+// the .mcp.json we write here (not the real repo's).
+function tmpProject() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'kit-codexmcp-'));
+  fs.mkdirSync(path.join(dir, '.git'), { recursive: true });
+  return dir;
+}
+const rm = (dir) => fs.rmSync(dir, { recursive: true, force: true });
+const writeMcp = (dir, servers) =>
+  fs.writeFileSync(path.join(dir, '.mcp.json'), JSON.stringify({ mcpServers: servers }));
+
+test('registered is false when no .mcp.json exists', () => {
+  const dir = tmpProject();
+  try {
+    assert.deepEqual(codexMcpStatus({}, dir), { registered: false, owned: false });
+  } finally { rm(dir); }
+});
+
+test('registered is true when .mcp.json lists a codex server', () => {
+  const dir = tmpProject();
+  try {
+    writeMcp(dir, { codex: { command: 'codex', args: ['mcp-server'] } });
+    assert.equal(codexMcpStatus({}, dir).registered, true);
+  } finally { rm(dir); }
+});
+
+test('registered is false when .mcp.json has other servers but not codex', () => {
+  const dir = tmpProject();
+  try {
+    writeMcp(dir, { 'claude-flow': { command: 'ruflo' } });
+    assert.equal(codexMcpStatus({}, dir).registered, false);
+  } finally { rm(dir); }
+});
+
+test('owned reflects the kit.json ak-ownership marker', () => {
+  const dir = tmpProject();
+  try {
+    writeMcp(dir, { codex: {} });
+    assert.equal(codexMcpStatus({ providers: { codexMcp: 'ak' } }, dir).owned, true);
+    assert.equal(codexMcpStatus({ providers: { codexMcp: null } }, dir).owned, false);
+    assert.equal(codexMcpStatus({}, dir).owned, false);
+  } finally { rm(dir); }
+});
+
+test('a pre-existing (unowned) codex server is registered but not owned', () => {
+  const dir = tmpProject();
+  try {
+    writeMcp(dir, { codex: {} });
+    assert.deepEqual(codexMcpStatus({ providers: { codexMcp: null } }, dir),
+      { registered: true, owned: false });
+  } finally { rm(dir); }
+});
+
+test('malformed .mcp.json degrades to not-registered (no throw)', () => {
+  const dir = tmpProject();
+  try {
+    fs.writeFileSync(path.join(dir, '.mcp.json'), '{ not valid json');
+    assert.deepEqual(codexMcpStatus({}, dir), { registered: false, owned: false });
+  } finally { rm(dir); }
+});


### PR DESCRIPTION
## Summary

Follow-up polish to #39 (dual-host per-activity LLM routing, merged `fd74187`), plus the resolution of **#36 Phase 4**.

### Task 1 — #36 Phase 4 decision (verified, no code)

Phase 4 proposed a persisted `kit.json` role-split preference that scaffolds `package.json` `dual:*` scripts. **Both halves are obviated by #39** — closing #36 as complete (decision posted as a comment there):

- **Persisted role-split preference** → already delivered by `providers.dualRouting` (`src/lib/config.mjs:25`, resolved in `src/lib/routing.mjs`). It's a per-activity `{host, model, escalate?, source}` policy — a *superset* of a per-template role split, with provenance so user edits survive re-seeding.
- **`package.json dual:* scaffolding`** → superseded by `ak dual run <template> "<task>"` (`src/commands/dual.mjs`), which reads that same policy and shells to `claude-flow-codex dual run`. Strictly better than mutating the user's `package.json`: no file writes, works in any repo (not just Node), and adds `--route`/`--escalate`/`--dry-run`.

Building the scaffolding would write opinionated scripts into the user's `package.json` for ~no gain, so it was **not** built (per the issue's own "opt-in only, explicit sign-off" framing).

### Task 2 — polish (this PR's code)

**(a) codex MCP status visibility.** New `codex-mcp` row in `ak status` (+ PREF slot in `dashboard-server.mjs`) showing whether the project-scoped codex MCP backend (`mcp__codex__codex`, ADR-0001 projection #3) is registered. Surfaces only when the codex host is enabled.

Detection is a pure, spawn-free helper `codexMcpStatus(cfg, cwd)` in `mcp.mjs`: reads the project `.mcp.json` (what `claude mcp add -s project` writes — the deterministic equivalent of `claude mcp get codex`) plus the kit.json `providers.codexMcp === 'ak'` ownership marker. A pre-existing user-registered server is reported but flagged *not-ak-managed*. Mirrors `registrationStatus()`'s file-read approach; **6 new unit tests**, no `claude` spawn.

**(b) ruvnet/ruflo#2766 tracking.** Threaded the issue reference into `dual.mjs`'s `CLAUDE_FLOW_DB_PATH` workaround comments (the `@claude-flow/codex` shared-memory bootstrap bug the pin neutralizes), so the removal condition is unambiguous. The workaround stays until #2766 ships; a live end-to-end re-verify is deferred to that point.

## Verification

`pnpm run check` green — typecheck, eslint, markdownlint, build-check, and full test suite (incl. the 6 new `tests/kit/codex-mcp.test.mjs` cases).

Refs #36, #39, ruvnet/ruflo#2766