### PR TITLE
docs(upgrading): add UPGRADING.md — sync vs provider pick lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,8 @@ you opt in. Two independent axes:
 
 `ak x provider status` shows what's detected, wired, and routed; `ak x provider pick` chooses and
 applies (reversibly); `ak x provider off` restores the claude-only default. Full guide:
-[docs/PROVIDERS.md](docs/PROVIDERS.md).
+[docs/PROVIDERS.md](docs/PROVIDERS.md). Already on an older `ak` and adopting a later capability
+(like dual-host)? [docs/UPGRADING.md](docs/UPGRADING.md) covers the `sync` vs `provider pick` motion.
 
 ## Troubleshooting
 

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -34,6 +34,11 @@ for you:
 
 ## Level 1 — turn on codex (one command)
 
+> [!NOTE]
+> Already have an older `ak` installed and want a capability that shipped later (like
+> dual-host)? Updating the binary and enabling the feature are two separate motions —
+> see [UPGRADING.md](UPGRADING.md) for the `sync` vs `provider pick` distinction.
+
 ```bash
 ak x provider pick
 ```

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -1,0 +1,79 @@
+# Upgrading `ak` & adopting new capabilities
+
+New `ak` features almost always ship **opt-in**. That means moving your machine to the
+latest capability is *two* motions, not one: get the newer code, then turn the feature on.
+This page exists because those two are easy to conflate — and `ak sync`, despite its name,
+only does the first.
+
+## The one rule
+
+> **`ak sync` converges to the choices already recorded in `kit.json`.** It updates the
+> `ak` binary and heals whatever has drifted, but it **never makes a new opt-in decision for
+> you.** Adopting a capability that shipped after your install = run that capability's own
+> opt-in command.
+
+So a feature can be *installed* (the code is on disk) without being *enabled* (your
+`kit.json` never asked for it). `ak sync` will faithfully keep re-applying claude-only if
+that's what you recorded — the same way it won't pick an LLM provider or exclude an MCP
+family on your behalf.
+
+## `sync` vs `setup` vs `provider pick`
+
+| Command              | What it's for                                   | Changes your `kit.json` choices? |
+| -------------------- | ----------------------------------------------- | -------------------------------- |
+| `ak sync`            | update the binary + heal to your recorded state | **no** — converges, never decides |
+| `ak x provider pick` | opt into / retune hosts & LLM providers         | **yes** — this is the switch     |
+| `ak setup`           | first-time bootstrap of absent tooling          | only via explicit flags (`--codex`, `--primary-host`) |
+
+If you already have `ak` working, you almost never need `ak setup` again — it's the
+installer. Enabling a shipped-but-opt-in feature is a `provider pick` (or an `x mcp pick`,
+etc.), not a re-`setup`.
+
+## Worked example: adopting ambidextrous dual-host
+
+You have an older `ak` and both the `claude` and `codex` CLIs installed, and you want the
+ambidextrous dual-host experience (per-activity routing across Claude + Codex). Two motions:
+
+```bash
+ak sync                              # 1. update the binary (+ heal everything)
+ak x provider pick --host claude,codex   # 2. opt in → wires dual-host
+ak x provider status                 # 3. verify: hosts "enabled, wired" + routing table
+```
+
+Step 1 gets the newer code onto disk. Step 2 is what actually turns dual-host on — it
+records `codex` in `kit.json` and does the wiring: writes `ENABLE_CODEX` into
+`.claude/settings.local.json`, runs `ruflo init --dual`, seeds the per-activity routing
+policy, registers the Codex↔ruflo MCP bridge both ways, and generates the dual-mode agents.
+Add `--primary-host codex` if you want Codex to lead (Claude becomes the alternate).
+
+> [!NOTE]
+> `ak sync` self-updates **last** in its pass, so the newer code applies from your *next*
+> `ak` invocation — which is exactly `ak x provider pick` in the sequence above. Running the
+> two in this order is correct; the pick runs under the freshly-installed version.
+
+From then on, `ak sync` **maintains** the choice — it re-applies your recorded dual-host
+config idempotently on every run. `ak status` flags drift; `ak x provider off` reverts to
+the claude-only default, reversibly.
+
+The full menu of host/provider levels — QE provider selection, deterministic fallback
+chains, per-activity routing defaults, undo — lives in [PROVIDERS.md](PROVIDERS.md). This
+page is only about the *upgrade motion*.
+
+## Why `ak sync` pulled a prerelease
+
+The `4.0.0-alpha.*` train publishes to npm's **`next`** dist-tag, not `latest` (`latest`
+stays pinned at the last stable-ish release). A naive "is there a newer version?" check
+reads `latest` and would conclude your alpha is already ahead — so it would never offer the
+upgrade.
+
+`ak` handles this: when your **installed** version is itself a prerelease, the self-drift
+check consults **both** the `latest` and `next` dist-tags and takes the higher of the two.
+That's why `ak sync` on `alpha.19` correctly pulls `alpha.20` even though `latest` points
+further back. (If you'd rather move it by hand: `npm i -g @pacphi/agentic-kit@next`.)
+
+## Where the design lives
+
+The *why* behind primary-host selection and ambidextrous mirroring is captured as an ADR —
+[docs/adr/0006-primary-host-and-ambidextrous-mirroring.md](adr/0006-primary-host-and-ambidextrous-mirroring.md).
+The per-activity routing model spans ADR-0001..0005 (see [docs/adr/](adr/)). This page
+deliberately links rather than restates them, so the ADRs stay the source of truth.


### PR DESCRIPTION
## What

Adds **`docs/UPGRADING.md`** — a focused lifecycle doc for the "I have an older `ak`, how do I adopt a capability that shipped later?" question. Centered on one rule:

> `ak sync` converges to the choices already recorded in `kit.json`. It updates the binary and heals drift, but never makes a new opt-in decision for you — adopting a later feature = run that feature's opt-in command.

## Why

The existing `PROVIDERS.md` is a *feature* doc; it assumes you're already on a current `ak`. There was no home for the *upgrade motion*, so the `sync` vs `setup` vs `provider pick` distinction (and why `ak sync` even pulls a prerelease) went undocumented. Real user hit this enabling ambidextrous dual-host.

## Contents

- The one rule, stated up front.
- A **`sync` vs `setup` vs `provider pick`** disambiguation table (does it change your `kit.json` choices?).
- The **dual-host worked example**: `ak sync` → `ak x provider pick --host claude,codex` → `ak x provider status`, including why the self-update-last ordering makes that sequence correct.
- **Why `ak sync` pulls a prerelease** — the `latest`/`next` dist-tag behavior, grounded in `selfDrift` (`src/lib/versions.mjs`).
- Links out to **ADR-0006** and **PROVIDERS.md** rather than restating them, keeping the ADRs authoritative.

## Discoverability

Cross-linked so it isn't orphaned:
- `docs/PROVIDERS.md` Level 1 — a `> [!NOTE]` callout for upgraders.
- `README.md` frontier-hosts section — pointer alongside the existing "Full guide" link.

## Test plan

Docs-only. Verified locally:
- `pnpm run lint:md` → `0 issues`
- `pnpm run lint:links:internal` → `0 Errors` (all new cross-links resolve)

🤖 Generated with [Claude Code](https://claude.com/claude-code)