### PR TITLE
Usage panel: Codex accuracy, transcript attribution, and a self-verifying docs system

### DIFF
--- a/docs/CODEX-USAGE-DIAGNOSTIC.md
+++ b/docs/CODEX-USAGE-DIAGNOSTIC.md
@@ -36,9 +36,8 @@ activity. Never affected any dollar or token figure.
 that matters for your numbers. Codex CLI's `thread_spawn` subagent
 delegation writes a session-log file for the spawned subagent that
 **replays its parent thread's entire prior token history** as duplicate
-events, before the subagent's own new turns even begin. This is a
-documented, previously-reported behavior of Codex CLI itself — not a theory
-invented for this project:
+events, before the subagent's own new turns even begin. This is documented,
+previously-reported Codex CLI behavior:
 
 - [`openai/codex#14489`](https://github.com/openai/codex/issues/14489) —
   Codex re-emitting a stale cumulative token count on rate-limit-only
@@ -134,8 +133,8 @@ discrepancy has a different explanation worth digging into further. If a
 meaningful percentage is excluded, that's the concrete number behind it —
 not a guess.
 
-## Reference
+## Appendix — references
 
 - Script: [`scripts/codex-usage-diagnostic.mjs`](../scripts/codex-usage-diagnostic.mjs)
-- Full metrics reference: [`docs/USAGE-SCORECARD-METRICS.md`](USAGE-SCORECARD-METRICS.md) (§15 covers these two bugs in full engineering detail)
+- Full metrics reference: [`docs/USAGE-SCORECARD-METRICS.md`](USAGE-SCORECARD-METRICS.md) (its Appendix A covers these two bugs in full engineering detail)
 - Design record: [`docs/adr/0009-usage-scorecard-local-transcript-analytics.md`](adr/0009-usage-scorecard-local-transcript-analytics.md)

--- a/docs/CODEX-USAGE-DIAGNOSTIC.md
+++ b/docs/CODEX-USAGE-DIAGNOSTIC.md
@@ -1,0 +1,141 @@
+# Verifying the Codex usage-scorecard fix on your own machine
+
+**For:** anyone who uses Codex CLI and wants to check whether the two bugs
+fixed on this branch affected their own numbers — without sharing any
+transcript content, session ids, titles, or file paths with anyone.
+
+**You don't need to read the rest of this repo to use this document.**
+Everything you need is below: what was wrong, why the fix can be trusted
+without re-auditing the code yourself, how to run one script, and exactly
+what to send back.
+
+---
+
+## The short version
+
+A usage dashboard in this project ([`ak x dashboard`](../README.md), Usage
+tab) reads local Claude Code and Codex CLI session logs and estimates what
+they'd have cost at list-price API rates. On one real machine, the Codex
+side of that estimate looked implausible — a single model row showing
+roughly $935,000 and 1.46 trillion tokens, attributed to under 2,000
+sessions, with **zero** recorded responses despite that volume.
+
+Investigation found two real bugs in how this project's code parses Codex's
+session logs (`src/lib/usage-index.mjs`, function `parseCodex`) — nothing
+wrong with Codex CLI itself, and nothing you did. Both are fixed on this
+branch. This document lets you check, on your own machine, whether either
+bug was actually inflating *your* numbers, and by how much.
+
+## What was wrong
+
+**Bug A — response counts were dropped for Codex.** Cosmetic only: every
+Codex model row showed "0 responses" in the dashboard regardless of real
+activity. Never affected any dollar or token figure.
+
+**Bug B — subagent delegation could double-bill tokens.** This is the one
+that matters for your numbers. Codex CLI's `thread_spawn` subagent
+delegation writes a session-log file for the spawned subagent that
+**replays its parent thread's entire prior token history** as duplicate
+events, before the subagent's own new turns even begin. This is a
+documented, previously-reported behavior of Codex CLI itself — not a theory
+invented for this project:
+
+- [`openai/codex#14489`](https://github.com/openai/codex/issues/14489) —
+  Codex re-emitting a stale cumulative token count on rate-limit-only
+  updates, which a naive reader double-counts.
+- [`ccusage/ccusage#884`](https://github.com/ccusage/ccusage/issues/884) —
+  a different Codex usage-analytics tool (same job as this project's Usage
+  tab) documenting that summing raw cumulative snapshots instead of taking
+  the last one matched only 131 of 732 real sessions correctly.
+- [`ccusage/ccusage#950`](https://github.com/ccusage/ccusage/issues/950) —
+  the closest match to what was found here: a parent session that spawned
+  12 subagents had its usage effectively counted 13 times over, because
+  every subagent's log replayed the full parent history. Measured **91×**
+  cost inflation in a real corpus (reported ~$9,041 against actual spend of
+  ~$100).
+
+This project's parser took each Codex log file's final cumulative token
+count at face value, with no check for whether that file was a subagent
+replaying its parent's history. The fix reads the field Codex CLI itself
+writes to mark this (`session_meta.thread_source`) and excludes a
+`"subagent"`-sourced file's tokens/cost from every total — while still
+showing the session itself in the dashboard's session list, so nothing is
+silently hidden.
+
+## Why you can trust this without re-reading the diff
+
+Three independent layers, so you don't have to take any single one on
+faith:
+
+1. **Prior art.** The three GitHub issues above describe this exact Codex
+   CLI behavior, observed by other people, in other tools, before this
+   project encountered it.
+2. **Regression tests.** The fix is pinned by test cases built from the
+   documented bug signature (`tests/kit/usage-index.test.mjs`), currently
+   passing 87/87.
+3. **A before/after comparison you can run yourself**, on your own data,
+   computed by code that does **not** import or reuse the fix — so it's an
+   independent check, not a restatement of the same claim. That's the
+   script below.
+
+If you want the full engineering detail — exact formulas, file:line
+citations, provider pricing sources — that's
+[`docs/USAGE-SCORECARD-METRICS.md`](USAGE-SCORECARD-METRICS.md). You do not
+need to read it to use this document.
+
+## How to check your own numbers
+
+You'll need Node.js 18 or newer (`node --version` to check) and a terminal.
+Nothing else — no `npm install`, no cloning this repo, no network access
+beyond the one download below, and nothing gets written to your disk except
+the script file itself.
+
+**1. Get the script.** If you already have this branch checked out:
+
+```bash
+node scripts/codex-usage-diagnostic.mjs
+```
+
+If you don't have the repo, just download the one file:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/pacphi/agentic-kit/fix/codex-usage-scorecard-metrics/scripts/codex-usage-diagnostic.mjs -o codex-usage-diagnostic.mjs
+node codex-usage-diagnostic.mjs
+```
+
+**2. Read the output before sending anything.** The script prints a report
+with two totals: **"before the fix"** (every session log counted — this
+should be close to what you'd currently see if you ran the unpatched
+dashboard) and **"after the fix"** (subagent-replay logs excluded). It also
+tells you what percentage of tokens/cost, if any, is attributable to
+subagent-replay logs.
+
+The script's own source is short and readable — open it in an editor if
+you want to confirm for yourself what it does before running it. In short:
+it walks `~/.codex/sessions/**/rollout-*.jsonl`, reads exactly three kinds
+of field per line (`type`, `session_meta.thread_source`, and the numeric
+fields inside `token_count.info.total_token_usage`), and never touches,
+stores, or prints anything else — no prompts, no titles, no session ids, no
+file paths, no timestamps. There is no code path in the script that could
+emit those even by accident, because it never reads them into a variable in
+the first place.
+
+## What to send back
+
+**Just the printed output block, in full — nothing else.** That's the
+complete, minimal report; there's no need to trim it further or describe
+your sessions in your own words. If you'd rather have a copy-pasteable
+single blob instead of the human-readable report, run it with `--json`
+instead.
+
+If "before" and "after" are close (a low or zero percentage excluded), this
+fix doesn't materially change what you were seeing, and the earlier
+discrepancy has a different explanation worth digging into further. If a
+meaningful percentage is excluded, that's the concrete number behind it —
+not a guess.
+
+## Reference
+
+- Script: [`scripts/codex-usage-diagnostic.mjs`](../scripts/codex-usage-diagnostic.mjs)
+- Full metrics reference: [`docs/USAGE-SCORECARD-METRICS.md`](USAGE-SCORECARD-METRICS.md) (§15 covers these two bugs in full engineering detail)
+- Design record: [`docs/adr/0009-usage-scorecard-local-transcript-analytics.md`](adr/0009-usage-scorecard-local-transcript-analytics.md)

--- a/docs/MANAGED-TOOLS.md
+++ b/docs/MANAGED-TOOLS.md
@@ -5,11 +5,8 @@ version-detected, and displayed. This doc states the contract's four
 invariants, maps every managed tool onto them, and gives the checklist for
 adding a new tool without breaking them.
 
-The contract exists because the failure modes it prevents were all observed
-live: a version stamp disagreeing with what was actually on disk, a statusline
-showing a different version than `ak status`, a third-party self-updater
-rewriting managed files behind ak's back, and an "update available" banner
-that stayed silent for tools it didn't know about.
+Each invariant traces to a live failure it prevents — the appendix records
+them.
 
 ## The four invariants
 
@@ -28,9 +25,9 @@ that stayed silent for tools it didn't know about.
 
 3. **Same-namespace comparisons.** Installed and latest are always compared
    in the same version namespace: npm semver vs npm semver, GitHub release
-   tag vs release tag. A comparison across namespaces (the original
-   ruvnet-brain bug: plugin semver `0.5.0-dev` vs release tag `3.0.1`) can
-   never converge. "Latest" is not always npm-latest either — agentdb's
+   tag vs release tag. A comparison across namespaces can never converge
+   (the appendix records the live case). "Latest" is not always npm-latest
+   either — agentdb's
    authority is ruflo's *bundled* version, because a latest-chasing agentdb
    is the store-corruption risk its coherence guard exists to prevent.
 
@@ -98,3 +95,14 @@ dashboard.
 6. **Lock it with tests**: the install spec + suppression flags (regression
    lock), the disk-read parser's edge cases (missing / malformed / junk),
    and the display resolution order.
+
+## Appendix — the observed failures behind the contract
+
+Each invariant exists because its failure mode was observed live, not
+hypothesized: a version stamp disagreeing with what was actually on disk; a
+statusline showing a different version than `ak status`; a third-party
+self-updater rewriting managed files behind ak's back; an "update available"
+banner that stayed silent for tools it didn't know about; and the original
+ruvnet-brain drift bug — a cross-namespace comparison (plugin semver
+`0.5.0-dev` vs release tag `3.0.1`) that could never converge, the live case
+behind invariant 3.

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -150,8 +150,7 @@ When **both** hosts are enabled and `agentic-qe ≥ 3.13.1` is installed, `ak` s
 review, …) is routed to the host and model that suits it — Claude for reasoning/review,
 Codex for execution — and materialized into `.agentic-qe/llm-config.json` (`agentOverrides`).
 It's seeded automatically on `ak x provider pick` / `ak setup`; nothing happens for
-claude-only projects. Grounded in ruflo's own dual-mode templates (see
-[docs/adr/](adr/) — ADR-0001..0005).
+claude-only projects.
 
 ```bash
 ak x provider pick --host claude,codex        # enables both → seeds routing → prints the table
@@ -215,7 +214,7 @@ The two config stores each knob below lives in — and their precedence — are 
 
 | You want to…                         | `ak` way                          | The raw ruflo/aqe way it maps to                    |
 | ------------------------------------ | --------------------------------- | --------------------------------------------------- |
-| Enable claude/codex hosts            | `ak x provider pick`              | `ENABLE_CLAUDE_CODE` / `ENABLE_CODEX` env (ADR-034) + `ruflo init --dual` |
+| Enable claude/codex hosts            | `ak x provider pick`              | `ENABLE_CLAUDE_CODE` / `ENABLE_CODEX` env + `ruflo init --dual` |
 | Register a ruflo LLM provider        | `--provider openai:gpt-5.6`       | `ruflo providers configure -p openai -m gpt-5.6`    |
 | Set which LLM runs QE                | `--aqe-provider gemini`           | `AQE_LLM_PROVIDER=gemini` (env)                     |
 | Order QE's fallback chain            | `--aqe-fallback '…'`              | edit `.agentic-qe/llm-config.json` / `aqe llm-router config` |
@@ -240,3 +239,12 @@ status` and `ak sync` keep everything converged and flag drift in between.
 **The shape of the whole thing:** Level 0 is the 90% case and costs nothing. Each level up is
 one flag, and the bottom is always the tools' own knobs — `ak` never traps your config, it
 just makes the good default automatic and the customization reversible.
+
+## Appendix — design references
+
+- Per-activity routing and dual-host seeding: [docs/adr/](adr/) ADR-0001..0005;
+  grounded in ruflo's own dual-mode templates.
+- Primary-host selection and ambidextrous mirroring:
+  [ADR-0006](adr/0006-primary-host-and-ambidextrous-mirroring.md).
+- Host env flags (`ENABLE_CLAUDE_CODE` / `ENABLE_CODEX`): upstream ruflo
+  ADR-034, "Optional MCP Backends".

--- a/docs/TRANSCRIPTS.md
+++ b/docs/TRANSCRIPTS.md
@@ -1,4 +1,4 @@
-# Transcripts & Session Detail — Maintainer Reference
+# Transcripts & Session Detail — Reference
 
 **Audience.** agentic-kit maintainers and contributors touching the transcript
 pipeline — `src/lib/usage-index.mjs` (parsing, `readSession`) or
@@ -160,7 +160,7 @@ and image-only pastes get the right kind" (the two edges).
 
 ## 4. The `readSession` pipeline — how one session becomes a payload
 
-`readSession(id, opts)` (`usage-index.mjs:1050-1139`) is the only way
+`readSession(id, opts)` (`usage-index.mjs:1050-1133`) is the only way
 transcript content leaves the module, and every step is a gate:
 
 ### 4.1 Locate, contain, bound
@@ -205,8 +205,8 @@ serialization**, then length-capped at `MAX_TURN_CHARS` (40,000,
 
 The two kinds of withholding keep distinct vocabulary end-to-end: masking
 renders as `…redacted` marks (`markRedactions`,
-`dashboard-server.mjs:2171`), truncation as a `truncated · N of M` badge
-(`truncBadge`, `dashboard-server.mjs:2187`, deriving N from the received
+`dashboard-server.mjs:2184`), truncation as a `truncated · N of M` badge
+(`truncBadge`, `dashboard-server.mjs:2222`, deriving N from the received
 text so a changed constant can't desync the display).
 
 ---
@@ -250,13 +250,13 @@ nothing on the page to reveal (ADR-0009 §8).
 
 ### 6.1 Sessions view — the row and its expander
 
-`renderSessions` (`dashboard-server.mjs:2120`) renders the project tree
+`renderSessions` (`dashboard-server.mjs:2133`) renders the project tree
 (collapsed by default; every project starts closed so the cross-project
 comparison stays above the fold). Each session is a `sessionRow`
-(`dashboard-server.mjs:2094-2118`): host chip (claude/codex), title,
+(`dashboard-server.mjs:2107-2131`): host chip (claude/codex), title,
 worktree glyph, category chip (dimmed when confidence < 0.6 or
 Unclassified), start, duration, `prompts/responses`, tokens, cost — and an
-expander (`sdetail`, `dashboard-server.mjs:2061-2091`) carrying the ten
+expander (`sdetail`, `dashboard-server.mjs:2074-2104`) carrying the ten
 fields that once shipped on the wire and rendered nowhere (ADR-0009 §5
 Amendment): classification `basis` + confidence, per-session `models`, the
 token split, top tools, and the `skill`/`plugin`/`sidechain`/`worktree`
@@ -265,10 +265,10 @@ field that vanishes when null teaches the reader it doesn't exist.
 
 ### 6.2 Transcript view — attribution, redaction, truncation
 
-`renderTranscript` (`dashboard-server.mjs:2203`) renders the crumb (title,
+`renderTranscript` (`dashboard-server.mjs:2238`) renders the crumb (title,
 project, duration, `prompts/responses`, tokens, cost — all from masked
 `meta`) and the turn list. **The label comes from `kind`, never from role**
-(`dashboard-server.mjs:2219-2236`):
+(`dashboard-server.mjs:2254-2271`):
 
 | Turn | Label | Styling |
 |---|---|---|
@@ -280,9 +280,26 @@ project, duration, `prompts/responses`, tokens, cost — all from masked
 A turn without `kind` (defensive only — the reader path never serves cached
 turns) falls back to the `prompt` flag, `false` ⇒ `tool result`.
 
+**Harness sentinel markup is restyled, never rewritten.** Claude Code writes
+XML wrappers into transcript *text* — a slash command records as a
+`<command-name>/<command-message>/<command-args>` triple, and injected
+context as `<system-reminder>` / `<local-command-caveat>` /
+`<local-command-stdout>` blocks (the six shapes measured in the real corpus;
+`command-contents`/`stderr`: zero occurrences). Rendered literally they read
+as angle-bracket soup, so `fmtHarness` (`dashboard-server.mjs:2197-2210`)
+reformats them client-side: the command triple becomes a `/clear`-style chip
+(args kept, the redundant message surfaced as a hover title only when it
+differs from the name), and the three block wrappers become quiet labelled
+panels (`system reminder` / `caveat` / `command output` — CSS
+`dashboard-server.mjs:1275-1287`). This is presentation only, per the same
+no-silent-alteration rule that governs masking: **wrapped content stays
+verbatim; only the wrapper tags become styling.** It runs on escaped text
+(after `markRedactions`), and an unmatched tag — e.g. one cut mid-block by
+turn truncation — is left raw rather than half-formatted.
+
 Deep links: `#usage/<sessionId>` opens the Transcript view directly
-(`syncHash`, `dashboard-server.mjs:1390-1391`); the view lazy-fetches via
-`loadTranscript` (`dashboard-server.mjs:1864`).
+(`syncHash`, `dashboard-server.mjs:1403-1404`); the view lazy-fetches via
+`loadTranscript` (`dashboard-server.mjs:1877`).
 
 ### 6.3 Verified against real data
 

--- a/docs/TRANSCRIPTS.md
+++ b/docs/TRANSCRIPTS.md
@@ -34,44 +34,44 @@ rewritten; rule 3 of the module header, `usage-index.mjs:22-29`):
 
 | Provider | Store | Discovered by |
 |---|---|---|
-| Claude Code | `~/.claude/projects/<encoded-project-dir>/<sessionId>.jsonl` | `listClaude` (`usage-index.mjs:579`) — exactly one level of project directories |
-| Codex CLI | `~/.codex/sessions/<yyyy>/<mm>/<dd>/rollout-<ts>-<uuid>.jsonl` | `listCodex` (`usage-index.mjs:594`) — the `yyyy/mm/dd` tree walk |
+| Claude Code | `~/.claude/projects/<encoded-project-dir>/<sessionId>.jsonl` | `listClaude` (`usage-index.mjs:607`) — exactly one level of project directories |
+| Codex CLI | `~/.codex/sessions/<yyyy>/<mm>/<dd>/rollout-<ts>-<uuid>.jsonl` | `listCodex` (`usage-index.mjs:622`) — the `yyyy/mm/dd` tree walk |
 
-Roots come from `defaultRoots()` (`usage-index.mjs:571`) and are injectable
+Roots come from `defaultRoots()` (`usage-index.mjs:599`) and are injectable
 for tests. A malformed line is skipped, never fatal (`jsonLines`,
-`usage-index.mjs:270` — one corrupt line must not cost a whole file).
+`usage-index.mjs:274` — one corrupt line must not cost a whole file).
 
 ### 1.1 Claude entry vocabulary
 
 Each line has a top-level `type`. The parser (`parseClaude`,
-`usage-index.mjs:389-472`) reads:
+`usage-index.mjs:417-500`) reads:
 
 | `type` | What the parser takes from it |
 |---|---|
-| `ai-title` | The model-written session title (`usage-index.mjs:397`) — preferred over the first-prompt fallback |
+| `ai-title` | The model-written session title (`usage-index.mjs:425`) — preferred over the first-prompt fallback |
 | `user` | A user-**role** turn — which is *not* the same as "the human"; see §3 |
-| `assistant` | A model turn: `model` id, per-turn `usage` token counts, `tool_use` blocks (`usage-index.mjs:417-460`) |
-| any | Side-band fields read regardless of type: `attributionSkill`/`attributionPlugin` (`usage-index.mjs:398-399`), `isSidechain` (`usage-index.mjs:400`), `cwd` for project derivation |
+| `assistant` | A model turn: `model` id, per-turn `usage` token counts, `tool_use` blocks (`usage-index.mjs:445-488`) |
+| any | Side-band fields read regardless of type: `attributionSkill`/`attributionPlugin` (`usage-index.mjs:426-427`), `isSidechain` (`usage-index.mjs:428`), `cwd` for project derivation |
 
 An assistant entry with `isApiErrorMessage: true` is a **local placeholder**
 Claude Code writes when a request dies before a real completion (connection
 drop, rate limit, auth failure — `model: "<synthetic>"`, all-zero usage). It
 is real engaged time but not a model attempt: counted as an *exception*, never
-pushed into `models` or priced (`usage-index.mjs:431-440`; the full story is
+pushed into `models` or priced (`usage-index.mjs:459-468`; the full story is
 [`USAGE-SCORECARD-METRICS.md`](USAGE-SCORECARD-METRICS.md) §10).
 
 ### 1.2 Codex entry vocabulary
 
 Codex rollout lines carry `type` + `payload`. The parser (`parseCodex`,
-`usage-index.mjs:489-559`) reads:
+`usage-index.mjs:517-587`) reads:
 
 | `type` / `payload.type` | What the parser takes from it |
 |---|---|
-| `session_meta` | Authoritative session id, `cwd`, and `thread_source` (`usage-index.mjs:501-506`) — `"subagent"` marks a thread_spawn replay whose tokens are excluded from aggregation (`usage-index.mjs:544`; `USAGE-SCORECARD-METRICS.md` §15 Bug B) |
-| `turn_context` | The model id in effect from this point on (`usage-index.mjs:507`) |
-| `event_msg` → `token_count` | A **cumulative** usage snapshot; only the last one is kept (`usage-index.mjs:514`) |
-| `event_msg` → `user_message` | A real human prompt — Codex does not route tool output through this event (`usage-index.mjs:519-527`) |
-| `event_msg` → `agent_message` | A model response (`usage-index.mjs:529-540`) |
+| `session_meta` | Authoritative session id, `cwd`, and `thread_source` (`usage-index.mjs:529-534`) — `"subagent"` marks a thread_spawn replay whose tokens are excluded from aggregation (`usage-index.mjs:572`; `USAGE-SCORECARD-METRICS.md` §15 Bug B) |
+| `turn_context` | The model id in effect from this point on (`usage-index.mjs:535`) |
+| `event_msg` → `token_count` | A **cumulative** usage snapshot; only the last one is kept (`usage-index.mjs:542`) |
+| `event_msg` → `user_message` | A real human prompt — Codex does not route tool output through this event (`usage-index.mjs:547-555`) |
+| `event_msg` → `agent_message` | A model response (`usage-index.mjs:557-568`) |
 
 Codex tool calls and tool outputs travel in event types the parser does not
 surface as turns at all — so a Codex transcript renders as a prompt/response
@@ -87,14 +87,14 @@ The same parsers serve two very different callers, switched by `withTurns`:
 
 | Path | Entry point | `withTurns` | Message bodies | Cached? |
 |---|---|---|---|---|
-| **Scan** — the aggregate index behind the Scorecard/Findings/Sessions views | `buildIndex` → `parseFile` (`usage-index.mjs:624`) | `false` | never held — holding them would balloon memory across 3,000+ files (`usage-index.mjs:385-388`) | yes: per-file derived records in `~/.config/agentic-kit/usage-index.json`, keyed `(path, mtime, size)`, invalidated wholesale by `SCHEMA_VERSION` (`usage-index.mjs:46`) |
-| **Reader** — one transcript for the Transcript view | `readSession` (`usage-index.mjs:1050`) | `true` | full turn list built | **never** — every call re-reads and re-parses the one file |
+| **Scan** — the aggregate index behind the Scorecard/Findings/Sessions views | `buildIndex` → `parseFile` (`usage-index.mjs:652`) | `false` | never held — holding them would balloon memory across 3,000+ files (`usage-index.mjs:413-416`) | yes: per-file derived records in `~/.config/agentic-kit/usage-index.json`, keyed `(path, mtime, size)`, invalidated wholesale by `SCHEMA_VERSION` (`usage-index.mjs:50`) |
+| **Reader** — one transcript for the Transcript view | `readSession` (`usage-index.mjs:1078`) | `true` | full turn list built | **never** — every call re-reads and re-parses the one file |
 
 The reader path being cache-free is load-bearing for maintainers: **turn-shape
 changes (like the `kind` field, §3) need no `SCHEMA_VERSION` bump**, because
 no turn is ever served from cache — whereas *session-record* fields (like
 `exceptions`) do, since stale cached records would otherwise sum `undefined`
-into totals (the v4 bump note, `usage-index.mjs:39-45`, records exactly that
+into totals (the v4/v5 bump notes, `usage-index.mjs:39-49`, records exactly that
 incident).
 
 ---
@@ -107,11 +107,11 @@ incident).
 |---|---|---|
 | `role` | all | `"user"` or `"assistant"` — the **Messages-API role**, not the author (see below) |
 | `at` | all | ISO timestamp |
-| `text` | all | Flattened display text (`claudeText`, `usage-index.mjs:334` — binary payloads dropped: a pasted screenshot renders as `[image]`, a tool result is prefixed `[tool result]`) |
-| `model` | assistant | The model id; the literal string `exception` for an API-error placeholder turn (`usage-index.mjs:435`) |
+| `text` | all | Flattened display text (`claudeText`, `usage-index.mjs:338` — binary payloads dropped: a pasted screenshot renders as `[image]`, a tool result is prefixed `[tool result]`) |
+| `model` | assistant | The model id; the literal string `exception` for an API-error placeholder turn (`usage-index.mjs:463`) |
 | `tools` | assistant | Tool names invoked in the turn |
-| `prompt` | user | `isHumanPrompt`'s verdict (`usage-index.mjs:354-362`) — drives the **prompt counts** |
-| `kind` | user | `'prompt'` \| `'tool-result'` \| `'context'` — drives the **attribution label** (`userTurnKind`, `usage-index.mjs:377-388`) |
+| `prompt` | user | `isHumanPrompt`'s verdict (`usage-index.mjs:378-387`) — drives the **prompt counts** |
+| `kind` | user | `'prompt'` \| `'tool-result'` \| `'context'` — drives the **attribution label** (`userTurnKind`, `usage-index.mjs:405-416`) |
 | `exception` | assistant | `true` on API-error placeholder turns |
 | `truncated`, `originalChars` | any | Present **only** when the turn was abridged (§4.3) |
 
@@ -129,13 +129,13 @@ machinery fixes (ADR-0009 §8, Amendment 2026-07-26).
 
 ### 3.2 `kind` — the attribution field
 
-`userTurnKind` (`usage-index.mjs:377-388`) classifies every user-role turn:
+`userTurnKind` (`usage-index.mjs:405-416`) classifies every user-role turn:
 
 | `kind` | Test | Meaning |
 |---|---|---|
 | `tool-result` | content carries a `tool_result` block | Output the **harness** fed back to the model after a tool call |
-| `context` | `isMeta` | Harness-injected context — command output, system reminders |
-| `prompt` | everything else | The person |
+| `context` | `isMeta`, **or** the text opens with a harness-output envelope (`HARNESS_OUTPUT_RE`: `task-notification`, `bash-stdout`/`-stderr`, `local-command-stdout`/`-stderr`, `local-command-caveat`) | Harness-injected content — neither the person **nor the model**. These envelopes carry neither `isMeta` nor a `tool_result`, so text shape is the only signal; measured on the real corpus: task-notification 550, bash-stdout 85, local-command-stdout 60 — all previously labelled "you" |
+| `prompt` | everything else | The person — including `bash-input` (a `! command` the person typed) and slash-command records (the person invoked them) |
 
 Two deliberate subtleties:
 
@@ -144,12 +144,17 @@ Two deliberate subtleties:
   *counted* as a text prompt) — but it **is** the person acting, and
   `userTurnKind` returns `'prompt'` for it. "Not countable as a text prompt"
   and "not the human" are different claims; conflating them was how the
-  original bug happened. The `prompt` boolean is left untouched so prompt
-  counts don't shift.
+  original bug happened.
+- **Harness-output envelopes are excluded from the prompt *count* too.**
+  `isHumanPrompt` shares `HARNESS_OUTPUT_RE`, so a session's `prompts` figure
+  no longer counts stdout dumps or task notifications as things the person
+  said — on the reference session this corrected 32 claimed prompts to 20
+  real ones. Cached session records carry the old inflated counts, hence
+  `SCHEMA_VERSION` 5 (`usage-index.mjs:46-50`).
 - **`tool-result` outranks `context`**: a `tool_result` block on an `isMeta`
   entry is still tool feedback.
 
-Codex user turns are `kind: 'prompt'` by construction (`usage-index.mjs:519-527`)
+Codex user turns are `kind: 'prompt'` by construction (`usage-index.mjs:547-555`)
 — rollouts only record real prompts as `user_message` events (§1.2).
 
 Coverage: `tests/kit/usage-index.test.mjs` — "user-role turns carry a kind"
@@ -160,31 +165,31 @@ and image-only pastes get the right kind" (the two edges).
 
 ## 4. The `readSession` pipeline — how one session becomes a payload
 
-`readSession(id, opts)` (`usage-index.mjs:1050-1133`) is the only way
+`readSession(id, opts)` (`usage-index.mjs:1078-1161`) is the only way
 transcript content leaves the module, and every step is a gate:
 
 ### 4.1 Locate, contain, bound
 
 1. **Id grammar before any filesystem access** — `VALID_ID`
-   (`/^[A-Za-z0-9._-]{1,128}$/`, `usage-index.mjs:61`) rejects traversal
-   shapes with `ERR_INVALID_SESSION_ID` (`usage-index.mjs:1051`).
-2. **Locate by id** across both roots (`locate`, `usage-index.mjs:1009`),
+   (`/^[A-Za-z0-9._-]{1,128}$/`, `usage-index.mjs:65`) rejects traversal
+   shapes with `ERR_INVALID_SESSION_ID` (`usage-index.mjs:1079`).
+2. **Locate by id** across both roots (`locate`, `usage-index.mjs:1037`),
    consulting the scan cache when present but never requiring it —
    `readSession` works with no prior `buildIndex`.
-3. **Realpath containment** (`usage-index.mjs:1057-1071`) — the resolved file
+3. **Realpath containment** (`usage-index.mjs:1085-1099`) — the resolved file
    must live under a transcript root *after* `realpathSync` collapses
    symlinks; a symlink planted inside a root pointing at `/etc/anything`
    passes a lexical `startsWith` but fails this. Roots are realpath'd too so
    a symlinked dotfiles setup still works.
-4. **Size cap** — `MAX_SESSION_BYTES` (64 MB, `usage-index.mjs:60`): a
+4. **Size cap** — `MAX_SESSION_BYTES` (64 MB, `usage-index.mjs:64`): a
    transcript is read whole and JSON-expands ~5×, so an unbounded read is a
    memory-amplification primitive. Oversized reads as unavailable, not risky.
 
 ### 4.2 Parse and price
 
 The file is parsed with `withTurns: true` by the provider's parser
-(`usage-index.mjs:1082-1088`), and `meta` is assembled
-(`usage-index.mjs:1096-1115`) with the same fields the Sessions view rows
+(`usage-index.mjs:1110-1116`), and `meta` is assembled
+(`usage-index.mjs:1124-1143`) with the same fields the Sessions view rows
 carry — `prompts`, `responses`, `exceptions`, `sidechain`, `threadSource`,
 `models`, `tools`, `skill`/`plugin`, worktree — plus a `cost` priced from the
 same per-model usage rows `aggregate()` uses (the header used to render a
@@ -192,11 +197,11 @@ hardcoded `$0.00`; the comment at the site records why).
 
 ### 4.3 Mask, then truncate — both marked, differently
 
-Every turn body is passed through `maskSecrets` (`usage-index.mjs:162` — the
+Every turn body is passed through `maskSecrets` (`usage-index.mjs:166` — the
 21 secret shapes ADR-0009 §8 enumerates) **server-side, before
 serialization**, then length-capped at `MAX_TURN_CHARS` (40,000,
-`usage-index.mjs:55`) with the marker appended
-(`usage-index.mjs:1116-1132`). Two invariants:
+`usage-index.mjs:59`) with the marker appended
+(`usage-index.mjs:1144-1160`). Two invariants:
 
 - **Presence is the signal.** `truncated`/`originalChars` are emitted only
   when the slice fired, so a complete turn cannot be misread as abridged.
@@ -206,7 +211,7 @@ serialization**, then length-capped at `MAX_TURN_CHARS` (40,000,
 The two kinds of withholding keep distinct vocabulary end-to-end: masking
 renders as `…redacted` marks (`markRedactions`,
 `dashboard-server.mjs:2184`), truncation as a `truncated · N of M` badge
-(`truncBadge`, `dashboard-server.mjs:2222`, deriving N from the received
+(`truncBadge`, `dashboard-server.mjs:2228`, deriving N from the received
 text so a changed constant can't desync the display).
 
 ---
@@ -265,10 +270,10 @@ field that vanishes when null teaches the reader it doesn't exist.
 
 ### 6.2 Transcript view — attribution, redaction, truncation
 
-`renderTranscript` (`dashboard-server.mjs:2238`) renders the crumb (title,
+`renderTranscript` (`dashboard-server.mjs:2244`) renders the crumb (title,
 project, duration, `prompts/responses`, tokens, cost — all from masked
 `meta`) and the turn list. **The label comes from `kind`, never from role**
-(`dashboard-server.mjs:2254-2271`):
+(`dashboard-server.mjs:2260-2277`):
 
 | Turn | Label | Styling |
 |---|---|---|
@@ -281,17 +286,22 @@ A turn without `kind` (defensive only — the reader path never serves cached
 turns) falls back to the `prompt` flag, `false` ⇒ `tool result`.
 
 **Harness sentinel markup is restyled, never rewritten.** Claude Code writes
-XML wrappers into transcript *text* — a slash command records as a
-`<command-name>/<command-message>/<command-args>` triple, and injected
-context as `<system-reminder>` / `<local-command-caveat>` /
-`<local-command-stdout>` blocks (the six shapes measured in the real corpus;
-`command-contents`/`stderr`: zero occurrences). Rendered literally they read
-as angle-bracket soup, so `fmtHarness` (`dashboard-server.mjs:2197-2210`)
-reformats them client-side: the command triple becomes a `/clear`-style chip
-(args kept, the redundant message surfaced as a hover title only when it
-differs from the name), and the three block wrappers become quiet labelled
-panels (`system reminder` / `caveat` / `command output` — CSS
-`dashboard-server.mjs:1275-1287`). This is presentation only, per the same
+XML wrappers into transcript *text*: a slash command records as a
+`<command-name>/<command-message>/<command-args>` triple, a `! command` the
+person ran records as `<bash-input>`, and harness-fed content as
+`<bash-stdout>`/`<bash-stderr>`, `<local-command-stdout>`/`-stderr`,
+`<local-command-caveat>`, `<system-reminder>`, and `<task-notification>`
+blocks (envelope census on the real corpus: task-notification 550,
+local-command-caveat 183, command-name 180, bash-input 85, bash-stdout 85,
+local-command-stdout 60; the stderr variants are the symmetric error-path
+siblings). Rendered literally they read as angle-bracket soup, so
+`fmtHarness` (`dashboard-server.mjs:2197-2216`; CSS
+`dashboard-server.mjs:1275-1287`) reformats them client-side: the command
+triple and `bash-input`
+become chips (`/clear`-style; the bash chip prefixed `!` so it reads as the
+shell invocation it was), and the block wrappers become quiet labelled
+panels (`system reminder` / `caveat` / `command output` / `bash output` /
+`task notification`). This is presentation only, per the same
 no-silent-alteration rule that governs masking: **wrapped content stays
 verbatim; only the wrapper tags become styling.** It runs on escaped text
 (after `markRedactions`), and an unmatched tag — e.g. one cut mid-block by

--- a/docs/TRANSCRIPTS.md
+++ b/docs/TRANSCRIPTS.md
@@ -1,0 +1,328 @@
+# Transcripts & Session Detail — Maintainer Reference
+
+**Audience.** agentic-kit maintainers and contributors touching the transcript
+pipeline — `src/lib/usage-index.mjs` (parsing, `readSession`) or
+`src/lib/dashboard-server.mjs` (the `/api/session` route, the Sessions and
+Transcript views) — and anyone auditing why a transcript turn is labelled,
+masked, truncated, or attributed the way it is.
+
+**Purpose.** The Transcript view renders raw session content, which makes it
+the panel's highest-stakes surface: a wrong label misattributes work, an
+unmarked redaction misrepresents content, and a leaked secret amplifies into a
+screenshare. This document explains, with source citations, how a session on
+disk becomes the metadata and turns the browser renders — the full path:
+transcript stores → parsers → turn model → `readSession` → masking/truncation
+→ HTTP → UI. Its companion,
+[`USAGE-SCORECARD-METRICS.md`](USAGE-SCORECARD-METRICS.md), covers the
+*aggregate* pipeline (cost/token/time arithmetic); this document covers the
+*per-session* pipeline. The design rationale for both is ADR-0009
+([`docs/adr/0009-usage-scorecard-local-transcript-analytics.md`](adr/0009-usage-scorecard-local-transcript-analytics.md)),
+§8 in particular.
+
+**Pinned to.** branch `fix/codex-usage-scorecard-metrics`, 2026-07-26 (the
+commit introducing turn `kind` attribution). Line numbers drift as code
+changes; every citation below was content-verified against the source at
+writing time.
+
+---
+
+## 1. The two transcript stores
+
+Both providers write complete session logs to disk as JSONL — one JSON object
+per line — and the kit reads them **read-only** (transcripts are never
+rewritten; rule 3 of the module header, `usage-index.mjs:22-29`):
+
+| Provider | Store | Discovered by |
+|---|---|---|
+| Claude Code | `~/.claude/projects/<encoded-project-dir>/<sessionId>.jsonl` | `listClaude` (`usage-index.mjs:579`) — exactly one level of project directories |
+| Codex CLI | `~/.codex/sessions/<yyyy>/<mm>/<dd>/rollout-<ts>-<uuid>.jsonl` | `listCodex` (`usage-index.mjs:594`) — the `yyyy/mm/dd` tree walk |
+
+Roots come from `defaultRoots()` (`usage-index.mjs:571`) and are injectable
+for tests. A malformed line is skipped, never fatal (`jsonLines`,
+`usage-index.mjs:270` — one corrupt line must not cost a whole file).
+
+### 1.1 Claude entry vocabulary
+
+Each line has a top-level `type`. The parser (`parseClaude`,
+`usage-index.mjs:389-472`) reads:
+
+| `type` | What the parser takes from it |
+|---|---|
+| `ai-title` | The model-written session title (`usage-index.mjs:397`) — preferred over the first-prompt fallback |
+| `user` | A user-**role** turn — which is *not* the same as "the human"; see §3 |
+| `assistant` | A model turn: `model` id, per-turn `usage` token counts, `tool_use` blocks (`usage-index.mjs:417-460`) |
+| any | Side-band fields read regardless of type: `attributionSkill`/`attributionPlugin` (`usage-index.mjs:398-399`), `isSidechain` (`usage-index.mjs:400`), `cwd` for project derivation |
+
+An assistant entry with `isApiErrorMessage: true` is a **local placeholder**
+Claude Code writes when a request dies before a real completion (connection
+drop, rate limit, auth failure — `model: "<synthetic>"`, all-zero usage). It
+is real engaged time but not a model attempt: counted as an *exception*, never
+pushed into `models` or priced (`usage-index.mjs:431-440`; the full story is
+[`USAGE-SCORECARD-METRICS.md`](USAGE-SCORECARD-METRICS.md) §10).
+
+### 1.2 Codex entry vocabulary
+
+Codex rollout lines carry `type` + `payload`. The parser (`parseCodex`,
+`usage-index.mjs:489-559`) reads:
+
+| `type` / `payload.type` | What the parser takes from it |
+|---|---|
+| `session_meta` | Authoritative session id, `cwd`, and `thread_source` (`usage-index.mjs:501-506`) — `"subagent"` marks a thread_spawn replay whose tokens are excluded from aggregation (`usage-index.mjs:544`; `USAGE-SCORECARD-METRICS.md` §15 Bug B) |
+| `turn_context` | The model id in effect from this point on (`usage-index.mjs:507`) |
+| `event_msg` → `token_count` | A **cumulative** usage snapshot; only the last one is kept (`usage-index.mjs:514`) |
+| `event_msg` → `user_message` | A real human prompt — Codex does not route tool output through this event (`usage-index.mjs:519-527`) |
+| `event_msg` → `agent_message` | A model response (`usage-index.mjs:529-540`) |
+
+Codex tool calls and tool outputs travel in event types the parser does not
+surface as turns at all — so a Codex transcript renders as a prompt/response
+conversation without the tool-result interleaving a Claude transcript shows.
+That is a fidelity gap (less detail), not an attribution bug (nothing is
+mislabelled).
+
+---
+
+## 2. Two read paths: scan vs reader
+
+The same parsers serve two very different callers, switched by `withTurns`:
+
+| Path | Entry point | `withTurns` | Message bodies | Cached? |
+|---|---|---|---|---|
+| **Scan** — the aggregate index behind the Scorecard/Findings/Sessions views | `buildIndex` → `parseFile` (`usage-index.mjs:624`) | `false` | never held — holding them would balloon memory across 3,000+ files (`usage-index.mjs:385-388`) | yes: per-file derived records in `~/.config/agentic-kit/usage-index.json`, keyed `(path, mtime, size)`, invalidated wholesale by `SCHEMA_VERSION` (`usage-index.mjs:46`) |
+| **Reader** — one transcript for the Transcript view | `readSession` (`usage-index.mjs:1050`) | `true` | full turn list built | **never** — every call re-reads and re-parses the one file |
+
+The reader path being cache-free is load-bearing for maintainers: **turn-shape
+changes (like the `kind` field, §3) need no `SCHEMA_VERSION` bump**, because
+no turn is ever served from cache — whereas *session-record* fields (like
+`exceptions`) do, since stale cached records would otherwise sum `undefined`
+into totals (the v4 bump note, `usage-index.mjs:39-45`, records exactly that
+incident).
+
+---
+
+## 3. The turn model — and why `role: "user"` does not mean "the human"
+
+`readSession` returns `{ meta, turns }`. Each turn carries:
+
+| Field | On | Meaning |
+|---|---|---|
+| `role` | all | `"user"` or `"assistant"` — the **Messages-API role**, not the author (see below) |
+| `at` | all | ISO timestamp |
+| `text` | all | Flattened display text (`claudeText`, `usage-index.mjs:334` — binary payloads dropped: a pasted screenshot renders as `[image]`, a tool result is prefixed `[tool result]`) |
+| `model` | assistant | The model id; the literal string `exception` for an API-error placeholder turn (`usage-index.mjs:435`) |
+| `tools` | assistant | Tool names invoked in the turn |
+| `prompt` | user | `isHumanPrompt`'s verdict (`usage-index.mjs:354-362`) — drives the **prompt counts** |
+| `kind` | user | `'prompt'` \| `'tool-result'` \| `'context'` — drives the **attribution label** (`userTurnKind`, `usage-index.mjs:377-388`) |
+| `exception` | assistant | `true` on API-error placeholder turns |
+| `truncated`, `originalChars` | any | Present **only** when the turn was abridged (§4.3) |
+
+### 3.1 The role≠author problem
+
+The Messages API records two things under `role: "user"` that the person never
+typed: **tool results** (after the model calls a tool, the harness feeds the
+output back as a user-role message — that is the wire format, not a kit
+choice) and **harness context injections** (`isMeta` entries: command outputs,
+system reminders). In a heavily agentic session these dominate: a measured
+real session on the reference machine had **20 human prompts and 276 tool
+results** — so a renderer that labels by role attributes ~93% of "you" turns
+to a person who never typed them. That was the shipped bug this section's
+machinery fixes (ADR-0009 §8, Amendment 2026-07-26).
+
+### 3.2 `kind` — the attribution field
+
+`userTurnKind` (`usage-index.mjs:377-388`) classifies every user-role turn:
+
+| `kind` | Test | Meaning |
+|---|---|---|
+| `tool-result` | content carries a `tool_result` block | Output the **harness** fed back to the model after a tool call |
+| `context` | `isMeta` | Harness-injected context — command output, system reminders |
+| `prompt` | everything else | The person |
+
+Two deliberate subtleties:
+
+- **`kind` is broader than `prompt` on the image-only edge.** An image-only
+  paste has no text block, so `isHumanPrompt` returns `false` (it is not
+  *counted* as a text prompt) — but it **is** the person acting, and
+  `userTurnKind` returns `'prompt'` for it. "Not countable as a text prompt"
+  and "not the human" are different claims; conflating them was how the
+  original bug happened. The `prompt` boolean is left untouched so prompt
+  counts don't shift.
+- **`tool-result` outranks `context`**: a `tool_result` block on an `isMeta`
+  entry is still tool feedback.
+
+Codex user turns are `kind: 'prompt'` by construction (`usage-index.mjs:519-527`)
+— rollouts only record real prompts as `user_message` events (§1.2).
+
+Coverage: `tests/kit/usage-index.test.mjs` — "user-role turns carry a kind"
+(both providers, the fixture's real `tool_result` entry) and "isMeta context
+and image-only pastes get the right kind" (the two edges).
+
+---
+
+## 4. The `readSession` pipeline — how one session becomes a payload
+
+`readSession(id, opts)` (`usage-index.mjs:1050-1139`) is the only way
+transcript content leaves the module, and every step is a gate:
+
+### 4.1 Locate, contain, bound
+
+1. **Id grammar before any filesystem access** — `VALID_ID`
+   (`/^[A-Za-z0-9._-]{1,128}$/`, `usage-index.mjs:61`) rejects traversal
+   shapes with `ERR_INVALID_SESSION_ID` (`usage-index.mjs:1051`).
+2. **Locate by id** across both roots (`locate`, `usage-index.mjs:1009`),
+   consulting the scan cache when present but never requiring it —
+   `readSession` works with no prior `buildIndex`.
+3. **Realpath containment** (`usage-index.mjs:1057-1071`) — the resolved file
+   must live under a transcript root *after* `realpathSync` collapses
+   symlinks; a symlink planted inside a root pointing at `/etc/anything`
+   passes a lexical `startsWith` but fails this. Roots are realpath'd too so
+   a symlinked dotfiles setup still works.
+4. **Size cap** — `MAX_SESSION_BYTES` (64 MB, `usage-index.mjs:60`): a
+   transcript is read whole and JSON-expands ~5×, so an unbounded read is a
+   memory-amplification primitive. Oversized reads as unavailable, not risky.
+
+### 4.2 Parse and price
+
+The file is parsed with `withTurns: true` by the provider's parser
+(`usage-index.mjs:1082-1088`), and `meta` is assembled
+(`usage-index.mjs:1096-1115`) with the same fields the Sessions view rows
+carry — `prompts`, `responses`, `exceptions`, `sidechain`, `threadSource`,
+`models`, `tools`, `skill`/`plugin`, worktree — plus a `cost` priced from the
+same per-model usage rows `aggregate()` uses (the header used to render a
+hardcoded `$0.00`; the comment at the site records why).
+
+### 4.3 Mask, then truncate — both marked, differently
+
+Every turn body is passed through `maskSecrets` (`usage-index.mjs:162` — the
+21 secret shapes ADR-0009 §8 enumerates) **server-side, before
+serialization**, then length-capped at `MAX_TURN_CHARS` (40,000,
+`usage-index.mjs:55`) with the marker appended
+(`usage-index.mjs:1116-1132`). Two invariants:
+
+- **Presence is the signal.** `truncated`/`originalChars` are emitted only
+  when the slice fired, so a complete turn cannot be misread as abridged.
+- **`originalChars` is measured after masking** — it describes loss due to
+  truncation alone, never a raw-file length.
+
+The two kinds of withholding keep distinct vocabulary end-to-end: masking
+renders as `…redacted` marks (`markRedactions`,
+`dashboard-server.mjs:2171`), truncation as a `truncated · N of M` badge
+(`truncBadge`, `dashboard-server.mjs:2187`, deriving N from the received
+text so a changed constant can't desync the display).
+
+---
+
+## 5. The HTTP surface
+
+All routes inherit the dashboard's loopback bind, DNS-rebinding `Host` guard,
+and cross-site fetch-metadata guard (ADR-0005/0007; `dashboard-server.mjs`
+request handler preamble). Transcript-relevant routes:
+
+| Route | Serves | Notes |
+|---|---|---|
+| `GET /api/usage?days=N` | the aggregate minus `sessions[]` (`dashboard-server.mjs:337`) | Scorecard + Findings + the project tree |
+| `GET /api/sessions` | session rows, filtered/paginated (`dashboard-server.mjs:355`) | the Sessions view's "load all" |
+| `GET /api/session/:id` | one transcript (`dashboard-server.mjs:372-403`) | the Transcript view |
+
+`/api/session/:id` order of operations, each step deliberate:
+
+1. `parseSessionId` (`dashboard-server.mjs:174`) + `resolvesInsideRoot`
+   (`dashboard-server.mjs:188`) — **validation before the index is touched**;
+   a rejected id 400s without any filesystem call.
+2. `readSession` — a well-formed id matching no file is **404, not
+   200-with-null** (200 made every nonexistent session look empty and the
+   route a mild existence oracle).
+3. **The masking gate covers the whole payload**: `maskMeta`
+   (`dashboard-server.mjs:218`) *and* `maskTurns`
+   (`dashboard-server.mjs:199-208`), both fail-closed — no masker, no
+   transcript, ever. `maskTurns` rewrites **string fields only**, which is
+   what lets the non-string attribution fields (`kind`, `prompt`,
+   `truncated`, `originalChars`) survive to the browser; asserted by test
+   ("maskTurns preserves the non-string attribution fields",
+   `tests/dashboard.test.cjs`).
+
+There is deliberately **no download or copy-all control, and no
+click-to-reveal**: the original never reaches the browser, so there is
+nothing on the page to reveal (ADR-0009 §8).
+
+---
+
+## 6. UI surfacing
+
+### 6.1 Sessions view — the row and its expander
+
+`renderSessions` (`dashboard-server.mjs:2120`) renders the project tree
+(collapsed by default; every project starts closed so the cross-project
+comparison stays above the fold). Each session is a `sessionRow`
+(`dashboard-server.mjs:2094-2118`): host chip (claude/codex), title,
+worktree glyph, category chip (dimmed when confidence < 0.6 or
+Unclassified), start, duration, `prompts/responses`, tokens, cost — and an
+expander (`sdetail`, `dashboard-server.mjs:2061-2091`) carrying the ten
+fields that once shipped on the wire and rendered nowhere (ADR-0009 §5
+Amendment): classification `basis` + confidence, per-session `models`, the
+token split, top tools, and the `skill`/`plugin`/`sidechain`/`worktree`
+flags. A measured-but-absent value renders as `—`, never disappears — a
+field that vanishes when null teaches the reader it doesn't exist.
+
+### 6.2 Transcript view — attribution, redaction, truncation
+
+`renderTranscript` (`dashboard-server.mjs:2203`) renders the crumb (title,
+project, duration, `prompts/responses`, tokens, cost — all from masked
+`meta`) and the turn list. **The label comes from `kind`, never from role**
+(`dashboard-server.mjs:2219-2236`):
+
+| Turn | Label | Styling |
+|---|---|---|
+| user, `kind: 'prompt'` | `you` | accent — reserved for the person (`.t-user .t-who`, `dashboard-server.mjs:1270`) |
+| user, `kind: 'tool-result'` | `tool result` | purple, rhyming with the tool chips (`.t-tool .t-who`, `dashboard-server.mjs:1274`); hover title states the harness — not the person — sent it |
+| user, `kind: 'context'` | `context` | same purple + hover title |
+| assistant | the model id | dim mono (`exception` placeholder turns label as `exception`) |
+
+A turn without `kind` (defensive only — the reader path never serves cached
+turns) falls back to the `prompt` flag, `false` ⇒ `tool result`.
+
+Deep links: `#usage/<sessionId>` opens the Transcript view directly
+(`syncHash`, `dashboard-server.mjs:1390-1391`); the view lazy-fetches via
+`loadTranscript` (`dashboard-server.mjs:1864`).
+
+### 6.3 Verified against real data
+
+Run against this machine's real stores at implementation time (2026-07-26):
+
+- A real Claude session (this feature's own working session, 884 turns):
+  `{ prompt: 20, context: 6, 'tool-result': 276, assistant: 588 }`, zero
+  user turns missing `kind`. All 276 tool results previously rendered as
+  `YOU`.
+- A real Codex rollout (8 user turns): every one `kind: 'prompt'`, as §1.2
+  predicts.
+
+---
+
+## 7. Provider differences at a glance
+
+| | Claude Code | Codex CLI |
+|---|---|---|
+| Human prompts | `user` entries passing `isHumanPrompt` | `user_message` events |
+| Tool results as turns | yes — `kind: 'tool-result'` | not surfaced (different event types; fidelity gap, §1.2) |
+| Harness context as turns | yes — `kind: 'context'` (`isMeta`) | not surfaced |
+| Model per assistant turn | per-turn `message.model` | last `turn_context` model in effect |
+| Token usage | per-assistant-turn `usage` object | cumulative `token_count`; last snapshot wins |
+| API-error placeholders | `<synthetic>` / `isApiErrorMessage` → exceptions | none observed |
+| Delegation markers | `isSidechain` → `sidechain` flag | `thread_source: "subagent"` → excluded from aggregation, session kept visible |
+| Session title | model-written `ai-title`, first-prompt fallback | first prompt clipped |
+
+**Planned third provider:** OpenRouter-served sessions are invisible to the
+scorecard today; ingesting them (discovery → parser → `kind` attribution →
+pricing → by-host UI) is tracked as
+[#59](https://github.com/pacphi/agentic-kit/issues/59).
+
+---
+
+## 8. Verification methodology
+
+Every citation above was content-checked against the live source at writing
+time (the same automated approach `USAGE-SCORECARD-METRICS.md` §16 records:
+extract every `file:line` reference, assert an expected substring at that
+line, zero tolerance). The kind-attribution behavior is pinned by unit tests
+at both layers — parser (`tests/kit/usage-index.test.mjs`) and served page +
+masking gate (`tests/dashboard.test.cjs`) — and was additionally verified
+against real transcripts from both providers (§6.3), not only fixtures.

--- a/docs/TRANSCRIPTS.md
+++ b/docs/TRANSCRIPTS.md
@@ -15,14 +15,15 @@ transcript stores → parsers → turn model → `readSession` → masking/trunc
 → HTTP → UI. Its companion,
 [`USAGE-SCORECARD-METRICS.md`](USAGE-SCORECARD-METRICS.md), covers the
 *aggregate* pipeline (cost/token/time arithmetic); this document covers the
-*per-session* pipeline. The design rationale for both is ADR-0009
-([`docs/adr/0009-usage-scorecard-local-transcript-analytics.md`](adr/0009-usage-scorecard-local-transcript-analytics.md)),
-§8 in particular.
+*per-session* pipeline. The design rationale for both is mapped in
+[Appendix C](#appendix-c--design-rationale-adr-map).
 
-**Pinned to.** branch `fix/codex-usage-scorecard-metrics`, 2026-07-26 (the
-commit introducing turn `kind` attribution). Line numbers drift as code
-changes; every citation below was content-verified against the source at
-writing time.
+**Citations are machine-checked.** Every `file:line` citation below is
+verified against the current source by the test suite
+(`tests/kit/doc-citations.test.mjs`; see
+[Appendix B](#appendix-b--verification-record)).
+
+![Figure: the per-session pipeline — a session file passes from the transcript stores through readSession's numbered gates (id grammar, locate, realpath containment, size cap, parse, secret masking, truncation), then the guarded HTTP route, into the Transcript view](assets/transcript-pipeline.svg)
 
 ---
 
@@ -67,7 +68,7 @@ Codex rollout lines carry `type` + `payload`. The parser (`parseCodex`,
 
 | `type` / `payload.type` | What the parser takes from it |
 |---|---|
-| `session_meta` | Authoritative session id, `cwd`, and `thread_source` (`usage-index.mjs:529-534`) — `"subagent"` marks a thread_spawn replay whose tokens are excluded from aggregation (`usage-index.mjs:572`; `USAGE-SCORECARD-METRICS.md` §15 Bug B) |
+| `session_meta` | Authoritative session id, `cwd`, and `thread_source` (`usage-index.mjs:529-534`) — `"subagent"` marks a thread_spawn replay whose tokens are excluded from aggregation (`usage-index.mjs:572`; `USAGE-SCORECARD-METRICS.md` Appendix A, Bug B) |
 | `turn_context` | The model id in effect from this point on (`usage-index.mjs:535`) |
 | `event_msg` → `token_count` | A **cumulative** usage snapshot; only the last one is kept (`usage-index.mjs:542`) |
 | `event_msg` → `user_message` | A real human prompt — Codex does not route tool output through this event (`usage-index.mjs:547-555`) |
@@ -90,12 +91,14 @@ The same parsers serve two very different callers, switched by `withTurns`:
 | **Scan** — the aggregate index behind the Scorecard/Findings/Sessions views | `buildIndex` → `parseFile` (`usage-index.mjs:652`) | `false` | never held — holding them would balloon memory across 3,000+ files (`usage-index.mjs:413-416`) | yes: per-file derived records in `~/.config/agentic-kit/usage-index.json`, keyed `(path, mtime, size)`, invalidated wholesale by `SCHEMA_VERSION` (`usage-index.mjs:50`) |
 | **Reader** — one transcript for the Transcript view | `readSession` (`usage-index.mjs:1078`) | `true` | full turn list built | **never** — every call re-reads and re-parses the one file |
 
+![Figure: one parser, two read paths — the scan path (withTurns false) caches per-file records keyed by path, mtime and size; the reader path (withTurns true) builds full turns and is never cached](assets/transcript-read-paths.svg)
+
 The reader path being cache-free is load-bearing for maintainers: **turn-shape
 changes (like the `kind` field, §3) need no `SCHEMA_VERSION` bump**, because
 no turn is ever served from cache — whereas *session-record* fields (like
 `exceptions`) do, since stale cached records would otherwise sum `undefined`
-into totals (the v4/v5 bump notes, `usage-index.mjs:39-49`, records exactly that
-incident).
+into totals (`usage-index.mjs:39-49`; the incidents behind that rule are
+recorded in `USAGE-SCORECARD-METRICS.md` Appendix A).
 
 ---
 
@@ -123,9 +126,11 @@ output back as a user-role message — that is the wire format, not a kit
 choice) and **harness context injections** (`isMeta` entries: command outputs,
 system reminders). In a heavily agentic session these dominate: a measured
 real session on the reference machine had **20 human prompts and 276 tool
-results** — so a renderer that labels by role attributes ~93% of "you" turns
-to a person who never typed them. That was the shipped bug this section's
-machinery fixes (ADR-0009 §8, Amendment 2026-07-26).
+results** — so a renderer that labels by role would attribute ~93% of "you"
+turns to a person who never typed them. (Such a renderer shipped once; the
+story is [Appendix A](#appendix-a--fix-history).)
+
+![Figure: the kind decision cascade for user-role turns — tool_result block, then isMeta or harness envelope, else prompt — and the measured 884-turn session where 276 of 302 user-role turns are tool results](assets/transcript-turn-attribution.svg)
 
 ### 3.2 `kind` — the attribution field
 
@@ -134,7 +139,7 @@ machinery fixes (ADR-0009 §8, Amendment 2026-07-26).
 | `kind` | Test | Meaning |
 |---|---|---|
 | `tool-result` | content carries a `tool_result` block | Output the **harness** fed back to the model after a tool call |
-| `context` | `isMeta`, **or** the text opens with a harness-output envelope (`HARNESS_OUTPUT_RE`: `task-notification`, `bash-stdout`/`-stderr`, `local-command-stdout`/`-stderr`, `local-command-caveat`) | Harness-injected content — neither the person **nor the model**. These envelopes carry neither `isMeta` nor a `tool_result`, so text shape is the only signal; measured on the real corpus: task-notification 550, bash-stdout 85, local-command-stdout 60 — all previously labelled "you" |
+| `context` | `isMeta`, **or** the text opens with a harness-output envelope (`HARNESS_OUTPUT_RE`: `task-notification`, `bash-stdout`/`-stderr`, `local-command-stdout`/`-stderr`, `local-command-caveat`) | Harness-injected content — neither the person **nor the model**. These envelopes carry neither `isMeta` nor a `tool_result`, so text shape is the only signal (the envelope census is in §6.2) |
 | `prompt` | everything else | The person — including `bash-input` (a `! command` the person typed) and slash-command records (the person invoked them) |
 
 Two deliberate subtleties:
@@ -143,14 +148,12 @@ Two deliberate subtleties:
   paste has no text block, so `isHumanPrompt` returns `false` (it is not
   *counted* as a text prompt) — but it **is** the person acting, and
   `userTurnKind` returns `'prompt'` for it. "Not countable as a text prompt"
-  and "not the human" are different claims; conflating them was how the
-  original bug happened.
+  and "not the human" are different claims.
 - **Harness-output envelopes are excluded from the prompt *count* too.**
   `isHumanPrompt` shares `HARNESS_OUTPUT_RE`, so a session's `prompts` figure
-  no longer counts stdout dumps or task notifications as things the person
-  said — on the reference session this corrected 32 claimed prompts to 20
-  real ones. Cached session records carry the old inflated counts, hence
-  `SCHEMA_VERSION` 5 (`usage-index.mjs:46-50`).
+  never counts stdout dumps or task notifications as things the person said
+  (`SCHEMA_VERSION` 5, `usage-index.mjs:46-50`; the correction this shipped
+  with is in [Appendix A](#appendix-a--fix-history)).
 - **`tool-result` outranks `context`**: a `tool_result` block on an `isMeta`
   entry is still tool feedback.
 
@@ -198,7 +201,7 @@ hardcoded `$0.00`; the comment at the site records why).
 ### 4.3 Mask, then truncate — both marked, differently
 
 Every turn body is passed through `maskSecrets` (`usage-index.mjs:166` — the
-21 secret shapes ADR-0009 §8 enumerates) **server-side, before
+21 secret shapes) **server-side, before
 serialization**, then length-capped at `MAX_TURN_CHARS` (40,000,
 `usage-index.mjs:59`) with the marker appended
 (`usage-index.mjs:1144-1160`). Two invariants:
@@ -214,13 +217,15 @@ renders as `…redacted` marks (`markRedactions`,
 (`truncBadge`, `dashboard-server.mjs:2228`, deriving N from the received
 text so a changed constant can't desync the display).
 
+![Figure: a turn body passes through maskSecrets (leaving redaction marks) and then the 40,000-character cap (leaving a truncated · N of M badge); originalChars is measured after masking](assets/transcript-mask-truncate.svg)
+
 ---
 
 ## 5. The HTTP surface
 
 All routes inherit the dashboard's loopback bind, DNS-rebinding `Host` guard,
-and cross-site fetch-metadata guard (ADR-0005/0007; `dashboard-server.mjs`
-request handler preamble). Transcript-relevant routes:
+and cross-site fetch-metadata guard (`dashboard-server.mjs` request handler
+preamble). Transcript-relevant routes:
 
 | Route | Serves | Notes |
 |---|---|---|
@@ -247,7 +252,7 @@ request handler preamble). Transcript-relevant routes:
 
 There is deliberately **no download or copy-all control, and no
 click-to-reveal**: the original never reaches the browser, so there is
-nothing on the page to reveal (ADR-0009 §8).
+nothing on the page to reveal.
 
 ---
 
@@ -261,11 +266,10 @@ comparison stays above the fold). Each session is a `sessionRow`
 (`dashboard-server.mjs:2107-2131`): host chip (claude/codex), title,
 worktree glyph, category chip (dimmed when confidence < 0.6 or
 Unclassified), start, duration, `prompts/responses`, tokens, cost — and an
-expander (`sdetail`, `dashboard-server.mjs:2074-2104`) carrying the ten
-fields that once shipped on the wire and rendered nowhere (ADR-0009 §5
-Amendment): classification `basis` + confidence, per-session `models`, the
-token split, top tools, and the `skill`/`plugin`/`sidechain`/`worktree`
-flags. A measured-but-absent value renders as `—`, never disappears — a
+expander (`sdetail`, `dashboard-server.mjs:2074-2104`) carrying the
+per-session detail fields: classification `basis` + confidence, per-session
+`models`, the token split, top tools, and the
+`skill`/`plugin`/`sidechain`/`worktree` flags. A measured-but-absent value renders as `—`, never disappears — a
 field that vanishes when null teaches the reader it doesn't exist.
 
 ### 6.2 Transcript view — attribution, redaction, truncation
@@ -311,17 +315,6 @@ Deep links: `#usage/<sessionId>` opens the Transcript view directly
 (`syncHash`, `dashboard-server.mjs:1403-1404`); the view lazy-fetches via
 `loadTranscript` (`dashboard-server.mjs:1877`).
 
-### 6.3 Verified against real data
-
-Run against this machine's real stores at implementation time (2026-07-26):
-
-- A real Claude session (this feature's own working session, 884 turns):
-  `{ prompt: 20, context: 6, 'tool-result': 276, assistant: 588 }`, zero
-  user turns missing `kind`. All 276 tool results previously rendered as
-  `YOU`.
-- A real Codex rollout (8 user turns): every one `kind: 'prompt'`, as §1.2
-  predicts.
-
 ---
 
 ## 7. Provider differences at a glance
@@ -344,12 +337,56 @@ pricing → by-host UI) is tracked as
 
 ---
 
-## 8. Verification methodology
+## Appendix A — Fix history
 
-Every citation above was content-checked against the live source at writing
-time (the same automated approach `USAGE-SCORECARD-METRICS.md` §16 records:
-extract every `file:line` reference, assert an expected substring at that
-line, zero tolerance). The kind-attribution behavior is pinned by unit tests
-at both layers — parser (`tests/kit/usage-index.test.mjs`) and served page +
-masking gate (`tests/dashboard.test.cjs`) — and was additionally verified
-against real transcripts from both providers (§6.3), not only fixtures.
+The main body describes only current behavior; this appendix records what
+was wrong before, for the curious.
+
+- **User-role turns rendered as "you" (fixed 2026-07-26).** Before `kind`
+  existed, the Transcript view labelled every user-role turn as the person.
+  On the reference session that misattributed 276 tool results and 6 harness
+  context injections — ~93% of its "you" turns (§3.1's measured split). The
+  turn-`kind` machinery in §3 is the fix.
+- **Prompt counts included harness output (SCHEMA_VERSION 5).**
+  `isHumanPrompt` once counted harness-output envelopes as human prompts —
+  32 claimed vs 20 real on the reference session. Cached session records
+  carried the inflated counts, hence the wholesale `SCHEMA_VERSION` 5 cache
+  invalidation (`usage-index.mjs:46-50`).
+- **Session expander fields shipped but unrendered.** The per-session fields
+  §6.1's expander now renders (classification `basis` + confidence, the
+  token split, flags) once travelled on the wire and rendered nowhere.
+- **Aggregate-side incidents** (the v4/v5 cache bumps, the Codex parsing
+  defects) are recorded in `USAGE-SCORECARD-METRICS.md` Appendix A.
+
+---
+
+## Appendix B — Verification record
+
+**Methodology.** Every `file:line` citation above is checked against the
+current source on every test run by `tests/kit/doc-citations.test.mjs`
+(mechanism and upkeep: `USAGE-SCORECARD-METRICS.md` Appendix B). The
+kind-attribution behavior is pinned by unit tests at both layers — parser
+(`tests/kit/usage-index.test.mjs`) and served page + masking gate
+(`tests/dashboard.test.cjs`).
+
+**Against real data** (this machine's real stores, 2026-07-26):
+
+- A real Claude session (this feature's own working session, 884 turns):
+  `{ prompt: 20, context: 6, 'tool-result': 276, assistant: 588 }`, zero
+  user turns missing `kind`.
+- A real Codex rollout (8 user turns): every one `kind: 'prompt'`, as §1.2
+  predicts.
+
+---
+
+## Appendix C — Design rationale (ADR map)
+
+Design decisions are deliberately kept out of the main body; they live in
+the ADRs:
+
+| Main-body topic | Design record |
+|---|---|
+| Masking, truncation, no-reveal transcript rules (§4–§6) | [ADR-0009](adr/0009-usage-scorecard-local-transcript-analytics.md) §8 |
+| Turn-`kind` attribution (§3) | ADR-0009 §8 (amendment 2026-07-26) |
+| Session-expander classification fields (§6.1) | ADR-0009 §5 |
+| Dashboard HTTP guards — loopback bind, `Host` guard, fetch metadata (§5) | ADR-0005, ADR-0007 |

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -37,17 +37,6 @@ ak sync             # apply it
 > The `natives … WASM fallback` row is the one that loses data: on the WASM path,
 > memory writes print "OK" and silently vanish. Treat it as the highest-priority fix.
 
-One entry above deserves its history spelled out:
-
-> [!NOTE]
-> **Historical:** earlier kit versions flagged any `.rvf.lock` starting with `FLVR`
-> bytes as corruption and deleted the store beside it. That signal was measured
-> unsound — `FLVR` is the *normal* lock magic (`SFVR` is the store's) — and
-> agentic-qe ≥ 3.12.3 self-heals genuinely unusable stores non-destructively
-> ([aqe #563](https://github.com/proffesor-for-testing/agentic-qe/issues/563)).
-> The kit now guards only store *size*. If you see `brain.rvf.corrupt-<pid>`
-> droppings from that era, they are safe to delete.
-
 ## Deep proofs (slow, spawn real CLIs)
 
 ```bash
@@ -64,7 +53,16 @@ ak x verify all
 - ruflo's generated CLI examples say `npx @claude-flow/cli@latest …`; prefer the
   installed `ruflo` binary (no npm fetch per call).
 
-## History
+## Appendix — history
+
+**The FLVR false-corruption signal.** Earlier kit versions flagged any
+`.rvf.lock` starting with `FLVR` bytes as corruption and deleted the store
+beside it. That signal was measured unsound — `FLVR` is the *normal* lock
+magic (`SFVR` is the store's) — and agentic-qe ≥ 3.12.3 self-heals genuinely
+unusable stores non-destructively
+([aqe #563](https://github.com/proffesor-for-testing/agentic-qe/issues/563)).
+The kit now guards only store *size*. If you see `brain.rvf.corrupt-<pid>`
+droppings from that era, they are safe to delete.
 
 Why this kit exists, the original root-cause investigations (Node-ABI/WASM memory
 loss, the F1–F6 self-improvement findings, the June-2026 token-burn incident), and

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -74,8 +74,7 @@ machines), the Claude↔Codex MCP bridge (both
 directions), and the statusline footer. These can drift with **no version change at all** —
 a kit update (or, on an npm-linked dev checkout, merely merging a PR that edits a
 `claude/*.md` template) revises the source of truth, and the rendered copies lag until the
-next `ak sync`. Previously that lag was silent until someone happened to run `ak status`;
-the nudge closes the window. It uses the exact drift definitions `ak status` uses (the two
+next `ak sync`. The nudge closes that window, using the exact drift definitions `ak status` uses (the two
 can never disagree) and stays quiet after `status`, `sync`, and `ak x reference`, which
 already show the same information.
 
@@ -91,7 +90,7 @@ check consults **both** the `latest` and `next` dist-tags and takes the higher o
 That's why `ak sync` on `alpha.19` correctly pulls `alpha.20` even though `latest` points
 further back. (If you'd rather move it by hand: `npm i -g @pacphi/agentic-kit@next`.)
 
-## Where the design lives
+## Appendix — design references
 
 The *why* behind primary-host selection and ambidextrous mirroring is captured as an ADR —
 [docs/adr/0006-primary-host-and-ambidextrous-mirroring.md](adr/0006-primary-host-and-ambidextrous-mirroring.md).

--- a/docs/USAGE-SCORECARD-METRICS.md
+++ b/docs/USAGE-SCORECARD-METRICS.md
@@ -99,7 +99,7 @@ responses = Σ over included sessions of session.responses
 - Totals: `totals.responses += s.responses` per included session
   (`usage-index.mjs:811`).
 - Render: `kpi("sessions", fmtNum(t.sessions), fmtNum(t.responses)+" assistant
-  turns", "")` (`dashboard-server.mjs:1920`).
+  turns", "")` (`dashboard-server.mjs:1933`).
 
 **Worked example.** A session with 3 user turns and 2 assistant turns
 contributes `sessions += 1, responses += 2` — prompts (user turns) are tracked
@@ -206,13 +206,13 @@ tokens = input + output + cacheRead + cacheWrite   (summed across all rows in wi
 `usage-index.mjs:755` (`rowTokens = row.input + row.output + row.cacheRead +
 row.cacheWrite`) and rolled into `totals.tokens` via `addTo`
 (`usage-index.mjs:710`). Rendered with `fmtTok()`
-(`dashboard-server.mjs:1830-1836`): `≥1e9` → `"X.XB"`, `≥1e6` → `"X.XM"`,
+(`dashboard-server.mjs:1843-1849`): `≥1e9` → `"X.XB"`, `≥1e6` → `"X.XM"`,
 `≥1e3` → `"X.XK"`, else the rounded integer.
 
 The **token composition bar** immediately below the hero row (cache read /
 cache write / output / input, as four coloured segments) is the same four
-numbers as percentages of `t.tokens` (`dashboard-server.mjs:1956-1963`,
-`pct(a,b) = b ? a/b*100 : 0`, `dashboard-server.mjs:1844`).
+numbers as percentages of `t.tokens` (`dashboard-server.mjs:1969-1976`,
+`pct(a,b) = b ? a/b*100 : 0`, `dashboard-server.mjs:1857`).
 
 **What "input" excludes.** For both providers, the `input` counter recorded
 per row is **gross input minus cached input** — Claude's parser reads
@@ -253,8 +253,8 @@ cacheRead + cacheWrite), **not** as a share of input alone. On the reference
 figures (`cacheRead = 1464.3B`, `tokens = 1495.2B`): `1464.3 / 1495.2 × 100 =
 97.93%`, which rounds to the displayed `97.9%` — confirming the denominator.
 
-**Source:** `dashboard-server.mjs:1918` (`cacheShare = pct(t.cacheRead,
-t.tokens)`), rendered `dashboard-server.mjs:1926`.
+**Source:** `dashboard-server.mjs:1931` (`cacheShare = pct(t.cacheRead,
+t.tokens)`), rendered `dashboard-server.mjs:1939`.
 
 **Why this number matters more than it looks like it should.** ADR-0009's
 own motivating data point: on the reference corpus, 96.3% of tokens were
@@ -272,7 +272,7 @@ Codex CLI do by default.
 
 **Displayed as:** `ENGAGED TIME` hero tile — `403h`, subtitle `3286h summed`
 plus a `sessions overlap` note. Hovering the tile reveals a tooltip with all
-three tiers (ADR-0009's "ladder," `dashboard-server.mjs:1908-1914`).
+three tiers (ADR-0009's "ladder," `dashboard-server.mjs:1921-1927`).
 
 This is the single most heavily-caveated metric on the tab, because a naive
 version of it was **wrong by roughly 3×** during ADR-0009's own design pass
@@ -321,9 +321,9 @@ session data, and each needs its own fix:
   mergeIntervals(sessions.map(s => s._span))` (`usage-index.mjs:853`);
   `totals.spanMinutes` is a running sum of `s._span[1] - s._span[0]` across
   the loop (`usage-index.mjs:815`, finalized `usage-index.mjs:852`).
-- Render: `fmtHours()` (`dashboard-server.mjs:1837`, `≥10h` rounds to the
+- Render: `fmtHours()` (`dashboard-server.mjs:1850`, `≥10h` rounds to the
   nearest hour, else one decimal place) and `fmtMins()`
-  (`dashboard-server.mjs:1838`, `≥60min` rounds to hours, else whole
+  (`dashboard-server.mjs:1851`, `≥60min` rounds to hours, else whole
   minutes).
 
 **Worked example**, ADR-0009's own reference-corpus measurement (14-day
@@ -375,7 +375,7 @@ session that runs from 23:58 local to 00:05 local is billed to the day its
 `tests/kit/usage-index.test.mjs:556`, "a session that opens before midnight
 is counted on its first billed day"). Accumulation:
 `byDay[row.day].cost += rowCost` (`usage-index.mjs:758`). Bar height:
-`h = maxDay ? max(2, cost/maxDay*100) : 2` (`dashboard-server.mjs:1937`) —
+`h = maxDay ? max(2, cost/maxDay*100) : 2` (`dashboard-server.mjs:1950`) —
 every non-empty day gets a visually nonzero bar (floor of 2%), so a very
 cheap day is never rendered as invisible.
 
@@ -392,7 +392,7 @@ rather than a continuous 30-day series.
 **Displayed as:** two cards, `claude` and `codex`, each showing cost,
 session count, and total tokens; an idle host (`sessions == 0 && cost == 0`)
 renders "no sessions in window" instead of zeroed figures
-(`dashboard-server.mjs:1949-1953`).
+(`dashboard-server.mjs:1962-1966`).
 
 **Formula:** identical aggregation to every other bucket
 (`byProvider[s.provider]`, populated via `addTo()`, `usage-index.mjs:706-715`,
@@ -438,7 +438,7 @@ punchcard[dow + "-" + hour] += 1   per assistant/agent_message response, at its 
 `agent_message` (`usage-index.mjs:532-533`), merged into the window-level
 `punchcard` object per session (`usage-index.mjs:832`). Cell intensity is
 linear against the single busiest cell in the window:
-`v = pcMax ? n/pcMax : 0` (`dashboard-server.mjs:1973`) — this is a
+`v = pcMax ? n/pcMax : 0` (`dashboard-server.mjs:1986`) — this is a
 **relative**, not absolute, scale, so the heatmap's brightest cell is always
 "the busiest hour-of-week in *this* window," not a fixed response-count
 threshold, and comparing brightness across two different date-range views is
@@ -489,9 +489,9 @@ previously omitted for Codex and every Codex model showed 0 responses
 regardless of real activity).
 
 **Render:** `bar(name, fmtUsd(cost), fmtTok(tokens)+" · "+fmtNum(responses)+"
-resp", pct(cost, topModelCost), false)` (`dashboard-server.mjs:1986-1989`),
+resp", pct(cost, topModelCost), false)` (`dashboard-server.mjs:1999-2002`),
 list itself sorted cost-descending by the shared `entries()` helper
-(`dashboard-server.mjs:1845-1850`).
+(`dashboard-server.mjs:1858-1863`).
 
 **Exceptions — a turn that never resolved to a model is excluded here, not
 shown as a $0 row.** A dropped connection, rate limit, or authentication
@@ -516,7 +516,7 @@ create a `byModel` row of any kind. It increments a separate
 (`usage-index.mjs:775`, alongside the existing `sidechain`/`threadSource`
 flags — inspectable in the Sessions tab, never hidden). When
 `totals.exceptions > 0`, the panel header shows a small `"· N
-dropped/errored turns excluded"` note (`dashboard-server.mjs:1990-1995`);
+dropped/errored turns excluded"` note (`dashboard-server.mjs:2003-2008`);
 when it's zero, the note renders empty rather than always claiming a
 count of zero.
 
@@ -564,7 +564,7 @@ worktree's *branch name* was reported as its own project, silently
 undercounting the true repo's total by whatever work happened in the
 worktree.
 
-**Source:** ranking and truncation, `dashboard-server.mjs:1997-2004`
+**Source:** ranking and truncation, `dashboard-server.mjs:2010-2017`
 (`shown = projects.slice(0,8)`); accumulation via the same `addTo()`/
 `entries()` machinery as §10, keyed by `s.project` instead of `s.models`.
 
@@ -580,7 +580,7 @@ rather than silently absent from the total.
 **Displayed as:** a ranked bar list of categories, bar width relative to
 the top category's cost; each row shows `cost`, `N sess · $/sess`; a small
 confidence dot on classified rows (opacity `0.5 + confidence×0.5`,
-`dashboard-server.mjs:2011-2012`); `Unclassified` is always shown, never
+`dashboard-server.mjs:2024-2025`); `Unclassified` is always shown, never
 hidden, and carries no confidence dot.
 
 This is the only Scorecard metric that is **not** pure arithmetic over
@@ -647,9 +647,9 @@ keyword hit.
 cannot classify most sessions and layer 2 (title + tool-mix rules) carries
 the bulk of the load.
 
-**Render:** `dashboard-server.mjs:2007-2018`, sorted cost-descending via the
+**Render:** `dashboard-server.mjs:2020-2031`, sorted cost-descending via the
 shared `entries()` helper, with `$/sess = cost / max(sessions, 1)` guarding
-the zero-session edge case (`dashboard-server.mjs:2009`).
+the zero-session edge case (`dashboard-server.mjs:2022`).
 
 **What this does not model:** the classifier reads only the session's
 *title* (Claude's own `ai-title`, written by the model itself at session
@@ -714,7 +714,7 @@ Anthropic which publishes a fetchable pricing document. OpenAI's rates in
 this table are therefore maintained by hand against OpenAI's own developer
 documentation and are the most drift-prone entries in the file — this is
 explicitly why `PRICES_AS_OF` is surfaced in the UI (`u-asof`,
-`dashboard-server.mjs:1927`) rather than assumed current.
+`dashboard-server.mjs:1940`) rather than assumed current.
 
 | Model (kit key) | Input | Output | Cache read (0.1×, derived) |
 |---|---|---|---|

--- a/docs/USAGE-SCORECARD-METRICS.md
+++ b/docs/USAGE-SCORECARD-METRICS.md
@@ -57,16 +57,16 @@ Every metric section below follows the same shape:
 ## 1. Data provenance
 
 Two transcript stores, read-only, parsed at most once per file (cache keyed by
-`(path, mtime, size)`; SCHEMA_VERSION `3` invalidates the whole cache on a
-schema change — `src/lib/usage-index.mjs:39`):
+`(path, mtime, size)`; SCHEMA_VERSION `4` invalidates the whole cache on a
+schema change — `src/lib/usage-index.mjs:46`):
 
 | Provider | Store | Format |
 |---|---|---|
 | Claude Code | `~/.claude/projects/<project>/<sessionId>.jsonl` | one JSON object per line: `user`/`assistant` turns, each assistant turn carrying its own `usage` object |
 | Codex CLI | `~/.codex/sessions/<yyyy>/<mm>/<dd>/rollout-<ts>-<sessionId>.jsonl` | one JSON object per line: `session_meta`, `turn_context`, and `event_msg` records, the latter carrying **cumulative** `token_count` snapshots, not per-turn deltas |
 
-The parsers are `parseClaude` (`usage-index.mjs:362-426`) and `parseCodex`
-(`usage-index.mjs:443-510`). Both are pure functions over the raw file bytes —
+The parsers are `parseClaude` (`usage-index.mjs:369-452`) and `parseCodex`
+(`usage-index.mjs:469-536`). Both are pure functions over the raw file bytes —
 no network, no clock dependency beyond the transcript's own timestamps — so
 every downstream number traces back to bytes already on the user's disk.
 Nothing in this pipeline calls a provider API or a billing endpoint; **no
@@ -90,14 +90,14 @@ responses = Σ over included sessions of session.responses
 **Source:**
 
 - Filter: a parsed record with zero assistant turns is dropped entirely — "no
-  assistant turn → not a session" (`usage-index.mjs:691`) — and a record whose
+  assistant turn → not a session" (`usage-index.mjs:717`) — and a record whose
   last activity falls outside the requested window is dropped too
-  (`usage-index.mjs:692`).
+  (`usage-index.mjs:718`).
 - `responses` accumulation: Claude increments per assistant message
-  (`usage-index.mjs:392`); Codex increments per `agent_message` event
-  (`usage-index.mjs:481`).
+  (`usage-index.mjs:399`); Codex increments per `agent_message` event
+  (`usage-index.mjs:507`).
 - Totals: `totals.responses += s.responses` per included session
-  (`usage-index.mjs:762`).
+  (`usage-index.mjs:788`).
 - Render: `kpi("sessions", fmtNum(t.sessions), fmtNum(t.responses)+" assistant
   turns", "")` (`dashboard-server.mjs:1916`).
 
@@ -203,9 +203,9 @@ tokens = input + output + cacheRead + cacheWrite   (summed across all rows in wi
 ```
 
 **Source:** `t.tokens` from `totals`, accumulated per row at
-`usage-index.mjs:706` (`rowTokens = row.input + row.output + row.cacheRead +
+`usage-index.mjs:732` (`rowTokens = row.input + row.output + row.cacheRead +
 row.cacheWrite`) and rolled into `totals.tokens` via `addTo`
-(`usage-index.mjs:661`). Rendered with `fmtTok()`
+(`usage-index.mjs:687`). Rendered with `fmtTok()`
 (`dashboard-server.mjs:1826-1832`): `≥1e9` → `"X.XB"`, `≥1e6` → `"X.XM"`,
 `≥1e3` → `"X.XK"`, else the rounded integer.
 
@@ -217,9 +217,9 @@ numbers as percentages of `t.tokens` (`dashboard-server.mjs:1952-1959`,
 **What "input" excludes.** For both providers, the `input` counter recorded
 per row is **gross input minus cached input** — Claude's parser reads
 `cache_read_input_tokens` and `cache_creation_input_tokens` as separate fields
-the provider already reports separately (`usage-index.mjs:399-402`); Codex's
+the provider already reports separately (`usage-index.mjs:427-430`); Codex's
 parser subtracts `cached_input_tokens` from `input_tokens` explicitly
-(`usage-index.mjs:496-500`, `input: Math.max(0, gross - cacheRead)`) because
+(`usage-index.mjs:522-526`, `input: Math.max(0, gross - cacheRead)`) because
 Codex's own `input_tokens` field **includes** cached tokens and would
 double-count them against the separately-reported `cacheRead` figure if left
 as-is. This is asserted by test:
@@ -303,24 +303,24 @@ session data, and each needs its own fix:
    human, or genuinely idle) donates its *entire* idle stretch to the span,
    even though no work happened during it. Fix: split each session into
    active sub-intervals wherever the gap between two consecutive timestamps
-   exceeds `IDLE_GAP_MS` (15 minutes, `usage-index.mjs:45`), then union
+   exceeds `IDLE_GAP_MS` (15 minutes, `usage-index.mjs:52`), then union
    *those* sub-intervals — this is `engagedSeconds`.
 
 **Source:**
 
-- `mergeIntervals()` (`usage-index.mjs:72-97`) — the pure union primitive,
+- `mergeIntervals()` (`usage-index.mjs:79-104`) — the pure union primitive,
   sorts intervals and merges any two that overlap **or exactly touch**
-  (`s <= curEnd`, `usage-index.mjs:88`), returning total covered seconds
+  (`s <= curEnd`, `usage-index.mjs:95`), returning total covered seconds
   rounded to the nearest second.
-- `activeIntervals()` (`usage-index.mjs:295-307`) — splits one session's
+- `activeIntervals()` (`usage-index.mjs:302-314`) — splits one session's
   sorted timestamp list into sub-intervals wherever a gap exceeds
   `IDLE_GAP_MS`; "a run of one timestamp yields a zero-length interval and so
-  contributes nothing" (comment, `usage-index.mjs:293`).
+  contributes nothing" (comment, `usage-index.mjs:300`).
 - Aggregation: `totals.engagedSeconds = mergeIntervals(sessions.flatMap(s =>
-  s._active))` (`usage-index.mjs:804`); `totals.spanUnionSeconds =
-  mergeIntervals(sessions.map(s => s._span))` (`usage-index.mjs:803`);
+  s._active))` (`usage-index.mjs:831`); `totals.spanUnionSeconds =
+  mergeIntervals(sessions.map(s => s._span))` (`usage-index.mjs:830`);
   `totals.spanMinutes` is a running sum of `s._span[1] - s._span[0]` across
-  the loop (`usage-index.mjs:765`, finalized `usage-index.mjs:802`).
+  the loop (`usage-index.mjs:792`, finalized `usage-index.mjs:829`).
 - Render: `fmtHours()` (`dashboard-server.mjs:1833`, `≥10h` rounds to the
   nearest hour, else one decimal place) and `fmtMins()`
   (`dashboard-server.mjs:1834`, `≥60min` rounds to hours, else whole
@@ -369,12 +369,12 @@ byDay[day].cost = Σ costOf(row) for every usage row whose day == that key
 
 **Source:** the day key is the row's own `row.day`, computed once at parse
 time as **local calendar day**, not UTC
-(`usage-index.mjs:398`/`usage-index.mjs:499` call `localDay(at)`) — so a
+(`usage-index.mjs:426`/`usage-index.mjs:525` call `localDay(at)`) — so a
 session that runs from 23:58 local to 00:05 local is billed to the day its
 *first* row landed on (test:
 `tests/kit/usage-index.test.mjs:556`, "a session that opens before midnight
 is counted on its first billed day"). Accumulation:
-`byDay[row.day].cost += rowCost` (`usage-index.mjs:709`). Bar height:
+`byDay[row.day].cost += rowCost` (`usage-index.mjs:735`). Bar height:
 `h = maxDay ? max(2, cost/maxDay*100) : 2` (`dashboard-server.mjs:1933`) —
 every non-empty day gets a visually nonzero bar (floor of 2%), so a very
 cheap day is never rendered as invisible.
@@ -395,11 +395,11 @@ renders "no sessions in window" instead of zeroed figures
 (`dashboard-server.mjs:1945-1949`).
 
 **Formula:** identical aggregation to every other bucket
-(`byProvider[s.provider]`, populated via `addTo()`, `usage-index.mjs:657-666`,
-called once per session at `usage-index.mjs:767`), keyed by the literal string
+(`byProvider[s.provider]`, populated via `addTo()`, `usage-index.mjs:683-692`,
+called once per session at `usage-index.mjs:794`), keyed by the literal string
 `"claude"` or `"codex"` assigned at parse time
 (`blankSession(id, 'claude')` / `blankSession(id, 'codex')`,
-`usage-index.mjs:274-280`, `parseClaude`/`parseCodex` entry points).
+`usage-index.mjs:281-287`, `parseClaude`/`parseCodex` entry points).
 
 **Why this pairing is the one under the most scrutiny.** Both providers'
 tokens are summed into the *same* `tokens`/`cost` fields using the *same*
@@ -434,9 +434,9 @@ punchcard[dow + "-" + hour] += 1   per assistant/agent_message response, at its 
 ```
 
 **Source:** incremented once per Claude assistant turn
-(`usage-index.mjs:405-406`, keyed by `punchKey(at)`) and once per Codex
-`agent_message` (`usage-index.mjs:483-484`), merged into the window-level
-`punchcard` object per session (`usage-index.mjs:782`). Cell intensity is
+(`usage-index.mjs:401-402`, keyed by `punchKey(at)`) and once per Codex
+`agent_message` (`usage-index.mjs:509-510`), merged into the window-level
+`punchcard` object per session (`usage-index.mjs:809`). Cell intensity is
 linear against the single busiest cell in the window:
 `v = pcMax ? n/pcMax : 0` (`dashboard-server.mjs:1969`) — this is a
 **relative**, not absolute, scale, so the heatmap's brightest cell is always
@@ -469,9 +469,9 @@ byModel[model].sessions  = count of DISTINCT sessions whose s.models includes th
 ```
 
 **Source:** cost/tokens/responses accumulate inside the usage-row loop
-(`usage-index.mjs:696-713`); the `sessions` count is deliberately computed
+(`usage-index.mjs:722-739`); the `sessions` count is deliberately computed
 **separately**, once per session over its `s.models` array
-(`usage-index.mjs:775-780`) rather than inside the cost loop, precisely
+(`usage-index.mjs:802-807`) rather than inside the cost loop, precisely
 **so that a model can appear in `byModel` — with a nonzero session count —
 even in a session that contributed zero cost/tokens/responses for that
 model.** This is not an edge case invented for this document: it is the
@@ -480,11 +480,11 @@ by an excluded subagent-replay session still shows up as "used," at zero
 cost, rather than vanishing).
 
 `byModel[...].responses` is populated from `row.responses`
-(`usage-index.mjs:711`), which in turn comes from the `responses` field
+(`usage-index.mjs:737`), which in turn comes from the `responses` field
 passed into `addUsage()` at the call site — `1` per Claude assistant turn
-(`usage-index.mjs:398-404`), or `rec.responses` (the session's whole response
+(`usage-index.mjs:426-432`), or `rec.responses` (the session's whole response
 count) once per Codex session, passed at the single point Codex calls
-`addUsage` (`usage-index.mjs:499-506`; see §15 Bug A for why this field was
+`addUsage` (`usage-index.mjs:525-532`; see §15 Bug A for why this field was
 previously omitted for Codex and every Codex model showed 0 responses
 regardless of real activity).
 
@@ -492,6 +492,59 @@ regardless of real activity).
 resp", pct(cost, topModelCost), false)` (`dashboard-server.mjs:1982-1985`),
 list itself sorted cost-descending by the shared `entries()` helper
 (`dashboard-server.mjs:1841-1846`).
+
+**Exceptions — a turn that never resolved to a model is excluded here, not
+shown as a $0 row.** A dropped connection, rate limit, or authentication
+failure makes Claude Code synthesize a local placeholder turn — `model:
+"<synthetic>"`, `isApiErrorMessage: true`, every usage field zero — rather
+than a real completion (confirmed directly against this machine's own
+transcripts: 33 such turns across the whole corpus, split `server_error`
+27, `authentication_failed` 3, `rate_limit` 3 — three distinct underlying
+causes, one placeholder shape). Before this was handled explicitly, that
+placeholder's model id landed in `rec.models` like any other, so it
+surfaced here as its own ranked row: `<synthetic> · $0.00 · 0 tok · N
+resp` — real-looking but meaningless, since no model ever ran.
+
+The parser now branches on `isApiErrorMessage === true`
+(`usage-index.mjs:411-420`): the turn still increments `rec.responses`
+and the punchcard (`usage-index.mjs:399-402`) — it *is* real engaged
+time, someone was genuinely waiting on it — but it is never pushed into
+`rec.models` and `addUsage()` is never called for it, so it can no longer
+create a `byModel` row of any kind. It increments a separate
+`rec.exceptions` counter instead (`usage-index.mjs:412`), rolled up into
+`totals.exceptions` (`usage-index.mjs:777-788`) and surfaced per-session
+(`usage-index.mjs:752`, alongside the existing `sidechain`/`threadSource`
+flags — inspectable in the Sessions tab, never hidden). When
+`totals.exceptions > 0`, the panel header shows a small `"· N
+dropped/errored turns excluded"` note (`dashboard-server.mjs:1986-1991`);
+when it's zero, the note renders empty rather than always claiming a
+count of zero.
+
+This is the same "never hide it, don't misrepresent it either" principle
+as §15's Codex exclusions and Unclassified in §12 — the difference is
+*where* the exception surfaces: a `$0`, `0`-token, real-looking model row
+was actively misleading (it implies a model ran and simply cost nothing),
+so the fix removes it from the ranking entirely rather than merely
+re-labeling it in place.
+
+**A cache-schema gotcha this change surfaced, worth recording exactly
+because a unit test could not have caught it:** `exceptions` is a new
+required field on every session record, but the on-disk index
+(`~/.config/agentic-kit/usage-index.json`) caches previously-parsed
+records keyed by `(path, mtime, size)` — a session parsed before this
+change has no `exceptions` field at all. Summing `undefined` into
+`totals.exceptions` silently produces `NaN`, which `JSON.stringify`
+serializes as `null` over the wire — a live query against this machine's
+real cached index (1,656 sessions, 90-day window) returned
+`totals.exceptions: null` and still showed the `<synthetic>` row in
+`byModel` on the first run after this change, purely because the cache
+predated it; every unit test still passed, since they only ever exercise
+a fresh parse with no cache involved. `SCHEMA_VERSION` is now `4`
+(`usage-index.mjs:35-46`) specifically to force that one-time
+re-parse. Re-querying the same live server after the bump returned
+`totals.exceptions: 20` and confirmed `<synthetic>` no longer appears
+in `byModel` at all — the number this section describes, not a
+projected one.
 
 ---
 
@@ -511,7 +564,7 @@ worktree's *branch name* was reported as its own project, silently
 undercounting the true repo's total by whatever work happened in the
 worktree.
 
-**Source:** ranking and truncation, `dashboard-server.mjs:1987-1994`
+**Source:** ranking and truncation, `dashboard-server.mjs:1993-2000`
 (`shown = projects.slice(0,8)`); accumulation via the same `addTo()`/
 `entries()` machinery as §10, keyed by `s.project` instead of `s.models`.
 
@@ -527,7 +580,7 @@ rather than silently absent from the total.
 **Displayed as:** a ranked bar list of categories, bar width relative to
 the top category's cost; each row shows `cost`, `N sess · $/sess`; a small
 confidence dot on classified rows (opacity `0.5 + confidence×0.5`,
-`dashboard-server.mjs:2001-2002`); `Unclassified` is always shown, never
+`dashboard-server.mjs:2007-2008`); `Unclassified` is always shown, never
 hidden, and carries no confidence dot.
 
 This is the only Scorecard metric that is **not** pure arithmetic over
@@ -594,9 +647,9 @@ keyword hit.
 cannot classify most sessions and layer 2 (title + tool-mix rules) carries
 the bulk of the load.
 
-**Render:** `dashboard-server.mjs:1997-2008`, sorted cost-descending via the
+**Render:** `dashboard-server.mjs:2003-2014`, sorted cost-descending via the
 shared `entries()` helper, with `$/sess = cost / max(sessions, 1)` guarding
-the zero-session edge case (`dashboard-server.mjs:1999`).
+the zero-session edge case (`dashboard-server.mjs:2005`).
 
 **What this does not model:** the classifier reads only the session's
 *title* (Claude's own `ai-title`, written by the model itself at session
@@ -770,14 +823,14 @@ provider-agnostic). Fixed in commit `540be18` on this branch.
 
 `parseCodex`'s single `addUsage()` call never included a `responses` field —
 Claude's parser passes `responses: 1` per assistant turn
-(`usage-index.mjs:403`, as it existed before this fix), but Codex's call
+(`usage-index.mjs:431`, as it existed before this fix), but Codex's call
 passed no such field at all. Because `byModel[model].responses` is summed
-directly from each usage row's `responses` field (`usage-index.mjs:711`,
+directly from each usage row's `responses` field (`usage-index.mjs:737`,
 `m.responses += row.responses`), **every** Codex model in §10's "Models in
 Play" list displayed `0 resp` regardless of real token/cost volume or actual
 `agent_message` count. **Fix:** `parseCodex` now passes `responses:
 rec.responses` (the session's own tallied response count,
-`usage-index.mjs:481`) on its `addUsage()` call.
+`usage-index.mjs:507`) on its `addUsage()` call.
 
 ### Bug B — subagent thread-replay could double-bill tokens
 
@@ -797,13 +850,13 @@ at face value (correctly avoiding the separate naive-summing bug **[C5]**
 documents, since it already used last-event-only logic — see §4's worked
 example) but performed **no de-duplication** against a parent session a
 subagent file might be replaying. **Fix:** the parser now reads
-`session_meta.thread_source` (`usage-index.mjs:458`, confirmed as a real
+`session_meta.thread_source` (`usage-index.mjs:484`, confirmed as a real
 Codex rollout field by **[C7]**) and skips the `addUsage()` call entirely
-when its value is `'subagent'` (`usage-index.mjs:495`, guard condition
+when its value is `'subagent'` (`usage-index.mjs:521`, guard condition
 `rec.threadSource !== 'subagent'`). The session record itself is **not**
 dropped — it remains visible in the Sessions tab with `threadSource`
 surfaced (mirroring the existing `sidechain` flag Claude sessions already
-carry, `usage-index.mjs:277`), so a maintainer auditing the raw data can
+carry, `usage-index.mjs:284`), so a maintainer auditing the raw data can
 still see it; it simply contributes zero tokens/cost, exactly as intended by
 the "models still shows up in §10's list, with zero cost" mechanism §10
 describes.

--- a/docs/USAGE-SCORECARD-METRICS.md
+++ b/docs/USAGE-SCORECARD-METRICS.md
@@ -1,0 +1,865 @@
+# Usage Scorecard — Metrics Reference & Research Backup
+
+**Audience.** agentic-kit maintainers, contributors reviewing a PR that touches
+`src/lib/usage-index.mjs` / `src/lib/pricing.mjs` / `src/lib/usage-classify.mjs` /
+`src/lib/dashboard-server.mjs`, and anyone auditing a specific number a user has
+questioned on the **Scorecard** tab of `ak x dashboard`'s Usage panel.
+
+**Purpose.** Every figure on the Scorecard tab is either (a) an exact, checkable
+arithmetic derivation from the user's own local transcripts, or (b) a published
+provider rate. This document states, for each figure, which of those two it is,
+cites the exact source line, cites the external rate where one is used, and
+records what the figure deliberately does **not** model. The goal is that a
+skeptical reader — a user who thinks a number "looks questionable," or a
+maintainer reviewing a pricing-table change — can verify every claim here
+against either the cited source code or the cited external page, without
+having to trust this document on faith.
+
+**Pinned to.** commit `540be18` on branch `fix/codex-usage-scorecard-metrics`
+(2026-07-25). Line numbers below will drift as the code changes; if a citation
+no longer matches, `git log -p -L<line>,<line>:<file>` from this commit is the
+fastest way to find where it moved.
+
+**Scope.** This document covers the **Scorecard** tab only — the five hero KPIs
+(Sessions, API-Equivalent, Tokens, Engaged Time, Cache Read) and the six
+supporting panels (cost per day, by host, token composition bar, when you work,
+models in play, projects, what you worked on). The **Findings**, **Sessions**,
+and **Transcript** tabs are governed by separate rules (ADR-0009 §6 and §8) and
+are out of scope here except where they share a data source with a Scorecard
+metric.
+
+**Companion document.** This is a *metrics reference*, not a design record. The
+"why" behind each design choice — why three time tiers, why rules-based
+classification, why cost is never called billing — is ADR-0009's job and is
+cited, not repeated, below. Read
+[`docs/adr/0009-usage-scorecard-local-transcript-analytics.md`](adr/0009-usage-scorecard-local-transcript-analytics.md)
+first if you want motivation; read this document if you want to check an
+arithmetic claim.
+
+---
+
+## 0. How to read an entry
+
+Every metric section below follows the same shape:
+
+- **Displayed as** — the exact label and format the browser renders.
+- **Formula** — the arithmetic, in mathematical notation.
+- **Source** — file:line citations for both the number's derivation (usually
+  `src/lib/usage-index.mjs`) and its rendering (`src/lib/dashboard-server.mjs`).
+- **Worked example** — a real or realistic set of inputs run through the
+  formula by hand, cross-checked against a live test assertion where one
+  exists.
+- **What this does not model** — limitations stated up front rather than left
+  for a user to discover.
+
+---
+
+## 1. Data provenance
+
+Two transcript stores, read-only, parsed at most once per file (cache keyed by
+`(path, mtime, size)`; SCHEMA_VERSION `3` invalidates the whole cache on a
+schema change — `src/lib/usage-index.mjs:39`):
+
+| Provider | Store | Format |
+|---|---|---|
+| Claude Code | `~/.claude/projects/<project>/<sessionId>.jsonl` | one JSON object per line: `user`/`assistant` turns, each assistant turn carrying its own `usage` object |
+| Codex CLI | `~/.codex/sessions/<yyyy>/<mm>/<dd>/rollout-<ts>-<sessionId>.jsonl` | one JSON object per line: `session_meta`, `turn_context`, and `event_msg` records, the latter carrying **cumulative** `token_count` snapshots, not per-turn deltas |
+
+The parsers are `parseClaude` (`usage-index.mjs:362-426`) and `parseCodex`
+(`usage-index.mjs:443-510`). Both are pure functions over the raw file bytes —
+no network, no clock dependency beyond the transcript's own timestamps — so
+every downstream number traces back to bytes already on the user's disk.
+Nothing in this pipeline calls a provider API or a billing endpoint; **no
+metric on this tab is ever a copy of an actual invoice.** That is the whole
+reason every dollar figure is labelled "API-equivalent."
+
+---
+
+## 2. Sessions & Responses
+
+**Displayed as:** `SESSIONS` hero tile — `4,981`, subtitle `693,964 assistant
+turns`.
+
+**Formula:**
+
+```text
+sessions = count of session records with responses > 0 AND end >= cutoff
+responses = Σ over included sessions of session.responses
+```
+
+**Source:**
+
+- Filter: a parsed record with zero assistant turns is dropped entirely — "no
+  assistant turn → not a session" (`usage-index.mjs:691`) — and a record whose
+  last activity falls outside the requested window is dropped too
+  (`usage-index.mjs:692`).
+- `responses` accumulation: Claude increments per assistant message
+  (`usage-index.mjs:392`); Codex increments per `agent_message` event
+  (`usage-index.mjs:481`).
+- Totals: `totals.responses += s.responses` per included session
+  (`usage-index.mjs:762`).
+- Render: `kpi("sessions", fmtNum(t.sessions), fmtNum(t.responses)+" assistant
+  turns", "")` (`dashboard-server.mjs:1916`).
+
+**Worked example.** A session with 3 user turns and 2 assistant turns
+contributes `sessions += 1, responses += 2` — prompts (user turns) are tracked
+separately and never appear in this KPI. Verified in
+`tests/kit/usage-index.test.mjs:330` (`s.responses === 2, s.prompts === 1` for
+a fixture with exactly that shape).
+
+**What this does not model:** a session that opened but received no assistant
+reply (e.g. immediately abandoned) is invisible to every Scorecard number —
+by design, not oversight, since a session with no response has nothing to
+attribute cost or category to.
+
+---
+
+## 3. API-Equivalent Cost
+
+**Displayed as:** `API-EQUIVALENT` hero tile — `$961,036`, subtitle `list
+price · not plan billing`.
+
+**Formula**, per `(session, day, model)` usage row:
+
+```text
+inputUnits = input + cacheWrite × 1.25 + cacheRead × 0.1
+cost = (inputUnits × rate_in + output × rate_out) / 1,000,000
+```
+
+summed across every row in the window.
+
+**Source:** `costOf()`, `src/lib/pricing.mjs:169-176`, reproduced verbatim:
+
+```js
+export function costOf(usage) {
+  const { model, provider, input, output, cacheRead, cacheWrite } = usage ?? {};
+  const { in: rin, out: rout } = priceFor(model, provider);
+  const inputUnits = tokens(input)
+    + tokens(cacheWrite) * CACHE_WRITE_MULTIPLIER
+    + tokens(cacheRead) * CACHE_READ_MULTIPLIER;
+  return (inputUnits * rin + tokens(output) * rout) / 1e6;
+}
+```
+
+`CACHE_READ_MULTIPLIER = 0.1`, `CACHE_WRITE_MULTIPLIER = 1.25`
+(`pricing.mjs:112-113`) — see §13 for why these two numbers are correct for
+**both** Anthropic and OpenAI, which is why `costOf` needs no per-provider
+branch on the multiplier (only on the base `rate_in`/`rate_out`, resolved by
+`priceFor`, `pricing.mjs:141-152`).
+
+Rate resolution is **longest-prefix match** on a normalized model id
+(`pricing.mjs:121-130`), so a dated release (`claude-haiku-4-5-20251001`)
+resolves to the same entry as its bare alias, and a more specific entry
+(`gpt-5.6-sol`) is never shadowed by a shorter one (`gpt-5.6`). An id matching
+nothing gets `FALLBACK_PRICE` — Sonnet-class rate, `$3`/`$15`
+(`pricing.mjs:109`) — rather than `$0`, so an unrecognized model can never be
+silently free; `matched: false` travels with the result so a maintainer can
+find fallback-priced rows if the table needs a new entry.
+
+**Worked example** (from the Anthropic pricing page's own published example,
+[C1] below — reproduced here because it is the cleanest independent check of
+the formula's arithmetic, not because it is agentic-kit's number): a Claude
+Opus 5 session with 10,000 uncached input tokens, 40,000 cache-read tokens,
+and 15,000 output tokens:
+
+```text
+inputUnits = 10,000 + 0 × 1.25 + 40,000 × 0.1 = 10,000 + 4,000 = 14,000
+cost       = (14,000 × $5 + 15,000 × $25) / 1e6
+           = ($70,000 + $375,000) / 1e6
+           = $0.445
+```
+
+Anthropic's own worked example ([C1]) reports uncached-input $0.05 +
+cache-read $0.02 + output $0.375 = **$0.525** for a similar but not identical
+split (their example has 10,000 uncached / 40,000 cached / 15,000 output at
+the *same* per-token rate, computed line-by-line rather than via the combined
+formula above) — the two computations are the same formula applied to the
+same inputs; the $0.08 difference between $0.445 and $0.525 in this paragraph
+is **session-runtime billing** ($0.08/hour), which is a Claude *Managed
+Agents* billing dimension this scorecard does not model (see §14) — plain API
+usage has no runtime component, so `$0.445` is the correct API-equivalent
+figure for a plain Messages-API session with these token counts.
+
+**What this does not model:** the panel prices every session as if it were
+metered per-token API usage. On a Claude Max/Pro subscription, or Codex via a
+ChatGPT plan, **the user is not billed this way at all** — this is why the
+subtitle says "list price · not plan billing" as a first-class UI element
+(ADR-0009 §3), not a footnote. See §14 for the full list of pricing factors
+this cost figure does not include (regional-processing uplift, large-prompt
+surcharges, service tiers, `inference_geo` multiplier, Batch API discount,
+Managed Agents session-runtime billing).
+
+---
+
+## 4. Tokens
+
+**Displayed as:** `TOKENS` hero tile — `1495.2B`, subtitle `3.0B out ·
+1464.3B cached`.
+
+**Formula:**
+
+```text
+tokens = input + output + cacheRead + cacheWrite   (summed across all rows in window)
+```
+
+**Source:** `t.tokens` from `totals`, accumulated per row at
+`usage-index.mjs:706` (`rowTokens = row.input + row.output + row.cacheRead +
+row.cacheWrite`) and rolled into `totals.tokens` via `addTo`
+(`usage-index.mjs:661`). Rendered with `fmtTok()`
+(`dashboard-server.mjs:1826-1832`): `≥1e9` → `"X.XB"`, `≥1e6` → `"X.XM"`,
+`≥1e3` → `"X.XK"`, else the rounded integer.
+
+The **token composition bar** immediately below the hero row (cache read /
+cache write / output / input, as four coloured segments) is the same four
+numbers as percentages of `t.tokens` (`dashboard-server.mjs:1952-1959`,
+`pct(a,b) = b ? a/b*100 : 0`, `dashboard-server.mjs:1840`).
+
+**What "input" excludes.** For both providers, the `input` counter recorded
+per row is **gross input minus cached input** — Claude's parser reads
+`cache_read_input_tokens` and `cache_creation_input_tokens` as separate fields
+the provider already reports separately (`usage-index.mjs:399-402`); Codex's
+parser subtracts `cached_input_tokens` from `input_tokens` explicitly
+(`usage-index.mjs:496-500`, `input: Math.max(0, gross - cacheRead)`) because
+Codex's own `input_tokens` field **includes** cached tokens and would
+double-count them against the separately-reported `cacheRead` figure if left
+as-is. This is asserted by test:
+`tests/kit/usage-index.test.mjs:330-350` ("Codex tokens come from the LAST
+token_count event, never the sum") pins a fixture where the naive sum of two
+cumulative snapshots (4000/1600/400) would be wrong, and the correct
+last-event-only answer (3000/1200/300, split into `input: 1800, cacheRead:
+1200`) is what the assertion requires.
+
+**What this does not model:** reasoning tokens (`reasoning_output_tokens`,
+present in Codex's `token_count` payload) are not broken out as a separate
+figure — they are folded into `output` implicitly via the provider's own
+`output_tokens` field, which on OpenAI's reasoning-model line already
+includes them.
+
+---
+
+## 5. Cache Read %
+
+**Displayed as:** `CACHE READ` hero tile — `97.9%`, subtitle `priced at
+0.1× input`.
+
+**Formula:**
+
+```text
+cacheShare = cacheRead / tokens × 100
+```
+
+Note this is cache-read tokens **as a share of all tokens** (input + output +
+cacheRead + cacheWrite), **not** as a share of input alone. On the reference
+figures (`cacheRead = 1464.3B`, `tokens = 1495.2B`): `1464.3 / 1495.2 × 100 =
+97.93%`, which rounds to the displayed `97.9%` — confirming the denominator.
+
+**Source:** `dashboard-server.mjs:1914` (`cacheShare = pct(t.cacheRead,
+t.tokens)`), rendered `dashboard-server.mjs:1922`.
+
+**Why this number matters more than it looks like it should.** ADR-0009's
+own motivating data point: on the reference corpus, 96.3% of tokens were
+cache reads, and pricing them as fresh input (rather than at the 0.1×
+multiplier) would overstate cost by roughly 10× (`pricing.mjs:8-9`, ADR-0009
+§Context point 2). A cache-read share this high is not an anomaly to be
+suspicious of on its own — it is the expected steady state for any
+long-running agentic session that resends a large, mostly-unchanged system
+prompt and tool-result history on every turn, which both Claude Code and
+Codex CLI do by default.
+
+---
+
+## 6. Engaged Time
+
+**Displayed as:** `ENGAGED TIME` hero tile — `403h`, subtitle `3286h summed`
+plus a `sessions overlap` note. Hovering the tile reveals a tooltip with all
+three tiers (ADR-0009's "ladder," `dashboard-server.mjs:1904-1910`).
+
+This is the single most heavily-caveated metric on the tab, because a naive
+version of it was **wrong by roughly 3×** during ADR-0009's own design pass
+(ADR-0009 §4) — worth understanding in full before trusting the number.
+
+**Three tiers**, each a genuinely different question, computed as three
+separate interval-union operations:
+
+| Tier | Question it answers | Formula |
+|---|---|---|
+| `engagedSeconds` (**the headline figure**) | Time actually spent working, never double-counted, never inflated by idle time | union of every session's **active sub-intervals** |
+| `spanUnionSeconds` (tooltip only) | Wall-clock time with *some* session open, overlap collapsed but idle time NOT split out | union of every session's **whole span** (first timestamp → last timestamp) |
+| `spanMinutes×60` (subtitle, labelled "summed") | The naive, double-counting sum — kept and clearly labelled as the dishonest one, not hidden | **sum** of every session's span, no union at all |
+
+The asserted invariant is `engagedSeconds ≤ spanUnionSeconds ≤
+spanMinutes×60`, and it is checked directly by test
+(`tests/kit/usage-index.test.mjs`, the `mergeIntervals` suite starting around
+line 97, plus the aggregate-level tests around lines 495-509).
+
+**Why three tiers instead of one.** Two independent distortions stack in raw
+session data, and each needs its own fix:
+
+1. **Overlap.** Subagent and parallel sessions run concurrently in wall-clock
+   time. Summing their spans counts the same clock-minute once per concurrent
+   session. Fix: union, not sum — this alone is the `spanUnionSeconds` tier.
+2. **Idle time inside a session.** A session's span is first-timestamp to
+   last-timestamp. A session left open for hours between turns (waiting on a
+   human, or genuinely idle) donates its *entire* idle stretch to the span,
+   even though no work happened during it. Fix: split each session into
+   active sub-intervals wherever the gap between two consecutive timestamps
+   exceeds `IDLE_GAP_MS` (15 minutes, `usage-index.mjs:45`), then union
+   *those* sub-intervals — this is `engagedSeconds`.
+
+**Source:**
+
+- `mergeIntervals()` (`usage-index.mjs:72-97`) — the pure union primitive,
+  sorts intervals and merges any two that overlap **or exactly touch**
+  (`s <= curEnd`, `usage-index.mjs:88`), returning total covered seconds
+  rounded to the nearest second.
+- `activeIntervals()` (`usage-index.mjs:295-307`) — splits one session's
+  sorted timestamp list into sub-intervals wherever a gap exceeds
+  `IDLE_GAP_MS`; "a run of one timestamp yields a zero-length interval and so
+  contributes nothing" (comment, `usage-index.mjs:293`).
+- Aggregation: `totals.engagedSeconds = mergeIntervals(sessions.flatMap(s =>
+  s._active))` (`usage-index.mjs:804`); `totals.spanUnionSeconds =
+  mergeIntervals(sessions.map(s => s._span))` (`usage-index.mjs:803`);
+  `totals.spanMinutes` is a running sum of `s._span[1] - s._span[0]` across
+  the loop (`usage-index.mjs:765`, finalized `usage-index.mjs:802`).
+- Render: `fmtHours()` (`dashboard-server.mjs:1833`, `≥10h` rounds to the
+  nearest hour, else one decimal place) and `fmtMins()`
+  (`dashboard-server.mjs:1834`, `≥60min` rounds to hours, else whole
+  minutes).
+
+**Worked example**, ADR-0009's own reference-corpus measurement (14-day
+window, 582–584 sessions depending on exact cutoff), reproduced here as the
+canonical sanity check of the three-tier design:
+
+| Tier | Total | Per day |
+|---|---|---|
+| `engagedSeconds` | 100.7 h | 7.2 h |
+| `spanUnionSeconds` | 230.8 h | 16.5 h |
+| `spanMinutes×60` | 296.4 h | 21.2 h |
+
+The naive sum (296.4 h / 21.2 h/day) implies a person working 21-hour days —
+"not a rounding error, it is a false statement" (ADR-0009 §4). The
+span-union fixes overlap but still implies 16.5 h/day, because 11 in-window
+sessions individually spanned over 6 hours (the longest 27.4 h) without
+splitting at idle gaps. Only the fully-split, unioned figure — 7.2 h/day — is
+both overlap-corrected and idle-corrected, which is why it is the one
+promoted to the hero tile; the other two are demoted to a subtitle and a
+tooltip respectively, never deleted, so the invariant chain stays checkable
+from the running panel (ADR-0009 §4, "Amendment (2026-07-25)").
+
+**What this does not model:** `IDLE_GAP_MS = 15 min` is a judgement call, not
+a measured constant — a maintainer who believes work with 20-minute pauses
+should still count as one continuous stretch will get a lower
+`engagedSeconds` than they'd expect, and the constant is exported and named
+specifically so that disagreement is visible and adjustable in one place
+rather than buried.
+
+---
+
+## 7. Cost per Day
+
+**Displayed as:** the bar chart directly under the hero row, one bar per
+calendar day in the window, height proportional to that day's cost. Hovering
+a bar shows `day · cost · tokens · sessions`.
+
+**Formula:**
+
+```text
+byDay[day].cost = Σ costOf(row) for every usage row whose day == that key
+```
+
+**Source:** the day key is the row's own `row.day`, computed once at parse
+time as **local calendar day**, not UTC
+(`usage-index.mjs:398`/`usage-index.mjs:499` call `localDay(at)`) — so a
+session that runs from 23:58 local to 00:05 local is billed to the day its
+*first* row landed on (test:
+`tests/kit/usage-index.test.mjs:556`, "a session that opens before midnight
+is counted on its first billed day"). Accumulation:
+`byDay[row.day].cost += rowCost` (`usage-index.mjs:709`). Bar height:
+`h = maxDay ? max(2, cost/maxDay*100) : 2` (`dashboard-server.mjs:1933`) —
+every non-empty day gets a visually nonzero bar (floor of 2%), so a very
+cheap day is never rendered as invisible.
+
+**What this does not model:** a day is only present in `byDay` if at least
+one usage row landed on it — a day with zero activity produces no bar at all
+(not a zero-height bar), which is why the chart in the reference screenshot
+shows a long run of essentially-empty low bars at the start of the window
+rather than a continuous 30-day series.
+
+---
+
+## 8. By Host (Claude vs Codex)
+
+**Displayed as:** two cards, `claude` and `codex`, each showing cost,
+session count, and total tokens; an idle host (`sessions == 0 && cost == 0`)
+renders "no sessions in window" instead of zeroed figures
+(`dashboard-server.mjs:1945-1949`).
+
+**Formula:** identical aggregation to every other bucket
+(`byProvider[s.provider]`, populated via `addTo()`, `usage-index.mjs:657-666`,
+called once per session at `usage-index.mjs:767`), keyed by the literal string
+`"claude"` or `"codex"` assigned at parse time
+(`blankSession(id, 'claude')` / `blankSession(id, 'codex')`,
+`usage-index.mjs:274-280`, `parseClaude`/`parseCodex` entry points).
+
+**Why this pairing is the one under the most scrutiny.** Both providers'
+tokens are summed into the *same* `tokens`/`cost` fields using the *same*
+formula (§3, §4) — the aggregation code has no branch that treats a Codex
+session differently from a Claude session once `costOf()` has priced its
+rows. Any divergence between the two hosts' per-session averages is
+therefore either (a) a genuine usage-pattern difference, or (b) a defect in
+how one provider's raw transcript is *parsed into rows* upstream of
+aggregation — never a defect in the aggregation itself, since both hosts
+share it. §15 documents two real defects of exactly that kind, found and
+fixed on 2026-07-25 in `parseCodex` specifically.
+
+**What this does not model:** the by-host cards do not distinguish a session
+that used both providers (not currently possible in this data model — a
+session record has exactly one `provider`) from one that used only one; a
+workflow that hands off between Claude and Codex mid-task (e.g. `ak dual
+run`) produces two separate session records, one per host, each correctly
+priced on its own, rather than one blended record.
+
+---
+
+## 9. When You Work
+
+**Displayed as:** a 7×24 heatmap (day-of-week × local hour), cell intensity
+proportional to response count in that bucket; the axis leads with `Mon`
+(day index 0).
+
+**Formula:**
+
+```text
+punchcard[dow + "-" + hour] += 1   per assistant/agent_message response, at its local timestamp
+```
+
+**Source:** incremented once per Claude assistant turn
+(`usage-index.mjs:405-406`, keyed by `punchKey(at)`) and once per Codex
+`agent_message` (`usage-index.mjs:483-484`), merged into the window-level
+`punchcard` object per session (`usage-index.mjs:782`). Cell intensity is
+linear against the single busiest cell in the window:
+`v = pcMax ? n/pcMax : 0` (`dashboard-server.mjs:1969`) — this is a
+**relative**, not absolute, scale, so the heatmap's brightest cell is always
+"the busiest hour-of-week in *this* window," not a fixed response-count
+threshold, and comparing brightness across two different date-range views is
+not meaningful without checking the underlying counts (available via the
+tooltip on each cell).
+
+**What this does not model:** the heatmap counts *responses*, not elapsed
+time — a hint at rhythm, not at engaged-time distribution (that's §6). A hint
+that reads as heavy weekend activity, for instance, does not by itself imply
+long weekend sessions, only frequent ones.
+
+---
+
+## 10. Models in Play
+
+**Displayed as:** a ranked bar list, one row per model id seen in the
+window, sorted by cost descending, bar width relative to the top model's
+cost; each row shows `cost`, `tokens · N resp`.
+
+**Formula:**
+
+```text
+byModel[model].cost      = Σ costOf(row) for every usage row with that model id
+byModel[model].tokens    = Σ rowTokens for every usage row with that model id
+byModel[model].responses = Σ row.responses for every usage row with that model id
+byModel[model].sessions  = count of DISTINCT sessions whose s.models includes this model id
+                            (a session using two models counts once under EACH)
+```
+
+**Source:** cost/tokens/responses accumulate inside the usage-row loop
+(`usage-index.mjs:696-713`); the `sessions` count is deliberately computed
+**separately**, once per session over its `s.models` array
+(`usage-index.mjs:775-780`) rather than inside the cost loop, precisely
+**so that a model can appear in `byModel` — with a nonzero session count —
+even in a session that contributed zero cost/tokens/responses for that
+model.** This is not an edge case invented for this document: it is the
+exact mechanism that makes §15's subagent-replay fix safe (a model used only
+by an excluded subagent-replay session still shows up as "used," at zero
+cost, rather than vanishing).
+
+`byModel[...].responses` is populated from `row.responses`
+(`usage-index.mjs:711`), which in turn comes from the `responses` field
+passed into `addUsage()` at the call site — `1` per Claude assistant turn
+(`usage-index.mjs:398-404`), or `rec.responses` (the session's whole response
+count) once per Codex session, passed at the single point Codex calls
+`addUsage` (`usage-index.mjs:499-506`; see §15 Bug A for why this field was
+previously omitted for Codex and every Codex model showed 0 responses
+regardless of real activity).
+
+**Render:** `bar(name, fmtUsd(cost), fmtTok(tokens)+" · "+fmtNum(responses)+"
+resp", pct(cost, topModelCost), false)` (`dashboard-server.mjs:1982-1985`),
+list itself sorted cost-descending by the shared `entries()` helper
+(`dashboard-server.mjs:1841-1846`).
+
+---
+
+## 11. Projects
+
+**Displayed as:** a ranked bar list, top 8 shown, note reading `"top 8 of
+N"` when more exist; each row shows `cost`, `N sess · minutes`.
+
+**Formula:** identical shape to §10 (`byProject[project]`), plus a `project
+= 'unknown'` fallback and a repo/worktree collapsing rule that is worth
+citing precisely because it was itself the subject of an ADR-0009 amendment:
+`projectLabel(cwd)` collapses `<repo>/<marker>/worktrees/<rest>` (marker ∈
+`.autopilot`, `.claude`, `.git`) to `<repo>`, keeping `rest` as a separate
+`worktree` field on the session rather than either discarding it or letting
+it masquerade as a sibling project (ADR-0009 §4b). Before this fix, a git
+worktree's *branch name* was reported as its own project, silently
+undercounting the true repo's total by whatever work happened in the
+worktree.
+
+**Source:** ranking and truncation, `dashboard-server.mjs:1987-1994`
+(`shown = projects.slice(0,8)`); accumulation via the same `addTo()`/
+`entries()` machinery as §10, keyed by `s.project` instead of `s.models`.
+
+**What this does not model:** a session whose working directory could not be
+determined (e.g. missing `cwd` in the transcript) lands in a literal
+`"unknown"` bucket rather than being dropped — visible in the project list
+rather than silently absent from the total.
+
+---
+
+## 12. What You Worked On
+
+**Displayed as:** a ranked bar list of categories, bar width relative to
+the top category's cost; each row shows `cost`, `N sess · $/sess`; a small
+confidence dot on classified rows (opacity `0.5 + confidence×0.5`,
+`dashboard-server.mjs:2001-2002`); `Unclassified` is always shown, never
+hidden, and carries no confidence dot.
+
+This is the only Scorecard metric that is **not** pure arithmetic over
+token counts — it is a deterministic, rule-based classifier over each
+session's title and tool-call mix. Because it is the metric most likely to
+be second-guessed ("why did it call this a bug fix"), its full decision
+procedure is reproduced here rather than summarized.
+
+**Three layers, strictly ordered** (`src/lib/usage-classify.mjs:199-254`):
+
+1. **Provenance (confidence = 1.0, unconditional).** If the session carries
+   an `attributionSkill` or `attributionPlugin` matching a known prefix in
+   `SKILL_CAT` (`usage-classify.mjs:45-62`, e.g. `superpowers:brainstorming`
+   → `Design & planning`), that mapping **is** the category. This is not an
+   inference — it is a recorded fact about which skill actually ran, so it
+   overrides every other signal outright (`usage-classify.mjs:203-207`).
+
+2. **Weighted keyword rules over the title, nudged by tool mix.**
+   `RULES` (`usage-classify.mjs:76-150`) is a closed list of 14 categories,
+   each with `strong` keywords (weight 3) and `weak` keywords (weight 1),
+   matched as case-insensitive substrings of the session's title
+   (`usage-classify.mjs:210-217`). A tool-mix prior then nudges — never
+   solely decides — the ranking: an edit-heavy session (>30% of tool calls
+   are `Edit`/`MultiEdit`/`Write`/`NotebookEdit`) adds weight to
+   `Feature build`/`Refactor`/`Bug fix & debug`; a read-heavy, edit-light
+   session (>45% `Read`/`Grep`/`Glob`, <10% edit) adds weight to `Code
+   review`/`Security review`/`Research & exploration`; an agent-heavy
+   session (>12% `Agent`/`Task` calls) adds weight to `Orchestration`
+   (`TOOL_PRIOR`, `usage-classify.mjs:155-159`, applied
+   `usage-classify.mjs:219-232`).
+
+3. **The floor.** A category must clear `CONFIDENCE_FLOOR = 0.28`
+   (`usage-classify.mjs:168`) or the session is reported `Unclassified`
+   with `basis: 'weak signal'` — or `basis: 'no signal'` if no rule matched
+   at all (`usage-classify.mjs:234`, `:252`). `Unclassified` is a **first
+   class outcome**, not a failure state: forcing every session into a
+   category to reach 100% coverage would make every category
+   untrustworthy, not just the residue (ADR-0009 §5).
+
+**Confidence formula** (`usage-classify.mjs:236-250`), for the top-scoring
+category against its runner-up:
+
+```text
+strength = min(1, topScore / 7)                        // 7 ≈ two strong-keyword hits
+margin   = 1 - min(runnerUpScore / topScore, 1)
+grounded = 1 if the TITLE (not just the tool prior) contributed to the winning
+             category's score, else 0 — a category that wins on tool-mix
+             alone, with zero title evidence, is a guess, not a classification
+confidence = round2( min(0.9, strength × (0.35 + 0.65 × margin)) × grounded )
+```
+
+The `0.35` floor on a dead-even tie (`TIE_FLOOR`, `usage-classify.mjs:174`)
+means two equally-strong categories can never independently produce a
+confident pick — the margin term earns the rest. The `0.9` cap
+(`RULE_CONFIDENCE_CAP`, `usage-classify.mjs:177`) means confidence `1.0` is
+reserved exclusively for provenance-layer matches, so a `1.0` in the UI is
+always traceable to a specific attributed skill/plugin id, never to a lucky
+keyword hit.
+
+**Worked example**, from ADR-0009's own reference-corpus measurement
+(§5): signal coverage was `ai-title` 93%, tool mix 100%,
+`attributionSkill`/`attributionPlugin` 8%, slash commands 13% (mostly
+`/clear`/`/model`, not task-descriptive). This is why provenance alone
+cannot classify most sessions and layer 2 (title + tool-mix rules) carries
+the bulk of the load.
+
+**Render:** `dashboard-server.mjs:1997-2008`, sorted cost-descending via the
+shared `entries()` helper, with `$/sess = cost / max(sessions, 1)` guarding
+the zero-session edge case (`dashboard-server.mjs:1999`).
+
+**What this does not model:** the classifier reads only the session's
+*title* (Claude's own `ai-title`, written by the model itself at session
+end) and its *tool-call mix* — never the transcript body. A session with a
+generic or misleading title and an atypical tool mix for its actual work
+will be misclassified or land in `Unclassified`; the confidence figure and
+`basis` string exist specifically so a reader can tell when that has
+happened rather than trusting the category blindly (ADR-0009 §5 Amendment).
+An **optional**, off-by-default LLM-labelling layer 3 exists for exactly
+this residue (`--enrich`, applied only below the confidence floor, cached
+permanently per session — ADR-0009 §5) but is out of scope for this document
+since it is opt-in and not part of a default Scorecard render.
+
+---
+
+## 13. Provider pricing tables — verified rates
+
+Every rate in `src/lib/pricing.mjs:30-80` as of `PRICES_AS_OF = '2026-07-25'`
+(`pricing.mjs:18`), checked against the sources below on 2026-07-25.
+
+### 13.1 Anthropic — primary source, directly verified
+
+Fetched in full from **[C1]** on 2026-07-25. The table below is Anthropic's
+own published table, not a transcription from a secondary source:
+
+| Model | Base input | 5m cache write | 1h cache write | Cache read (hit) | Output |
+|---|---|---|---|---|---|
+| Claude Fable 5 / Mythos 5 | $10/MTok | $12.50/MTok | $20/MTok | $1/MTok | $50/MTok |
+| Claude Opus 5 | $5/MTok | $6.25/MTok | $10/MTok | $0.50/MTok | $25/MTok |
+| Claude Opus 4.8 / 4.7 / 4.6 / 4.5 | $5/MTok | $6.25/MTok | $10/MTok | $0.50/MTok | $25/MTok |
+| Claude Sonnet 5 (through 2026-08-31) | $2/MTok | $2.50/MTok | $4/MTok | $0.20/MTok | $10/MTok |
+| Claude Sonnet 5 (from 2026-09-01) | $3/MTok | $3.75/MTok | $6/MTok | $0.30/MTok | $15/MTok |
+| Claude Sonnet 4.6 / 4.5 | $3/MTok | $3.75/MTok | $6/MTok | $0.30/MTok | $15/MTok |
+| Claude Haiku 4.5 | $1/MTok | $1.25/MTok | $2/MTok | $0.10/MTok | $5/MTok |
+
+Every value in `pricing.mjs`'s Anthropic entries (`pricing.mjs:32-50`) matches
+this table's "Base input" and "Output" columns exactly. The cache-write and
+cache-read *columns* in this table are provider-published absolute rates; the
+kit's `pricing.mjs` instead stores the two **multipliers** (0.1× and 1.25×,
+5-minute TTL only — the kit does not currently distinguish 5-minute from
+1-hour cache TTL, since Claude Code transcripts do not record which TTL a
+given cache write used) and applies them to the base input rate at cost-compute
+time (`costOf()`, §3). Cross-checking one row: Opus 5's published $6.25
+5-minute cache-write rate is exactly *$5 × 1.25*; its published $0.50 cache-read
+rate is exactly *$5 × 0.1*. Every row in Anthropic's own table satisfies
+`cache_write_5m = input × 1.25` and `cache_read = input × 0.1` — confirming
+the multiplier approach is arithmetically identical to using the provider's
+published absolute cache rates directly, for every current Anthropic model.
+
+Anthropic's own prompt-caching documentation **[C2]** states the multipliers
+in prose, independent of the pricing table: *"5-minute cache write tokens are
+1.25 times the base input tokens price... Cache read tokens are 0.1 times the
+base input tokens price."* This is the second, independent confirmation of
+`CACHE_READ_MULTIPLIER`/`CACHE_WRITE_MULTIPLIER` (`pricing.mjs:112-113`).
+
+### 13.2 OpenAI (Codex) — hand-maintained, no canonical machine-readable source
+
+`pricing.mjs`'s own comment (`pricing.mjs:52-66`) records that
+`~/.codex/models_cache.json` was checked directly and contains **zero**
+price-related keys — Codex CLI does not ship pricing data locally, unlike
+Anthropic which publishes a fetchable pricing document. OpenAI's rates in
+this table are therefore maintained by hand against OpenAI's own developer
+documentation and are the most drift-prone entries in the file — this is
+explicitly why `PRICES_AS_OF` is surfaced in the UI (`u-asof`,
+`dashboard-server.mjs:1923`) rather than assumed current.
+
+| Model (kit key) | Input | Output | Cache read (0.1×, derived) |
+|---|---|---|---|
+| `gpt-5.6-sol` | $5/MTok | $30/MTok | $0.50/MTok |
+| `gpt-5.6-terra` | $2.50/MTok | $15/MTok | $0.25/MTok |
+| `gpt-5.6-luna` | $1/MTok | $6/MTok | $0.10/MTok |
+| `gpt-5.5` | $5/MTok | $30/MTok | $0.50/MTok |
+| `gpt-5.5-pro` | $30/MTok | $180/MTok | $3/MTok |
+
+Independently corroborated (aggregator sources, not OpenAI's own page —
+see the sourcing-tier note below) on 2026-07-25: GPT-5.6 Sol short-context
+pricing of $5 input / $30 output / $0.50 cache-read / $6.25 cache-write per
+MTok, rising to $10/$45 above a 272K-input-token threshold **[C3, C4, C5]**;
+OpenAI's cached-input discount is described industry-wide as "cached tokens
+cost approximately 10% of regular input" and "automatic for all requests
+containing 1,024+ tokens," and cache writes for the GPT-5.6+ model family
+specifically are described as costing 1.25× the uncached input rate
+**[C6]** — the same multiplier Anthropic publishes, which is why
+`pricing.mjs` applies one multiplier pair to both providers rather than
+maintaining two.
+
+**Sourcing-tier disclosure, stated plainly rather than glossed over:** the
+Anthropic table above (§13.1) was fetched directly from Anthropic's own
+documentation domain and is a primary source. The OpenAI table was
+corroborated via web search against multiple independent third-party
+pricing aggregators (all citing the same figures independently, which is
+reasonable but not equivalent evidence to a direct fetch of OpenAI's own
+pricing page); an attempt to directly fetch OpenAI's developer pricing
+documentation for this document was not completed. A maintainer updating
+this table should fetch `https://platform.openai.com/docs/pricing` (or
+whatever OpenAI's current canonical pricing URL is at the time) directly and
+upgrade this citation to primary-source status. Until then, treat the OpenAI
+rows in `pricing.mjs` — like the file's own comment already says — as
+hand-maintained and drift-prone, not vendor-confirmed via automated fetch.
+
+### 13.3 What the pricing table deliberately does not model
+
+Recorded verbatim from `pricing.mjs:82-99` (`UNMODELLED_PRICING_FACTORS`,
+`pricing.mjs:100-102`) because listing known gaps is what makes the
+*modelled* factors credible:
+
+- **Regional-processing uplift.** OpenAI charges +10% on data-residency
+  endpoints for models released on/after 2026-03-05; Codex CLI does not use
+  those endpoints by default and a transcript does not record which endpoint
+  served a given request, so this cannot be detected from local data.
+  (Anthropic's own equivalent — the `inference_geo: "us"` 1.1× multiplier,
+  confirmed in **[C1]** §"Inference geography" — is likewise unmodelled for
+  the same reason: a Claude transcript does not record which `inference_geo`
+  value a request used.)
+- **Large-prompt surcharge.** A reported 2× input / 1.5× output surcharge
+  above ~272K input tokens for the GPT-5.6 line is not restated on OpenAI's
+  current canonical pricing page as far as this audit could confirm, so it
+  is deliberately left unmodelled rather than encoded on one unconfirmed
+  source.
+- **`*-pro` models list no cached-input rate** in the maintained table
+  (caching appears unsupported for that tier); their transcripts report
+  zero cached tokens, so the 0.1× branch of `costOf()` is simply never
+  exercised for them — not a bug, just an unreachable code path for that
+  model family.
+- **Service tiers.** Batch API, Flex, and Priority-tier multipliers (on
+  both providers) are not applied. Anthropic's Batch API carries a
+  documented 50% input/output discount **[C1]** §"Batch processing"; Claude
+  Managed Agents sessions additionally bill **session runtime** at
+  $0.08/session-hour on top of tokens **[C1]** §"Claude Managed Agents
+  pricing" — neither transcript store records which billing surface (plain
+  Messages API, Batch, or Managed Agents) produced a given session, so none
+  of these are modelled.
+
+---
+
+## 14. Known limitations, restated as a single checklist
+
+For a reviewer who wants the "does this number lie to me" answer without
+reading every section above:
+
+- [x] Cost is always an **API-list-price equivalent**, never a claim about
+  actual billing (§3, §14 pricing gaps above).
+- [x] Engaged time leads with the most-corrected of three tiers; the other
+  two remain visible (subtitle + tooltip), not deleted (§6).
+- [x] `Unclassified` is always shown, never hidden or force-fit (§12).
+- [x] An unrecognized model id is priced at a stated fallback rate, never
+  silently zero (§3).
+- [x] A day, project, or model with zero window activity is simply absent
+  from its list — never rendered as a fabricated zero (§7, §11).
+- [x] Price tables are hand-maintained and date-stamped in the UI
+  (`rates as of <PRICES_AS_OF>`) precisely because they *will* drift
+  (ADR-0009 "Costs and risks").
+- [x] The pricing formula applies identically to every provider; a
+  cross-provider discrepancy in the by-host breakdown (§8) is diagnostic
+  evidence of a **parsing** defect upstream, not a pricing defect — see §15
+  for two real examples of exactly this kind of defect, found via this same
+  reasoning.
+
+---
+
+## 15. Bugs found and fixed during this audit (2026-07-25)
+
+This section exists because a user (via a friend using Codex) reported the
+Codex side of the by-host breakdown (§8) "looked questionable" compared to
+Claude's. Investigation traced two real defects — both in `parseCodex`
+specifically, neither in the shared aggregation or pricing logic those two
+parsers feed into (consistent with §8's claim that the aggregation code is
+provider-agnostic). Fixed in commit `540be18` on this branch.
+
+### Bug A — Codex model rows always showed 0 responses
+
+`parseCodex`'s single `addUsage()` call never included a `responses` field —
+Claude's parser passes `responses: 1` per assistant turn
+(`usage-index.mjs:403`, as it existed before this fix), but Codex's call
+passed no such field at all. Because `byModel[model].responses` is summed
+directly from each usage row's `responses` field (`usage-index.mjs:711`,
+`m.responses += row.responses`), **every** Codex model in §10's "Models in
+Play" list displayed `0 resp` regardless of real token/cost volume or actual
+`agent_message` count. **Fix:** `parseCodex` now passes `responses:
+rec.responses` (the session's own tallied response count,
+`usage-index.mjs:481`) on its `addUsage()` call.
+
+### Bug B — subagent thread-replay could double-bill tokens
+
+Codex CLI's `thread_spawn` subagent-delegation mechanism writes a rollout
+file for the spawned subagent that **replays its parent thread's entire
+prior cumulative token history as duplicate events**, re-timestamped to the
+subagent's creation time, before the subagent's own new turns begin. This is
+a documented, previously-reported Codex CLI behavior, not a hypothesis
+invented for this audit — see **[C4]**, **[C5]**, **[C6]** below, the last
+of which measured up to **91×** cost inflation in a real corpus from exactly
+this mechanism (one parent session with 12 spawned subagents, each replaying
+the parent's full history, so the parent's usage was counted 13 times over —
+once for itself, once per subagent replay).
+
+`parseCodex` took each rollout file's *last* cumulative `token_count` event
+at face value (correctly avoiding the separate naive-summing bug **[C5]**
+documents, since it already used last-event-only logic — see §4's worked
+example) but performed **no de-duplication** against a parent session a
+subagent file might be replaying. **Fix:** the parser now reads
+`session_meta.thread_source` (`usage-index.mjs:458`, confirmed as a real
+Codex rollout field by **[C7]**) and skips the `addUsage()` call entirely
+when its value is `'subagent'` (`usage-index.mjs:495`, guard condition
+`rec.threadSource !== 'subagent'`). The session record itself is **not**
+dropped — it remains visible in the Sessions tab with `threadSource`
+surfaced (mirroring the existing `sidechain` flag Claude sessions already
+carry, `usage-index.mjs:277`), so a maintainer auditing the raw data can
+still see it; it simply contributes zero tokens/cost, exactly as intended by
+the "models still shows up in §10's list, with zero cost" mechanism §10
+describes.
+
+**Verification performed, and its limits, stated honestly:**
+
+- Checked against **5 real local** `~/.codex/sessions/**/rollout-*.jsonl`
+  files on the machine this fix was authored on. All 5 carried
+  `thread_source: "user"` and unique `session_meta.id` values, with each
+  file's *first* `token_count` event starting near its own system-prompt
+  size (~12K tokens) rather than any elevated carryover value — i.e., **no
+  resumed-session token-carryover was reproduced in this sample**, and no
+  `thread_source: "subagent"` file was available to test the fix's guard
+  condition against real replayed data.
+- Regression coverage: a synthetic fixture reproducing the documented replay
+  signature (a rollout whose very first `token_count` event already reports
+  a large cumulative total, paired with `thread_source: "subagent"`) is
+  asserted in `tests/kit/usage-index.test.mjs` ("a subagent-sourced Codex
+  rollout (thread_spawn replay) is excluded from cost/token aggregation") to
+  contribute zero tokens/cost/responses while remaining visible as a
+  session.
+- **This means Bug B's fix is grounded in cited public evidence and covered
+  by synthetic regression tests, but has not yet been validated against a
+  genuine `thread_source: "subagent"` file on real hardware.** Any
+  maintainer whose machine accumulates such a file (most likely from heavy
+  `ak dual run` / hierarchical-mesh swarm usage routing through Codex) should
+  re-run this verification and update this note.
+
+---
+
+## 16. Verification methodology for this document
+
+Every code citation above was read directly from the source files at commit
+`540be18` (not recalled from memory or summarized secondhand); every
+external pricing claim was either fetched directly (Anthropic, §13.1) or
+corroborated across multiple independent third-party sources with the
+sourcing tier disclosed rather than implied (OpenAI, §13.2); every GitHub
+issue cited (§15) was located and its content quoted or paraphrased from the
+actual issue text, not inferred from its title. Where verification was
+incomplete (the OpenAI primary-source fetch, the Bug B real-data check),
+that incompleteness is stated in the relevant section rather than omitted —
+a maintainer-facing document that hides the edges of its own verification is
+exactly the failure mode this document exists to avoid in the metrics it
+describes.
+
+---
+
+## 17. References
+
+- **[C1]** Anthropic — *Pricing*. `https://platform.claude.com/docs/en/about-claude/pricing`. Fetched in full 2026-07-25; primary source for §13.1 (model rate table, prompt-caching multiplier table, worked cost example, Batch API discount, Managed Agents session-runtime billing, `inference_geo` multiplier).
+- **[C2]** Anthropic — *Prompt caching*. `https://platform.claude.com/docs/en/build-with-claude/prompt-caching`. Fetched 2026-07-25; independent confirmation of the 1.25×/2×/0.1× cache multipliers in prose form.
+- **[C3]** TLDL — *OpenAI API Pricing (July 2026)*. `https://www.tldl.io/resources/openai-api-pricing`. Accessed 2026-07-25; GPT-5.6 Sol/Terra/Luna tier pricing.
+- **[C4]** OpenRouter — *GPT-5.6 Sol: API Pricing & Benchmarks*. `https://openrouter.ai/openai/gpt-5.6-sol`. Accessed 2026-07-25; context window (1.05M) and long-context (272K threshold) pricing corroboration.
+- **[C5]** GitHub — `ccusage/ccusage#884`, *Parser overcounts duplicate token_count rows with unchanged total_token_usage*. `https://github.com/ccusage/ccusage/issues/884`. A Codex-usage-analytics tool (functionally the same job as this scorecard's Codex path) documenting that naive summation of cumulative `token_count` snapshots — rather than diffing or taking the last snapshot — matched only 131/732 real sessions correctly; delta/last-event logic matched 100%.
+- **[C6]** GitHub — `openai/codex#14489`, *Change `TokenCount` to not re-emit `last_token_usage` on rate-limit-only updates*. `https://github.com/openai/codex/issues/14489`. Documents Codex CLI re-emitting a stale `last_token_usage` value on rate-limit-only updates with an unchanged cumulative total, which a parser reading `last_token_usage` naively double-counts.
+- **[C7]** GitHub — `ccusage/ccusage#950`, *Bug: Massive token overcounting for Codex subagent sessions (91x inflation)*. `https://github.com/ccusage/ccusage/issues/950`. Source for Bug B (§15): documents `thread_spawn` subagent rollout files replaying the parent thread's entire token history as duplicate, re-timestamped events; measured a 91× real-world cost inflation (reported ~$9,041 against actual spend of ~$100) from a parent session with 12 spawned subagents. Also the source that identifies `session_meta.thread_source` / `source.subagent.thread_spawn` as the detectable field for this pattern.
+- **[C8]** GitHub — `openai/codex#23001`, *Codex App upgrade can break opening older local threads when rollout session_meta lacks thread_source*. `https://github.com/openai/codex/issues/23001`. Confirms `thread_source` is a genuine, if not universally-present, `session_meta` field in real Codex rollout files (older/pre-upgrade rollouts may lack it entirely, which is why the fix in §15 Bug B treats an absent `thread_source` as `'user'`-equivalent — i.e. included — rather than excluded).
+- **ADR-0009** — [`docs/adr/0009-usage-scorecard-local-transcript-analytics.md`](adr/0009-usage-scorecard-local-transcript-analytics.md). The design record this document's formulas implement; source of every reference-corpus figure quoted above (582–584 sessions, 96.3% cache share, 100.7h/230.8h/296.4h engaged-time ladder, 93%/100%/8%/13% classification signal coverage).
+- **In-repo source files**, all pinned to commit `540be18`: `src/lib/usage-index.mjs`, `src/lib/pricing.mjs`, `src/lib/usage-classify.mjs`, `src/lib/dashboard-server.mjs`, `tests/kit/usage-index.test.mjs`.

--- a/docs/USAGE-SCORECARD-METRICS.md
+++ b/docs/USAGE-SCORECARD-METRICS.md
@@ -832,6 +832,16 @@ describes.
   `ak dual run` / hierarchical-mesh swarm usage routing through Codex) should
   re-run this verification and update this note.
 
+**Independent, third-party verification.**
+[`docs/CODEX-USAGE-DIAGNOSTIC.md`](CODEX-USAGE-DIAGNOSTIC.md) is a
+non-maintainer-facing companion to this section: a standalone, zero-dependency
+script plus instructions for anyone with real Codex usage to compute the
+same before/after comparison on their own machine, from a separate
+reimplementation of the parsing logic, and report back an aggregate-only
+result with no transcript content. Point anyone questioning their own
+Codex numbers there first — it produces the real number instead of a
+promise.
+
 ---
 
 ## 16. Verification methodology for this document

--- a/docs/USAGE-SCORECARD-METRICS.md
+++ b/docs/USAGE-SCORECARD-METRICS.md
@@ -15,26 +15,25 @@ maintainer reviewing a pricing-table change — can verify every claim here
 against either the cited source code or the cited external page, without
 having to trust this document on faith.
 
-**Pinned to.** commit `540be18` on branch `fix/codex-usage-scorecard-metrics`
-(2026-07-25). Line numbers below will drift as the code changes; if a citation
-no longer matches, `git log -p -L<line>,<line>:<file>` from this commit is the
-fastest way to find where it moved.
+**Citations are machine-checked.** Every `file:line` citation below is
+verified against the current source by the test suite
+(`tests/kit/doc-citations.test.mjs`): an identifier named beside the citation
+must appear at the cited lines. A passing build means the citations match the
+code you have; upkeep is covered in
+[Appendix B](#appendix-b--verification-methodology).
 
 **Scope.** This document covers the **Scorecard** tab only — the five hero KPIs
 (Sessions, API-Equivalent, Tokens, Engaged Time, Cache Read) and the six
 supporting panels (cost per day, by host, token composition bar, when you work,
 models in play, projects, what you worked on). The **Findings**, **Sessions**,
-and **Transcript** tabs are governed by separate rules (ADR-0009 §6 and §8) and
-are out of scope here except where they share a data source with a Scorecard
-metric.
+and **Transcript** tabs are governed by separate rules and are out of scope
+here except where they share a data source with a Scorecard metric.
 
-**Companion document.** This is a *metrics reference*, not a design record. The
-"why" behind each design choice — why three time tiers, why rules-based
-classification, why cost is never called billing — is ADR-0009's job and is
-cited, not repeated, below. Read
-[`docs/adr/0009-usage-scorecard-local-transcript-analytics.md`](adr/0009-usage-scorecard-local-transcript-analytics.md)
-first if you want motivation; read this document if you want to check an
-arithmetic claim.
+**Companion document.** This is a *metrics reference*, not a design record.
+The "why" behind each design choice — why three time tiers, why rules-based
+classification, why cost is never called billing — lives with the design
+records mapped in [Appendix C](#appendix-c--design-rationale-adr-map). Read
+this document to check an arithmetic claim.
 
 ---
 
@@ -57,7 +56,7 @@ Every metric section below follows the same shape:
 ## 1. Data provenance
 
 Two transcript stores, read-only, parsed at most once per file (cache keyed by
-`(path, mtime, size)`; SCHEMA_VERSION `5` invalidates the whole cache on a
+`(path, mtime, size)`; `SCHEMA_VERSION` invalidates the whole cache on a
 schema change — `src/lib/usage-index.mjs:50`):
 
 | Provider | Store | Format |
@@ -117,9 +116,8 @@ text the harness wrote — task notifications, `bash-stdout`/
 `local-command-stdout` dumps, caveats — are not human prompts and no longer
 count as such (`isHumanPrompt` + `HARNESS_OUTPUT_RE`; the full envelope
 taxonomy is [`TRANSCRIPTS.md`](TRANSCRIPTS.md) §3.2). A `! command` the
-person typed (`bash-input`) still counts. On a reference session this
-corrected 32 claimed prompts to 20 real ones; cached records carried the
-inflated figure, hence the v5 cache invalidation.
+person typed (`bash-input`) still counts. (The correction this rule shipped
+with is recorded in [Appendix A](#appendix-a--fix-history).)
 
 ---
 
@@ -192,8 +190,8 @@ figure for a plain Messages-API session with these token counts.
 **What this does not model:** the panel prices every session as if it were
 metered per-token API usage. On a Claude Max/Pro subscription, or Codex via a
 ChatGPT plan, **the user is not billed this way at all** — this is why the
-subtitle says "list price · not plan billing" as a first-class UI element
-(ADR-0009 §3), not a footnote. See §14 for the full list of pricing factors
+subtitle says "list price · not plan billing" as a first-class UI element,
+not a footnote. See §14 for the full list of pricing factors
 this cost figure does not include (regional-processing uplift, large-prompt
 surcharges, service tiers, `inference_geo` multiplier, Batch API discount,
 Managed Agents session-runtime billing).
@@ -238,6 +236,8 @@ cumulative snapshots (4000/1600/400) would be wrong, and the correct
 last-event-only answer (3000/1200/300, split into `input: 1800, cacheRead:
 1200`) is what the assertion requires.
 
+![Figure: Claude sums per-turn usage deltas while Codex reports cumulative token_count snapshots where only the last one counts — summing snapshots would double-count](assets/usage-token-accounting.svg)
+
 **What this does not model:** reasoning tokens (`reasoning_output_tokens`,
 present in Codex's `token_count` payload) are not broken out as a separate
 figure — they are folded into `output` implicitly via the provider's own
@@ -265,11 +265,10 @@ figures (`cacheRead = 1464.3B`, `tokens = 1495.2B`): `1464.3 / 1495.2 × 100 =
 **Source:** `dashboard-server.mjs:1931` (`cacheShare = pct(t.cacheRead,
 t.tokens)`), rendered `dashboard-server.mjs:1939`.
 
-**Why this number matters more than it looks like it should.** ADR-0009's
-own motivating data point: on the reference corpus, 96.3% of tokens were
-cache reads, and pricing them as fresh input (rather than at the 0.1×
-multiplier) would overstate cost by roughly 10× (`pricing.mjs:8-9`, ADR-0009
-§Context point 2). A cache-read share this high is not an anomaly to be
+**Why this number matters more than it looks like it should.** On the
+reference corpus, 96.3% of tokens were cache reads — pricing them as fresh
+input (rather than at the 0.1× multiplier) would overstate cost by roughly
+10× (`pricing.mjs:8-9`). A cache-read share this high is not an anomaly to be
 suspicious of on its own — it is the expected steady state for any
 long-running agentic session that resends a large, mostly-unchanged system
 prompt and tool-result history on every turn, which both Claude Code and
@@ -281,11 +280,11 @@ Codex CLI do by default.
 
 **Displayed as:** `ENGAGED TIME` hero tile — `403h`, subtitle `3286h summed`
 plus a `sessions overlap` note. Hovering the tile reveals a tooltip with all
-three tiers (ADR-0009's "ladder," `dashboard-server.mjs:1921-1927`).
+three tiers (the "ladder," `dashboard-server.mjs:1921-1927`).
 
 This is the single most heavily-caveated metric on the tab, because a naive
-version of it was **wrong by roughly 3×** during ADR-0009's own design pass
-(ADR-0009 §4) — worth understanding in full before trusting the number.
+version of it is **wrong by roughly 3×** on the reference corpus — worth
+understanding in full before trusting the number.
 
 **Three tiers**, each a genuinely different question, computed as three
 separate interval-union operations:
@@ -335,9 +334,9 @@ session data, and each needs its own fix:
   (`dashboard-server.mjs:1851`, `≥60min` rounds to hours, else whole
   minutes).
 
-**Worked example**, ADR-0009's own reference-corpus measurement (14-day
-window, 582–584 sessions depending on exact cutoff), reproduced here as the
-canonical sanity check of the three-tier design:
+**Worked example**, the reference-corpus measurement (14-day window, 582–584
+sessions depending on exact cutoff), the canonical sanity check of the
+three-tier design:
 
 | Tier | Total | Per day |
 |---|---|---|
@@ -346,14 +345,14 @@ canonical sanity check of the three-tier design:
 | `spanMinutes×60` | 296.4 h | 21.2 h |
 
 The naive sum (296.4 h / 21.2 h/day) implies a person working 21-hour days —
-"not a rounding error, it is a false statement" (ADR-0009 §4). The
+not a rounding error but a false statement. The
 span-union fixes overlap but still implies 16.5 h/day, because 11 in-window
 sessions individually spanned over 6 hours (the longest 27.4 h) without
 splitting at idle gaps. Only the fully-split, unioned figure — 7.2 h/day — is
 both overlap-corrected and idle-corrected, which is why it is the one
 promoted to the hero tile; the other two are demoted to a subtitle and a
 tooltip respectively, never deleted, so the invariant chain stays checkable
-from the running panel (ADR-0009 §4, "Amendment (2026-07-25)").
+from the running panel.
 
 **What this does not model:** `IDLE_GAP_MS = 15 min` is a judgement call, not
 a measured constant — a maintainer who believes work with 20-minute pauses
@@ -381,7 +380,7 @@ time as **local calendar day**, not UTC
 (`usage-index.mjs:474`/`usage-index.mjs:576` call `localDay(at)`) — so a
 session that runs from 23:58 local to 00:05 local is billed to the day its
 *first* row landed on (test:
-`tests/kit/usage-index.test.mjs:556`, "a session that opens before midnight
+`tests/kit/usage-index.test.mjs:608`, "a session that opens before midnight
 is counted on its first billed day"). Accumulation:
 `byDay[row.day].cost += rowCost` (`usage-index.mjs:786`). Bar height:
 `h = maxDay ? max(2, cost/maxDay*100) : 2` (`dashboard-server.mjs:1950`) —
@@ -418,8 +417,8 @@ rows. Any divergence between the two hosts' per-session averages is
 therefore either (a) a genuine usage-pattern difference, or (b) a defect in
 how one provider's raw transcript is *parsed into rows* upstream of
 aggregation — never a defect in the aggregation itself, since both hosts
-share it. §15 documents two real defects of exactly that kind, found and
-fixed on 2026-07-25 in `parseCodex` specifically.
+share it. [Appendix A](#appendix-a--fix-history) documents two real defects
+of exactly that kind, both in `parseCodex`.
 
 **What this does not model:** the by-host cards do not distinguish a session
 that used both providers (not currently possible in this data model — a
@@ -484,18 +483,17 @@ byModel[model].sessions  = count of DISTINCT sessions whose s.models includes th
 **so that a model can appear in `byModel` — with a nonzero session count —
 even in a session that contributed zero cost/tokens/responses for that
 model.** This is not an edge case invented for this document: it is the
-exact mechanism that makes §15's subagent-replay fix safe (a model used only
-by an excluded subagent-replay session still shows up as "used," at zero
-cost, rather than vanishing).
+exact mechanism that makes the subagent-replay exclusion
+([Appendix A](#appendix-a--fix-history)) safe — a model used only by an
+excluded subagent-replay session still shows up as "used," at zero cost,
+rather than vanishing.
 
 `byModel[...].responses` is populated from `row.responses`
 (`usage-index.mjs:788`), which in turn comes from the `responses` field
 passed into `addUsage()` at the call site — `1` per Claude assistant turn
 (`usage-index.mjs:474-480`), or `rec.responses` (the session's whole response
 count) once per Codex session, passed at the single point Codex calls
-`addUsage` (`usage-index.mjs:576-583`; see §15 Bug A for why this field was
-previously omitted for Codex and every Codex model showed 0 responses
-regardless of real activity).
+`addUsage` (`usage-index.mjs:576-583`).
 
 **Render:** `bar(name, fmtUsd(cost), fmtTok(tokens)+" · "+fmtNum(responses)+"
 resp", pct(cost, topModelCost), false)` (`dashboard-server.mjs:1999-2002`),
@@ -506,15 +504,11 @@ list itself sorted cost-descending by the shared `entries()` helper
 shown as a $0 row.** A dropped connection, rate limit, or authentication
 failure makes Claude Code synthesize a local placeholder turn — `model:
 "<synthetic>"`, `isApiErrorMessage: true`, every usage field zero — rather
-than a real completion (confirmed directly against this machine's own
-transcripts: 33 such turns across the whole corpus, split `server_error`
-27, `authentication_failed` 3, `rate_limit` 3 — three distinct underlying
-causes, one placeholder shape). Before this was handled explicitly, that
-placeholder's model id landed in `rec.models` like any other, so it
-surfaced here as its own ranked row: `<synthetic> · $0.00 · 0 tok · N
-resp` — real-looking but meaningless, since no model ever ran.
+than a real completion (measured on the reference corpus: 33 such turns,
+split `server_error` 27, `authentication_failed` 3, `rate_limit` 3 — three
+distinct underlying causes, one placeholder shape).
 
-The parser now branches on `isApiErrorMessage === true`
+The parser branches on `isApiErrorMessage === true`
 (`usage-index.mjs:459-468`): the turn still increments `rec.responses`
 and the punchcard (`usage-index.mjs:447-450`) — it *is* real engaged
 time, someone was genuinely waiting on it — but it is never pushed into
@@ -530,30 +524,11 @@ when it's zero, the note renders empty rather than always claiming a
 count of zero.
 
 This is the same "never hide it, don't misrepresent it either" principle
-as §15's Codex exclusions and Unclassified in §12 — the difference is
-*where* the exception surfaces: a `$0`, `0`-token, real-looking model row
-was actively misleading (it implies a model ran and simply cost nothing),
-so the fix removes it from the ranking entirely rather than merely
-re-labeling it in place.
-
-**A cache-schema gotcha this change surfaced, worth recording exactly
-because a unit test could not have caught it:** `exceptions` is a new
-required field on every session record, but the on-disk index
-(`~/.config/agentic-kit/usage-index.json`) caches previously-parsed
-records keyed by `(path, mtime, size)` — a session parsed before this
-change has no `exceptions` field at all. Summing `undefined` into
-`totals.exceptions` silently produces `NaN`, which `JSON.stringify`
-serializes as `null` over the wire — a live query against this machine's
-real cached index (1,656 sessions, 90-day window) returned
-`totals.exceptions: null` and still showed the `<synthetic>` row in
-`byModel` on the first run after this change, purely because the cache
-predated it; every unit test still passed, since they only ever exercise
-a fresh parse with no cache involved. `SCHEMA_VERSION` went to `4` for this
-(`usage-index.mjs:35-50`; since superseded by `5` — the prompts correction,
-§2) specifically to force that one-time re-parse. Re-querying the same live server after the bump returned
-`totals.exceptions: 20` and confirmed `<synthetic>` no longer appears
-in `byModel` at all — the number this section describes, not a
-projected one.
+as the Codex exclusions ([Appendix A](#appendix-a--fix-history)) and
+Unclassified in §12 — the difference is *where* the exception surfaces: a
+`$0`, `0`-token, real-looking model row would be actively misleading (it
+implies a model ran and simply cost nothing), so it is excluded from the
+ranking entirely rather than merely re-labelled in place.
 
 ---
 
@@ -563,15 +538,12 @@ projected one.
 N"` when more exist; each row shows `cost`, `N sess · minutes`.
 
 **Formula:** identical shape to §10 (`byProject[project]`), plus a `project
-= 'unknown'` fallback and a repo/worktree collapsing rule that is worth
-citing precisely because it was itself the subject of an ADR-0009 amendment:
+= 'unknown'` fallback and a repo/worktree collapsing rule:
 `projectLabel(cwd)` collapses `<repo>/<marker>/worktrees/<rest>` (marker ∈
 `.autopilot`, `.claude`, `.git`) to `<repo>`, keeping `rest` as a separate
 `worktree` field on the session rather than either discarding it or letting
-it masquerade as a sibling project (ADR-0009 §4b). Before this fix, a git
-worktree's *branch name* was reported as its own project, silently
-undercounting the true repo's total by whatever work happened in the
-worktree.
+it masquerade as a sibling project. (The mislabelling this rule corrected is
+recorded in [Appendix A](#appendix-a--fix-history).)
 
 **Source:** ranking and truncation, `dashboard-server.mjs:2010-2017`
 (`shown = projects.slice(0,8)`); accumulation via the same `addTo()`/
@@ -598,7 +570,7 @@ session's title and tool-call mix. Because it is the metric most likely to
 be second-guessed ("why did it call this a bug fix"), its full decision
 procedure is reproduced here rather than summarized.
 
-**Three layers, strictly ordered** (`src/lib/usage-classify.mjs:199-254`):
+**Three layers, strictly ordered** (`classify()`, `src/lib/usage-classify.mjs:199-254`):
 
 1. **Provenance (confidence = 1.0, unconditional).** If the session carries
    an `attributionSkill` or `attributionPlugin` matching a known prefix in
@@ -627,7 +599,9 @@ procedure is reproduced here rather than summarized.
    at all (`usage-classify.mjs:234`, `:252`). `Unclassified` is a **first
    class outcome**, not a failure state: forcing every session into a
    category to reach 100% coverage would make every category
-   untrustworthy, not just the residue (ADR-0009 §5).
+   untrustworthy, not just the residue.
+
+![Figure: the classifier's three layers — the provenance early exit at confidence 1.0, the all-rules scoring round with a worked title, and the 0.28 confidence floor below which a session stays Unclassified](assets/usage-classifier-layers.svg)
 
 **Confidence formula** (`usage-classify.mjs:236-250`), for the top-scoring
 category against its runner-up:
@@ -649,8 +623,10 @@ reserved exclusively for provenance-layer matches, so a `1.0` in the UI is
 always traceable to a specific attributed skill/plugin id, never to a lucky
 keyword hit.
 
-**Worked example**, from ADR-0009's own reference-corpus measurement
-(§5): signal coverage was `ai-title` 93%, tool mix 100%,
+![Figure: confidence versus margin for four topScore levels, with the shaded Unclassified region below 0.28, the dashed 0.9 rules cap, and the lone 1.0 provenance point](assets/usage-classifier-confidence.svg)
+
+**Worked example**, from the reference-corpus measurement: signal
+coverage was `ai-title` 93%, tool mix 100%,
 `attributionSkill`/`attributionPlugin` 8%, slash commands 13% (mostly
 `/clear`/`/model`, not task-descriptive). This is why provenance alone
 cannot classify most sessions and layer 2 (title + tool-mix rules) carries
@@ -666,10 +642,10 @@ end) and its *tool-call mix* — never the transcript body. A session with a
 generic or misleading title and an atypical tool mix for its actual work
 will be misclassified or land in `Unclassified`; the confidence figure and
 `basis` string exist specifically so a reader can tell when that has
-happened rather than trusting the category blindly (ADR-0009 §5 Amendment).
+happened rather than trusting the category blindly.
 An **optional**, off-by-default LLM-labelling layer 3 exists for exactly
 this residue (`--enrich`, applied only below the confidence floor, cached
-permanently per session — ADR-0009 §5) but is out of scope for this document
+permanently per session) but is out of scope for this document
 since it is opt-in and not part of a default Scorecard render.
 
 ---
@@ -809,26 +785,30 @@ reading every section above:
 - [x] A day, project, or model with zero window activity is simply absent
   from its list — never rendered as a fabricated zero (§7, §11).
 - [x] Price tables are hand-maintained and date-stamped in the UI
-  (`rates as of <PRICES_AS_OF>`) precisely because they *will* drift
-  (ADR-0009 "Costs and risks").
+  (`rates as of <PRICES_AS_OF>`) precisely because they *will* drift.
 - [x] The pricing formula applies identically to every provider; a
   cross-provider discrepancy in the by-host breakdown (§8) is diagnostic
-  evidence of a **parsing** defect upstream, not a pricing defect — see §15
-  for two real examples of exactly this kind of defect, found via this same
-  reasoning.
+  evidence of a **parsing** defect upstream, not a pricing defect — see
+  [Appendix A](#appendix-a--fix-history) for two real examples found via
+  this same reasoning.
 
 ---
 
-## 15. Bugs found and fixed during this audit (2026-07-25)
+## Appendix A — Fix history
 
-This section exists because a user (via a friend using Codex) reported the
-Codex side of the by-host breakdown (§8) "looked questionable" compared to
-Claude's. Investigation traced two real defects — both in `parseCodex`
-specifically, neither in the shared aggregation or pricing logic those two
-parsers feed into (consistent with §8's claim that the aggregation code is
-provider-agnostic). Fixed in commit `540be18` on this branch.
+The main body describes only current behavior; this appendix records what
+was wrong before, for the curious.
 
-### Bug A — Codex model rows always showed 0 responses
+### The 2026-07-25 Codex audit
+
+A user (via a friend using Codex) reported the Codex side of the by-host
+breakdown (§8) "looked questionable" compared to Claude's. Investigation
+traced two real defects — both in `parseCodex` specifically, neither in the
+shared aggregation or pricing logic those two parsers feed into (consistent
+with §8's claim that the aggregation code is provider-agnostic). Fixed in
+commit `540be18` on this branch.
+
+#### Bug A — Codex model rows always showed 0 responses
 
 `parseCodex`'s single `addUsage()` call never included a `responses` field —
 Claude's parser passes `responses: 1` per assistant turn
@@ -841,14 +821,14 @@ Play" list displayed `0 resp` regardless of real token/cost volume or actual
 rec.responses` (the session's own tallied response count,
 `usage-index.mjs:558`) on its `addUsage()` call.
 
-### Bug B — subagent thread-replay could double-bill tokens
+#### Bug B — subagent thread-replay could double-bill tokens
 
 Codex CLI's `thread_spawn` subagent-delegation mechanism writes a rollout
 file for the spawned subagent that **replays its parent thread's entire
 prior cumulative token history as duplicate events**, re-timestamped to the
 subagent's creation time, before the subagent's own new turns begin. This is
 a documented, previously-reported Codex CLI behavior, not a hypothesis
-invented for this audit — see **[C4]**, **[C5]**, **[C6]** below, the last
+invented for this audit — see **[C5]**, **[C6]**, **[C7]** below, the last
 of which measured up to **91×** cost inflation in a real corpus from exactly
 this mechanism (one parent session with 12 spawned subagents, each replaying
 the parent's full history, so the parent's usage was counted 13 times over —
@@ -904,16 +884,49 @@ result with no transcript content. Point anyone questioning their own
 Codex numbers there first — it produces the real number instead of a
 promise.
 
+### Smaller corrections
+
+- **Prompt counts included harness output (SCHEMA_VERSION 5).**
+  `isHumanPrompt` counted harness-written user-role text — task
+  notifications, stdout dumps — as human prompts: 32 claimed vs 20 real on
+  the reference session (§2 states the current rule). Cached records carried
+  the inflated counts, hence the v5 wholesale cache invalidation.
+- **`<synthetic>` placeholder turns ranked as a model row.** Before §10's
+  `isApiErrorMessage` branch, the placeholder's model id landed in
+  `rec.models` like any other and surfaced as its own ranked row —
+  `<synthetic> · $0.00 · 0 tok · N resp` — real-looking but meaningless,
+  since no model ever ran.
+- **The cache-schema gotcha behind SCHEMA_VERSION 4** — recorded exactly
+  because a unit test could not have caught it: `exceptions` was a new
+  required field on every session record, but the on-disk index caches
+  previously-parsed records keyed by `(path, mtime, size)` — a session
+  parsed before the change had no `exceptions` field at all. Summing
+  `undefined` into `totals.exceptions` silently produced `NaN`, which
+  `JSON.stringify` serialized as `null` over the wire — a live query against
+  a real cached index (1,656 sessions, 90-day window) returned
+  `totals.exceptions: null` and still showed the `<synthetic>` row in
+  `byModel` on the first run after the change, purely because the cache
+  predated it; every unit test still passed, since tests only exercise a
+  fresh parse. `SCHEMA_VERSION` went to `4` (`usage-index.mjs:35-50`; since
+  superseded by `5`, above) specifically to force the one-time re-parse.
+  Re-querying the same live server after the bump returned
+  `totals.exceptions: 20` with `<synthetic>` absent from `byModel` —
+  measured, not projected.
+- **Worktree branches masqueraded as projects.** Before §11's collapsing
+  rule, a git worktree's *branch name* was reported as its own project,
+  silently undercounting the true repo's total by whatever work happened in
+  the worktree.
+
 ---
 
-## 16. Verification methodology for this document
+## Appendix B — Verification methodology
 
 Every code citation above was read directly from the source files at commit
 `540be18` (not recalled from memory or summarized secondhand); every
 external pricing claim was either fetched directly (Anthropic, §13.1) or
 corroborated across multiple independent third-party sources with the
 sourcing tier disclosed rather than implied (OpenAI, §13.2); every GitHub
-issue cited (§15) was located and its content quoted or paraphrased from the
+issue cited (Appendix A) was located and its content quoted or paraphrased from the
 actual issue text, not inferred from its title. Where verification was
 incomplete (the OpenAI primary-source fetch, the Bug B real-data check),
 that incompleteness is stated in the relevant section rather than omitted —
@@ -921,9 +934,37 @@ a maintainer-facing document that hides the edges of its own verification is
 exactly the failure mode this document exists to avoid in the metrics it
 describes.
 
+**Citation upkeep.** `tests/kit/doc-citations.test.mjs` extracts every
+`file:line` citation from this document (and from `TRANSCRIPTS.md`) and
+asserts that an identifier or quoted string named beside the citation occurs
+within the cited range (±10 lines) of the **current** source — so citation
+rot fails `pnpm test` instead of accumulating silently. On failure, the error
+names the citation and where its anchor now lives; update the line number (or
+the named anchor, if the code was renamed). When the hint isn't enough,
+`git log -p -L<start>,<end>:<file>` reconstructs where a range moved.
+
 ---
 
-## 17. References
+## Appendix C — Design rationale (ADR map)
+
+The "why" behind the design is deliberately kept out of the main body; it
+lives in
+[`docs/adr/0009-usage-scorecard-local-transcript-analytics.md`](adr/0009-usage-scorecard-local-transcript-analytics.md).
+Where a main-body section implements a recorded decision:
+
+| Main-body topic | Design record |
+|---|---|
+| "API-equivalent, never billing" cost framing (§3) | ADR-0009 §3 |
+| The three-tier engaged-time ladder (§6) | ADR-0009 §4 (and its 2026-07-25 amendment) |
+| Worktree→repo project collapsing (§11) | ADR-0009 §4b |
+| Rule-based classification; Unclassified as first-class; `--enrich` (§12) | ADR-0009 §5 (amendment: confidence/basis surfacing) |
+| Findings / Sessions / Transcript tab rules (out of scope here) | ADR-0009 §6, §8 |
+| Hand-maintained, date-stamped price tables (§13) | ADR-0009 "Costs and risks" |
+| Reference-corpus figures quoted throughout (582–584 sessions, 96.3% cache share, the engaged-time ladder, signal coverage) | ADR-0009 |
+
+---
+
+## Appendix D — References
 
 - **[C1]** Anthropic — *Pricing*. `https://platform.claude.com/docs/en/about-claude/pricing`. Fetched in full 2026-07-25; primary source for §13.1 (model rate table, prompt-caching multiplier table, worked cost example, Batch API discount, Managed Agents session-runtime billing, `inference_geo` multiplier).
 - **[C2]** Anthropic — *Prompt caching*. `https://platform.claude.com/docs/en/build-with-claude/prompt-caching`. Fetched 2026-07-25; independent confirmation of the 1.25×/2×/0.1× cache multipliers in prose form.
@@ -931,7 +972,7 @@ describes.
 - **[C4]** OpenRouter — *GPT-5.6 Sol: API Pricing & Benchmarks*. `https://openrouter.ai/openai/gpt-5.6-sol`. Accessed 2026-07-25; context window (1.05M) and long-context (272K threshold) pricing corroboration.
 - **[C5]** GitHub — `ccusage/ccusage#884`, *Parser overcounts duplicate token_count rows with unchanged total_token_usage*. `https://github.com/ccusage/ccusage/issues/884`. A Codex-usage-analytics tool (functionally the same job as this scorecard's Codex path) documenting that naive summation of cumulative `token_count` snapshots — rather than diffing or taking the last snapshot — matched only 131/732 real sessions correctly; delta/last-event logic matched 100%.
 - **[C6]** GitHub — `openai/codex#14489`, *Change `TokenCount` to not re-emit `last_token_usage` on rate-limit-only updates*. `https://github.com/openai/codex/issues/14489`. Documents Codex CLI re-emitting a stale `last_token_usage` value on rate-limit-only updates with an unchanged cumulative total, which a parser reading `last_token_usage` naively double-counts.
-- **[C7]** GitHub — `ccusage/ccusage#950`, *Bug: Massive token overcounting for Codex subagent sessions (91x inflation)*. `https://github.com/ccusage/ccusage/issues/950`. Source for Bug B (§15): documents `thread_spawn` subagent rollout files replaying the parent thread's entire token history as duplicate, re-timestamped events; measured a 91× real-world cost inflation (reported ~$9,041 against actual spend of ~$100) from a parent session with 12 spawned subagents. Also the source that identifies `session_meta.thread_source` / `source.subagent.thread_spawn` as the detectable field for this pattern.
-- **[C8]** GitHub — `openai/codex#23001`, *Codex App upgrade can break opening older local threads when rollout session_meta lacks thread_source*. `https://github.com/openai/codex/issues/23001`. Confirms `thread_source` is a genuine, if not universally-present, `session_meta` field in real Codex rollout files (older/pre-upgrade rollouts may lack it entirely, which is why the fix in §15 Bug B treats an absent `thread_source` as `'user'`-equivalent — i.e. included — rather than excluded).
+- **[C7]** GitHub — `ccusage/ccusage#950`, *Bug: Massive token overcounting for Codex subagent sessions (91x inflation)*. `https://github.com/ccusage/ccusage/issues/950`. Documents `thread_spawn` subagent rollout files replaying the parent thread's entire token history as duplicate, re-timestamped events; measured a 91× real-world cost inflation (reported ~$9,041 against actual spend of ~$100) from a parent session with 12 spawned subagents. Also the source that identifies `session_meta.thread_source` / `source.subagent.thread_spawn` as the detectable field for this pattern. Source for Appendix A's Bug B.
+- **[C8]** GitHub — `openai/codex#23001`, *Codex App upgrade can break opening older local threads when rollout session_meta lacks thread_source*. `https://github.com/openai/codex/issues/23001`. Confirms `thread_source` is a genuine, if not universally-present, `session_meta` field in real Codex rollout files (older/pre-upgrade rollouts may lack it entirely, which is why Appendix A's Bug B fix treats an absent `thread_source` as `'user'`-equivalent — i.e. included — rather than excluded).
 - **ADR-0009** — [`docs/adr/0009-usage-scorecard-local-transcript-analytics.md`](adr/0009-usage-scorecard-local-transcript-analytics.md). The design record this document's formulas implement; source of every reference-corpus figure quoted above (582–584 sessions, 96.3% cache share, 100.7h/230.8h/296.4h engaged-time ladder, 93%/100%/8%/13% classification signal coverage).
 - **In-repo source files**, all pinned to commit `540be18`: `src/lib/usage-index.mjs`, `src/lib/pricing.mjs`, `src/lib/usage-classify.mjs`, `src/lib/dashboard-server.mjs`, `tests/kit/usage-index.test.mjs`.

--- a/docs/USAGE-SCORECARD-METRICS.md
+++ b/docs/USAGE-SCORECARD-METRICS.md
@@ -65,8 +65,8 @@ schema change — `src/lib/usage-index.mjs:46`):
 | Claude Code | `~/.claude/projects/<project>/<sessionId>.jsonl` | one JSON object per line: `user`/`assistant` turns, each assistant turn carrying its own `usage` object |
 | Codex CLI | `~/.codex/sessions/<yyyy>/<mm>/<dd>/rollout-<ts>-<sessionId>.jsonl` | one JSON object per line: `session_meta`, `turn_context`, and `event_msg` records, the latter carrying **cumulative** `token_count` snapshots, not per-turn deltas |
 
-The parsers are `parseClaude` (`usage-index.mjs:369-452`) and `parseCodex`
-(`usage-index.mjs:469-536`). Both are pure functions over the raw file bytes —
+The parsers are `parseClaude` (`usage-index.mjs:389-472`) and `parseCodex`
+(`usage-index.mjs:489-559`). Both are pure functions over the raw file bytes —
 no network, no clock dependency beyond the transcript's own timestamps — so
 every downstream number traces back to bytes already on the user's disk.
 Nothing in this pipeline calls a provider API or a billing endpoint; **no
@@ -90,16 +90,16 @@ responses = Σ over included sessions of session.responses
 **Source:**
 
 - Filter: a parsed record with zero assistant turns is dropped entirely — "no
-  assistant turn → not a session" (`usage-index.mjs:717`) — and a record whose
+  assistant turn → not a session" (`usage-index.mjs:740`) — and a record whose
   last activity falls outside the requested window is dropped too
-  (`usage-index.mjs:718`).
+  (`usage-index.mjs:741`).
 - `responses` accumulation: Claude increments per assistant message
-  (`usage-index.mjs:399`); Codex increments per `agent_message` event
-  (`usage-index.mjs:507`).
+  (`usage-index.mjs:419`); Codex increments per `agent_message` event
+  (`usage-index.mjs:530`).
 - Totals: `totals.responses += s.responses` per included session
-  (`usage-index.mjs:788`).
+  (`usage-index.mjs:811`).
 - Render: `kpi("sessions", fmtNum(t.sessions), fmtNum(t.responses)+" assistant
-  turns", "")` (`dashboard-server.mjs:1916`).
+  turns", "")` (`dashboard-server.mjs:1920`).
 
 **Worked example.** A session with 3 user turns and 2 assistant turns
 contributes `sessions += 1, responses += 2` — prompts (user turns) are tracked
@@ -203,23 +203,23 @@ tokens = input + output + cacheRead + cacheWrite   (summed across all rows in wi
 ```
 
 **Source:** `t.tokens` from `totals`, accumulated per row at
-`usage-index.mjs:732` (`rowTokens = row.input + row.output + row.cacheRead +
+`usage-index.mjs:755` (`rowTokens = row.input + row.output + row.cacheRead +
 row.cacheWrite`) and rolled into `totals.tokens` via `addTo`
-(`usage-index.mjs:687`). Rendered with `fmtTok()`
-(`dashboard-server.mjs:1826-1832`): `≥1e9` → `"X.XB"`, `≥1e6` → `"X.XM"`,
+(`usage-index.mjs:710`). Rendered with `fmtTok()`
+(`dashboard-server.mjs:1830-1836`): `≥1e9` → `"X.XB"`, `≥1e6` → `"X.XM"`,
 `≥1e3` → `"X.XK"`, else the rounded integer.
 
 The **token composition bar** immediately below the hero row (cache read /
 cache write / output / input, as four coloured segments) is the same four
-numbers as percentages of `t.tokens` (`dashboard-server.mjs:1952-1959`,
-`pct(a,b) = b ? a/b*100 : 0`, `dashboard-server.mjs:1840`).
+numbers as percentages of `t.tokens` (`dashboard-server.mjs:1956-1963`,
+`pct(a,b) = b ? a/b*100 : 0`, `dashboard-server.mjs:1844`).
 
 **What "input" excludes.** For both providers, the `input` counter recorded
 per row is **gross input minus cached input** — Claude's parser reads
 `cache_read_input_tokens` and `cache_creation_input_tokens` as separate fields
-the provider already reports separately (`usage-index.mjs:427-430`); Codex's
+the provider already reports separately (`usage-index.mjs:447-450`); Codex's
 parser subtracts `cached_input_tokens` from `input_tokens` explicitly
-(`usage-index.mjs:522-526`, `input: Math.max(0, gross - cacheRead)`) because
+(`usage-index.mjs:545-549`, `input: Math.max(0, gross - cacheRead)`) because
 Codex's own `input_tokens` field **includes** cached tokens and would
 double-count them against the separately-reported `cacheRead` figure if left
 as-is. This is asserted by test:
@@ -253,8 +253,8 @@ cacheRead + cacheWrite), **not** as a share of input alone. On the reference
 figures (`cacheRead = 1464.3B`, `tokens = 1495.2B`): `1464.3 / 1495.2 × 100 =
 97.93%`, which rounds to the displayed `97.9%` — confirming the denominator.
 
-**Source:** `dashboard-server.mjs:1914` (`cacheShare = pct(t.cacheRead,
-t.tokens)`), rendered `dashboard-server.mjs:1922`.
+**Source:** `dashboard-server.mjs:1918` (`cacheShare = pct(t.cacheRead,
+t.tokens)`), rendered `dashboard-server.mjs:1926`.
 
 **Why this number matters more than it looks like it should.** ADR-0009's
 own motivating data point: on the reference corpus, 96.3% of tokens were
@@ -272,7 +272,7 @@ Codex CLI do by default.
 
 **Displayed as:** `ENGAGED TIME` hero tile — `403h`, subtitle `3286h summed`
 plus a `sessions overlap` note. Hovering the tile reveals a tooltip with all
-three tiers (ADR-0009's "ladder," `dashboard-server.mjs:1904-1910`).
+three tiers (ADR-0009's "ladder," `dashboard-server.mjs:1908-1914`).
 
 This is the single most heavily-caveated metric on the tab, because a naive
 version of it was **wrong by roughly 3×** during ADR-0009's own design pass
@@ -317,13 +317,13 @@ session data, and each needs its own fix:
   `IDLE_GAP_MS`; "a run of one timestamp yields a zero-length interval and so
   contributes nothing" (comment, `usage-index.mjs:300`).
 - Aggregation: `totals.engagedSeconds = mergeIntervals(sessions.flatMap(s =>
-  s._active))` (`usage-index.mjs:831`); `totals.spanUnionSeconds =
-  mergeIntervals(sessions.map(s => s._span))` (`usage-index.mjs:830`);
+  s._active))` (`usage-index.mjs:854`); `totals.spanUnionSeconds =
+  mergeIntervals(sessions.map(s => s._span))` (`usage-index.mjs:853`);
   `totals.spanMinutes` is a running sum of `s._span[1] - s._span[0]` across
-  the loop (`usage-index.mjs:792`, finalized `usage-index.mjs:829`).
-- Render: `fmtHours()` (`dashboard-server.mjs:1833`, `≥10h` rounds to the
+  the loop (`usage-index.mjs:815`, finalized `usage-index.mjs:852`).
+- Render: `fmtHours()` (`dashboard-server.mjs:1837`, `≥10h` rounds to the
   nearest hour, else one decimal place) and `fmtMins()`
-  (`dashboard-server.mjs:1834`, `≥60min` rounds to hours, else whole
+  (`dashboard-server.mjs:1838`, `≥60min` rounds to hours, else whole
   minutes).
 
 **Worked example**, ADR-0009's own reference-corpus measurement (14-day
@@ -369,13 +369,13 @@ byDay[day].cost = Σ costOf(row) for every usage row whose day == that key
 
 **Source:** the day key is the row's own `row.day`, computed once at parse
 time as **local calendar day**, not UTC
-(`usage-index.mjs:426`/`usage-index.mjs:525` call `localDay(at)`) — so a
+(`usage-index.mjs:446`/`usage-index.mjs:548` call `localDay(at)`) — so a
 session that runs from 23:58 local to 00:05 local is billed to the day its
 *first* row landed on (test:
 `tests/kit/usage-index.test.mjs:556`, "a session that opens before midnight
 is counted on its first billed day"). Accumulation:
-`byDay[row.day].cost += rowCost` (`usage-index.mjs:735`). Bar height:
-`h = maxDay ? max(2, cost/maxDay*100) : 2` (`dashboard-server.mjs:1933`) —
+`byDay[row.day].cost += rowCost` (`usage-index.mjs:758`). Bar height:
+`h = maxDay ? max(2, cost/maxDay*100) : 2` (`dashboard-server.mjs:1937`) —
 every non-empty day gets a visually nonzero bar (floor of 2%), so a very
 cheap day is never rendered as invisible.
 
@@ -392,11 +392,11 @@ rather than a continuous 30-day series.
 **Displayed as:** two cards, `claude` and `codex`, each showing cost,
 session count, and total tokens; an idle host (`sessions == 0 && cost == 0`)
 renders "no sessions in window" instead of zeroed figures
-(`dashboard-server.mjs:1945-1949`).
+(`dashboard-server.mjs:1949-1953`).
 
 **Formula:** identical aggregation to every other bucket
-(`byProvider[s.provider]`, populated via `addTo()`, `usage-index.mjs:683-692`,
-called once per session at `usage-index.mjs:794`), keyed by the literal string
+(`byProvider[s.provider]`, populated via `addTo()`, `usage-index.mjs:706-715`,
+called once per session at `usage-index.mjs:817`), keyed by the literal string
 `"claude"` or `"codex"` assigned at parse time
 (`blankSession(id, 'claude')` / `blankSession(id, 'codex')`,
 `usage-index.mjs:281-287`, `parseClaude`/`parseCodex` entry points).
@@ -434,11 +434,11 @@ punchcard[dow + "-" + hour] += 1   per assistant/agent_message response, at its 
 ```
 
 **Source:** incremented once per Claude assistant turn
-(`usage-index.mjs:401-402`, keyed by `punchKey(at)`) and once per Codex
-`agent_message` (`usage-index.mjs:509-510`), merged into the window-level
-`punchcard` object per session (`usage-index.mjs:809`). Cell intensity is
+(`usage-index.mjs:421-422`, keyed by `punchKey(at)`) and once per Codex
+`agent_message` (`usage-index.mjs:532-533`), merged into the window-level
+`punchcard` object per session (`usage-index.mjs:832`). Cell intensity is
 linear against the single busiest cell in the window:
-`v = pcMax ? n/pcMax : 0` (`dashboard-server.mjs:1969`) — this is a
+`v = pcMax ? n/pcMax : 0` (`dashboard-server.mjs:1973`) — this is a
 **relative**, not absolute, scale, so the heatmap's brightest cell is always
 "the busiest hour-of-week in *this* window," not a fixed response-count
 threshold, and comparing brightness across two different date-range views is
@@ -469,9 +469,9 @@ byModel[model].sessions  = count of DISTINCT sessions whose s.models includes th
 ```
 
 **Source:** cost/tokens/responses accumulate inside the usage-row loop
-(`usage-index.mjs:722-739`); the `sessions` count is deliberately computed
+(`usage-index.mjs:745-762`); the `sessions` count is deliberately computed
 **separately**, once per session over its `s.models` array
-(`usage-index.mjs:802-807`) rather than inside the cost loop, precisely
+(`usage-index.mjs:825-830`) rather than inside the cost loop, precisely
 **so that a model can appear in `byModel` — with a nonzero session count —
 even in a session that contributed zero cost/tokens/responses for that
 model.** This is not an edge case invented for this document: it is the
@@ -480,18 +480,18 @@ by an excluded subagent-replay session still shows up as "used," at zero
 cost, rather than vanishing).
 
 `byModel[...].responses` is populated from `row.responses`
-(`usage-index.mjs:737`), which in turn comes from the `responses` field
+(`usage-index.mjs:760`), which in turn comes from the `responses` field
 passed into `addUsage()` at the call site — `1` per Claude assistant turn
-(`usage-index.mjs:426-432`), or `rec.responses` (the session's whole response
+(`usage-index.mjs:446-452`), or `rec.responses` (the session's whole response
 count) once per Codex session, passed at the single point Codex calls
-`addUsage` (`usage-index.mjs:525-532`; see §15 Bug A for why this field was
+`addUsage` (`usage-index.mjs:548-555`; see §15 Bug A for why this field was
 previously omitted for Codex and every Codex model showed 0 responses
 regardless of real activity).
 
 **Render:** `bar(name, fmtUsd(cost), fmtTok(tokens)+" · "+fmtNum(responses)+"
-resp", pct(cost, topModelCost), false)` (`dashboard-server.mjs:1982-1985`),
+resp", pct(cost, topModelCost), false)` (`dashboard-server.mjs:1986-1989`),
 list itself sorted cost-descending by the shared `entries()` helper
-(`dashboard-server.mjs:1841-1846`).
+(`dashboard-server.mjs:1845-1850`).
 
 **Exceptions — a turn that never resolved to a model is excluded here, not
 shown as a $0 row.** A dropped connection, rate limit, or authentication
@@ -506,17 +506,17 @@ surfaced here as its own ranked row: `<synthetic> · $0.00 · 0 tok · N
 resp` — real-looking but meaningless, since no model ever ran.
 
 The parser now branches on `isApiErrorMessage === true`
-(`usage-index.mjs:411-420`): the turn still increments `rec.responses`
-and the punchcard (`usage-index.mjs:399-402`) — it *is* real engaged
+(`usage-index.mjs:431-440`): the turn still increments `rec.responses`
+and the punchcard (`usage-index.mjs:419-422`) — it *is* real engaged
 time, someone was genuinely waiting on it — but it is never pushed into
 `rec.models` and `addUsage()` is never called for it, so it can no longer
 create a `byModel` row of any kind. It increments a separate
-`rec.exceptions` counter instead (`usage-index.mjs:412`), rolled up into
-`totals.exceptions` (`usage-index.mjs:777-788`) and surfaced per-session
-(`usage-index.mjs:752`, alongside the existing `sidechain`/`threadSource`
+`rec.exceptions` counter instead (`usage-index.mjs:432`), rolled up into
+`totals.exceptions` (`usage-index.mjs:800-811`) and surfaced per-session
+(`usage-index.mjs:775`, alongside the existing `sidechain`/`threadSource`
 flags — inspectable in the Sessions tab, never hidden). When
 `totals.exceptions > 0`, the panel header shows a small `"· N
-dropped/errored turns excluded"` note (`dashboard-server.mjs:1986-1991`);
+dropped/errored turns excluded"` note (`dashboard-server.mjs:1990-1995`);
 when it's zero, the note renders empty rather than always claiming a
 count of zero.
 
@@ -564,7 +564,7 @@ worktree's *branch name* was reported as its own project, silently
 undercounting the true repo's total by whatever work happened in the
 worktree.
 
-**Source:** ranking and truncation, `dashboard-server.mjs:1993-2000`
+**Source:** ranking and truncation, `dashboard-server.mjs:1997-2004`
 (`shown = projects.slice(0,8)`); accumulation via the same `addTo()`/
 `entries()` machinery as §10, keyed by `s.project` instead of `s.models`.
 
@@ -580,7 +580,7 @@ rather than silently absent from the total.
 **Displayed as:** a ranked bar list of categories, bar width relative to
 the top category's cost; each row shows `cost`, `N sess · $/sess`; a small
 confidence dot on classified rows (opacity `0.5 + confidence×0.5`,
-`dashboard-server.mjs:2007-2008`); `Unclassified` is always shown, never
+`dashboard-server.mjs:2011-2012`); `Unclassified` is always shown, never
 hidden, and carries no confidence dot.
 
 This is the only Scorecard metric that is **not** pure arithmetic over
@@ -647,9 +647,9 @@ keyword hit.
 cannot classify most sessions and layer 2 (title + tool-mix rules) carries
 the bulk of the load.
 
-**Render:** `dashboard-server.mjs:2003-2014`, sorted cost-descending via the
+**Render:** `dashboard-server.mjs:2007-2018`, sorted cost-descending via the
 shared `entries()` helper, with `$/sess = cost / max(sessions, 1)` guarding
-the zero-session edge case (`dashboard-server.mjs:2005`).
+the zero-session edge case (`dashboard-server.mjs:2009`).
 
 **What this does not model:** the classifier reads only the session's
 *title* (Claude's own `ai-title`, written by the model itself at session
@@ -714,7 +714,7 @@ Anthropic which publishes a fetchable pricing document. OpenAI's rates in
 this table are therefore maintained by hand against OpenAI's own developer
 documentation and are the most drift-prone entries in the file — this is
 explicitly why `PRICES_AS_OF` is surfaced in the UI (`u-asof`,
-`dashboard-server.mjs:1923`) rather than assumed current.
+`dashboard-server.mjs:1927`) rather than assumed current.
 
 | Model (kit key) | Input | Output | Cache read (0.1×, derived) |
 |---|---|---|---|
@@ -823,14 +823,14 @@ provider-agnostic). Fixed in commit `540be18` on this branch.
 
 `parseCodex`'s single `addUsage()` call never included a `responses` field —
 Claude's parser passes `responses: 1` per assistant turn
-(`usage-index.mjs:431`, as it existed before this fix), but Codex's call
+(`usage-index.mjs:451`, as it existed before this fix), but Codex's call
 passed no such field at all. Because `byModel[model].responses` is summed
-directly from each usage row's `responses` field (`usage-index.mjs:737`,
+directly from each usage row's `responses` field (`usage-index.mjs:760`,
 `m.responses += row.responses`), **every** Codex model in §10's "Models in
 Play" list displayed `0 resp` regardless of real token/cost volume or actual
 `agent_message` count. **Fix:** `parseCodex` now passes `responses:
 rec.responses` (the session's own tallied response count,
-`usage-index.mjs:507`) on its `addUsage()` call.
+`usage-index.mjs:530`) on its `addUsage()` call.
 
 ### Bug B — subagent thread-replay could double-bill tokens
 
@@ -850,9 +850,9 @@ at face value (correctly avoiding the separate naive-summing bug **[C5]**
 documents, since it already used last-event-only logic — see §4's worked
 example) but performed **no de-duplication** against a parent session a
 subagent file might be replaying. **Fix:** the parser now reads
-`session_meta.thread_source` (`usage-index.mjs:484`, confirmed as a real
+`session_meta.thread_source` (`usage-index.mjs:504`, confirmed as a real
 Codex rollout field by **[C7]**) and skips the `addUsage()` call entirely
-when its value is `'subagent'` (`usage-index.mjs:521`, guard condition
+when its value is `'subagent'` (`usage-index.mjs:544`, guard condition
 `rec.threadSource !== 'subagent'`). The session record itself is **not**
 dropped — it remains visible in the Sessions tab with `threadSource`
 surfaced (mirroring the existing `sidechain` flag Claude sessions already

--- a/docs/USAGE-SCORECARD-METRICS.md
+++ b/docs/USAGE-SCORECARD-METRICS.md
@@ -57,16 +57,16 @@ Every metric section below follows the same shape:
 ## 1. Data provenance
 
 Two transcript stores, read-only, parsed at most once per file (cache keyed by
-`(path, mtime, size)`; SCHEMA_VERSION `4` invalidates the whole cache on a
-schema change — `src/lib/usage-index.mjs:46`):
+`(path, mtime, size)`; SCHEMA_VERSION `5` invalidates the whole cache on a
+schema change — `src/lib/usage-index.mjs:50`):
 
 | Provider | Store | Format |
 |---|---|---|
 | Claude Code | `~/.claude/projects/<project>/<sessionId>.jsonl` | one JSON object per line: `user`/`assistant` turns, each assistant turn carrying its own `usage` object |
 | Codex CLI | `~/.codex/sessions/<yyyy>/<mm>/<dd>/rollout-<ts>-<sessionId>.jsonl` | one JSON object per line: `session_meta`, `turn_context`, and `event_msg` records, the latter carrying **cumulative** `token_count` snapshots, not per-turn deltas |
 
-The parsers are `parseClaude` (`usage-index.mjs:389-472`) and `parseCodex`
-(`usage-index.mjs:489-559`). Both are pure functions over the raw file bytes —
+The parsers are `parseClaude` (`usage-index.mjs:417-500`) and `parseCodex`
+(`usage-index.mjs:517-587`). Both are pure functions over the raw file bytes —
 no network, no clock dependency beyond the transcript's own timestamps — so
 every downstream number traces back to bytes already on the user's disk.
 Nothing in this pipeline calls a provider API or a billing endpoint; **no
@@ -90,14 +90,14 @@ responses = Σ over included sessions of session.responses
 **Source:**
 
 - Filter: a parsed record with zero assistant turns is dropped entirely — "no
-  assistant turn → not a session" (`usage-index.mjs:740`) — and a record whose
+  assistant turn → not a session" (`usage-index.mjs:768`) — and a record whose
   last activity falls outside the requested window is dropped too
-  (`usage-index.mjs:741`).
+  (`usage-index.mjs:769`).
 - `responses` accumulation: Claude increments per assistant message
-  (`usage-index.mjs:419`); Codex increments per `agent_message` event
-  (`usage-index.mjs:530`).
+  (`usage-index.mjs:447`); Codex increments per `agent_message` event
+  (`usage-index.mjs:558`).
 - Totals: `totals.responses += s.responses` per included session
-  (`usage-index.mjs:811`).
+  (`usage-index.mjs:839`).
 - Render: `kpi("sessions", fmtNum(t.sessions), fmtNum(t.responses)+" assistant
   turns", "")` (`dashboard-server.mjs:1933`).
 
@@ -111,6 +111,15 @@ a fixture with exactly that shape).
 reply (e.g. immediately abandoned) is invisible to every Scorecard number —
 by design, not oversight, since a session with no response has nothing to
 attribute cost or category to.
+
+**What "prompts" excludes (since SCHEMA_VERSION 5):** user-role entries whose
+text the harness wrote — task notifications, `bash-stdout`/
+`local-command-stdout` dumps, caveats — are not human prompts and no longer
+count as such (`isHumanPrompt` + `HARNESS_OUTPUT_RE`; the full envelope
+taxonomy is [`TRANSCRIPTS.md`](TRANSCRIPTS.md) §3.2). A `! command` the
+person typed (`bash-input`) still counts. On a reference session this
+corrected 32 claimed prompts to 20 real ones; cached records carried the
+inflated figure, hence the v5 cache invalidation.
 
 ---
 
@@ -203,9 +212,9 @@ tokens = input + output + cacheRead + cacheWrite   (summed across all rows in wi
 ```
 
 **Source:** `t.tokens` from `totals`, accumulated per row at
-`usage-index.mjs:755` (`rowTokens = row.input + row.output + row.cacheRead +
+`usage-index.mjs:783` (`rowTokens = row.input + row.output + row.cacheRead +
 row.cacheWrite`) and rolled into `totals.tokens` via `addTo`
-(`usage-index.mjs:710`). Rendered with `fmtTok()`
+(`usage-index.mjs:738`). Rendered with `fmtTok()`
 (`dashboard-server.mjs:1843-1849`): `≥1e9` → `"X.XB"`, `≥1e6` → `"X.XM"`,
 `≥1e3` → `"X.XK"`, else the rounded integer.
 
@@ -217,9 +226,9 @@ numbers as percentages of `t.tokens` (`dashboard-server.mjs:1969-1976`,
 **What "input" excludes.** For both providers, the `input` counter recorded
 per row is **gross input minus cached input** — Claude's parser reads
 `cache_read_input_tokens` and `cache_creation_input_tokens` as separate fields
-the provider already reports separately (`usage-index.mjs:447-450`); Codex's
+the provider already reports separately (`usage-index.mjs:475-478`); Codex's
 parser subtracts `cached_input_tokens` from `input_tokens` explicitly
-(`usage-index.mjs:545-549`, `input: Math.max(0, gross - cacheRead)`) because
+(`usage-index.mjs:573-577`, `input: Math.max(0, gross - cacheRead)`) because
 Codex's own `input_tokens` field **includes** cached tokens and would
 double-count them against the separately-reported `cacheRead` figure if left
 as-is. This is asserted by test:
@@ -303,24 +312,24 @@ session data, and each needs its own fix:
    human, or genuinely idle) donates its *entire* idle stretch to the span,
    even though no work happened during it. Fix: split each session into
    active sub-intervals wherever the gap between two consecutive timestamps
-   exceeds `IDLE_GAP_MS` (15 minutes, `usage-index.mjs:52`), then union
+   exceeds `IDLE_GAP_MS` (15 minutes, `usage-index.mjs:56`), then union
    *those* sub-intervals — this is `engagedSeconds`.
 
 **Source:**
 
-- `mergeIntervals()` (`usage-index.mjs:79-104`) — the pure union primitive,
+- `mergeIntervals()` (`usage-index.mjs:83-108`) — the pure union primitive,
   sorts intervals and merges any two that overlap **or exactly touch**
-  (`s <= curEnd`, `usage-index.mjs:95`), returning total covered seconds
+  (`s <= curEnd`, `usage-index.mjs:99`), returning total covered seconds
   rounded to the nearest second.
-- `activeIntervals()` (`usage-index.mjs:302-314`) — splits one session's
+- `activeIntervals()` (`usage-index.mjs:306-318`) — splits one session's
   sorted timestamp list into sub-intervals wherever a gap exceeds
   `IDLE_GAP_MS`; "a run of one timestamp yields a zero-length interval and so
-  contributes nothing" (comment, `usage-index.mjs:300`).
+  contributes nothing" (comment, `usage-index.mjs:304`).
 - Aggregation: `totals.engagedSeconds = mergeIntervals(sessions.flatMap(s =>
-  s._active))` (`usage-index.mjs:854`); `totals.spanUnionSeconds =
-  mergeIntervals(sessions.map(s => s._span))` (`usage-index.mjs:853`);
+  s._active))` (`usage-index.mjs:882`); `totals.spanUnionSeconds =
+  mergeIntervals(sessions.map(s => s._span))` (`usage-index.mjs:881`);
   `totals.spanMinutes` is a running sum of `s._span[1] - s._span[0]` across
-  the loop (`usage-index.mjs:815`, finalized `usage-index.mjs:852`).
+  the loop (`usage-index.mjs:843`, finalized `usage-index.mjs:880`).
 - Render: `fmtHours()` (`dashboard-server.mjs:1850`, `≥10h` rounds to the
   nearest hour, else one decimal place) and `fmtMins()`
   (`dashboard-server.mjs:1851`, `≥60min` rounds to hours, else whole
@@ -369,12 +378,12 @@ byDay[day].cost = Σ costOf(row) for every usage row whose day == that key
 
 **Source:** the day key is the row's own `row.day`, computed once at parse
 time as **local calendar day**, not UTC
-(`usage-index.mjs:446`/`usage-index.mjs:548` call `localDay(at)`) — so a
+(`usage-index.mjs:474`/`usage-index.mjs:576` call `localDay(at)`) — so a
 session that runs from 23:58 local to 00:05 local is billed to the day its
 *first* row landed on (test:
 `tests/kit/usage-index.test.mjs:556`, "a session that opens before midnight
 is counted on its first billed day"). Accumulation:
-`byDay[row.day].cost += rowCost` (`usage-index.mjs:758`). Bar height:
+`byDay[row.day].cost += rowCost` (`usage-index.mjs:786`). Bar height:
 `h = maxDay ? max(2, cost/maxDay*100) : 2` (`dashboard-server.mjs:1950`) —
 every non-empty day gets a visually nonzero bar (floor of 2%), so a very
 cheap day is never rendered as invisible.
@@ -395,11 +404,11 @@ renders "no sessions in window" instead of zeroed figures
 (`dashboard-server.mjs:1962-1966`).
 
 **Formula:** identical aggregation to every other bucket
-(`byProvider[s.provider]`, populated via `addTo()`, `usage-index.mjs:706-715`,
-called once per session at `usage-index.mjs:817`), keyed by the literal string
+(`byProvider[s.provider]`, populated via `addTo()`, `usage-index.mjs:734-743`,
+called once per session at `usage-index.mjs:845`), keyed by the literal string
 `"claude"` or `"codex"` assigned at parse time
 (`blankSession(id, 'claude')` / `blankSession(id, 'codex')`,
-`usage-index.mjs:281-287`, `parseClaude`/`parseCodex` entry points).
+`usage-index.mjs:285-291`, `parseClaude`/`parseCodex` entry points).
 
 **Why this pairing is the one under the most scrutiny.** Both providers'
 tokens are summed into the *same* `tokens`/`cost` fields using the *same*
@@ -434,9 +443,9 @@ punchcard[dow + "-" + hour] += 1   per assistant/agent_message response, at its 
 ```
 
 **Source:** incremented once per Claude assistant turn
-(`usage-index.mjs:421-422`, keyed by `punchKey(at)`) and once per Codex
-`agent_message` (`usage-index.mjs:532-533`), merged into the window-level
-`punchcard` object per session (`usage-index.mjs:832`). Cell intensity is
+(`usage-index.mjs:449-450`, keyed by `punchKey(at)`) and once per Codex
+`agent_message` (`usage-index.mjs:560-561`), merged into the window-level
+`punchcard` object per session (`usage-index.mjs:860`). Cell intensity is
 linear against the single busiest cell in the window:
 `v = pcMax ? n/pcMax : 0` (`dashboard-server.mjs:1986`) — this is a
 **relative**, not absolute, scale, so the heatmap's brightest cell is always
@@ -469,9 +478,9 @@ byModel[model].sessions  = count of DISTINCT sessions whose s.models includes th
 ```
 
 **Source:** cost/tokens/responses accumulate inside the usage-row loop
-(`usage-index.mjs:745-762`); the `sessions` count is deliberately computed
+(`usage-index.mjs:773-790`); the `sessions` count is deliberately computed
 **separately**, once per session over its `s.models` array
-(`usage-index.mjs:825-830`) rather than inside the cost loop, precisely
+(`usage-index.mjs:853-858`) rather than inside the cost loop, precisely
 **so that a model can appear in `byModel` — with a nonzero session count —
 even in a session that contributed zero cost/tokens/responses for that
 model.** This is not an edge case invented for this document: it is the
@@ -480,11 +489,11 @@ by an excluded subagent-replay session still shows up as "used," at zero
 cost, rather than vanishing).
 
 `byModel[...].responses` is populated from `row.responses`
-(`usage-index.mjs:760`), which in turn comes from the `responses` field
+(`usage-index.mjs:788`), which in turn comes from the `responses` field
 passed into `addUsage()` at the call site — `1` per Claude assistant turn
-(`usage-index.mjs:446-452`), or `rec.responses` (the session's whole response
+(`usage-index.mjs:474-480`), or `rec.responses` (the session's whole response
 count) once per Codex session, passed at the single point Codex calls
-`addUsage` (`usage-index.mjs:548-555`; see §15 Bug A for why this field was
+`addUsage` (`usage-index.mjs:576-583`; see §15 Bug A for why this field was
 previously omitted for Codex and every Codex model showed 0 responses
 regardless of real activity).
 
@@ -506,14 +515,14 @@ surfaced here as its own ranked row: `<synthetic> · $0.00 · 0 tok · N
 resp` — real-looking but meaningless, since no model ever ran.
 
 The parser now branches on `isApiErrorMessage === true`
-(`usage-index.mjs:431-440`): the turn still increments `rec.responses`
-and the punchcard (`usage-index.mjs:419-422`) — it *is* real engaged
+(`usage-index.mjs:459-468`): the turn still increments `rec.responses`
+and the punchcard (`usage-index.mjs:447-450`) — it *is* real engaged
 time, someone was genuinely waiting on it — but it is never pushed into
 `rec.models` and `addUsage()` is never called for it, so it can no longer
 create a `byModel` row of any kind. It increments a separate
-`rec.exceptions` counter instead (`usage-index.mjs:432`), rolled up into
-`totals.exceptions` (`usage-index.mjs:800-811`) and surfaced per-session
-(`usage-index.mjs:775`, alongside the existing `sidechain`/`threadSource`
+`rec.exceptions` counter instead (`usage-index.mjs:460`), rolled up into
+`totals.exceptions` (`usage-index.mjs:828-839`) and surfaced per-session
+(`usage-index.mjs:803`, alongside the existing `sidechain`/`threadSource`
 flags — inspectable in the Sessions tab, never hidden). When
 `totals.exceptions > 0`, the panel header shows a small `"· N
 dropped/errored turns excluded"` note (`dashboard-server.mjs:2003-2008`);
@@ -539,9 +548,9 @@ real cached index (1,656 sessions, 90-day window) returned
 `totals.exceptions: null` and still showed the `<synthetic>` row in
 `byModel` on the first run after this change, purely because the cache
 predated it; every unit test still passed, since they only ever exercise
-a fresh parse with no cache involved. `SCHEMA_VERSION` is now `4`
-(`usage-index.mjs:35-46`) specifically to force that one-time
-re-parse. Re-querying the same live server after the bump returned
+a fresh parse with no cache involved. `SCHEMA_VERSION` went to `4` for this
+(`usage-index.mjs:35-50`; since superseded by `5` — the prompts correction,
+§2) specifically to force that one-time re-parse. Re-querying the same live server after the bump returned
 `totals.exceptions: 20` and confirmed `<synthetic>` no longer appears
 in `byModel` at all — the number this section describes, not a
 projected one.
@@ -823,14 +832,14 @@ provider-agnostic). Fixed in commit `540be18` on this branch.
 
 `parseCodex`'s single `addUsage()` call never included a `responses` field —
 Claude's parser passes `responses: 1` per assistant turn
-(`usage-index.mjs:451`, as it existed before this fix), but Codex's call
+(`usage-index.mjs:479`, as it existed before this fix), but Codex's call
 passed no such field at all. Because `byModel[model].responses` is summed
-directly from each usage row's `responses` field (`usage-index.mjs:760`,
+directly from each usage row's `responses` field (`usage-index.mjs:788`,
 `m.responses += row.responses`), **every** Codex model in §10's "Models in
 Play" list displayed `0 resp` regardless of real token/cost volume or actual
 `agent_message` count. **Fix:** `parseCodex` now passes `responses:
 rec.responses` (the session's own tallied response count,
-`usage-index.mjs:530`) on its `addUsage()` call.
+`usage-index.mjs:558`) on its `addUsage()` call.
 
 ### Bug B — subagent thread-replay could double-bill tokens
 
@@ -850,13 +859,13 @@ at face value (correctly avoiding the separate naive-summing bug **[C5]**
 documents, since it already used last-event-only logic — see §4's worked
 example) but performed **no de-duplication** against a parent session a
 subagent file might be replaying. **Fix:** the parser now reads
-`session_meta.thread_source` (`usage-index.mjs:504`, confirmed as a real
+`session_meta.thread_source` (`usage-index.mjs:532`, confirmed as a real
 Codex rollout field by **[C7]**) and skips the `addUsage()` call entirely
-when its value is `'subagent'` (`usage-index.mjs:544`, guard condition
+when its value is `'subagent'` (`usage-index.mjs:572`, guard condition
 `rec.threadSource !== 'subagent'`). The session record itself is **not**
 dropped — it remains visible in the Sessions tab with `threadSource`
 surfaced (mirroring the existing `sidechain` flag Claude sessions already
-carry, `usage-index.mjs:284`), so a maintainer auditing the raw data can
+carry, `usage-index.mjs:288`), so a maintainer auditing the raw data can
 still see it; it simply contributes zero tokens/cost, exactly as intended by
 the "models still shows up in §10's list, with zero cost" mechanism §10
 describes.

--- a/docs/adr/0009-usage-scorecard-local-transcript-analytics.md
+++ b/docs/adr/0009-usage-scorecard-local-transcript-analytics.md
@@ -274,6 +274,11 @@ with different vocabulary keeps them distinguishable to the reader.
 
 ## References
 
+- **[`docs/USAGE-SCORECARD-METRICS.md`](../USAGE-SCORECARD-METRICS.md)** — the maintainer-facing
+  metrics reference: every Scorecard-tab figure's exact formula, source-line citation, worked
+  example, and external pricing citation, added 2026-07-25 after a user-reported Codex-vs-Claude
+  cost discrepancy traced to two real bugs in `parseCodex` (fixed same day). Read that document to
+  verify or dispute a specific number; read this ADR for the design motivation behind it.
 - ADR-0005 (dashboard as read-only offline-first diagnostic); ADR-0007 (egress split);
   ADR-0008 (machine vs repo scope).
 - Spec (archived on completion, per `docs/archive/README.md`): [`docs/archive/2026-07-25-superpowers-spec-usage-scorecard.md`](../archive/2026-07-25-superpowers-spec-usage-scorecard.md).

--- a/docs/adr/0009-usage-scorecard-local-transcript-analytics.md
+++ b/docs/adr/0009-usage-scorecard-local-transcript-analytics.md
@@ -244,6 +244,23 @@ masking, because masking already runs before the slice — so `originalChars` de
 *truncation* alone, and must not be read as a raw-file length. Marking the two kinds of withholding
 with different vocabulary keeps them distinguishable to the reader.
 
+**Amendment (2026-07-26).** The reader labelled every `role: "user"` turn **"you"** — but the
+Messages API records *tool results* and *harness context injections* under the user role, so in a
+heavily agentic session the overwhelming majority of "you" turns were output the harness fed back to
+the model, not anything the person typed (a measured real session: 20 human prompts against 276
+tool results, every one attributed to the human). Misattributing the harness's work to the person is
+the same honesty failure this section exists to prevent, in the attribution column instead of the
+content column. The parser now stamps each user turn with a `kind` — `prompt` (the person, including
+image-only pastes that carry no text block), `tool-result` (a `tool_result` block fed back after a
+tool call), or `context` (`isMeta` harness injections) — and the renderer labels from *kind*, never
+from role: `you` is reserved for `prompt`, tool results render as **tool result** and context as
+**context**, both purple like the tool chips and carrying a hover title stating the harness — not
+the person — sent them. The existing `prompt` boolean (which drives the prompt *counts*) is
+unchanged; `kind` is deliberately broader on the image-only edge, because "not countable as a text
+prompt" and "not the human" are different claims. Codex rollouts record only real prompts as
+`user_message` events, so every Codex user turn is `kind: prompt` by construction. Full mechanics:
+[`docs/TRANSCRIPTS.md`](../TRANSCRIPTS.md).
+
 ## Consequences
 
 ### Good

--- a/docs/assets/transcript-mask-truncate.svg
+++ b/docs/assets/transcript-mask-truncate.svg
@@ -1,0 +1,107 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="880" height="422" viewBox="0 0 880 422"
+     role="img" aria-labelledby="fig-title fig-desc">
+  <title id="fig-title">Mask, then truncate</title>
+  <desc id="fig-desc">A single turn body passes through two server-side withholding stages in readSession: maskSecrets replaces the 21 secret shapes with a redacted mark, then a 40,000-character length cap slices the body and appends a truncated marker. Each kind of withholding gets its own vocabulary.</desc>
+  <style>
+    svg { font-family: system-ui, -apple-system, "Segoe UI", sans-serif; }
+    :root {
+      --surface: #fcfcfb; --border: rgba(11,11,11,0.10);
+      --ink: #0b0b0b; --ink2: #52514e; --muted: #898781;
+      --grid: #e1e0d9; --axis: #c3c2b7;
+      --s1: #2a78d6; --s2: #eb6834; --s3: #1baf7a;
+      --r1: #86b6ef; --r2: #5598e7; --r3: #2a78d6; --r4: #184f95;
+      --wash1: rgba(42,120,214,0.08); --wash2: rgba(235,104,52,0.08);
+      --wash3: rgba(27,175,122,0.08); --washg: rgba(137,135,129,0.10);
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --surface: #1a1a19; --border: rgba(255,255,255,0.10);
+        --ink: #ffffff; --ink2: #c3c2b7; --muted: #898781;
+        --grid: #2c2c2a; --axis: #383835;
+        --s1: #3987e5; --s2: #d95926; --s3: #199e70;
+        --wash1: rgba(57,135,229,0.14); --wash2: rgba(217,89,38,0.14);
+        --wash3: rgba(25,158,112,0.14); --washg: rgba(137,135,129,0.14);
+      }
+    }
+    text { fill: var(--ink); font-size: 12px; }
+    .h1 { font-size: 16px; font-weight: 600; }
+    .h2 { font-size: 13px; font-weight: 600; }
+    .hb { font-size: 12.5px; font-weight: 600; }
+    .t2 { fill: var(--ink2); } .tm { fill: var(--muted); }
+    .small { font-size: 11px; }
+    .mono { font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 11.5px; }
+    .monob { font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 12.5px; font-weight: 600; }
+    .num { font-variant-numeric: tabular-nums; }
+    .box { fill: var(--surface); stroke: var(--border); }
+    .flow { stroke: var(--muted); stroke-width: 1.5; fill: none; }
+    .arrfill { fill: var(--muted); }
+    .lbl { letter-spacing: 0.8px; }
+  </style>
+  <defs>
+    <marker id="arr" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7"
+            markerHeight="7" orient="auto-start-reverse">
+      <path d="M0 0L10 5L0 10z" class="arrfill"/>
+    </marker>
+  </defs>
+  <rect x="0.5" y="0.5" width="879" height="421" rx="8" fill="var(--surface)" stroke="var(--border)"/>
+
+  <!-- ── title block ─────────────────────────────────────────────────── -->
+  <text class="h1" x="24" y="36">Mask, then truncate — two kinds of withholding, marked differently</text>
+  <text class="t2 small" x="24" y="55">Both happen server-side in <tspan class="mono">readSession</tspan>, before anything is serialized.</text>
+
+  <!-- legend: two accents, two identities -->
+  <rect x="690" y="31" width="10" height="10" rx="2" fill="var(--s2)"/>
+  <text class="t2 small" x="706" y="40">masking</text>
+  <rect x="768" y="31" width="10" height="10" rx="2" fill="var(--s1)"/>
+  <text class="t2 small" x="784" y="40">truncation</text>
+
+  <!-- ── input: the raw turn body ────────────────────────────────────── -->
+  <text class="t2" x="24" y="89">turn body (raw text)</text>
+  <text class="tm small" x="24" y="105">as it arrives from the session file</text>
+  <rect class="box" x="344" y="76" width="512" height="26" rx="3"/>
+  <text class="mono t2" x="356" y="93">api_key = sk-live-7f2c; deploy failed, retrying now, tail goes on…</text>
+
+  <line class="flow" x1="600" y1="108" x2="600" y2="138" marker-end="url(#arr)"/>
+
+  <!-- ── stage 1: maskSecrets ────────────────────────────────────────── -->
+  <rect x="24" y="118" width="300" height="74" rx="6" fill="var(--wash2)" stroke="var(--border)"/>
+  <rect x="25" y="132" width="4" height="46" rx="2" fill="var(--s2)"/>
+  <text x="44" y="141"><tspan class="tm small lbl">STAGE 1</tspan><tspan class="tm small"> · </tspan><tspan class="monob">maskSecrets</tspan></text>
+  <text class="t2 small" x="44" y="161">the 21 secret shapes are replaced</text>
+  <text class="t2 small" x="44" y="177">before serialization</text>
+
+  <rect class="box" x="344" y="142" width="512" height="26" rx="3"/>
+  <text class="mono t2" x="356" y="159">api_key = </text>
+  <rect x="429" y="147" width="76" height="16" rx="3" fill="var(--wash2)" stroke="var(--s2)"/>
+  <text class="mono t2" x="436" y="159">…redacted</text>
+  <text class="mono t2" x="509" y="159">; deploy failed, retrying now, tail goes on…</text>
+
+  <line class="flow" x1="600" y1="174" x2="600" y2="226" marker-end="url(#arr)"/>
+
+  <!-- ── stage 2: length cap ─────────────────────────────────────────── -->
+  <rect x="24" y="206" width="300" height="74" rx="6" fill="var(--wash1)" stroke="var(--border)"/>
+  <rect x="25" y="220" width="4" height="46" rx="2" fill="var(--s1)"/>
+  <text x="44" y="229"><tspan class="tm small lbl">STAGE 2</tspan><tspan class="tm small"> · </tspan><tspan class="hb">length cap</tspan></text>
+  <text class="t2 small" x="44" y="249"><tspan class="mono num">MAX_TURN_CHARS = 40,000</tspan> — the slice</text>
+  <text class="t2 small" x="44" y="265">appends a marker</text>
+
+  <rect class="box" x="344" y="230" width="321" height="26" rx="3"/>
+  <text class="mono t2" x="356" y="247">api_key = </text>
+  <rect x="429" y="235" width="76" height="16" rx="3" fill="var(--wash2)" stroke="var(--s2)"/>
+  <text class="mono t2" x="436" y="247">…redacted</text>
+  <rect x="513" y="235" width="140" height="16" rx="3" fill="var(--wash1)" stroke="var(--s1)"/>
+  <text class="mono t2" x="521" y="247">truncated · N of M</text>
+
+  <rect x="673" y="230" width="183" height="26" rx="3" fill="none" stroke="var(--axis)" stroke-dasharray="4 3"/>
+  <text class="tm small" x="764" y="247" text-anchor="middle">sliced away</text>
+
+  <!-- ── invariants ──────────────────────────────────────────────────── -->
+  <rect x="24" y="298" width="832" height="100" rx="6" fill="var(--washg)" stroke="var(--border)"/>
+  <text class="tm small lbl" x="42" y="320">INVARIANTS</text>
+  <text class="tm" x="42" y="344">·</text>
+  <text class="t2 small" x="56" y="344">Presence is the signal — <tspan class="mono">truncated</tspan> / <tspan class="mono">originalChars</tspan> are emitted only when the slice fired; a complete turn cannot be misread as abridged.</text>
+  <text class="tm" x="42" y="365">·</text>
+  <text class="t2 small" x="56" y="365"><tspan class="mono">originalChars</tspan> is measured AFTER masking — it describes loss due to truncation alone, never a raw-file length.</text>
+  <text class="tm" x="42" y="386">·</text>
+  <text class="t2 small" x="56" y="386">Distinct vocabulary end-to-end: masking → <tspan class="mono">…redacted</tspan> marks; truncation → a <tspan class="mono">truncated · N of M</tspan> badge.</text>
+</svg>

--- a/docs/assets/transcript-pipeline.svg
+++ b/docs/assets/transcript-pipeline.svg
@@ -1,0 +1,167 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="880" height="556" viewBox="0 0 880 556"
+     role="img" aria-labelledby="fig-title fig-desc">
+  <title id="fig-title">From disk to browser: the per-session pipeline</title>
+  <desc id="fig-desc">A transcript session moves from the Claude Code and Codex CLI transcript stores through readSession's numbered gates — id grammar, location, realpath containment, size cap, parse, secret masking, truncation — then through the HTTP route's guards, and finally into the browser transcript view.</desc>
+  <style>
+    svg { font-family: system-ui, -apple-system, "Segoe UI", sans-serif; }
+    :root {
+      --surface: #fcfcfb; --border: rgba(11,11,11,0.10);
+      --ink: #0b0b0b; --ink2: #52514e; --muted: #898781;
+      --grid: #e1e0d9; --axis: #c3c2b7;
+      --s1: #2a78d6; --s2: #eb6834; --s3: #1baf7a;
+      --r1: #86b6ef; --r2: #5598e7; --r3: #2a78d6; --r4: #184f95;
+      --wash1: rgba(42,120,214,0.08); --wash2: rgba(235,104,52,0.08);
+      --wash3: rgba(27,175,122,0.08); --washg: rgba(137,135,129,0.10);
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --surface: #1a1a19; --border: rgba(255,255,255,0.10);
+        --ink: #ffffff; --ink2: #c3c2b7; --muted: #898781;
+        --grid: #2c2c2a; --axis: #383835;
+        --s1: #3987e5; --s2: #d95926; --s3: #199e70;
+        --wash1: rgba(57,135,229,0.14); --wash2: rgba(217,89,38,0.14);
+        --wash3: rgba(25,158,112,0.14); --washg: rgba(137,135,129,0.14);
+      }
+    }
+    text { fill: var(--ink); font-size: 12px; }
+    .h1 { font-size: 16px; font-weight: 600; }
+    .h2 { font-size: 13px; font-weight: 600; }
+    .t2 { fill: var(--ink2); } .tm { fill: var(--muted); }
+    .small { font-size: 11px; }
+    .mono { font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 11.5px; }
+    .monoh { font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 13px; font-weight: 600; }
+    .num { font-variant-numeric: tabular-nums; }
+    .box { fill: var(--surface); stroke: var(--border); }
+    .flow { stroke: var(--muted); stroke-width: 1.5; fill: none; }
+    .arrfill { fill: var(--muted); }
+    .rule { stroke: var(--border); stroke-width: 1; fill: none; }
+    .chip { fill: var(--surface); stroke: var(--border); }
+    .washp { fill: var(--washg); stroke: var(--border); }
+    .acc { fill: var(--wash1); stroke: var(--s1); }
+    .accchip { fill: var(--surface); stroke: var(--s1); }
+  </style>
+  <defs>
+    <marker id="arr" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7"
+            markerHeight="7" orient="auto-start-reverse">
+      <path d="M0 0L10 5L0 10z" class="arrfill"/>
+    </marker>
+  </defs>
+  <rect x="0.5" y="0.5" width="879" height="555" rx="8" fill="var(--surface)" stroke="var(--border)"/>
+
+  <!-- header -->
+  <text class="h1" x="24" y="36">From disk to browser: the per-session pipeline</text>
+  <text class="t2 small" x="24" y="56">Every step is a gate — content that fails a check reads as unavailable, never as risky.</text>
+
+  <!-- ===================== column 1 · transcript stores ===================== -->
+  <text class="h2" x="24" y="92">TRANSCRIPT STORES</text>
+  <path class="rule" d="M24 100H238"/>
+
+  <rect class="box" x="24" y="112" width="214" height="84" rx="6"/>
+  <text class="small t2" x="38" y="137">Claude Code</text>
+  <text class="mono" x="38" y="160">~/.claude/projects/</text>
+  <text class="mono" x="38" y="178">&lt;project&gt;/&lt;sessionId&gt;.jsonl</text>
+
+  <rect class="box" x="24" y="220" width="214" height="84" rx="6"/>
+  <text class="small t2" x="38" y="245">Codex CLI</text>
+  <text class="mono" x="38" y="268">~/.codex/sessions/</text>
+  <text class="mono" x="38" y="286">yyyy/mm/dd/rollout-*.jsonl</text>
+
+  <rect class="washp" x="24" y="340" width="214" height="82" rx="6"/>
+  <text class="small t2" x="38" y="368">read-only — transcripts are</text>
+  <text class="small t2" x="38" y="386">never rewritten; a malformed</text>
+  <text class="small t2" x="38" y="404">line is skipped, never fatal</text>
+
+  <!-- stores -> readSession -->
+  <path class="flow" d="M238 208H250V143H260" marker-end="url(#arr)"/>
+
+  <!-- ===================== column 2 · readSession corridor ===================== -->
+  <text class="monoh" x="264" y="92">readSession(id)</text>
+  <path class="rule" d="M264 100H600"/>
+
+  <!-- gate 1 -->
+  <rect class="box" x="264" y="112" width="336" height="62" rx="6"/>
+  <circle class="chip" cx="286" cy="143" r="9.5"/>
+  <text class="small num" x="286" y="147" text-anchor="middle">1</text>
+  <text x="306" y="132">id grammar — <tspan class="mono">VALID_ID</tspan></text>
+  <text class="mono" x="306" y="148">^[A-Za-z0-9._-]{1,128}$</text>
+  <text class="small t2" x="306" y="164">rejects traversal before any filesystem access</text>
+  <path class="flow" d="M286 174V186" marker-end="url(#arr)"/>
+
+  <!-- gate 2 -->
+  <rect class="box" x="264" y="186" width="336" height="34" rx="6"/>
+  <circle class="chip" cx="286" cy="203" r="9.5"/>
+  <text class="small num" x="286" y="207" text-anchor="middle">2</text>
+  <text x="306" y="207">locate across both roots</text>
+  <path class="flow" d="M286 220V232" marker-end="url(#arr)"/>
+
+  <!-- gate 3 -->
+  <rect class="box" x="264" y="232" width="336" height="48" rx="6"/>
+  <circle class="chip" cx="286" cy="256" r="9.5"/>
+  <text class="small num" x="286" y="260" text-anchor="middle">3</text>
+  <text x="306" y="253"><tspan class="mono">realpath</tspan> containment — symlinks collapsed;</text>
+  <text class="small t2" x="306" y="269">resolved file must live under a transcript root</text>
+  <path class="flow" d="M286 280V292" marker-end="url(#arr)"/>
+
+  <!-- gate 4 -->
+  <rect class="box" x="264" y="292" width="336" height="48" rx="6"/>
+  <circle class="chip" cx="286" cy="316" r="9.5"/>
+  <text class="small num" x="286" y="320" text-anchor="middle">4</text>
+  <text x="306" y="313">size cap — <tspan class="mono">MAX_SESSION_BYTES 64 MB</tspan></text>
+  <text class="small t2" x="306" y="329">(oversized reads as unavailable)</text>
+  <path class="flow" d="M286 340V352" marker-end="url(#arr)"/>
+
+  <!-- parse -->
+  <rect class="washp" x="264" y="352" width="336" height="48" rx="6"/>
+  <text class="mono" x="286" y="373">parseClaude / parseCodex</text>
+  <text x="286" y="389"><tspan class="mono">withTurns: true</tspan> → meta + turns</text>
+  <path class="flow" d="M286 400V412" marker-end="url(#arr)"/>
+
+  <!-- gate 5 · masking (accent) -->
+  <rect class="acc" x="264" y="412" width="336" height="48" rx="6"/>
+  <circle class="accchip" cx="286" cy="436" r="9.5"/>
+  <text class="small num" x="286" y="440" text-anchor="middle">5</text>
+  <text x="306" y="433"><tspan class="mono">maskSecrets</tspan> — 21 secret shapes,</text>
+  <text class="small t2" x="306" y="449">server-side, before serialization</text>
+  <path class="flow" d="M286 460V472" marker-end="url(#arr)"/>
+
+  <!-- gate 6 -->
+  <rect class="box" x="264" y="472" width="336" height="48" rx="6"/>
+  <circle class="chip" cx="286" cy="496" r="9.5"/>
+  <text class="small num" x="286" y="500" text-anchor="middle">6</text>
+  <text x="306" y="493"><tspan class="mono">truncate</tspan> — <tspan class="mono">MAX_TURN_CHARS 40,000</tspan></text>
+  <text class="small t2" x="306" y="509">marker appended (never silent)</text>
+
+  <!-- readSession -> HTTP -->
+  <path class="flow" d="M600 496H613V199H622" marker-end="url(#arr)"/>
+
+  <!-- ===================== column 3 · HTTP, then the view ===================== -->
+  <text class="h2" x="626" y="92">HTTP</text>
+  <path class="rule" d="M626 100H856"/>
+
+  <rect class="box" x="626" y="112" width="230" height="180" rx="6"/>
+  <text class="mono" x="640" y="133">GET /api/session/:id</text>
+  <text class="tm" x="640" y="155">–</text><text class="small t2" x="652" y="155">loopback bind</text>
+  <text class="tm" x="640" y="172">–</text><text class="small t2" x="652" y="172">Host guard</text>
+  <text class="tm" x="640" y="189">–</text><text class="small t2" x="652" y="189">fetch-metadata guard</text>
+  <text class="tm" x="640" y="206">–</text><text class="small t2" x="652" y="206">unknown id ⇒ 404 (not 200)</text>
+  <rect class="acc" x="634" y="216" width="214" height="62" rx="5"/>
+  <text x="646" y="236"><tspan class="mono">maskMeta</tspan> + <tspan class="mono">maskTurns</tspan></text>
+  <text class="small t2" x="646" y="252">fail-closed — no masker,</text>
+  <text class="small t2" x="646" y="268">no transcript</text>
+
+  <path class="flow" d="M741 292V318" marker-end="url(#arr)"/>
+
+  <text class="h2" x="626" y="340">TRANSCRIPT VIEW<tspan class="small t2"> (browser)</tspan></text>
+  <path class="rule" d="M626 348H856"/>
+
+  <rect class="box" x="626" y="360" width="230" height="170" rx="6"/>
+  <text class="tm" x="640" y="382">–</text><text x="652" y="382">labels come from <tspan class="mono">kind</tspan>,</text>
+  <text class="small t2" x="652" y="398">never <tspan class="mono">role</tspan></text>
+  <text class="tm" x="640" y="416">–</text><text x="652" y="416">redactions render as marks</text>
+  <text class="tm" x="640" y="434">–</text><text x="652" y="434">truncation as a</text>
+  <text class="mono" x="652" y="450">truncated · N of M<tspan class="small t2" style="font-family:system-ui"> badge</tspan></text>
+  <text class="tm" x="640" y="468">–</text><text x="652" y="468">no download, no copy-all,</text>
+  <text x="652" y="484">no click-to-reveal</text>
+  <text class="small t2" x="652" y="502">(the original never reaches</text>
+  <text class="small t2" x="652" y="518">the browser)</text>
+</svg>

--- a/docs/assets/transcript-read-paths.svg
+++ b/docs/assets/transcript-read-paths.svg
@@ -1,0 +1,127 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="880" height="474" viewBox="0 0 880 474"
+     role="img" aria-labelledby="fig-title fig-desc">
+  <title id="fig-title">One parser, two read paths</title>
+  <desc id="fig-desc">The shared transcript parsers fork into a cached scan path used by the scorecard views and an uncached reader path used by the transcript view.</desc>
+  <style>
+    svg { font-family: system-ui, -apple-system, "Segoe UI", sans-serif; }
+    :root {
+      --surface: #fcfcfb; --border: rgba(11,11,11,0.10);
+      --ink: #0b0b0b; --ink2: #52514e; --muted: #898781;
+      --grid: #e1e0d9; --axis: #c3c2b7;
+      --s1: #2a78d6; --s2: #eb6834; --s3: #1baf7a;
+      --r1: #86b6ef; --r2: #5598e7; --r3: #2a78d6; --r4: #184f95;
+      --wash1: rgba(42,120,214,0.08); --wash2: rgba(235,104,52,0.08);
+      --wash3: rgba(27,175,122,0.08); --washg: rgba(137,135,129,0.10);
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --surface: #1a1a19; --border: rgba(255,255,255,0.10);
+        --ink: #ffffff; --ink2: #c3c2b7; --muted: #898781;
+        --grid: #2c2c2a; --axis: #383835;
+        --s1: #3987e5; --s2: #d95926; --s3: #199e70;
+        --wash1: rgba(57,135,229,0.14); --wash2: rgba(217,89,38,0.14);
+        --wash3: rgba(25,158,112,0.14); --washg: rgba(137,135,129,0.14);
+      }
+    }
+    text { fill: var(--ink); font-size: 12px; }
+    .h1 { font-size: 16px; font-weight: 600; }
+    .h2 { font-size: 13px; font-weight: 600; }
+    .t2 { fill: var(--ink2); } .tm { fill: var(--muted); }
+    .small { font-size: 11px; }
+    .mono { font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 11.5px; }
+    .path { font-size: 10.8px; }
+    .num { font-variant-numeric: tabular-nums; }
+    .box { fill: var(--surface); stroke: var(--border); }
+    .flow { stroke: var(--muted); stroke-width: 1.5; fill: none; }
+    .arrfill { fill: var(--muted); }
+    .mid { text-anchor: middle; }
+  </style>
+  <defs>
+    <marker id="arr" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7"
+            markerHeight="7" orient="auto-start-reverse">
+      <path d="M0 0L10 5L0 10z" class="arrfill"/>
+    </marker>
+  </defs>
+  <rect x="0.5" y="0.5" width="879" height="473" rx="8" fill="var(--surface)" stroke="var(--border)"/>
+
+  <!-- header -->
+  <text class="h1" x="24" y="36">One parser, two read paths</text>
+  <text class="t2 small" x="24" y="56">The same parsers serve two very different callers, switched by <tspan class="mono">withTurns</tspan>.</text>
+
+  <!-- legend -->
+  <rect x="670" y="31" width="11" height="11" rx="2" fill="var(--s1)"/>
+  <text class="t2 small" x="687" y="41">scan path</text>
+  <rect x="766" y="31" width="11" height="11" rx="2" fill="var(--s2)"/>
+  <text class="t2 small" x="783" y="41">reader path</text>
+
+  <!-- left column: source file -> shared parser -->
+  <rect class="box" x="24" y="124" width="128" height="50" rx="6"/>
+  <text class="mid" x="88" y="146">JSONL</text>
+  <text class="mid t2" x="88" y="163">transcript file</text>
+
+  <path class="flow" d="M88 174 V196" marker-end="url(#arr)"/>
+
+  <rect class="box" x="24" y="198" width="128" height="76" rx="6"/>
+  <text class="h2 mid" x="88" y="221">shared parser</text>
+  <text class="mono mid t2" x="88" y="241">parseClaude</text>
+  <text class="mono mid t2" x="88" y="258">parseCodex</text>
+
+  <!-- fork -->
+  <path class="flow" d="M152 236 H166 Q176 236 176 226 V172 Q176 162 186 162 H190" marker-end="url(#arr)"/>
+  <path class="flow" d="M152 236 H166 Q176 236 176 246 V300 Q176 310 186 310 H190" marker-end="url(#arr)"/>
+
+  <!-- ==================== top branch: scan ==================== -->
+  <rect x="196" y="80" width="146" height="22" rx="11" fill="var(--wash1)" stroke="var(--s1)"/>
+  <circle cx="209" cy="91" r="4" fill="var(--s1)"/>
+  <text class="mono" x="220" y="95">withTurns: false</text>
+
+  <rect class="box" x="196" y="124" width="224" height="76" rx="6"/>
+  <text x="208" y="148"><tspan class="mono">buildIndex</tspan><tspan class="tm" dx="7">&#8594;</tspan><tspan class="mono" dx="7">parseFile</tspan></text>
+  <text class="t2 small" x="208" y="170">message bodies never held</text>
+  <text class="t2 small" x="208" y="186">(3,000+ files would balloon memory)</text>
+
+  <path class="flow" d="M420 162 H434" marker-end="url(#arr)"/>
+
+  <rect x="440" y="118" width="276" height="88" rx="6" fill="var(--wash1)" stroke="var(--s1)"/>
+  <text class="small" x="452" y="140">per-file records cached in</text>
+  <text class="mono path" x="452" y="158">~/.config/agentic-kit/usage-index.json</text>
+  <text class="t2 small" x="452" y="178">&#8212; keyed (<tspan class="mono">path, mtime, size</tspan>), invalidated</text>
+  <text class="t2 small" x="452" y="194">wholesale by <tspan class="mono">SCHEMA_VERSION</tspan></text>
+
+  <path class="flow" d="M716 162 H730" marker-end="url(#arr)"/>
+
+  <rect class="box" x="736" y="127" width="120" height="70" rx="6"/>
+  <text class="mid" x="796" y="150" font-size="11.5">Scorecard &#183;</text>
+  <text class="mid" x="796" y="167" font-size="11.5">Findings &#183;</text>
+  <text class="mid" x="796" y="184" font-size="11.5">Sessions views</text>
+
+  <!-- ==================== bottom branch: reader ==================== -->
+  <rect x="196" y="228" width="140" height="22" rx="11" fill="var(--wash2)" stroke="var(--s2)"/>
+  <circle cx="209" cy="239" r="4" fill="var(--s2)"/>
+  <text class="mono" x="220" y="243">withTurns: true</text>
+
+  <rect class="box" x="196" y="280" width="224" height="60" rx="6"/>
+  <text class="mono" x="208" y="304">readSession</text>
+  <text class="t2 small" x="208" y="324">full turn list built</text>
+
+  <path class="flow" d="M420 310 H434" marker-end="url(#arr)"/>
+
+  <rect x="440" y="270" width="276" height="80" rx="6" fill="var(--wash2)" stroke="var(--s2)"/>
+  <rect class="box" x="452" y="282" width="52" height="20" rx="6"/>
+  <text class="t2 small mid" x="478" y="296">cache</text>
+  <path d="M446 292 H510" stroke="var(--s2)" stroke-width="1.8" stroke-linecap="round" fill="none"/>
+  <text class="h2" x="516" y="297">never cached</text>
+  <text class="t2 small" x="452" y="321">&#8212; every call re-reads and re-parses</text>
+  <text class="t2 small" x="452" y="337">the one file</text>
+
+  <path class="flow" d="M716 310 H730" marker-end="url(#arr)"/>
+
+  <rect class="box" x="736" y="288" width="120" height="44" rx="6"/>
+  <text class="mid" x="796" y="315">Transcript view</text>
+
+  <!-- ==================== callout ==================== -->
+  <rect x="24" y="376" width="832" height="74" rx="6" fill="var(--washg)" stroke="var(--border)"/>
+  <text x="44" y="400">Why the <tspan class="mono">kind</tspan> field needed no <tspan class="mono">SCHEMA_VERSION</tspan> bump: turns are never served from cache.</text>
+  <text class="t2" x="44" y="419">Session-record fields (<tspan class="mono">prompts</tspan>, <tspan class="mono">exceptions</tspan>) DO need one &#8212; stale cached records</text>
+  <text class="t2" x="44" y="437">would sum <tspan class="mono">undefined</tspan> into totals.</text>
+</svg>

--- a/docs/assets/transcript-turn-attribution.svg
+++ b/docs/assets/transcript-turn-attribution.svg
@@ -1,0 +1,152 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="880" height="644" viewBox="0 0 880 644"
+     role="img" aria-labelledby="fig-title fig-desc">
+  <title id="fig-title">role is not author: how a user-role turn gets its kind</title>
+  <desc id="fig-desc">An ordered first-match-wins cascade that assigns kind tool-result, context, or prompt to a user-role transcript turn, and a stacked bar showing that of 302 user-role turns in a real 884-turn session, 276 were tool results, 20 were prompts, and 6 were harness context.</desc>
+  <style>
+    svg { font-family: system-ui, -apple-system, "Segoe UI", sans-serif; }
+    :root {
+      --surface: #fcfcfb; --border: rgba(11,11,11,0.10);
+      --ink: #0b0b0b; --ink2: #52514e; --muted: #898781;
+      --grid: #e1e0d9; --axis: #c3c2b7;
+      --s1: #2a78d6; --s2: #eb6834; --s3: #1baf7a;
+      --r1: #86b6ef; --r2: #5598e7; --r3: #2a78d6; --r4: #184f95;
+      --wash1: rgba(42,120,214,0.08); --wash2: rgba(235,104,52,0.08);
+      --wash3: rgba(27,175,122,0.08); --washg: rgba(137,135,129,0.10);
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --surface: #1a1a19; --border: rgba(255,255,255,0.10);
+        --ink: #ffffff; --ink2: #c3c2b7; --muted: #898781;
+        --grid: #2c2c2a; --axis: #383835;
+        --s1: #3987e5; --s2: #d95926; --s3: #199e70;
+        --wash1: rgba(57,135,229,0.14); --wash2: rgba(217,89,38,0.14);
+        --wash3: rgba(25,158,112,0.14); --washg: rgba(137,135,129,0.14);
+      }
+    }
+    text { fill: var(--ink); font-size: 12px; }
+    .h1 { font-size: 16px; font-weight: 600; }
+    .h2 { font-size: 13px; font-weight: 600; }
+    .t2 { fill: var(--ink2); } .tm { fill: var(--muted); }
+    .small { font-size: 11px; }
+    .mono { font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 11.5px; }
+    .mi { font-family: ui-monospace, "SF Mono", Menlo, monospace; }
+    .num { font-variant-numeric: tabular-nums; }
+    .box { fill: var(--surface); stroke: var(--border); }
+    .flow { stroke: var(--muted); stroke-width: 1.5; fill: none; }
+    .arrfill { fill: var(--muted); }
+    .badge { fill: var(--washg); stroke: var(--border); }
+    .bnum { font-size: 11px; font-weight: 600; }
+  </style>
+  <defs>
+    <marker id="arr" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7"
+            markerHeight="7" orient="auto-start-reverse">
+      <path d="M0 0L10 5L0 10z" class="arrfill"/>
+    </marker>
+  </defs>
+  <rect x="0.5" y="0.5" width="879" height="643" rx="8" fill="var(--surface)" stroke="var(--border)"/>
+
+  <!-- ── header ───────────────────────────────────────────────────────────── -->
+  <text class="h1" x="28" y="34">role ≠ author: how a user-role turn gets its <tspan class="mi">kind</tspan></text>
+  <text class="t2 small" x="28" y="54">The Messages API records tool results and harness context under <tspan class="mono">role: "user"</tspan> — <tspan class="mono">kind</tspan> restores authorship.</text>
+
+  <!-- ── top half: ordered decision cascade ───────────────────────────────── -->
+  <text class="h2" x="28" y="80">Decision cascade</text>
+  <text class="tm small" x="158" y="80">first match wins, evaluated top to bottom</text>
+
+  <!-- entry -->
+  <rect class="box" x="168" y="90" width="140" height="26" rx="13"/>
+  <text x="238" y="107" text-anchor="middle">user-role turn</text>
+  <line class="flow" x1="238" y1="116" x2="238" y2="130" marker-end="url(#arr)"/>
+
+  <!-- test 1 -->
+  <rect class="box" x="28" y="132" width="420" height="46" rx="6"/>
+  <circle class="badge" cx="48" cy="155" r="10"/>
+  <text class="bnum" x="48" y="159" text-anchor="middle">1</text>
+  <text x="68" y="159">content carries a <tspan class="mono">tool_result</tspan> block?</text>
+  <line class="flow" x1="448" y1="155" x2="482" y2="155" marker-end="url(#arr)"/>
+  <text class="tm small" x="465" y="148" text-anchor="middle">yes</text>
+
+  <!-- outcome 1: tool-result -->
+  <rect x="484" y="132" width="368" height="110" rx="6" fill="var(--wash2)" stroke="var(--border)"/>
+  <rect x="498" y="145" width="10" height="10" rx="2" fill="var(--s2)"/>
+  <text class="mono" x="516" y="154">kind: 'tool-result'</text>
+  <text class="t2 small" x="498" y="173">output the harness fed back after a tool call</text>
+  <text class="t2 small" x="498" y="188">(labelled “tool result” in the UI)</text>
+  <rect class="box" x="498" y="198" width="340" height="34" rx="4"/>
+  <text class="tm small" x="508" y="213">outranks context: a <tspan class="mono">tool_result</tspan> on an <tspan class="mono">isMeta</tspan></text>
+  <text class="tm small" x="508" y="227">entry is still tool feedback.</text>
+
+  <!-- no → test 2 -->
+  <line class="flow" x1="238" y1="178" x2="238" y2="246" marker-end="url(#arr)"/>
+  <text class="tm small" x="248" y="202">no</text>
+
+  <!-- test 2 -->
+  <rect class="box" x="28" y="248" width="420" height="84" rx="6"/>
+  <circle class="badge" cx="48" cy="271" r="10"/>
+  <text class="bnum" x="48" y="275" text-anchor="middle">2</text>
+  <text class="small" x="68" y="275"><tspan class="mono">isMeta</tspan>, OR text opens with a harness-output envelope</text>
+  <text class="small" x="68" y="290">(<tspan class="mono">HARNESS_OUTPUT_RE</tspan>: <tspan class="mono">task-notification</tspan>,</text>
+  <text class="small" x="68" y="305"><tspan class="mono">bash-stdout/-stderr, local-command-stdout/-stderr,</tspan></text>
+  <text class="small" x="68" y="320"><tspan class="mono">local-command-caveat</tspan>)?</text>
+  <line class="flow" x1="448" y1="270" x2="482" y2="270" marker-end="url(#arr)"/>
+  <text class="tm small" x="465" y="263" text-anchor="middle">yes</text>
+
+  <!-- outcome 2: context -->
+  <rect x="484" y="248" width="368" height="54" rx="6" fill="var(--wash3)" stroke="var(--border)"/>
+  <rect x="498" y="261" width="10" height="10" rx="2" fill="var(--s3)"/>
+  <text class="mono" x="516" y="270">kind: 'context'</text>
+  <text class="t2 small" x="498" y="289">harness-injected; neither the person nor the model</text>
+
+  <!-- else → outcome 3 -->
+  <path class="flow" d="M238 332 L238 358 Q238 364 244 364 L482 364" marker-end="url(#arr)"/>
+  <text class="tm small" x="250" y="350">else</text>
+
+  <!-- outcome 3: prompt -->
+  <rect x="484" y="322" width="368" height="84" rx="6" fill="var(--wash1)" stroke="var(--border)"/>
+  <rect x="498" y="335" width="10" height="10" rx="2" fill="var(--s1)"/>
+  <text class="mono" x="516" y="344">kind: 'prompt'</text>
+  <text class="t2 small" x="498" y="363">the person — includes <tspan class="mono">bash-input</tspan> (a ! command they</text>
+  <text class="t2 small" x="498" y="378">typed), slash-command records, and image-only pastes</text>
+  <text class="t2 small" x="498" y="393">(not countable as a text prompt, but still the person acting)</text>
+
+  <!-- side note: codex -->
+  <rect x="28" y="376" width="3" height="32" rx="1.5" fill="var(--axis)"/>
+  <text class="tm small" x="42" y="389">Codex user turns are <tspan class="mono">kind: 'prompt'</tspan> by construction —</text>
+  <text class="tm small" x="42" y="404">rollouts only record real prompts.</text>
+
+  <line x1="28" y1="436" x2="852" y2="436" stroke="var(--border)"/>
+
+  <!-- ── bottom half: measured split ──────────────────────────────────────── -->
+  <text class="h2" x="28" y="464">Measured on a real 884-turn session</text>
+  <text class="t2 small" x="28" y="482">all 302 user-role turns in that session, by <tspan class="mono">kind</tspan></text>
+
+  <!-- value labels + leader ticks -->
+  <text class="num" x="55" y="506" text-anchor="middle">20</text>
+  <text class="tm small num" x="55" y="519" text-anchor="middle">6.6%</text>
+  <line x1="55" y1="524" x2="55" y2="532" stroke="var(--axis)"/>
+
+  <text class="num" x="459" y="506" text-anchor="middle">276</text>
+  <text class="tm small num" x="459" y="519" text-anchor="middle">91.4%</text>
+  <line x1="459" y1="524" x2="459" y2="532" stroke="var(--axis)"/>
+
+  <text class="num" x="844" y="506" text-anchor="middle">6</text>
+  <text class="tm small num" x="844" y="519" text-anchor="middle">2.0%</text>
+  <line x1="844" y1="524" x2="844" y2="532" stroke="var(--axis)"/>
+
+  <!-- stacked bar: 100% of the 302 user-role turns -->
+  <rect x="28" y="532" width="54.3" height="22" rx="3" fill="var(--s1)"/>
+  <rect x="84.3" y="532" width="749.4" height="22" rx="3" fill="var(--s2)"/>
+  <rect x="835.7" y="532" width="16.3" height="22" rx="3" fill="var(--s3)"/>
+
+  <!-- legend -->
+  <rect x="28" y="575" width="10" height="10" rx="2" fill="var(--s1)"/>
+  <text x="44" y="584"><tspan class="mono">prompt</tspan> (you)</text>
+  <rect x="138" y="575" width="10" height="10" rx="2" fill="var(--s2)"/>
+  <text class="mono" x="154" y="584">tool-result</text>
+  <rect x="250" y="575" width="10" height="10" rx="2" fill="var(--s3)"/>
+  <text class="mono" x="266" y="584">context</text>
+
+  <!-- takeaway -->
+  <rect x="28" y="598" width="824" height="30" rx="6" fill="var(--wash2)" stroke="var(--border)"/>
+  <text class="small" x="42" y="617">~93% of user-role turns are not the person — <tspan class="mono">kind</tspan> is what tells them apart.</text>
+</svg>

--- a/docs/assets/usage-classifier-confidence.svg
+++ b/docs/assets/usage-classifier-confidence.svg
@@ -1,0 +1,141 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="880" height="496" viewBox="0 0 880 496"
+     role="img" aria-labelledby="fig-title fig-desc">
+  <title id="fig-title">Classifier confidence curves</title>
+  <desc id="fig-desc">Confidence rises with the winner's margin over the runner-up and with its raw topScore, but is discarded below a floor of 0.28 and capped at 0.9, so only provenance can reach 1.0.</desc>
+  <style>
+    svg { font-family: system-ui, -apple-system, "Segoe UI", sans-serif; }
+    :root {
+      --surface: #fcfcfb; --border: rgba(11,11,11,0.10);
+      --ink: #0b0b0b; --ink2: #52514e; --muted: #898781;
+      --grid: #e1e0d9; --axis: #c3c2b7;
+      --s1: #2a78d6; --s2: #eb6834; --s3: #1baf7a;
+      --r1: #86b6ef; --r2: #5598e7; --r3: #2a78d6; --r4: #184f95;
+      --wash1: rgba(42,120,214,0.08); --wash2: rgba(235,104,52,0.08);
+      --wash3: rgba(27,175,122,0.08); --washg: rgba(137,135,129,0.10);
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --surface: #1a1a19; --border: rgba(255,255,255,0.10);
+        --ink: #ffffff; --ink2: #c3c2b7; --muted: #898781;
+        --grid: #2c2c2a; --axis: #383835;
+        --s1: #3987e5; --s2: #d95926; --s3: #199e70;
+        --wash1: rgba(57,135,229,0.14); --wash2: rgba(217,89,38,0.14);
+        --wash3: rgba(25,158,112,0.14); --washg: rgba(137,135,129,0.14);
+      }
+    }
+    text { fill: var(--ink); font-size: 12px; }
+    .h1 { font-size: 16px; font-weight: 600; }
+    .h2 { font-size: 13px; font-weight: 600; }
+    .t2 { fill: var(--ink2); } .tm { fill: var(--muted); }
+    .small { font-size: 11px; }
+    .mono { font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 11.5px; }
+    .num { font-variant-numeric: tabular-nums; }
+    .box { fill: var(--surface); stroke: var(--border); }
+    .flow { stroke: var(--muted); stroke-width: 1.5; fill: none; }
+    .arrfill { fill: var(--muted); }
+    .grid { stroke: var(--grid); stroke-width: 1; }
+    .ax { stroke: var(--axis); stroke-width: 1; }
+    .ref { stroke: var(--muted); stroke-width: 1.25; stroke-dasharray: 4 3; fill: none; }
+    .curve { fill: none; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+    .c1 { stroke: var(--r1); } .c2 { stroke: var(--r2); }
+    .c3 { stroke: var(--r3); } .c4 { stroke: var(--r4); }
+    .f1 { fill: var(--r1); } .f2 { fill: var(--r2); }
+    .f3 { fill: var(--r3); } .f4 { fill: var(--r4); }
+    .lead { stroke: var(--muted); stroke-width: 1; fill: none; }
+    .halo { stroke: var(--surface); stroke-width: 1.75; }
+  </style>
+  <defs>
+    <marker id="arr" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7"
+            markerHeight="7" orient="auto-start-reverse">
+      <path d="M0 0L10 5L0 10z" class="arrfill"/>
+    </marker>
+  </defs>
+  <rect x="0.5" y="0.5" width="879" height="495" rx="8" fill="var(--surface)" stroke="var(--border)"/>
+
+  <!-- ── heading ───────────────────────────────────────────────────────── -->
+  <text class="h1" x="24" y="34">Confidence = strength × (0.35 + 0.65 × margin), gated</text>
+  <text class="t2 small" x="24" y="54">The floor discards weak winners; the cap reserves 1.0 for provenance.</text>
+
+  <!-- ── plot: x 96..656 (margin 0..1), y 376..96 (confidence 0..1) ────── -->
+
+  <!-- below-floor wash -->
+  <rect x="96" y="297.6" width="560" height="78.4" style="fill:var(--washg)"/>
+  <line x1="96" y1="297.6" x2="656" y2="297.6" class="ref"/>
+
+  <!-- gridline at 0.5 -->
+  <line x1="96" y1="236" x2="656" y2="236" class="grid"/>
+
+  <!-- axes -->
+  <line x1="96" y1="96" x2="96" y2="376" class="ax"/>
+  <line x1="96" y1="376" x2="656" y2="376" class="ax"/>
+  <line x1="96" y1="96" x2="108" y2="96" class="ax"/>
+  <line x1="96" y1="376" x2="96" y2="381" class="ax"/>
+  <line x1="236" y1="376" x2="236" y2="381" class="ax"/>
+  <line x1="376" y1="376" x2="376" y2="381" class="ax"/>
+  <line x1="516" y1="376" x2="516" y2="381" class="ax"/>
+  <line x1="656" y1="376" x2="656" y2="381" class="ax"/>
+
+  <!-- y tick labels -->
+  <text class="t2 small num" x="86" y="100"   text-anchor="end">1</text>
+  <text class="t2 small num" x="86" y="128"   text-anchor="end">0.9</text>
+  <text class="t2 small num" x="86" y="240"   text-anchor="end">0.5</text>
+  <text class="t2 small num" x="86" y="301.6" text-anchor="end">0.28</text>
+  <text class="t2 small num" x="86" y="380"   text-anchor="end">0</text>
+  <text class="t2 small" x="44" y="236" text-anchor="middle"
+        transform="rotate(-90 44 236)">confidence</text>
+
+  <!-- x tick labels -->
+  <text class="t2 small num" x="96"  y="393" text-anchor="middle">0</text>
+  <text class="t2 small num" x="236" y="393" text-anchor="middle">0.25</text>
+  <text class="t2 small num" x="376" y="393" text-anchor="middle">0.5</text>
+  <text class="t2 small num" x="516" y="393" text-anchor="middle">0.75</text>
+  <text class="t2 small num" x="656" y="393" text-anchor="middle">1</text>
+  <text class="t2 small" x="376" y="412" text-anchor="middle">margin over runner-up</text>
+
+  <!-- cap reference line -->
+  <line x1="96" y1="124" x2="656" y2="124" class="ref"/>
+  <text class="small" x="104" y="141"><tspan class="mono">RULE_CONFIDENCE_CAP</tspan><tspan class="t2"> — rules can never reach </tspan><tspan class="t2 num">1.0</tspan></text>
+
+  <!-- curves -->
+  <path class="curve c1" d="M96 347.58L656 294.80"/>
+  <path class="curve c2" d="M96 320.14L656 216.40"/>
+  <path class="curve c3" d="M96 291.72L656 135.20"/>
+  <path class="curve c4" d="M96 278.00L569.85 124.00L656 124.00"/>
+
+  <!-- below-floor annotation -->
+  <text class="small" x="112" y="364"><tspan class="t2">Unclassified — below </tspan><tspan class="mono">CONFIDENCE_FLOOR</tspan><tspan class="t2 num"> 0.28</tspan><tspan class="t2"> (“weak signal”)</tspan></text>
+
+  <!-- worked example on the topScore-6 curve -->
+  <path class="lead" d="M654 143L644 198"/>
+  <circle cx="656" cy="135.2" r="5" class="f3 halo"/>
+  <text class="small t2" x="640" y="208" text-anchor="end">sole scorer: margin <tspan class="num">1.0</tspan> → <tspan class="num">0.86</tspan></text>
+
+  <!-- provenance-only point, above the plotted frame -->
+  <path d="M600 89L606.5 96L600 103L593.5 96Z" style="fill:var(--s2)" class="halo"/>
+  <text class="small" x="586" y="100" text-anchor="end"><tspan class="num">1.0</tspan><tspan class="t2"> = provenance only (attributed skill/plugin)</tspan></text>
+
+  <!-- direct curve labels -->
+  <rect x="666" y="115.5" width="9" height="9" rx="2" class="f4"/>
+  <text x="681" y="124"><tspan class="mono">topScore</tspan> ≥7</text>
+  <rect x="666" y="145.5" width="9" height="9" rx="2" class="f3"/>
+  <text class="num" x="681" y="154">6</text>
+  <rect x="666" y="212" width="9" height="9" rx="2" class="f2"/>
+  <text class="num" x="681" y="220.5">4</text>
+  <rect x="666" y="290.3" width="9" height="9" rx="2" class="f1"/>
+  <text class="num" x="681" y="299">2</text>
+
+  <!-- ── legend ────────────────────────────────────────────────────────── -->
+  <text class="mono t2" x="96" y="436">topScore</text>
+  <rect x="166" y="427.5" width="10" height="10" rx="2" class="f4"/>
+  <text class="small" x="182" y="436">≥7 · <tspan class="t2">strength</tspan> <tspan class="num">1.0</tspan></text>
+  <rect x="304" y="427.5" width="10" height="10" rx="2" class="f3"/>
+  <text class="small" x="320" y="436"><tspan class="num">6</tspan> · <tspan class="t2">strength</tspan> <tspan class="num">0.86</tspan></text>
+  <rect x="442" y="427.5" width="10" height="10" rx="2" class="f2"/>
+  <text class="small" x="458" y="436"><tspan class="num">4</tspan> · <tspan class="t2">strength</tspan> <tspan class="num">0.57</tspan></text>
+  <rect x="580" y="427.5" width="10" height="10" rx="2" class="f1"/>
+  <text class="small" x="596" y="436"><tspan class="num">2</tspan> · <tspan class="t2">strength</tspan> <tspan class="num">0.29</tspan></text>
+
+  <!-- ── footnote ──────────────────────────────────────────────────────── -->
+  <text class="small tm" x="24" y="462">× grounded: if the winner has zero title evidence, confidence is ×<tspan class="num">0</tspan> — tool-mix alone can never classify.</text>
+  <text class="small tm" x="24" y="478">A dead-even tie keeps only <tspan class="mono">TIE_FLOOR</tspan> <tspan class="num">0.35</tspan> of its strength.</text>
+</svg>

--- a/docs/assets/usage-classifier-layers.svg
+++ b/docs/assets/usage-classifier-layers.svg
@@ -1,0 +1,169 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="880" height="728" viewBox="0 0 880 728"
+     role="img" aria-labelledby="fig-title fig-desc">
+  <title id="fig-title">The classifier is a tournament, not an if/else</title>
+  <desc id="fig-desc">Three layers of the usage classifier: layer 1 exits early on recorded provenance, layer 2 scores every category with no early exit, and layer 3 applies a confidence floor below which the result is Unclassified.</desc>
+  <style>
+    svg { font-family: system-ui, -apple-system, "Segoe UI", sans-serif; }
+    :root {
+      --surface: #fcfcfb; --border: rgba(11,11,11,0.10);
+      --ink: #0b0b0b; --ink2: #52514e; --muted: #898781;
+      --grid: #e1e0d9; --axis: #c3c2b7;
+      --s1: #2a78d6; --s2: #eb6834; --s3: #1baf7a;
+      --r1: #86b6ef; --r2: #5598e7; --r3: #2a78d6; --r4: #184f95;
+      --wash1: rgba(42,120,214,0.08); --wash2: rgba(235,104,52,0.08);
+      --wash3: rgba(27,175,122,0.08); --washg: rgba(137,135,129,0.10);
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --surface: #1a1a19; --border: rgba(255,255,255,0.10);
+        --ink: #ffffff; --ink2: #c3c2b7; --muted: #898781;
+        --grid: #2c2c2a; --axis: #383835;
+        --s1: #3987e5; --s2: #d95926; --s3: #199e70;
+        --wash1: rgba(57,135,229,0.14); --wash2: rgba(217,89,38,0.14);
+        --wash3: rgba(25,158,112,0.14); --washg: rgba(137,135,129,0.14);
+      }
+    }
+    text { fill: var(--ink); font-size: 12px; }
+    .h1 { font-size: 16px; font-weight: 600; }
+    .h2 { font-size: 13px; font-weight: 600; }
+    .t2 { fill: var(--ink2); } .tm { fill: var(--muted); }
+    .small { font-size: 11px; }
+    .mono { font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 11.5px; }
+    .num { font-variant-numeric: tabular-nums; }
+    .box { fill: var(--surface); stroke: var(--border); }
+    .flow { stroke: var(--muted); stroke-width: 1.5; fill: none; }
+    .arrfill { fill: var(--muted); }
+    .band { fill: var(--washg); stroke: var(--border); }
+  </style>
+  <defs>
+    <marker id="arr" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7"
+            markerHeight="7" orient="auto-start-reverse">
+      <path d="M0 0L10 5L0 10z" class="arrfill"/>
+    </marker>
+  </defs>
+  <rect x="0.5" y="0.5" width="879" height="727" rx="8" fill="var(--surface)" stroke="var(--border)"/>
+
+  <!-- ============ header ============ -->
+  <text class="h1" x="24" y="34">The classifier is a tournament, not an if/else</text>
+  <text class="t2 small" x="24" y="54">Only layer 1 short-circuits; layer 2 scores every category; layer 3 can declare no contest.</text>
+  <!-- key -->
+  <rect x="560" y="32" width="10" height="10" rx="2" fill="var(--s1)"/>
+  <text class="t2 small" x="576" y="41">worked example</text>
+  <rect x="671" y="32" width="10" height="10" rx="2" fill="var(--s2)"/>
+  <text class="t2 small" x="687" y="41">guard rail</text>
+
+  <!-- ============ LAYER 1 — PROVENANCE ============ -->
+  <rect class="band" x="20" y="70" width="840" height="144" rx="6"/>
+  <text class="h2" x="36" y="92">LAYER 1 — PROVENANCE</text>
+  <text class="tm small" x="214" y="92">the only early exit</text>
+
+  <rect class="box" x="36" y="104" width="214" height="58" rx="6"/>
+  <text x="50" y="127"><tspan class="mono">attributionSkill</tspan>&#160;&#160;/</text>
+  <text x="50" y="145"><tspan class="mono">attributionPlugin</tspan>&#160;&#160;present?</text>
+
+  <path class="flow" d="M250 133 H284" marker-end="url(#arr)"/>
+
+  <rect class="box" x="288" y="104" width="192" height="58" rx="6"/>
+  <text x="302" y="127">longest-prefix match in</text>
+  <text class="mono" x="302" y="146">SKILL_CAT</text>
+
+  <path class="flow" d="M480 133 H526" marker-end="url(#arr)"/>
+  <text class="tm small" x="503" y="124" text-anchor="middle">exit</text>
+
+  <rect x="534" y="104" width="310" height="58" rx="6"
+        fill="var(--wash1)" stroke="var(--s1)"/>
+  <text x="548" y="127">category assigned · confidence 1.0</text>
+  <text x="548" y="146">basis&#160;<tspan class="mono">skill:&lt;id&gt;</tspan></text>
+
+  <rect class="box" x="36" y="170" width="452" height="26" rx="6"/>
+  <text x="50" y="187"><tspan class="mono">skill:superpowers:brainstorming</tspan>&#160;&#160;→ Design &amp; planning&#160;<tspan class="num tm small">(conf 1.00)</tspan></text>
+  <text class="t2 small" x="502" y="187">a recorded fact, not an inference — layers 2–3 never run</text>
+
+  <!-- ============ LAYER 2 — SCORING ============ -->
+  <rect class="band" x="20" y="224" width="840" height="264" rx="6"/>
+  <text class="h2" x="36" y="246">LAYER 2 — SCORING</text>
+  <text class="tm small" x="178" y="246">all rules run · no early exit</text>
+
+  <rect class="box" x="36" y="262" width="441" height="26" rx="6"/>
+  <text class="tm small" x="50" y="279">title:</text>
+  <text class="mono" x="90" y="279">design claude usage dashboard with analytics scorecard</text>
+
+  <!-- scoreboard -->
+  <path d="M200 294 V380" style="stroke:var(--axis)" stroke-width="1"/>
+
+  <rect x="200" y="298" width="96" height="18" rx="3" fill="var(--s1)"/>
+  <text x="188" y="311" text-anchor="end">Design &amp; frontend</text>
+  <text class="num" x="304" y="311">6</text>
+  <text class="tm small" x="322" y="311">design +3 · dashboard +3</text>
+
+  <rect x="200" y="318" width="6" height="18" rx="3" fill="var(--washg)" stroke="var(--border)"/>
+  <text x="188" y="331" text-anchor="end">Feature build</text>
+  <text class="num tm small" x="214" y="331">0</text>
+
+  <rect x="200" y="338" width="6" height="18" rx="3" fill="var(--washg)" stroke="var(--border)"/>
+  <text x="188" y="351" text-anchor="end">Bug fix &amp; debug</text>
+  <text class="num tm small" x="214" y="351">0</text>
+
+  <rect x="200" y="358" width="6" height="18" rx="3" fill="var(--washg)" stroke="var(--border)"/>
+  <text x="188" y="371" text-anchor="end">Research &amp; exploration</text>
+  <text class="num tm small" x="214" y="371">0</text>
+
+  <text class="tm small" x="200" y="392">…10 more categories, all 0</text>
+
+  <text class="t2 small" x="36" y="418">every category leaves layer 2 with a score — nothing short-circuits,</text>
+  <text class="t2 small" x="36" y="432">so the order the rules fire in cannot change the outcome.</text>
+
+  <!-- tool-mix side panel -->
+  <rect class="box" x="498" y="262" width="346" height="210" rx="6"/>
+  <text class="h2" x="512" y="284">tool-mix prior: nudges, never decides</text>
+
+  <text class="mono" x="512" y="306">edit share &gt;30%</text>
+  <text class="t2 small" x="512" y="320">+1.5 → Feature build / Refactor / Bug fix &amp; debug</text>
+
+  <text class="mono" x="512" y="342">read &gt;45% and edit &lt;10%</text>
+  <text class="t2 small" x="512" y="356">+1.5 → Code review / Security review /</text>
+  <text class="t2 small" x="512" y="369">Research &amp; exploration</text>
+
+  <text class="mono" x="512" y="391">Agent/Task share &gt;12%</text>
+  <text class="t2 small" x="512" y="405">+2.5 → Orchestration</text>
+
+  <rect x="512" y="416" width="318" height="42" rx="6"
+        fill="var(--wash2)" stroke="var(--s2)"/>
+  <text class="small" x="524" y="433">grounded gate: a winner with ZERO title</text>
+  <text class="small" x="524" y="447">evidence is a guess ⇒ forced Unclassified</text>
+
+  <!-- ============ LAYER 3 — THE FLOOR ============ -->
+  <rect class="band" x="20" y="498" width="840" height="210" rx="6"/>
+  <text class="h2" x="36" y="520">LAYER 3 — THE FLOOR</text>
+  <text class="tm small" x="199" y="520">0 → 1 confidence scale</text>
+
+  <!-- marker labels -->
+  <text class="t2 small" x="820" y="536" text-anchor="end"><tspan class="num">1.0</tspan>&#160;· provenance only</text>
+  <text class="small" x="287" y="554" text-anchor="middle"><tspan class="num">0.28</tspan>&#160;·&#160;<tspan class="mono">CONFIDENCE_FLOOR</tspan></text>
+  <text class="t2 small" x="746" y="554" text-anchor="middle"><tspan class="num">0.9</tspan>&#160;· rules cap</text>
+
+  <!-- markers -->
+  <path d="M287 562 V626" style="stroke:var(--s2)" stroke-width="1.5" stroke-dasharray="4 3"/>
+  <path d="M746 562 V600" style="stroke:var(--muted)" stroke-width="1.5" stroke-dasharray="4 3"/>
+  <path d="M820 542 V578" style="stroke:var(--muted)" stroke-width="1" stroke-dasharray="2 3"/>
+
+  <!-- axis -->
+  <path d="M80 590 H820" style="stroke:var(--axis)" stroke-width="1.5"/>
+  <path d="M80 584 V596 M820 584 V596" style="stroke:var(--axis)" stroke-width="1.5"/>
+  <text class="num tm small" x="80" y="614" text-anchor="middle">0</text>
+
+  <!-- worked result dot at 0.86 -->
+  <circle cx="716" cy="590" r="5.5" fill="var(--s1)" stroke="var(--surface)" stroke-width="2"/>
+  <path d="M716 598 V626" style="stroke:var(--s1)" stroke-width="1.5" stroke-dasharray="4 3"/>
+
+  <rect class="box" x="36" y="626" width="340" height="44" rx="6"/>
+  <text class="t2 small" x="50" y="644">below ⇒ Unclassified — basis&#160;<tspan class="mono">weak signal</tspan>,</text>
+  <text class="t2 small" x="50" y="658">or&#160;<tspan class="mono">no signal</tspan>&#160;if nothing scored at all</text>
+
+  <rect x="396" y="626" width="448" height="44" rx="6"
+        fill="var(--wash1)" stroke="var(--s1)"/>
+  <text class="mono num" x="410" y="644">strength 6/7 = 0.86 × (0.35 + 0.65 × margin 1.0) = 0.86</text>
+  <text class="small" x="410" y="659">→ Design &amp; frontend · basis&#160;<tspan class="mono">title+tools</tspan></text>
+
+  <text class="t2 small" x="36" y="690">Unclassified is a first-class outcome, not a failure — force-fitting labels would make every category untrustworthy.</text>
+</svg>

--- a/docs/assets/usage-token-accounting.svg
+++ b/docs/assets/usage-token-accounting.svg
@@ -1,0 +1,127 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="880" height="456" viewBox="0 0 880 456"
+     role="img" aria-labelledby="fig-title fig-desc">
+  <title id="fig-title">Two token vocabularies: per-turn deltas vs cumulative snapshots</title>
+  <desc id="fig-desc">Claude Code reports a usage delta on every assistant turn, so a session total is the sum of the turns; Codex CLI reports a cumulative token_count snapshot, so a session total is the last snapshot and summing the snapshots double-counts.</desc>
+  <style>
+    svg { font-family: system-ui, -apple-system, "Segoe UI", sans-serif; }
+    :root {
+      --surface: #fcfcfb; --border: rgba(11,11,11,0.10);
+      --ink: #0b0b0b; --ink2: #52514e; --muted: #898781;
+      --grid: #e1e0d9; --axis: #c3c2b7;
+      --s1: #2a78d6; --s2: #eb6834; --s3: #1baf7a;
+      --r1: #86b6ef; --r2: #5598e7; --r3: #2a78d6; --r4: #184f95;
+      --wash1: rgba(42,120,214,0.08); --wash2: rgba(235,104,52,0.08);
+      --wash3: rgba(27,175,122,0.08); --washg: rgba(137,135,129,0.10);
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --surface: #1a1a19; --border: rgba(255,255,255,0.10);
+        --ink: #ffffff; --ink2: #c3c2b7; --muted: #898781;
+        --grid: #2c2c2a; --axis: #383835;
+        --s1: #3987e5; --s2: #d95926; --s3: #199e70;
+        --wash1: rgba(57,135,229,0.14); --wash2: rgba(217,89,38,0.14);
+        --wash3: rgba(25,158,112,0.14); --washg: rgba(137,135,129,0.14);
+      }
+    }
+    text { fill: var(--ink); font-size: 12px; }
+    .h1 { font-size: 16px; font-weight: 600; }
+    .h2 { font-size: 13px; font-weight: 600; }
+    .t2 { fill: var(--ink2); } .tm { fill: var(--muted); }
+    .small { font-size: 11px; }
+    .tiny { font-size: 10.5px; }
+    .mono { font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 11.5px; }
+    .num { font-variant-numeric: tabular-nums; }
+    .box { fill: var(--surface); stroke: var(--border); }
+    .flow { stroke: var(--muted); stroke-width: 1.5; fill: none; }
+    .arrfill { fill: var(--muted); }
+    .p1 { fill: var(--wash1); stroke: var(--border); }
+    .p2 { fill: var(--wash2); stroke: var(--border); }
+    .b1 { fill: var(--s1); }
+    .b2 { fill: var(--s2); }
+    .faded { fill-opacity: 0.3; stroke: var(--s2); stroke-opacity: 0.6; stroke-width: 1; }
+    .tot1 { fill: var(--surface); stroke: var(--s1); stroke-width: 1.5; }
+    .tot2 { fill: var(--surface); stroke: var(--s2); stroke-width: 1.5; }
+    .callout { fill: var(--wash2); stroke: var(--s2); stroke-width: 1.5; }
+    .sw1 { fill: var(--s1); }
+    .sw2 { fill: var(--s2); }
+  </style>
+  <defs>
+    <marker id="arr" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7"
+            markerHeight="7" orient="auto-start-reverse">
+      <path d="M0 0L10 5L0 10z" class="arrfill"/>
+    </marker>
+  </defs>
+  <rect x="0.5" y="0.5" width="879" height="455" rx="8" fill="var(--surface)" stroke="var(--border)"/>
+
+  <!-- header -->
+  <text class="h1" x="24" y="34">Two token vocabularies: per-turn deltas vs cumulative snapshots</text>
+  <text class="small t2" x="24" y="55">Illustrative numbers — the shapes, not the magnitudes, are the point.</text>
+
+  <!-- legend -->
+  <rect class="sw1" x="676" y="25" width="10" height="10" rx="2"/>
+  <text class="small" x="692" y="34">Claude Code</text>
+  <rect class="sw2" x="772" y="25" width="10" height="10" rx="2"/>
+  <text class="small" x="788" y="34">Codex CLI</text>
+  <text class="tiny tm" x="848" y="55" text-anchor="end">bar lengths scale within each panel</text>
+
+  <!-- ============ LEFT PANEL: Claude Code ============ -->
+  <rect class="p1" x="16.5" y="76.5" width="415" height="275" rx="6"/>
+  <rect class="sw1" x="32" y="92" width="10" height="10" rx="2"/>
+  <text class="h2" x="48" y="101">CLAUDE CODE</text>
+  <text class="small t2" x="32" y="121">each assistant turn carries its own <tspan class="mono">usage</tspan> object</text>
+
+  <rect class="box" x="32" y="140" width="118" height="30" rx="6"/>
+  <text class="small" x="44" y="159">assistant turn 1</text>
+  <rect class="b1" x="162" y="145" width="48" height="20" rx="3"/>
+  <text class="mono num" x="220" y="159">out 2k</text>
+
+  <rect class="box" x="32" y="188" width="118" height="30" rx="6"/>
+  <text class="small" x="44" y="207">assistant turn 2</text>
+  <rect class="b1" x="162" y="193" width="120" height="20" rx="3"/>
+  <text class="mono num" x="292" y="207">out 5k</text>
+
+  <rect class="box" x="32" y="236" width="118" height="30" rx="6"/>
+  <text class="small" x="44" y="255">assistant turn 3</text>
+  <rect class="b1" x="162" y="241" width="72" height="20" rx="3"/>
+  <text class="mono num" x="244" y="255">out 3k</text>
+
+  <path class="flow" d="M224 272 L224 288" marker-end="url(#arr)"/>
+  <rect class="tot1" x="32.75" y="292.75" width="382.5" height="43.5" rx="6"/>
+  <text x="224" y="319" text-anchor="middle">session total = Σ per-turn = <tspan class="mono num">10k</tspan></text>
+
+  <!-- ============ RIGHT PANEL: Codex CLI ============ -->
+  <rect class="p2" x="448.5" y="76.5" width="415" height="275" rx="6"/>
+  <rect class="sw2" x="464" y="92" width="10" height="10" rx="2"/>
+  <text class="h2" x="480" y="101">CODEX CLI</text>
+  <text class="small t2" x="464" y="121"><tspan class="mono">event_msg</tspan> → <tspan class="mono">token_count</tspan> is a CUMULATIVE snapshot</text>
+
+  <rect class="box" x="464" y="140" width="98" height="30" rx="6"/>
+  <text class="small" x="476" y="159">snapshot 1</text>
+  <rect class="b2 faded" x="574" y="145" width="38" height="20" rx="3"/>
+  <text class="mono num" x="622" y="159">10k</text>
+  <rect class="box" x="774" y="146" width="74" height="18" rx="4"/>
+  <text class="tiny tm" x="811" y="159" text-anchor="middle">superseded</text>
+
+  <rect class="box" x="464" y="188" width="98" height="30" rx="6"/>
+  <text class="small" x="476" y="207">snapshot 2</text>
+  <rect class="b2 faded" x="574" y="193" width="94" height="20" rx="3"/>
+  <text class="mono num" x="678" y="207">25k</text>
+  <rect class="box" x="774" y="194" width="74" height="18" rx="4"/>
+  <text class="tiny tm" x="811" y="207" text-anchor="middle">superseded</text>
+
+  <rect class="box" x="464" y="236" width="98" height="30" rx="6"/>
+  <text class="small" x="476" y="255">snapshot 3</text>
+  <rect class="b2" x="574" y="241" width="150" height="20" rx="3"/>
+  <text class="mono num" x="734" y="255">40k</text>
+
+  <path class="flow" d="M656 272 L656 288" marker-end="url(#arr)"/>
+  <rect class="tot2" x="464.75" y="292.75" width="382.5" height="43.5" rx="6"/>
+  <text x="656" y="319" text-anchor="middle">session total = LAST snapshot = <tspan class="mono num">40k</tspan></text>
+
+  <!-- ============ FOOTER: anti-pattern + subagent note ============ -->
+  <rect class="callout" x="16.75" y="366.75" width="846.5" height="37.5" rx="6"/>
+  <text class="small" x="32" y="390">summing snapshots double-counts: <tspan class="mono num">10k + 25k + 40k = 75k ≠ 40k</tspan> — never sum cumulative totals</text>
+
+  <text class="small tm" x="32" y="424"><tspan class="mono">session_meta</tspan> <tspan class="mono">thread_source: "subagent"</tspan> ⇒ the whole rollout is a <tspan class="mono">thread_spawn</tspan> replay of the</text>
+  <text class="small tm" x="32" y="440">parent's spend — excluded from aggregation, session kept visible</text>
+</svg>

--- a/scripts/codex-usage-diagnostic.mjs
+++ b/scripts/codex-usage-diagnostic.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // codex-usage-diagnostic.mjs — standalone, zero-dependency (Node built-ins
 // only), read-only diagnostic for the two Codex usage-scorecard bugs fixed in
-// this branch (see docs/USAGE-SCORECARD-METRICS.md §15):
+// this branch (see docs/USAGE-SCORECARD-METRICS.md Appendix A):
 //
 //   Bug A — Codex model rows always showed 0 responses (display-only, no $/tok effect).
 //   Bug B — a rollout whose session_meta.thread_source is "subagent" replays its

--- a/scripts/codex-usage-diagnostic.mjs
+++ b/scripts/codex-usage-diagnostic.mjs
@@ -1,0 +1,255 @@
+#!/usr/bin/env node
+// codex-usage-diagnostic.mjs — standalone, zero-dependency (Node built-ins
+// only), read-only diagnostic for the two Codex usage-scorecard bugs fixed in
+// this branch (see docs/USAGE-SCORECARD-METRICS.md §15):
+//
+//   Bug A — Codex model rows always showed 0 responses (display-only, no $/tok effect).
+//   Bug B — a rollout whose session_meta.thread_source is "subagent" replays its
+//           parent thread's ENTIRE prior token history as duplicate events before
+//           its own new turns (openai/codex thread_spawn behavior — see
+//           ccusage/ccusage#950, which measured up to 91x cost inflation from
+//           exactly this). The old code counted that replayed total as real spend.
+//
+// This script reproduces BOTH the OLD (buggy) and NEW (fixed) token totals
+// side by side, computed independently from this diagnostic's own small
+// reimplementation of the relevant parsing logic — not by importing the fix
+// itself — so the comparison is a genuine check, not a tautology:
+//
+//   "before" should match what your CURRENT (unpatched) dashboard shows you.
+//   "after"  is what it will show once this branch's fix lands.
+//
+// PRIVACY: this script never reads, stores, or prints session titles, prompts,
+// message bodies, file paths, session ids, or working directories. It reads
+// only three fields per rollout line: `type`, `session_meta.thread_source`,
+// and the numeric fields inside `token_count.info.total_token_usage`. The
+// entire printed report is aggregate counts — safe to paste back in full.
+//
+// USAGE:
+//   node codex-usage-diagnostic.mjs                # scans ~/.codex/sessions
+//   node codex-usage-diagnostic.mjs --root <path>   # scan a different root
+//   node codex-usage-diagnostic.mjs --json          # machine-readable output
+//   node codex-usage-diagnostic.mjs --help
+//
+// Requires Node 18+. No npm install, no network access, no writes to disk.
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+// ── CLI args ─────────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+if (args.includes('-h') || args.includes('--help')) {
+  console.log(`
+codex-usage-diagnostic.mjs — read-only, aggregate-only Codex usage check
+
+  --root <path>   directory to scan for rollout-*.jsonl (default: ~/.codex/sessions)
+  --json          print machine-readable JSON instead of the human-readable report
+  --help          show this message
+
+Prints only counts and token/cost totals. Never reads or prints prompts,
+titles, session ids, file paths, or timestamps of any individual session.
+`.trim());
+  process.exit(0);
+}
+const rootIdx = args.indexOf('--root');
+const root = rootIdx >= 0 && args[rootIdx + 1] ? args[rootIdx + 1] : path.join(os.homedir(), '.codex', 'sessions');
+const asJson = args.includes('--json');
+
+// ── minimal OpenAI rate table, for a $ estimate only ────────────────────
+// Kept intentionally tiny (Codex-relevant entries only) and mirrors
+// src/lib/pricing.mjs as of 2026-07-25. If this script is run long after
+// that date, treat the $ figures as directional, not exact — re-check
+// src/lib/pricing.mjs for the current table. Same cache multipliers as
+// Anthropic's own published rates (0.1x read, 1.25x write); see
+// docs/USAGE-SCORECARD-METRICS.md §13 for the citations behind those two
+// numbers.
+const RATES = [
+  ['gpt-5.6-sol', 5, 30],
+  ['gpt-5.6-terra', 2.5, 15],
+  ['gpt-5.6-luna', 1, 6],
+  ['gpt-5.5-pro', 30, 180],
+  ['gpt-5.5', 5, 30],
+  ['gpt-5.4-mini', 0.75, 4.5],
+  ['gpt-5.4-nano', 0.2, 1.25],
+  ['gpt-5.4-pro', 30, 180],
+  ['gpt-5.4', 2.5, 15],
+  ['gpt-5.3-codex', 1.75, 14],
+];
+const FALLBACK_RATE = [3, 15]; // unrecognized model: mid-line estimate, never $0
+// Codex rollouts report no separate cache-write figure (parseCodex always
+// passes cacheWrite: 0 — see src/lib/usage-index.mjs), so only the read
+// multiplier is needed here.
+const CACHE_READ_MULTIPLIER = 0.1;
+
+function rateFor(model) {
+  const id = String(model || '').toLowerCase();
+  const hit = RATES.find(([key]) => id === key || id.startsWith(`${key}-`));
+  return hit ? [hit[1], hit[2]] : FALLBACK_RATE;
+}
+
+function costOf({ model, input, output, cacheRead }) {
+  const [rin, rout] = rateFor(model);
+  const inputUnits = (Number(input) || 0) + (Number(cacheRead) || 0) * CACHE_READ_MULTIPLIER;
+  return (inputUnits * rin + (Number(output) || 0) * rout) / 1e6;
+}
+
+// ── walk root/<yyyy>/<mm>/<dd>/rollout-*.jsonl ──────────────────────────
+
+function readDirSafe(dir) {
+  try { return fs.readdirSync(dir, { withFileTypes: true }); } catch { return []; }
+}
+
+function findRolloutFiles(rootDir) {
+  const out = [];
+  for (const y of readDirSafe(rootDir)) {
+    if (!y.isDirectory()) continue;
+    for (const m of readDirSafe(path.join(rootDir, y.name))) {
+      if (!m.isDirectory()) continue;
+      for (const d of readDirSafe(path.join(rootDir, y.name, m.name))) {
+        if (!d.isDirectory()) continue;
+        const dir = path.join(rootDir, y.name, m.name, d.name);
+        for (const f of readDirSafe(dir)) {
+          if (f.isFile() && f.name.startsWith('rollout-') && f.name.endsWith('.jsonl')) {
+            out.push(path.join(dir, f.name));
+          }
+        }
+      }
+    }
+  }
+  return out;
+}
+
+// ── parse one rollout: mirrors src/lib/usage-index.mjs's parseCodex, but
+//    extracts ONLY thread_source, model, and the last cumulative token_count.
+//    Never reads or retains message text, prompts, ids, or paths. ─────────
+
+function parseRollout(file) {
+  let raw;
+  try { raw = fs.readFileSync(file, 'utf8'); } catch { return null; }
+
+  let threadSource = null;
+  let model = 'unknown';
+  let lastUsage = null;
+  let hasResponse = false;
+
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.charCodeAt(0) !== 123 /* '{' */) continue;
+    let e;
+    try { e = JSON.parse(trimmed); } catch { continue; }
+    if (!e || typeof e !== 'object') continue;
+    const p = e.payload ?? {};
+
+    if (e.type === 'session_meta') {
+      if (typeof p.thread_source === 'string') threadSource = p.thread_source;
+      continue;
+    }
+    if (e.type === 'turn_context') {
+      if (typeof p.model === 'string') model = p.model;
+      continue;
+    }
+    if (e.type !== 'event_msg') continue;
+
+    if (p.type === 'token_count') {
+      const t = p.info?.total_token_usage;
+      if (t && typeof t === 'object') lastUsage = t;
+      continue;
+    }
+    if (p.type === 'agent_message') hasResponse = true;
+  }
+
+  if (!hasResponse || !lastUsage) return null; // no assistant turn → not a session, per usage-index.mjs
+
+  const cacheRead = Number(lastUsage.cached_input_tokens) || 0;
+  const gross = Number(lastUsage.input_tokens) || 0;
+  return {
+    threadSource: threadSource ?? 'user', // absent field == "user" (openai/codex#23001: older rollouts predate the field)
+    model,
+    input: Math.max(0, gross - cacheRead),
+    output: Number(lastUsage.output_tokens) || 0,
+    cacheRead,
+  };
+}
+
+// ── run ──────────────────────────────────────────────────────────────────
+
+const files = findRolloutFiles(root);
+const sessions = [];
+let unparsed = 0;
+for (const f of files) {
+  const s = parseRollout(f);
+  if (s) sessions.push(s); else unparsed++;
+}
+
+const subagentSessions = sessions.filter((s) => s.threadSource === 'subagent');
+const otherThreadSources = [...new Set(
+  sessions.map((s) => s.threadSource).filter((v) => v !== 'user' && v !== 'subagent'),
+)];
+
+function sumTokens(list) {
+  return list.reduce(
+    (acc, s) => {
+      acc.input += s.input; acc.output += s.output; acc.cacheRead += s.cacheRead;
+      acc.cost += costOf(s);
+      return acc;
+    },
+    { input: 0, output: 0, cacheRead: 0, cost: 0 },
+  );
+}
+
+const before = sumTokens(sessions); // what the OLD, buggy code counts — every session, replays included
+const after = sumTokens(sessions.filter((s) => s.threadSource !== 'subagent')); // what the FIXED code counts
+const excluded = sumTokens(subagentSessions);
+
+const round2 = (n) => Math.round(n * 100) / 100;
+const pct = (part, whole) => (whole ? round2((part / whole) * 100) : 0);
+const totalTok = (t) => t.input + t.output + t.cacheRead;
+
+const report = {
+  rolloutFilesFound: files.length,
+  parsedAsSessions: sessions.length,
+  unreadableOrNoAssistantTurn: unparsed,
+  threadSourceCounts: {
+    user: sessions.length - subagentSessions.length - sessions.filter((s) => otherThreadSources.includes(s.threadSource)).length,
+    subagent: subagentSessions.length,
+    other: otherThreadSources.length ? otherThreadSources : undefined,
+  },
+  tokens: {
+    beforeFix_allSessions: { ...before, total: totalTok(before) },
+    afterFix_excludingSubagentReplays: { ...after, total: totalTok(after) },
+    excludedAsSubagentReplay: { ...excluded, total: totalTok(excluded) },
+    pctOfTotalTokensExcluded: pct(totalTok(excluded), totalTok(before)),
+    pctOfTotalCostExcluded: pct(excluded.cost, before.cost),
+  },
+  costEstimateNote: 'Uses a small embedded OpenAI rate table (gpt-5.x family) mirroring src/lib/pricing.mjs as of 2026-07-25 — directional, not authoritative. See docs/USAGE-SCORECARD-METRICS.md §13.2.',
+};
+
+if (asJson) {
+  console.log(JSON.stringify(report, null, 2));
+} else {
+  const usd = (n) => `$${Math.round(n).toLocaleString()}`;
+  const tok = (n) => n.toLocaleString();
+  console.log('Codex usage diagnostic — Bug B (subagent thread-replay) check');
+  console.log('='.repeat(64));
+  console.log('No prompts, titles, session ids, file paths, or timestamps below.');
+  console.log('This entire block is safe to paste back in full.\n');
+  console.log(`Rollout files scanned root: ${root}`);
+  console.log(`Rollout files found:        ${report.rolloutFilesFound}`);
+  console.log(`Counted as real sessions:   ${report.parsedAsSessions}  (>=1 assistant reply)`);
+  console.log(`Skipped (unreadable / no reply): ${report.unreadableOrNoAssistantTurn}\n`);
+  console.log(`thread_source = "user" (or absent): ${report.threadSourceCounts.user}`);
+  console.log(`thread_source = "subagent":          ${report.threadSourceCounts.subagent}`);
+  if (report.threadSourceCounts.other) {
+    console.log(`thread_source = other values seen:   ${report.threadSourceCounts.other.join(', ')}`);
+  }
+  console.log('');
+  console.log('BEFORE the fix (what your current dashboard shows — verify this matches):');
+  console.log(`  tokens: ${tok(before.input + before.output + before.cacheRead)}  (input ${tok(before.input)} · output ${tok(before.output)} · cache-read ${tok(before.cacheRead)})`);
+  console.log(`  API-equivalent cost estimate: ${usd(before.cost)}\n`);
+  console.log('AFTER the fix (excludes thread_source:"subagent" rollouts):');
+  console.log(`  tokens: ${tok(after.input + after.output + after.cacheRead)}  (input ${tok(after.input)} · output ${tok(after.output)} · cache-read ${tok(after.cacheRead)})`);
+  console.log(`  API-equivalent cost estimate: ${usd(after.cost)}\n`);
+  console.log(`Excluded as subagent replay: ${tok(totalTok(excluded))} tokens (${report.tokens.pctOfTotalTokensExcluded}% of before-fix total), ~${usd(excluded.cost)} (${report.tokens.pctOfTotalCostExcluded}% of before-fix cost)`);
+  console.log(`\n${report.costEstimateNote}`);
+}

--- a/scripts/codex-usage-diagnostic.mjs
+++ b/scripts/codex-usage-diagnostic.mjs
@@ -91,7 +91,7 @@ function rateFor(model) {
 function costOf({ model, input, output, cacheRead }) {
   const [rin, rout] = rateFor(model);
   const inputUnits = (Number(input) || 0) + (Number(cacheRead) || 0) * CACHE_READ_MULTIPLIER;
-  return (inputUnits * rin + (Number(output) || 0) * rout) / 1e6;
+  return (inputUnits * Number(rin) + (Number(output) || 0) * Number(rout)) / 1e6;
 }
 
 // ── walk root/<yyyy>/<mm>/<dd>/rollout-*.jsonl ──────────────────────────

--- a/src/lib/dashboard-server.mjs
+++ b/src/lib/dashboard-server.mjs
@@ -1272,6 +1272,19 @@ body{
    are not the person — purple ties them visually to the tool chips, and the
    accent stays reserved for turns the human actually typed. */
 .t-tool .t-who{color:var(--purple)}
+/* Harness sentinel markup, restyled (fmtHarness): a slash command renders as
+   a chip, and system-reminder / caveat / stdout blocks get a labelled quiet
+   panel — the wrapped content stays verbatim, only the XML wrappers go. */
+.h-cmd{
+  font-family:var(--mono); font-size:12px; color:var(--accent);
+  border:1px solid color-mix(in srgb,var(--accent) 32%,transparent);
+  background:color-mix(in srgb,var(--accent) 10%,transparent); border-radius:5px; padding:1px 7px;
+}
+.h-note{display:block; border-left:2px solid var(--line-2); padding:5px 10px; margin:5px 0; color:var(--ink-dim)}
+.h-tag{
+  display:block; font-style:normal; font-family:var(--mono); font-size:9.5px;
+  text-transform:uppercase; letter-spacing:.06em; color:var(--ink-dim); opacity:.8; margin-bottom:2px;
+}
 .t-meta{display:block; font-size:9.5px; margin-top:3px; text-transform:none; letter-spacing:0}
 .t-body{font-size:13px; color:var(--ink-2); white-space:pre-wrap; word-break:break-word; min-width:0}
 .t-user .t-body{color:var(--ink)}
@@ -2174,6 +2187,28 @@ const JS = `
     });
   }
 
+  // Harness sentinel markup \u2014 the XML wrappers Claude Code writes into
+  // transcript text (<command-name>, <system-reminder>, <local-command-*>) \u2014
+  // rendered as styled structure instead of literal angle-bracket soup.
+  // PRESENTATION ONLY: the wrapped content is kept verbatim (ADR-0009 \u00a78's
+  // no-silent-alteration rule); only the wrapper tags become styling. Runs on
+  // ESCAPED html (after markRedactions), so patterns match &lt;tag&gt;. An
+  // unmatched tag (e.g. cut mid-sentinel by turn truncation) is left raw.
+  var H_TAGS={"system-reminder":"system reminder","local-command-caveat":"caveat","local-command-stdout":"command output"};
+  function fmtHarness(html){
+    return html
+      .replace(/&lt;command-name&gt;([\\s\\S]*?)&lt;\\/command-name&gt;\\s*(?:&lt;command-message&gt;([\\s\\S]*?)&lt;\\/command-message&gt;\\s*)?(?:&lt;command-args&gt;([\\s\\S]*?)&lt;\\/command-args&gt;)?/g,
+        function(_,name,msg,args){
+          var n=name.trim(), a=(args||"").trim(), m=(msg||"").trim();
+          return '<span class="h-cmd"'+(m&&m!==n.replace(/^\\//,"")?' title="'+m+'"':"")
+            +'>'+n+(a?" "+a:"")+"</span>";
+        })
+      .replace(/&lt;(system-reminder|local-command-caveat|local-command-stdout)&gt;\\s*([\\s\\S]*?)\\s*&lt;\\/\\1&gt;/g,
+        function(_,tag,body){
+          return '<span class="h-note"><i class="h-tag">'+H_TAGS[tag]+"</i>"+body+"</span>";
+        });
+  }
+
   // ADR-0009 §8 — an abridged turn must not be readable as a complete one, and
   // "truncated" alone is not enough: a reader who cannot tell 1% loss from 90%
   // loss knows something is missing and nothing about whether it matters.
@@ -2237,7 +2272,7 @@ const JS = `
       else{who="you"; cls="t-user";}
       return '<div class="turn '+cls+'"><div class="t-who"'+(title?' title="'+esc(title)+'"':"")+'>'
         +esc(who)+meta+"</div>"
-        +'<div class="t-body">'+markRedactions(String(text))+tools+"</div></div>";
+        +'<div class="t-body">'+fmtHarness(markRedactions(String(text)))+tools+"</div></div>";
     }).join(""):'<div class="empty">this session has no readable turns.</div>';
   }
 

--- a/src/lib/dashboard-server.mjs
+++ b/src/lib/dashboard-server.mjs
@@ -1268,6 +1268,10 @@ body{
 .turn:last-child{border-bottom:0}
 .t-who{font-family:var(--mono); font-size:10.5px; color:var(--ink-dim); text-transform:uppercase; letter-spacing:.06em}
 .t-user .t-who{color:var(--accent)}
+/* Tool results and harness context ride the user ROLE in the Messages API but
+   are not the person — purple ties them visually to the tool chips, and the
+   accent stays reserved for turns the human actually typed. */
+.t-tool .t-who{color:var(--purple)}
 .t-meta{display:block; font-size:9.5px; margin-top:3px; text-transform:none; letter-spacing:0}
 .t-body{font-size:13px; color:var(--ink-2); white-space:pre-wrap; word-break:break-word; min-width:0}
 .t-user .t-body{color:var(--ink)}
@@ -2219,8 +2223,20 @@ const JS = `
         ?'<div class="chips">'+tn.tools.map(function(x){return '<span class="tool">'+esc(x)+"</span>";}).join("")+"</div>":"";
       var meta=truncBadge(tn)
         +(tn.output?'<span class="t-meta mono">'+esc(fmtNum(tn.output))+" out</span>":"");
-      return '<div class="turn '+(user?"t-user":"t-asst")+'"><div class="t-who">'
-        +esc(user?"you":(tn.model||tn.role||"assistant"))+meta+"</div>"
+      // role "user" ≠ "the human typed this": the Messages API records tool
+      // results and harness context injections under the user role, and the
+      // parser marks WHICH via tn.kind. Only kind "prompt" earns "you" — a
+      // tool result labeled "you" attributes the harness's work to the person.
+      // Fallback for a turn without kind: the prompt flag (false ⇒ tool
+      // feedback was the overwhelmingly dominant non-prompt case).
+      var kind=tn.kind||(user?(tn.prompt===false?"tool-result":"prompt"):"");
+      var who,cls,title="";
+      if(!user){who=tn.model||tn.role||"assistant"; cls="t-asst";}
+      else if(kind==="tool-result"){who="tool result"; cls="t-tool"; title="output returned to the model by the tooling — not typed by you";}
+      else if(kind==="context"){who="context"; cls="t-tool"; title="context injected by the harness — not typed by you";}
+      else{who="you"; cls="t-user";}
+      return '<div class="turn '+cls+'"><div class="t-who"'+(title?' title="'+esc(title)+'"':"")+'>'
+        +esc(who)+meta+"</div>"
         +'<div class="t-body">'+markRedactions(String(text))+tools+"</div></div>";
     }).join(""):'<div class="empty">this session has no readable turns.</div>';
   }

--- a/src/lib/dashboard-server.mjs
+++ b/src/lib/dashboard-server.mjs
@@ -2194,7 +2194,9 @@ const JS = `
   // no-silent-alteration rule); only the wrapper tags become styling. Runs on
   // ESCAPED html (after markRedactions), so patterns match &lt;tag&gt;. An
   // unmatched tag (e.g. cut mid-sentinel by turn truncation) is left raw.
-  var H_TAGS={"system-reminder":"system reminder","local-command-caveat":"caveat","local-command-stdout":"command output"};
+  var H_TAGS={"system-reminder":"system reminder","local-command-caveat":"caveat",
+    "local-command-stdout":"command output","local-command-stderr":"command stderr",
+    "bash-stdout":"bash output","bash-stderr":"bash stderr","task-notification":"task notification"};
   function fmtHarness(html){
     return html
       .replace(/&lt;command-name&gt;([\\s\\S]*?)&lt;\\/command-name&gt;\\s*(?:&lt;command-message&gt;([\\s\\S]*?)&lt;\\/command-message&gt;\\s*)?(?:&lt;command-args&gt;([\\s\\S]*?)&lt;\\/command-args&gt;)?/g,
@@ -2203,7 +2205,11 @@ const JS = `
           return '<span class="h-cmd"'+(m&&m!==n.replace(/^\\//,"")?' title="'+m+'"':"")
             +'>'+n+(a?" "+a:"")+"</span>";
         })
-      .replace(/&lt;(system-reminder|local-command-caveat|local-command-stdout)&gt;\\s*([\\s\\S]*?)\\s*&lt;\\/\\1&gt;/g,
+      // bash-input is the person's own "! command" — a chip, prefixed so it
+      // reads as the shell invocation it was, not as prose.
+      .replace(/&lt;bash-input&gt;([\\s\\S]*?)&lt;\\/bash-input&gt;/g,
+        function(_,cmd){return '<span class="h-cmd" title="shell command run with the ! prefix">! '+cmd.trim()+"</span>";})
+      .replace(/&lt;(system-reminder|local-command-caveat|local-command-stdout|local-command-stderr|bash-stdout|bash-stderr|task-notification)&gt;\\s*([\\s\\S]*?)\\s*&lt;\\/\\1&gt;/g,
         function(_,tag,body){
           return '<span class="h-note"><i class="h-tag">'+H_TAGS[tag]+"</i>"+body+"</span>";
         });

--- a/src/lib/dashboard-server.mjs
+++ b/src/lib/dashboard-server.mjs
@@ -587,7 +587,7 @@ function renderPage({ name, version }) {
       </div>
       <div class="two">
         <section class="strip">
-          <div class="sh"><h2>models in play</h2><span class="n mono">by api-equivalent cost</span></div>
+          <div class="sh"><h2>models in play</h2><span class="n mono">by api-equivalent cost<span id="u-models-note"></span></span></div>
           <div id="u-models"></div>
         </section>
         <section class="strip">
@@ -1983,6 +1983,12 @@ const JS = `
       return bar(esc(m.name),fmtUsd(m.cost),fmtTok(fld(m.v,"tokens"))+" · "+fmtNum(fld(m.v,"responses"))+" resp",
         pct(m.cost,mMax),false);
     }).join(""):'<div class="empty">no models in window.</div>';
+    // Dropped-connection / rate-limit / auth-failure turns never resolve to a
+    // model — excluded from this list entirely rather than shown as a $0 row
+    // (see docs/USAGE-SCORECARD-METRICS.md §10). Surfaced here instead, only
+    // when nonzero, so they stay visible rather than silently vanishing.
+    var exc=fld(t,"exceptions");
+    document.getElementById("u-models-note").textContent=exc?(" · "+fmtNum(exc)+" dropped/errored turn"+(exc===1?"":"s")+" excluded"):"";
 
     var projects=entries(d.byProject), pMax=projects.length?projects[0].cost:0;
     var shown=projects.slice(0,8);

--- a/src/lib/usage-index.mjs
+++ b/src/lib/usage-index.mjs
@@ -362,6 +362,26 @@ function isHumanPrompt(entry) {
 }
 
 /**
+ * What KIND of `user`-role turn is this, for transcript attribution? The
+ * Messages API records tool results and harness context injections under
+ * `role: "user"`, so role alone must never be read as "the human typed this":
+ *   'tool-result' — carries a tool_result block: output the HARNESS fed back
+ *                   to the model after a tool call.
+ *   'context'     — isMeta: harness-injected context (command output,
+ *                   system reminders), not typed by the person.
+ *   'prompt'      — the human. Deliberately broader than isHumanPrompt():
+ *                   an image-only paste has no text block (so it is not
+ *                   COUNTED as a prompt) but it IS the person acting, and
+ *                   labeling it "tool result" would misattribute it.
+ */
+function userTurnKind(entry) {
+  const content = entry?.message?.content;
+  if (Array.isArray(content) && content.some((b) => b?.type === 'tool_result')) return 'tool-result';
+  if (entry.isMeta) return 'context';
+  return 'prompt';
+}
+
+/**
  * Parse one Claude transcript. Returns `{ session, turns }`; `turns` is only
  * populated when `withTurns` (the reader path) — the scan path does not need
  * message bodies and holding them would balloon memory over 3,000 files.
@@ -389,7 +409,7 @@ function parseClaude(raw, { id, dirName, withTurns = false }) {
       }
       if (withTurns) {
         const text = claudeText(e.message?.content);
-        if (text) turns.push({ role: 'user', at: new Date(ms).toISOString(), text, prompt: human });
+        if (text) turns.push({ role: 'user', at: new Date(ms).toISOString(), text, prompt: human, kind: userTurnKind(e) });
       }
       continue;
     }
@@ -500,7 +520,10 @@ function parseCodex(raw, { id, withTurns = false }) {
       rec.prompts++;
       const text = typeof p.message === 'string' ? p.message : '';
       if (!firstPrompt) firstPrompt = text;
-      if (withTurns && text) turns.push({ role: 'user', at: new Date(ms).toISOString(), text, prompt: true });
+      // Codex rollouts record only real prompts as user_message events — tool
+      // output travels in other event types that are not surfaced as turns —
+      // so every Codex user turn is kind 'prompt' by construction.
+      if (withTurns && text) turns.push({ role: 'user', at: new Date(ms).toISOString(), text, prompt: true, kind: 'prompt' });
       continue;
     }
     if (p.type === 'agent_message') {

--- a/src/lib/usage-index.mjs
+++ b/src/lib/usage-index.mjs
@@ -42,8 +42,12 @@ import { configDir, claudeDir, codexDir } from './paths.mjs';
  *      that into `totals.exceptions` silently produces NaN (serialized as
  *      `null` over JSON) instead of a real count — caught by querying a real
  *      cached index during verification, not by the unit tests, which only
- *      ever exercise a fresh parse. */
-export const SCHEMA_VERSION = 4;
+ *      ever exercise a fresh parse.
+ *  v5: harness-output envelopes (task-notification, bash-stdout,
+ *      local-command-stdout, …) no longer count as human prompts, so the
+ *      cached `prompts` figure on every session parsed before this rule is
+ *      inflated and must be re-derived. */
+export const SCHEMA_VERSION = 5;
 
 /** Silence longer than this ends a stretch of engagement. A session is split
  *  into active sub-intervals at gaps ABOVE this bound (exactly this much is not
@@ -350,9 +354,30 @@ function claudeText(content) {
   return out.join('\n');
 }
 
-/** Is this `user` entry a human prompt, or a tool result being fed back? */
+/**
+ * Harness-output envelopes: user-role entries whose text the HARNESS wrote —
+ * background-task notifications, command stdout/stderr dumps, local-command
+ * caveats. They carry neither `isMeta` nor a tool_result block, so text shape
+ * is the only signal. Measured on the real corpus (envelope at start of user
+ * text): task-notification 550, bash-stdout 85, local-command-stdout 60,
+ * local-command-caveat 183; the stderr variants are the symmetric error-path
+ * siblings. NOT here: bash-input (the person typed that `! cmd`) and the
+ * command-name/-message/-args triple (the person invoked that slash command).
+ */
+const HARNESS_OUTPUT_RE = /^\s*<(task-notification|bash-stdout|bash-stderr|local-command-stdout|local-command-stderr|local-command-caveat)>/;
+
+function entryText(entry) {
+  const content = entry?.message?.content;
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  const t = content.find((b) => b?.type === 'text' && typeof b.text === 'string');
+  return t ? t.text : '';
+}
+
+/** Is this `user` entry a human prompt, or harness output being fed back? */
 function isHumanPrompt(entry) {
   if (entry.isMeta) return false;
+  if (HARNESS_OUTPUT_RE.test(entryText(entry))) return false;
   const content = entry?.message?.content;
   if (typeof content === 'string') return content.trim().length > 0;
   if (!Array.isArray(content)) return false;
@@ -367,17 +392,20 @@ function isHumanPrompt(entry) {
  * `role: "user"`, so role alone must never be read as "the human typed this":
  *   'tool-result' — carries a tool_result block: output the HARNESS fed back
  *                   to the model after a tool call.
- *   'context'     — isMeta: harness-injected context (command output,
- *                   system reminders), not typed by the person.
+ *   'context'     — isMeta OR a harness-output envelope (task notifications,
+ *                   command stdout/stderr, caveats): harness-injected, not
+ *                   typed by the person — and not the model either.
  *   'prompt'      — the human. Deliberately broader than isHumanPrompt():
  *                   an image-only paste has no text block (so it is not
  *                   COUNTED as a prompt) but it IS the person acting, and
- *                   labeling it "tool result" would misattribute it.
+ *                   labeling it "tool result" would misattribute it. Also
+ *                   covers bash-input (`! cmd`) and slash-command records —
+ *                   the person initiated those.
  */
 function userTurnKind(entry) {
   const content = entry?.message?.content;
   if (Array.isArray(content) && content.some((b) => b?.type === 'tool_result')) return 'tool-result';
-  if (entry.isMeta) return 'context';
+  if (entry.isMeta || HARNESS_OUTPUT_RE.test(entryText(entry))) return 'context';
   return 'prompt';
 }
 

--- a/src/lib/usage-index.mjs
+++ b/src/lib/usage-index.mjs
@@ -35,8 +35,15 @@ import { configDir, claudeDir, codexDir } from './paths.mjs';
 /** Bump to invalidate every cached entry wholesale.
  *  v2: cached records carry `active` sub-intervals for the idle-gap split.
  *  v3: project is the REPO, with the worktree kept separately — cached v2
- *      records carry the old worktree-as-project labels and must be re-derived. */
-export const SCHEMA_VERSION = 3;
+ *      records carry the old worktree-as-project labels and must be re-derived.
+ *  v4: `exceptions` (dropped-connection/rate-limit/auth-failure placeholder
+ *      turns) is a new required field on every session record. Without this
+ *      bump, a v3-cached session has `exceptions: undefined`, and summing
+ *      that into `totals.exceptions` silently produces NaN (serialized as
+ *      `null` over JSON) instead of a real count — caught by querying a real
+ *      cached index during verification, not by the unit tests, which only
+ *      ever exercise a fresh parse. */
+export const SCHEMA_VERSION = 4;
 
 /** Silence longer than this ends a stretch of engagement. A session is split
  *  into active sub-intervals at gaps ABOVE this bound (exactly this much is not
@@ -274,7 +281,7 @@ function* jsonLines(raw) {
 function blankSession(id, provider) {
   return {
     id, provider, title: '', project: 'unknown', start: null, end: null,
-    prompts: 0, responses: 0, sidechain: false, threadSource: null, models: [], tools: {},
+    prompts: 0, responses: 0, exceptions: 0, sidechain: false, threadSource: null, models: [], tools: {},
     skill: null, plugin: null, worktree: null, usage: [], punchcard: {}, active: [], stamps: [],
   };
 }
@@ -390,11 +397,32 @@ function parseClaude(raw, { id, dirName, withTurns = false }) {
     if (e.type !== 'assistant' || !e.message) continue;
     noteSpan(rec, ms);
     rec.responses++;
+    const at = Number.isFinite(ms) ? ms : (rec.start ?? Date.now());
+    const pk = punchKey(at);
+    rec.punchcard[pk] = (rec.punchcard[pk] ?? 0) + 1;
+
+    // A dropped connection, rate limit, or auth failure makes Claude Code
+    // synthesize a local placeholder turn (model: "<synthetic>",
+    // isApiErrorMessage: true) with no real completion behind it — usage is
+    // always zero. It IS real engaged time (counted above), but it is not a
+    // model attempt: excluded from `models`/cost attribution so it can never
+    // appear as a $0 "model in play," and counted instead as an EXCEPTION so
+    // it stays visible rather than silently vanishing.
+    if (e.isApiErrorMessage === true) {
+      rec.exceptions++;
+      if (withTurns) {
+        turns.push({
+          role: 'assistant', at: new Date(at).toISOString(), model: 'exception',
+          text: claudeText(e.message.content), tools: [], exception: true,
+        });
+      }
+      continue;
+    }
+
     const model = typeof e.message.model === 'string' ? e.message.model : 'unknown';
     if (!rec.models.includes(model)) rec.models.push(model);
 
     const u = e.message.usage ?? {};
-    const at = Number.isFinite(ms) ? ms : (rec.start ?? Date.now());
     addUsage(rec, localDay(at), model, {
       input: Number(u.input_tokens) || 0,
       output: Number(u.output_tokens) || 0,
@@ -402,8 +430,6 @@ function parseClaude(raw, { id, dirName, withTurns = false }) {
       cacheWrite: Number(u.cache_creation_input_tokens) || 0,
       responses: 1,
     });
-    const pk = punchKey(at);
-    rec.punchcard[pk] = (rec.punchcard[pk] ?? 0) + 1;
 
     const tools = [];
     for (const b of Array.isArray(e.message.content) ? e.message.content : []) {
@@ -723,8 +749,8 @@ function aggregate(records, { days, now, cutoff, deps }) {
       worktree: rec.worktree ?? null,
       start: new Date(rec.start ?? rec.end).toISOString(),
       minutes: Math.round(((rec.end - (rec.start ?? rec.end)) / 60_000) * 10) / 10,
-      prompts: rec.prompts, responses: rec.responses, sidechain: rec.sidechain,
-      threadSource: rec.threadSource,
+      prompts: rec.prompts, responses: rec.responses, exceptions: rec.exceptions,
+      sidechain: rec.sidechain, threadSource: rec.threadSource,
       models: rec.models.slice(),
       input, output, cacheRead, cacheWrite,
       tokens: input + output + cacheRead + cacheWrite,
@@ -749,7 +775,7 @@ function aggregate(records, { days, now, cutoff, deps }) {
   sessions.sort((a, b) => b.cost - a.cost || Date.parse(b.start) - Date.parse(a.start));
 
   const totals = {
-    sessions: sessions.length, responses: 0, input: 0, output: 0,
+    sessions: sessions.length, responses: 0, exceptions: 0, input: 0, output: 0,
     cacheRead: 0, cacheWrite: 0, tokens: 0, cost: 0,
     spanMinutes: 0, spanUnionSeconds: 0, engagedSeconds: 0,
   };
@@ -759,7 +785,8 @@ function aggregate(records, { days, now, cutoff, deps }) {
   let spanMs = 0;
 
   for (const s of sessions) {
-    totals.responses += s.responses; totals.input += s.input; totals.output += s.output;
+    totals.responses += s.responses; totals.exceptions += s.exceptions;
+    totals.input += s.input; totals.output += s.output;
     totals.cacheRead += s.cacheRead; totals.cacheWrite += s.cacheWrite;
     totals.tokens += s.tokens; totals.cost += s.cost;
     spanMs += s._span[1] - s._span[0];
@@ -1050,8 +1077,8 @@ export async function readSession(id, o = {}) {
       start: rec.start === null ? null : new Date(rec.start).toISOString(),
       end: rec.end === null ? null : new Date(rec.end).toISOString(),
       minutes: rec.start === null ? 0 : Math.round(((rec.end - rec.start) / 60_000) * 10) / 10,
-      prompts: rec.prompts, responses: rec.responses, sidechain: rec.sidechain,
-      threadSource: rec.threadSource,
+      prompts: rec.prompts, responses: rec.responses, exceptions: rec.exceptions,
+      sidechain: rec.sidechain, threadSource: rec.threadSource,
       models: rec.models.slice(), tools: { ...rec.tools },
       skill: rec.skill, plugin: rec.plugin,
       // Priced here from the same per-model rows aggregate() uses, rather than

--- a/src/lib/usage-index.mjs
+++ b/src/lib/usage-index.mjs
@@ -274,7 +274,7 @@ function* jsonLines(raw) {
 function blankSession(id, provider) {
   return {
     id, provider, title: '', project: 'unknown', start: null, end: null,
-    prompts: 0, responses: 0, sidechain: false, models: [], tools: {},
+    prompts: 0, responses: 0, sidechain: false, threadSource: null, models: [], tools: {},
     skill: null, plugin: null, worktree: null, usage: [], punchcard: {}, active: [], stamps: [],
   };
 }
@@ -430,6 +430,15 @@ function parseClaude(raw, { id, dirName, withTurns = false }) {
  * token_count event is the session total — summing them would multiply the
  * figure by the number of turns. `input_tokens` there INCLUDES
  * `cached_input_tokens`, which bill as cache reads, so the two are separated.
+ *
+ * A rollout whose `session_meta.thread_source` is `subagent` is a delegated
+ * thread whose file replays its parent thread's ENTIRE prior token history
+ * as duplicate events before its own new turns (openai/codex thread_spawn
+ * behavior — see ccusage/ccusage#950, which measured up to 91x cost
+ * inflation from exactly this). Its cumulative `total_token_usage` therefore
+ * double-counts tokens the parent session already billed, so it is excluded
+ * from cost/token aggregation here; the session record itself is kept
+ * (`threadSource` is surfaced on it) so it stays visible/auditable.
  */
 function parseCodex(raw, { id, withTurns = false }) {
   const rec = blankSession(id, 'codex');
@@ -446,6 +455,7 @@ function parseCodex(raw, { id, withTurns = false }) {
     if (e.type === 'session_meta') {
       if (typeof p.id === 'string' && p.id) rec.id = p.id;
       if (typeof p.cwd === 'string') applyProject(rec, projectLabel(p.cwd, null));
+      if (typeof p.thread_source === 'string') rec.threadSource = p.thread_source;
       continue;
     }
     if (e.type === 'turn_context') {
@@ -482,7 +492,7 @@ function parseCodex(raw, { id, withTurns = false }) {
     }
   }
 
-  if (lastUsage) {
+  if (lastUsage && rec.threadSource !== 'subagent') {
     const cacheRead = Number(lastUsage.cached_input_tokens) || 0;
     const gross = Number(lastUsage.input_tokens) || 0;
     const at = Number.isFinite(lastUsageAt) ? lastUsageAt : (rec.end ?? rec.start ?? Date.now());
@@ -491,6 +501,7 @@ function parseCodex(raw, { id, withTurns = false }) {
       output: Number(lastUsage.output_tokens) || 0,
       cacheRead,
       cacheWrite: 0,
+      responses: rec.responses,
     });
   }
 
@@ -713,6 +724,7 @@ function aggregate(records, { days, now, cutoff, deps }) {
       start: new Date(rec.start ?? rec.end).toISOString(),
       minutes: Math.round(((rec.end - (rec.start ?? rec.end)) / 60_000) * 10) / 10,
       prompts: rec.prompts, responses: rec.responses, sidechain: rec.sidechain,
+      threadSource: rec.threadSource,
       models: rec.models.slice(),
       input, output, cacheRead, cacheWrite,
       tokens: input + output + cacheRead + cacheWrite,
@@ -1039,6 +1051,7 @@ export async function readSession(id, o = {}) {
       end: rec.end === null ? null : new Date(rec.end).toISOString(),
       minutes: rec.start === null ? 0 : Math.round(((rec.end - rec.start) / 60_000) * 10) / 10,
       prompts: rec.prompts, responses: rec.responses, sidechain: rec.sidechain,
+      threadSource: rec.threadSource,
       models: rec.models.slice(), tools: { ...rec.tools },
       skill: rec.skill, plugin: rec.plugin,
       // Priced here from the same per-model rows aggregate() uses, rather than

--- a/tests/dashboard.test.cjs
+++ b/tests/dashboard.test.cjs
@@ -413,6 +413,23 @@ async function main() {
       assert(!/esc\(user\?"you"/.test(r.body), 'the old role-only "you" label must be gone');
     });
 
+    await test('harness sentinel markup is restyled, not rendered as literal XML', async () => {
+      // fmtHarness turns <command-name>/<system-reminder>/<local-command-*>
+      // wrappers into styled structure — content verbatim, wrappers gone. The
+      // page must carry the formatter, its two regex families, the CSS, and
+      // the human-readable labels; and it must run INSIDE the turn body
+      // builder (after markRedactions, so it operates on escaped text).
+      const r = await get(uiSrv.url);
+      contains(r.body, 'function fmtHarness');
+      contains(r.body, 'command-name');
+      contains(r.body, 'system-reminder|local-command-caveat|local-command-stdout');
+      contains(r.body, 'fmtHarness(markRedactions(');
+      contains(r.body, '.h-cmd{');
+      contains(r.body, '.h-note{');
+      contains(r.body, '"system reminder"');
+      contains(r.body, '"command output"');
+    });
+
     await test('poll control: default 30s, ten intervals, persisted as ak-dash-poll', async () => {
       const r = await get(uiSrv.url);
       contains(r.body, 'ak-dash-poll');

--- a/tests/dashboard.test.cjs
+++ b/tests/dashboard.test.cjs
@@ -422,12 +422,15 @@ async function main() {
       const r = await get(uiSrv.url);
       contains(r.body, 'function fmtHarness');
       contains(r.body, 'command-name');
-      contains(r.body, 'system-reminder|local-command-caveat|local-command-stdout');
+      contains(r.body, 'system-reminder|local-command-caveat|local-command-stdout|local-command-stderr|bash-stdout|bash-stderr|task-notification');
+      contains(r.body, 'bash-input');
       contains(r.body, 'fmtHarness(markRedactions(');
       contains(r.body, '.h-cmd{');
       contains(r.body, '.h-note{');
       contains(r.body, '"system reminder"');
       contains(r.body, '"command output"');
+      contains(r.body, '"bash output"');
+      contains(r.body, '"task notification"');
     });
 
     await test('poll control: default 30s, ten intervals, persisted as ak-dash-poll', async () => {

--- a/tests/dashboard.test.cjs
+++ b/tests/dashboard.test.cjs
@@ -244,6 +244,19 @@ async function main() {
     assert(threw, 'no masker → throw (fail closed); silently skipping masking is the bug this guards');
   });
 
+  await test('maskTurns preserves the non-string attribution fields (kind, prompt)', async () => {
+    // The transcript renderer labels turns from tn.kind / tn.prompt, so the
+    // masking gate must pass those through untouched — it rewrites strings
+    // only. If this ever fails, every tool result renders as "you" again.
+    const turns = [
+      { role: 'user', text: '[tool result] ok', prompt: false, kind: 'tool-result' },
+      { role: 'user', text: 'do the thing', prompt: true, kind: 'prompt' },
+    ];
+    const out = maskTurns(turns, (s) => s);
+    assert(out[0].kind === 'tool-result' && out[0].prompt === false, 'tool-result attribution survives masking');
+    assert(out[1].kind === 'prompt' && out[1].prompt === true, 'prompt attribution survives masking');
+  });
+
   // ── the routes, over real HTTP, with a spying usage module ──
   const AGG = {
     generatedAt: '2026-07-25T00:00:00.000Z', windowDays: 14, pricesAsOf: '2026-07-01',
@@ -384,6 +397,20 @@ async function main() {
         contains(r.body, 'id="v-' + v + '"');
         contains(r.body, 'data-view="' + v + '"');
       }
+    });
+
+    await test('transcript labels attribute by kind — a tool result never renders as "you"', async () => {
+      // The Messages API records tool results under role "user"; the renderer
+      // must label from tn.kind, and the page must carry the pieces that do it:
+      // the kind branch, the "tool result" label, the t-tool styling, and the
+      // hover title telling the reader the harness — not the person — sent it.
+      const r = await get(uiSrv.url);
+      contains(r.body, 'tn.kind');
+      contains(r.body, '"tool result"');
+      contains(r.body, 'kind==="context"');
+      contains(r.body, '.t-tool .t-who');
+      contains(r.body, 'not typed by you');
+      assert(!/esc\(user\?"you"/.test(r.body), 'the old role-only "you" label must be gone');
     });
 
     await test('poll control: default 30s, ten intervals, persisted as ak-dash-poll', async () => {

--- a/tests/kit/doc-citations.test.mjs
+++ b/tests/kit/doc-citations.test.mjs
@@ -1,0 +1,122 @@
+// doc-citations.test.mjs — the usage docs cite source as `file.mjs:NNN` (or
+// `:NNN-MMM`) next to the identifier they're citing. Line numbers rot as code
+// moves; this gate replaces the old "pinned to commit X, re-derive with git
+// log -L" disclaimer by checking every citation against the CURRENT source:
+// some identifier or quoted string named near the citation must occur inside
+// the cited range (±TOLERANCE lines). A failure names the citation and where
+// its anchor actually lives now, so re-anchoring is a one-line edit.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const DOCS = ['docs/USAGE-SCORECARD-METRICS.md', 'docs/TRANSCRIPTS.md'];
+// A citation is "fresh" if an anchor lands within the range widened by this
+// many lines each way — small drift stays readable; structural moves fail.
+const TOLERANCE = 10;
+
+// Map cited basenames to real paths by walking the source trees once.
+function fileIndex() {
+  const map = new Map();
+  const walk = (dir) => {
+    for (const name of readdirSync(join(ROOT, dir))) {
+      const rel = join(dir, name);
+      const st = statSync(join(ROOT, rel));
+      if (st.isDirectory()) { if (name !== 'node_modules') walk(rel); }
+      else if (/\.(mjs|cjs|js)$/.test(name) && !map.has(name)) map.set(name, rel);
+    }
+  };
+  for (const dir of ['src', 'tests', 'scripts']) walk(dir);
+  return map;
+}
+
+// Pull `file:start[-end]` citations out of one doc, attaching bare `:NNN`
+// follow-ups (the "`usage-classify.mjs:234`, `:252`" style) to the last file
+// seen in the same paragraph. Context = nearby doc lines, for anchor mining.
+function extractCitations(docText) {
+  const lines = docText.split('\n');
+  const cites = [];
+  let lastFile = null, lastFileLine = -10;
+  lines.forEach((line, i) => {
+    for (const m of line.matchAll(/`(?:[\w./-]*\/)?([\w.-]+\.(?:mjs|cjs|js)):(\d+)(?:-(\d+))?`/g)) {
+      lastFile = m[1]; lastFileLine = i;
+      cites.push({ file: m[1], start: +m[2], end: +(m[3] ?? m[2]), docLine: i + 1 });
+    }
+    for (const m of line.matchAll(/`:(\d+)(?:-(\d+))?`/g)) {
+      if (lastFile && i - lastFileLine <= 2) {
+        cites.push({ file: lastFile, start: +m[1], end: +(m[2] ?? m[1]), docLine: i + 1 });
+      }
+    }
+  });
+  // Pair code spans over the WHOLE document (CommonMark sequential pairing) so
+  // a context window can never start mid-span and invert what reads as code.
+  // Fenced blocks are blanked first — their ``` markers would garble pairing.
+  let fenced = false;
+  const masked = lines
+    .map((l) => { if (/^\s*```/.test(l)) { fenced = !fenced; return ''; } return fenced ? '' : l; })
+    .join('\n');
+  const spans = [];
+  for (const m of masked.matchAll(/`([^`]+)`/g)) {
+    const startLine = masked.slice(0, m.index).split('\n').length;
+    spans.push({ tok: m[1].replace(/\s+/g, ' '), line: startLine });
+  }
+  for (const c of cites) {
+    const anchors = new Set();
+    for (const s of spans) {
+      if (s.line < c.docLine - 3 || s.line > c.docLine + 1) continue;
+      if (/^[\w./-]+\.(mjs|cjs|js):\d/.test(s.tok) || /^:\d/.test(s.tok)) continue; // a citation, not an anchor
+      if (/^[\d.,%×x-]+$/.test(s.tok)) continue;                                    // bare numbers
+      for (const id of s.tok.matchAll(/[A-Za-z_$][\w$]{2,}/g)) anchors.add(id[0]);
+    }
+    const ctx = masked.split('\n').slice(Math.max(0, c.docLine - 4), c.docLine + 2).join(' ');
+    for (const m of ctx.matchAll(/"([^"]{8,90})"/g)) anchors.add(m[1]);
+    anchors.delete('the'); anchors.delete('and');
+    c.anchors = [...anchors];
+  }
+  return cites;
+}
+
+function checkDoc(docRel, index) {
+  const cites = extractCitations(readFileSync(join(ROOT, docRel), 'utf8'));
+  const failures = [], unanchored = [];
+  const sources = new Map();
+  for (const c of cites) {
+    const rel = index.get(c.file);
+    if (!rel) { failures.push(`${docRel}:${c.docLine} cites unknown file ${c.file}`); continue; }
+    if (!sources.has(rel)) sources.set(rel, readFileSync(join(ROOT, rel), 'utf8').split('\n'));
+    const src = sources.get(rel);
+    if (c.start > src.length) {
+      failures.push(`${docRel}:${c.docLine} cites ${c.file}:${c.start} but the file has ${src.length} lines`);
+      continue;
+    }
+    if (c.anchors.length === 0) { unanchored.push(c); continue; }
+    const lo = Math.max(0, c.start - 1 - TOLERANCE);
+    const hi = Math.min(src.length, c.end + TOLERANCE);
+    // Whitespace-normalized on both sides: doc wrapping and source wrapping
+    // must not defeat a match on the same words.
+    const window = src.slice(lo, hi).join(' ').replace(/\s+/g, ' ');
+    const hit = c.anchors.some((a) => window.includes(a.replace(/\s+/g, ' ')));
+    if (!hit) {
+      const seen = c.anchors
+        .map((a) => { const at = src.findIndex((l) => l.includes(a)); return at >= 0 ? `${a}@${at + 1}` : null; })
+        .filter(Boolean).slice(0, 3).join(', ');
+      failures.push(
+        `${docRel}:${c.docLine} cites ${c.file}:${c.start}${c.end !== c.start ? '-' + c.end : ''} ` +
+        `but none of its anchors appear within ±${TOLERANCE} lines` +
+        (seen ? ` (found elsewhere: ${seen})` : ' (anchors not found in file at all)'),
+      );
+    }
+  }
+  return { total: cites.length, unanchored: unanchored.length, failures };
+}
+
+const index = fileIndex();
+for (const doc of DOCS) {
+  test(`every file:line citation in ${doc} still points at its subject`, () => {
+    const { total, unanchored, failures } = checkDoc(doc, index);
+    assert.ok(total > 20, `expected a citation-dense doc, extracted only ${total}`);
+    assert.deepEqual(failures, [], `${failures.length}/${total} citations drifted (${unanchored} unanchored, checked at ±${TOLERANCE}):\n` + failures.join('\n'));
+  });
+}

--- a/tests/kit/usage-index.test.mjs
+++ b/tests/kit/usage-index.test.mjs
@@ -944,6 +944,59 @@ test('readSession returns codex user/agent messages as turns', async () => {
   assert.ok(turns[0].text.includes('port the parser'));
 });
 
+test('user-role turns carry a kind — a tool result is never attributed to the human', async () => {
+  // The Messages API records tool results under role "user", so role alone
+  // must never be read as "the person typed this". The parser stamps each
+  // user turn with kind: 'prompt' | 'tool-result' | 'context', and the
+  // transcript renderer labels from THAT, not from role.
+  _resetForTest();
+  const sb = sandbox();
+
+  // Claude: aaaa1111's fixture interleaves real prompts with a tool_result.
+  const claude = await readSession('aaaa1111', opts(sb));
+  const userTurns = claude.turns.filter((t) => t.role === 'user');
+  assert.equal(userTurns[0].kind, 'prompt', 'the opening human prompt is a prompt');
+  const toolTurn = userTurns.find((t) => t.text.startsWith('[tool result]'));
+  assert.ok(toolTurn, 'the tool_result user turn is present');
+  assert.equal(toolTurn.kind, 'tool-result');
+  assert.equal(toolTurn.prompt, false, 'and it never counted as a human prompt');
+
+  // Codex: rollouts only record real prompts as user_message events.
+  const codex = await readSession('dddd4444', opts(sb));
+  for (const t of codex.turns.filter((x) => x.role === 'user')) {
+    assert.equal(t.kind, 'prompt', 'every codex user turn is a prompt by construction');
+  }
+});
+
+test('isMeta context and image-only pastes get the right kind', async () => {
+  _resetForTest();
+  const sb = soloSandbox();
+  const base = Date.parse('2026-07-24T10:00:00.000Z');
+  const iso = (offMs) => new Date(base + offMs).toISOString();
+  const lines = [
+    // Harness-injected context (isMeta): not typed by the person.
+    { type: 'user', sessionId: 'jjjj0000', cwd: '/Users/me/proj', isMeta: true, timestamp: iso(0),
+      message: { role: 'user', content: [{ type: 'text', text: '<command-name>/status</command-name>' }] } },
+    // An image-only paste: no text block, so isHumanPrompt says false (it is
+    // not COUNTED as a prompt) — but it IS the person acting, and its kind
+    // must be 'prompt', never 'tool-result'.
+    { type: 'user', sessionId: 'jjjj0000', cwd: '/Users/me/proj', timestamp: iso(1000),
+      message: { role: 'user', content: [{ type: 'image', source: {} }] } },
+    { type: 'assistant', sessionId: 'jjjj0000', cwd: '/Users/me/proj', timestamp: iso(2000),
+      message: { role: 'assistant', model: 'claude-opus-5', usage: { input_tokens: 5, output_tokens: 5 }, content: [{ type: 'text', text: 'Looking at the screenshot.' }] } },
+  ];
+  fs.writeFileSync(path.join(sb.claude, 'jjjj0000.jsonl'), `${lines.map((l) => JSON.stringify(l)).join('\n')}\n`);
+
+  const { meta, turns } = await readSession('jjjj0000', {
+    days: 14, now: NOW, roots: sb.roots, cachePath: sb.cachePath, deps: deps(),
+  });
+  assert.equal(meta.prompts, 0, 'neither turn counts as a text prompt');
+  const userTurns = turns.filter((t) => t.role === 'user');
+  assert.equal(userTurns[0].kind, 'context', 'isMeta harness injection is context');
+  assert.equal(userTurns[1].kind, 'prompt', 'an image-only paste is still the person');
+  assert.equal(userTurns[1].text, '[image]');
+});
+
 test('readSession rejects a path-traversal id without touching the disk', async () => {
   _resetForTest();
   const sb = sandbox();

--- a/tests/kit/usage-index.test.mjs
+++ b/tests/kit/usage-index.test.mjs
@@ -968,6 +968,37 @@ test('user-role turns carry a kind — a tool result is never attributed to the 
   }
 });
 
+test('harness-output envelopes are context, never the person — and never counted as prompts', async () => {
+  // A user-role entry whose text the HARNESS wrote (task notifications,
+  // bash/local-command stdout) carries neither isMeta nor a tool_result, so
+  // text shape is the only signal. It must not be labelled "you" and must
+  // not inflate the prompt count. bash-input is the opposite case: the
+  // person typed that `! command`, so it stays a prompt on both axes.
+  _resetForTest();
+  const sb = soloSandbox();
+  const base = Date.parse('2026-07-24T10:00:00.000Z');
+  const iso = (offMs) => new Date(base + offMs).toISOString();
+  const u = (off, text) => ({ type: 'user', sessionId: 'kkkk1111', cwd: '/Users/me/proj', timestamp: iso(off),
+    message: { role: 'user', content: [{ type: 'text', text }] } });
+  const lines = [
+    u(0, 'promote the pipeline'),                                              // real prompt
+    { type: 'assistant', sessionId: 'kkkk1111', cwd: '/Users/me/proj', timestamp: iso(1000),
+      message: { role: 'assistant', model: 'claude-opus-5', usage: { input_tokens: 5, output_tokens: 5 }, content: [{ type: 'text', text: 'ok' }] } },
+    u(2000, '<bash-input>git checkout main && git pull</bash-input>'),          // the person's ! command
+    u(3000, '<bash-stdout>Switched to branch main</bash-stdout>'),              // harness output
+    u(4000, '<local-command-stdout>Set model to Fable 5</local-command-stdout>'),
+    u(5000, '<task-notification>\n<task-id>abc</task-id>\n</task-notification>'),
+  ];
+  fs.writeFileSync(path.join(sb.claude, 'kkkk1111.jsonl'), `${lines.map((l) => JSON.stringify(l)).join('\n')}\n`);
+
+  const { meta, turns } = await readSession('kkkk1111', {
+    days: 14, now: NOW, roots: sb.roots, cachePath: sb.cachePath, deps: deps(),
+  });
+  assert.equal(meta.prompts, 2, 'the real prompt and the bash-input count; harness output does not');
+  const kinds = turns.filter((t) => t.role === 'user').map((t) => t.kind);
+  assert.deepEqual(kinds, ['prompt', 'prompt', 'context', 'context', 'context']);
+});
+
 test('isMeta context and image-only pastes get the right kind', async () => {
   _resetForTest();
   const sb = soloSandbox();

--- a/tests/kit/usage-index.test.mjs
+++ b/tests/kit/usage-index.test.mjs
@@ -347,6 +347,58 @@ test('Codex tokens come from the LAST token_count event, never the sum', async (
   assert.equal(s.prompts, 1);
   assert.equal(s.project, 'other');
   assert.equal(s.minutes, 3);
+  // byModel must carry the session's response count too — it used to be
+  // dropped for Codex rows (Claude passed `responses: 1` per turn into
+  // addUsage; Codex passed none), leaving every Codex model stuck at "0 resp"
+  // in the dashboard regardless of real token/cost volume.
+  assert.equal(agg.byModel['gpt-5.6'].responses, 2);
+});
+
+test('a subagent-sourced Codex rollout (thread_spawn replay) is excluded from cost/token aggregation', async () => {
+  // openai/codex spawns delegated subagent threads whose rollout file replays
+  // the PARENT thread's entire prior token history as duplicate events before
+  // its own new turns (ccusage/ccusage#950 measured up to 91x cost inflation
+  // from exactly this). Its cumulative total_token_usage therefore double-
+  // counts tokens the parent session already billed, so it must not
+  // contribute to cost/token aggregation — but the session record itself
+  // stays visible (with threadSource surfaced) so it's still auditable.
+  _resetForTest();
+  const sb = soloSandbox();
+  const day = path.join(sb.roots.codex, '2026', '07', '24');
+  fs.mkdirSync(day, { recursive: true });
+  const base = Date.parse('2026-07-24T09:00:00.000Z');
+  const ts = (offMs) => new Date(base + offMs).toISOString();
+  const lines = [
+    { timestamp: ts(0), type: 'session_meta', payload: { id: 'eeee5555', timestamp: ts(0), cwd: '/Users/me/proj', thread_source: 'subagent' } },
+    { timestamp: ts(1000), type: 'turn_context', payload: { turn_id: 't1', model: 'gpt-5.6-sol', cwd: '/Users/me/proj' } },
+    { timestamp: ts(2000), type: 'event_msg', payload: { type: 'user_message', message: 'delegated task' } },
+    // A "first" cumulative total that is already huge is the replay signature:
+    // a genuinely fresh thread's first token_count starts near its own system-
+    // prompt size, not hundreds of thousands of tokens in.
+    { timestamp: ts(30_000), type: 'event_msg', payload: { type: 'token_count', info: { total_token_usage: { input_tokens: 900_000, cached_input_tokens: 850_000, output_tokens: 9000, reasoning_output_tokens: 0, total_tokens: 909_000 } } } },
+    { timestamp: ts(60_000), type: 'event_msg', payload: { type: 'agent_message', message: 'Done.' } },
+  ];
+  fs.writeFileSync(
+    path.join(day, 'rollout-2026-07-24T09-00-00-eeee5555.jsonl'),
+    `${lines.map((l) => JSON.stringify(l)).join('\n')}\n`,
+  );
+
+  const agg = await buildIndex(opts(sb));
+  const s = byId(agg, 'eeee5555');
+
+  assert.ok(s, 'subagent session is still listed, not silently dropped');
+  assert.equal(s.threadSource, 'subagent');
+  assert.equal(s.tokens, 0, 'replayed parent history contributes no tokens to its own record');
+  assert.equal(s.cost, 0);
+  // The model still appears in byModel — it's a real session that used it, and
+  // "models in play" is tracked independently of cost attribution (see the
+  // `s.models` loop in aggregate()) — but it must carry none of the replayed
+  // volume: zero tokens, cost, and responses from this session.
+  const b = agg.byModel['gpt-5.6-sol'];
+  assert.ok(b, 'the model is still listed as used by this session');
+  assert.equal(b.tokens, 0, 'no replayed tokens leak into the model bucket');
+  assert.equal(b.cost, 0);
+  assert.equal(b.responses, 0);
 });
 
 test('buildIndex never mutates a transcript', async () => {

--- a/tests/kit/usage-index.test.mjs
+++ b/tests/kit/usage-index.test.mjs
@@ -636,6 +636,49 @@ test('a session that opens before midnight is counted on its first billed day', 
   );
 });
 
+test('a dropped-connection turn (isApiErrorMessage) counts as an exception, never a $0 model', async () => {
+  // Claude Code synthesizes a local placeholder turn — model: "<synthetic>",
+  // isApiErrorMessage: true, all-zero usage — when a request's connection
+  // drops, rate-limits, or fails auth before a real completion returns. It
+  // must count as engaged time (a real turn happened) but must NOT create a
+  // byModel row: there was no model attempt to attribute cost/tokens to.
+  _resetForTest();
+  const sb = soloSandbox();
+  const base = Date.parse('2026-07-24T10:00:00.000Z');
+  const iso = (offMs) => new Date(base + offMs).toISOString();
+  const lines = [
+    { type: 'user', sessionId: 'iiii9999', cwd: '/Users/me/proj', timestamp: iso(0),
+      message: { role: 'user', content: [{ type: 'text', text: 'turn 1' }] } },
+    { type: 'assistant', sessionId: 'iiii9999', cwd: '/Users/me/proj', timestamp: iso(1000),
+      message: { role: 'assistant', model: 'claude-opus-5', usage: { input_tokens: 100, output_tokens: 50 }, content: [] } },
+    { type: 'user', sessionId: 'iiii9999', cwd: '/Users/me/proj', timestamp: iso(2000),
+      message: { role: 'user', content: [{ type: 'text', text: 'turn 2' }] } },
+    // The dropped-connection placeholder: same shape Claude Code actually writes.
+    { type: 'assistant', sessionId: 'iiii9999', cwd: '/Users/me/proj', timestamp: iso(3000),
+      isApiErrorMessage: true, error: 'server_error',
+      message: {
+        role: 'assistant', model: '<synthetic>', stop_reason: 'stop_sequence',
+        usage: { input_tokens: 0, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
+        content: [{ type: 'text', text: 'API Error: Connection closed mid-response.' }],
+      } },
+  ];
+  fs.writeFileSync(path.join(sb.claude, 'iiii9999.jsonl'), `${lines.map((l) => JSON.stringify(l)).join('\n')}\n`);
+
+  const agg = await buildIndex(opts(sb));
+  const s = byId(agg, 'iiii9999');
+
+  assert.ok(s, 'session indexed');
+  assert.equal(s.responses, 2, 'the error placeholder still counts as a real turn');
+  assert.equal(s.exceptions, 1);
+  assert.deepEqual(s.models, ['claude-opus-5'], '"<synthetic>" never enters the models list');
+  assert.equal(s.tokens, 150, 'only the real turn contributes tokens');
+  assert.ok(s.cost > 0);
+
+  assert.equal(agg.totals.exceptions, 1);
+  assert.equal(agg.byModel['<synthetic>'], undefined, 'no $0 "<synthetic>" row is ever created');
+  assert.equal(agg.byModel['claude-opus-5'].tokens, 150);
+});
+
 test('punchcard buckets responses by dow-hour with Monday as 0', async () => {
   _resetForTest();
   const sb = sandbox();


### PR DESCRIPTION
## Summary

This branch started as a fix for implausible Codex numbers on the Usage Scorecard and grew into three connected bodies of work: **(1)** parsing-accuracy fixes for both providers, **(2)** truthful attribution and rendering in the Transcript view, and **(3)** a documentation system for the whole pipeline — illustrated with dual-theme figures, restructured so main bodies state only current fact, and guarded by a test that machine-checks every `file:line` citation against the source on every build.

## Commits

| Commit | What it does | Why it matters |
|---|---|---|
| `540be18` | fix(usage): stop Codex model rows undercounting responses and subagent replays double-billing tokens | The headline accuracy fix — a `thread_spawn` subagent rollout replays its parent's entire token history (up to 91× inflation measured in the wild by ccusage#950); now excluded from totals while staying visible |
| `bd1d6da` | docs(usage): add cited maintainer reference for every Scorecard metric | Every number on the tab gets a formula, source citation, worked example, and stated limitations (`USAGE-SCORECARD-METRICS.md`) |
| `bf3355f` | feat(scripts): add standalone Codex usage diagnostic | Zero-dependency script anyone can run to measure the before/after on their own machine — independent reimplementation, no transcript content leaves the box |
| `e89f24b` | docs(usage): friend/third-party-facing Codex verification writeup | The non-maintainer companion (`CODEX-USAGE-DIAGNOSTIC.md`): what was wrong, why the fix is trustworthy, what to send back |
| `dd9040d` | feat(usage): stop dropped/rate-limited/auth-failed turns appearing as a $0 model | `<synthetic>` placeholder turns become a counted-and-surfaced `exceptions` figure instead of a fake model row; includes the SCHEMA_VERSION 4 cache lesson |
| `2d4aabe` | fix(usage): attribute transcript turns by `kind` | A tool result is never "you": on a real 884-turn session, 276 of 302 user-role turns (~93%) were harness traffic previously labelled as the person |
| `5c4e388` | feat(usage): render harness sentinel markup as structure | Slash commands, `bash-input`, system reminders, and output envelopes render as chips and labelled panels instead of angle-bracket soup — wrapped content stays verbatim |
| `5eaa4dd` | fix(usage): harness-output envelopes are neither the person nor the model | Prompt counts stop counting stdout dumps and task notifications as things the person said (32 claimed → 20 real on the reference session; SCHEMA_VERSION 5) |
| `24b886b` | docs: dual-theme figure set; restructure around active fact vs history | Seven hand-authored SVGs (light+dark in one file, CVD-validated palette) illustrating the pipelines; all seven docs restructured — fix history and ADR references relegated to per-doc appendices |
| `f3d03c6` | test(docs): gate every `file:line` citation against the current source | Replaces the "pinned to commit X, line numbers will drift" disclaimer with a build-time guarantee; its maiden run caught one real drift |

## Explanation

**Accuracy.** Both providers' transcripts flow through shared aggregation and pricing — so a by-host discrepancy is always a parsing defect upstream. Two were found in `parseCodex` (0-responses display, subagent replay double-billing) and one in the Claude path's handling of API-error placeholder turns. Each fix keeps the affected sessions *visible* while excluding them from the numbers they were corrupting — "never hide it, don't misrepresent it either."

**Attribution.** The Messages API records tool results and harness context under `role: "user"`. The Transcript view now classifies every user-role turn (`kind: prompt | tool-result | context`) and labels from `kind`, never role. Verified against real transcripts from both providers, not only fixtures.

**Documentation.** Two reference docs (per-session pipeline and aggregate metrics) explain every label and number with source citations; seven SVG figures make the load-bearing concepts visual (each renders correctly in GitHub light and dark from a single file). Every doc under `docs/` now keeps its main body to presently-active fact, with fix narratives, incidents, and ADR citations in appendices for the curious. The citation-freshness gate (`tests/kit/doc-citations.test.mjs`) makes the docs' central promise — "you can check every claim" — a property enforced by `pnpm test` rather than a snapshot that rots.

## Impact

- **Cost/token figures are trustworthy per host.** Subagent-replay inflation (the 91×-class failure mode) and phantom `$0` model rows are gone; response counts are real for Codex.
- **The Transcript view stops misattributing ~93% of user-role turns** in heavily agentic sessions, and prompt counts reflect what the person actually typed.
- **Anyone can independently verify the Codex fix** on their own data via the standalone diagnostic — aggregate numbers only, no content shared.
- **The docs cannot silently rot**: 96 citations in the metrics reference and every citation in the transcripts reference are re-verified against source on every test run; markdownlint and lychee (offline) run clean; the full unit suite passes with the new gate in the chain.
- **Cache-schema discipline is recorded**: the SCHEMA_VERSION 4/5 incidents are documented in the fix-history appendix so the next session-record field addition doesn't repeat them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
