### PR TITLE
Usage panel: plan limits, Codex ledger attribution, and dated pricing

### DIFF
--- a/docs/TRANSCRIPTS.md
+++ b/docs/TRANSCRIPTS.md
@@ -35,44 +35,44 @@ rewritten; rule 3 of the module header, `usage-index.mjs:22-29`):
 
 | Provider | Store | Discovered by |
 |---|---|---|
-| Claude Code | `~/.claude/projects/<encoded-project-dir>/<sessionId>.jsonl` | `listClaude` (`usage-index.mjs:607`) — exactly one level of project directories |
-| Codex CLI | `~/.codex/sessions/<yyyy>/<mm>/<dd>/rollout-<ts>-<uuid>.jsonl` | `listCodex` (`usage-index.mjs:622`) — the `yyyy/mm/dd` tree walk |
+| Claude Code | `~/.claude/projects/<encoded-project-dir>/<sessionId>.jsonl` | `listClaude` (`usage-index.mjs:648`) — exactly one level of project directories |
+| Codex CLI | `~/.codex/sessions/<yyyy>/<mm>/<dd>/rollout-<ts>-<uuid>.jsonl` | `listCodex` (`usage-index.mjs:663`) — the `yyyy/mm/dd` tree walk |
 
-Roots come from `defaultRoots()` (`usage-index.mjs:599`) and are injectable
+Roots come from `defaultRoots()` (`usage-index.mjs:640`) and are injectable
 for tests. A malformed line is skipped, never fatal (`jsonLines`,
-`usage-index.mjs:274` — one corrupt line must not cost a whole file).
+`usage-index.mjs:280` — one corrupt line must not cost a whole file).
 
 ### 1.1 Claude entry vocabulary
 
 Each line has a top-level `type`. The parser (`parseClaude`,
-`usage-index.mjs:417-500`) reads:
+`usage-index.mjs:427-510`) reads:
 
 | `type` | What the parser takes from it |
 |---|---|
-| `ai-title` | The model-written session title (`usage-index.mjs:425`) — preferred over the first-prompt fallback |
+| `ai-title` | The model-written session title (`usage-index.mjs:435`) — preferred over the first-prompt fallback |
 | `user` | A user-**role** turn — which is *not* the same as "the human"; see §3 |
-| `assistant` | A model turn: `model` id, per-turn `usage` token counts, `tool_use` blocks (`usage-index.mjs:445-488`) |
-| any | Side-band fields read regardless of type: `attributionSkill`/`attributionPlugin` (`usage-index.mjs:426-427`), `isSidechain` (`usage-index.mjs:428`), `cwd` for project derivation |
+| `assistant` | A model turn: `model` id, per-turn `usage` token counts, `tool_use` blocks (`usage-index.mjs:455-498`) |
+| any | Side-band fields read regardless of type: `attributionSkill`/`attributionPlugin` (`usage-index.mjs:436-437`), `isSidechain` (`usage-index.mjs:438`), `cwd` for project derivation |
 
 An assistant entry with `isApiErrorMessage: true` is a **local placeholder**
 Claude Code writes when a request dies before a real completion (connection
 drop, rate limit, auth failure — `model: "<synthetic>"`, all-zero usage). It
 is real engaged time but not a model attempt: counted as an *exception*, never
-pushed into `models` or priced (`usage-index.mjs:459-468`; the full story is
+pushed into `models` or priced (`usage-index.mjs:469-478`; the full story is
 [`USAGE-SCORECARD-METRICS.md`](USAGE-SCORECARD-METRICS.md) §10).
 
 ### 1.2 Codex entry vocabulary
 
 Codex rollout lines carry `type` + `payload`. The parser (`parseCodex`,
-`usage-index.mjs:517-587`) reads:
+`usage-index.mjs:527-628`) reads:
 
 | `type` / `payload.type` | What the parser takes from it |
 |---|---|
-| `session_meta` | Authoritative session id, `cwd`, and `thread_source` (`usage-index.mjs:529-534`) — `"subagent"` marks a thread_spawn replay whose tokens are excluded from aggregation (`usage-index.mjs:572`; `USAGE-SCORECARD-METRICS.md` Appendix A, Bug B) |
-| `turn_context` | The model id in effect from this point on (`usage-index.mjs:535`) |
-| `event_msg` → `token_count` | A **cumulative** usage snapshot; only the last one is kept (`usage-index.mjs:542`) |
-| `event_msg` → `user_message` | A real human prompt — Codex does not route tool output through this event (`usage-index.mjs:547-555`) |
-| `event_msg` → `agent_message` | A model response (`usage-index.mjs:557-568`) |
+| `session_meta` | Authoritative session id, `cwd`, and `thread_source` (`usage-index.mjs:539-544`) — `"subagent"` marks a thread_spawn replay whose tokens are excluded from aggregation (`usage-index.mjs:609`; `USAGE-SCORECARD-METRICS.md` Appendix A, Bug B) |
+| `turn_context` | The model id in effect from this point on (`usage-index.mjs:545`) |
+| `event_msg` → `token_count` | A **cumulative** usage snapshot; only the last one is kept (`usage-index.mjs:552`) |
+| `event_msg` → `user_message` | A real human prompt — Codex does not route tool output through this event (`usage-index.mjs:584-592`) |
+| `event_msg` → `agent_message` | A model response (`usage-index.mjs:594-605`) |
 
 Codex tool calls and tool outputs travel in event types the parser does not
 surface as turns at all — so a Codex transcript renders as a prompt/response
@@ -88,8 +88,8 @@ The same parsers serve two very different callers, switched by `withTurns`:
 
 | Path | Entry point | `withTurns` | Message bodies | Cached? |
 |---|---|---|---|---|
-| **Scan** — the aggregate index behind the Scorecard/Findings/Sessions views | `buildIndex` → `parseFile` (`usage-index.mjs:652`) | `false` | never held — holding them would balloon memory across 3,000+ files (`usage-index.mjs:413-416`) | yes: per-file derived records in `~/.config/agentic-kit/usage-index.json`, keyed `(path, mtime, size)`, invalidated wholesale by `SCHEMA_VERSION` (`usage-index.mjs:50`) |
-| **Reader** — one transcript for the Transcript view | `readSession` (`usage-index.mjs:1078`) | `true` | full turn list built | **never** — every call re-reads and re-parses the one file |
+| **Scan** — the aggregate index behind the Scorecard/Findings/Sessions views | `buildIndex` → `parseFile` (`usage-index.mjs:693`) | `false` | never held — holding them would balloon memory across 3,000+ files (`usage-index.mjs:423-426`) | yes: per-file derived records in `~/.config/agentic-kit/usage-index.json`, keyed `(path, mtime, size)`, invalidated wholesale by `SCHEMA_VERSION` (`usage-index.mjs:51`) |
+| **Reader** — one transcript for the Transcript view | `readSession` (`usage-index.mjs:1173`) | `true` | full turn list built | **never** — every call re-reads and re-parses the one file |
 
 ![Figure: one parser, two read paths — the scan path (withTurns false) caches per-file records keyed by path, mtime and size; the reader path (withTurns true) builds full turns and is never cached](assets/transcript-read-paths.svg)
 
@@ -97,7 +97,7 @@ The reader path being cache-free is load-bearing for maintainers: **turn-shape
 changes (like the `kind` field, §3) need no `SCHEMA_VERSION` bump**, because
 no turn is ever served from cache — whereas *session-record* fields (like
 `exceptions`) do, since stale cached records would otherwise sum `undefined`
-into totals (`usage-index.mjs:39-49`; the incidents behind that rule are
+into totals (`usage-index.mjs:40-50`; the incidents behind that rule are
 recorded in `USAGE-SCORECARD-METRICS.md` Appendix A).
 
 ---
@@ -110,11 +110,11 @@ recorded in `USAGE-SCORECARD-METRICS.md` Appendix A).
 |---|---|---|
 | `role` | all | `"user"` or `"assistant"` — the **Messages-API role**, not the author (see below) |
 | `at` | all | ISO timestamp |
-| `text` | all | Flattened display text (`claudeText`, `usage-index.mjs:338` — binary payloads dropped: a pasted screenshot renders as `[image]`, a tool result is prefixed `[tool result]`) |
-| `model` | assistant | The model id; the literal string `exception` for an API-error placeholder turn (`usage-index.mjs:463`) |
+| `text` | all | Flattened display text (`claudeText`, `usage-index.mjs:348` — binary payloads dropped: a pasted screenshot renders as `[image]`, a tool result is prefixed `[tool result]`) |
+| `model` | assistant | The model id; the literal string `exception` for an API-error placeholder turn (`usage-index.mjs:473`) |
 | `tools` | assistant | Tool names invoked in the turn |
-| `prompt` | user | `isHumanPrompt`'s verdict (`usage-index.mjs:378-387`) — drives the **prompt counts** |
-| `kind` | user | `'prompt'` \| `'tool-result'` \| `'context'` — drives the **attribution label** (`userTurnKind`, `usage-index.mjs:405-416`) |
+| `prompt` | user | `isHumanPrompt`'s verdict (`usage-index.mjs:388-397`) — drives the **prompt counts** |
+| `kind` | user | `'prompt'` \| `'tool-result'` \| `'context'` — drives the **attribution label** (`userTurnKind`, `usage-index.mjs:415-426`) |
 | `exception` | assistant | `true` on API-error placeholder turns |
 | `truncated`, `originalChars` | any | Present **only** when the turn was abridged (§4.3) |
 
@@ -134,7 +134,7 @@ story is [Appendix A](#appendix-a--fix-history).)
 
 ### 3.2 `kind` — the attribution field
 
-`userTurnKind` (`usage-index.mjs:405-416`) classifies every user-role turn:
+`userTurnKind` (`usage-index.mjs:415-426`) classifies every user-role turn:
 
 | `kind` | Test | Meaning |
 |---|---|---|
@@ -152,12 +152,12 @@ Two deliberate subtleties:
 - **Harness-output envelopes are excluded from the prompt *count* too.**
   `isHumanPrompt` shares `HARNESS_OUTPUT_RE`, so a session's `prompts` figure
   never counts stdout dumps or task notifications as things the person said
-  (`SCHEMA_VERSION` 5, `usage-index.mjs:46-50`; the correction this shipped
+  (`SCHEMA_VERSION` 5, `usage-index.mjs:47-51`; the correction this shipped
   with is in [Appendix A](#appendix-a--fix-history)).
 - **`tool-result` outranks `context`**: a `tool_result` block on an `isMeta`
   entry is still tool feedback.
 
-Codex user turns are `kind: 'prompt'` by construction (`usage-index.mjs:547-555`)
+Codex user turns are `kind: 'prompt'` by construction (`usage-index.mjs:584-592`)
 — rollouts only record real prompts as `user_message` events (§1.2).
 
 Coverage: `tests/kit/usage-index.test.mjs` — "user-role turns carry a kind"
@@ -168,31 +168,31 @@ and image-only pastes get the right kind" (the two edges).
 
 ## 4. The `readSession` pipeline — how one session becomes a payload
 
-`readSession(id, opts)` (`usage-index.mjs:1078-1161`) is the only way
+`readSession(id, opts)` (`usage-index.mjs:1173-1256`) is the only way
 transcript content leaves the module, and every step is a gate:
 
 ### 4.1 Locate, contain, bound
 
 1. **Id grammar before any filesystem access** — `VALID_ID`
-   (`/^[A-Za-z0-9._-]{1,128}$/`, `usage-index.mjs:65`) rejects traversal
-   shapes with `ERR_INVALID_SESSION_ID` (`usage-index.mjs:1079`).
-2. **Locate by id** across both roots (`locate`, `usage-index.mjs:1037`),
+   (`/^[A-Za-z0-9._-]{1,128}$/`, `usage-index.mjs:71`) rejects traversal
+   shapes with `ERR_INVALID_SESSION_ID` (`usage-index.mjs:1174`).
+2. **Locate by id** across both roots (`locate`, `usage-index.mjs:1132`),
    consulting the scan cache when present but never requiring it —
    `readSession` works with no prior `buildIndex`.
-3. **Realpath containment** (`usage-index.mjs:1085-1099`) — the resolved file
+3. **Realpath containment** (`usage-index.mjs:1180-1194`) — the resolved file
    must live under a transcript root *after* `realpathSync` collapses
    symlinks; a symlink planted inside a root pointing at `/etc/anything`
    passes a lexical `startsWith` but fails this. Roots are realpath'd too so
    a symlinked dotfiles setup still works.
-4. **Size cap** — `MAX_SESSION_BYTES` (64 MB, `usage-index.mjs:64`): a
+4. **Size cap** — `MAX_SESSION_BYTES` (64 MB, `usage-index.mjs:70`): a
    transcript is read whole and JSON-expands ~5×, so an unbounded read is a
    memory-amplification primitive. Oversized reads as unavailable, not risky.
 
 ### 4.2 Parse and price
 
 The file is parsed with `withTurns: true` by the provider's parser
-(`usage-index.mjs:1110-1116`), and `meta` is assembled
-(`usage-index.mjs:1124-1143`) with the same fields the Sessions view rows
+(`usage-index.mjs:1205-1211`), and `meta` is assembled
+(`usage-index.mjs:1219-1238`) with the same fields the Sessions view rows
 carry — `prompts`, `responses`, `exceptions`, `sidechain`, `threadSource`,
 `models`, `tools`, `skill`/`plugin`, worktree — plus a `cost` priced from the
 same per-model usage rows `aggregate()` uses (the header used to render a
@@ -200,11 +200,11 @@ hardcoded `$0.00`; the comment at the site records why).
 
 ### 4.3 Mask, then truncate — both marked, differently
 
-Every turn body is passed through `maskSecrets` (`usage-index.mjs:166` — the
+Every turn body is passed through `maskSecrets` (`usage-index.mjs:172` — the
 21 secret shapes) **server-side, before
 serialization**, then length-capped at `MAX_TURN_CHARS` (40,000,
-`usage-index.mjs:59`) with the marker appended
-(`usage-index.mjs:1144-1160`). Two invariants:
+`usage-index.mjs:65`) with the marker appended
+(`usage-index.mjs:1239-1255`). Two invariants:
 
 - **Presence is the signal.** `truncated`/`originalChars` are emitted only
   when the slice fired, so a complete turn cannot be misread as abridged.
@@ -213,8 +213,8 @@ serialization**, then length-capped at `MAX_TURN_CHARS` (40,000,
 
 The two kinds of withholding keep distinct vocabulary end-to-end: masking
 renders as `…redacted` marks (`markRedactions`,
-`dashboard-server.mjs:2184`), truncation as a `truncated · N of M` badge
-(`truncBadge`, `dashboard-server.mjs:2228`, deriving N from the received
+`dashboard-server.mjs:2333`), truncation as a `truncated · N of M` badge
+(`truncBadge`, `dashboard-server.mjs:2377`, deriving N from the received
 text so a changed constant can't desync the display).
 
 ![Figure: a turn body passes through maskSecrets (leaving redaction marks) and then the 40,000-character cap (leaving a truncated · N of M badge); originalChars is measured after masking](assets/transcript-mask-truncate.svg)
@@ -229,9 +229,9 @@ preamble). Transcript-relevant routes:
 
 | Route | Serves | Notes |
 |---|---|---|
-| `GET /api/usage?days=N` | the aggregate minus `sessions[]` (`dashboard-server.mjs:337`) | Scorecard + Findings + the project tree |
-| `GET /api/sessions` | session rows, filtered/paginated (`dashboard-server.mjs:355`) | the Sessions view's "load all" |
-| `GET /api/session/:id` | one transcript (`dashboard-server.mjs:372-403`) | the Transcript view |
+| `GET /api/usage?days=N` | the aggregate minus `sessions[]` (`dashboard-server.mjs:341`) | Scorecard + Findings + the project tree |
+| `GET /api/sessions` | session rows, filtered/paginated (`dashboard-server.mjs:375`) | the Sessions view's "load all" |
+| `GET /api/session/:id` | one transcript (`dashboard-server.mjs:392-423`) | the Transcript view |
 
 `/api/session/:id` order of operations, each step deliberate:
 
@@ -260,13 +260,13 @@ nothing on the page to reveal.
 
 ### 6.1 Sessions view — the row and its expander
 
-`renderSessions` (`dashboard-server.mjs:2133`) renders the project tree
+`renderSessions` (`dashboard-server.mjs:2282`) renders the project tree
 (collapsed by default; every project starts closed so the cross-project
 comparison stays above the fold). Each session is a `sessionRow`
-(`dashboard-server.mjs:2107-2131`): host chip (claude/codex), title,
+(`dashboard-server.mjs:2256-2280`): host chip (claude/codex), title,
 worktree glyph, category chip (dimmed when confidence < 0.6 or
 Unclassified), start, duration, `prompts/responses`, tokens, cost — and an
-expander (`sdetail`, `dashboard-server.mjs:2074-2104`) carrying the
+expander (`sdetail`, `dashboard-server.mjs:2220-2253`) carrying the
 per-session detail fields: classification `basis` + confidence, per-session
 `models`, the token split, top tools, and the
 `skill`/`plugin`/`sidechain`/`worktree` flags. A measured-but-absent value renders as `—`, never disappears — a
@@ -274,15 +274,15 @@ field that vanishes when null teaches the reader it doesn't exist.
 
 ### 6.2 Transcript view — attribution, redaction, truncation
 
-`renderTranscript` (`dashboard-server.mjs:2244`) renders the crumb (title,
+`renderTranscript` (`dashboard-server.mjs:2393`) renders the crumb (title,
 project, duration, `prompts/responses`, tokens, cost — all from masked
 `meta`) and the turn list. **The label comes from `kind`, never from role**
-(`dashboard-server.mjs:2260-2277`):
+(`dashboard-server.mjs:2409-2426`):
 
 | Turn | Label | Styling |
 |---|---|---|
-| user, `kind: 'prompt'` | `you` | accent — reserved for the person (`.t-user .t-who`, `dashboard-server.mjs:1270`) |
-| user, `kind: 'tool-result'` | `tool result` | purple, rhyming with the tool chips (`.t-tool .t-who`, `dashboard-server.mjs:1274`); hover title states the harness — not the person — sent it |
+| user, `kind: 'prompt'` | `you` | accent — reserved for the person (`.t-user .t-who`, `dashboard-server.mjs:1311`) |
+| user, `kind: 'tool-result'` | `tool result` | purple, rhyming with the tool chips (`.t-tool .t-who`, `dashboard-server.mjs:1315`); hover title states the harness — not the person — sent it |
 | user, `kind: 'context'` | `context` | same purple + hover title |
 | assistant | the model id | dim mono (`exception` placeholder turns label as `exception`) |
 
@@ -299,8 +299,8 @@ blocks (envelope census on the real corpus: task-notification 550,
 local-command-caveat 183, command-name 180, bash-input 85, bash-stdout 85,
 local-command-stdout 60; the stderr variants are the symmetric error-path
 siblings). Rendered literally they read as angle-bracket soup, so
-`fmtHarness` (`dashboard-server.mjs:2197-2216`; CSS
-`dashboard-server.mjs:1275-1287`) reformats them client-side: the command
+`fmtHarness` (`dashboard-server.mjs:2346-2365`; CSS
+`dashboard-server.mjs:1316-1328`) reformats them client-side: the command
 triple and `bash-input`
 become chips (`/clear`-style; the bash chip prefixed `!` so it reads as the
 shell invocation it was), and the block wrappers become quiet labelled
@@ -312,8 +312,8 @@ verbatim; only the wrapper tags become styling.** It runs on escaped text
 turn truncation — is left raw rather than half-formatted.
 
 Deep links: `#usage/<sessionId>` opens the Transcript view directly
-(`syncHash`, `dashboard-server.mjs:1403-1404`); the view lazy-fetches via
-`loadTranscript` (`dashboard-server.mjs:1877`).
+(`syncHash`, `dashboard-server.mjs:1444-1445`); the view lazy-fetches via
+`loadTranscript` (`dashboard-server.mjs:1918`).
 
 ---
 
@@ -351,7 +351,7 @@ was wrong before, for the curious.
   `isHumanPrompt` once counted harness-output envelopes as human prompts —
   32 claimed vs 20 real on the reference session. Cached session records
   carried the inflated counts, hence the wholesale `SCHEMA_VERSION` 5 cache
-  invalidation (`usage-index.mjs:46-50`).
+  invalidation (`usage-index.mjs:47-51`).
 - **Session expander fields shipped but unrendered.** The per-session fields
   §6.1's expander now renders (classification `basis` + confidence, the
   token split, flags) once travelled on the wire and rendered nowhere.

--- a/docs/TRANSCRIPTS.md
+++ b/docs/TRANSCRIPTS.md
@@ -213,8 +213,8 @@ serialization**, then length-capped at `MAX_TURN_CHARS` (40,000,
 
 The two kinds of withholding keep distinct vocabulary end-to-end: masking
 renders as `…redacted` marks (`markRedactions`,
-`dashboard-server.mjs:2333`), truncation as a `truncated · N of M` badge
-(`truncBadge`, `dashboard-server.mjs:2377`, deriving N from the received
+`dashboard-server.mjs:2341`), truncation as a `truncated · N of M` badge
+(`truncBadge`, `dashboard-server.mjs:2385`, deriving N from the received
 text so a changed constant can't desync the display).
 
 ![Figure: a turn body passes through maskSecrets (leaving redaction marks) and then the 40,000-character cap (leaving a truncated · N of M badge); originalChars is measured after masking](assets/transcript-mask-truncate.svg)
@@ -260,13 +260,13 @@ nothing on the page to reveal.
 
 ### 6.1 Sessions view — the row and its expander
 
-`renderSessions` (`dashboard-server.mjs:2282`) renders the project tree
+`renderSessions` (`dashboard-server.mjs:2290`) renders the project tree
 (collapsed by default; every project starts closed so the cross-project
 comparison stays above the fold). Each session is a `sessionRow`
-(`dashboard-server.mjs:2256-2280`): host chip (claude/codex), title,
+(`dashboard-server.mjs:2264-2288`): host chip (claude/codex), title,
 worktree glyph, category chip (dimmed when confidence < 0.6 or
 Unclassified), start, duration, `prompts/responses`, tokens, cost — and an
-expander (`sdetail`, `dashboard-server.mjs:2220-2253`) carrying the
+expander (`sdetail`, `dashboard-server.mjs:2228-2261`) carrying the
 per-session detail fields: classification `basis` + confidence, per-session
 `models`, the token split, top tools, and the
 `skill`/`plugin`/`sidechain`/`worktree` flags. A measured-but-absent value renders as `—`, never disappears — a
@@ -274,15 +274,15 @@ field that vanishes when null teaches the reader it doesn't exist.
 
 ### 6.2 Transcript view — attribution, redaction, truncation
 
-`renderTranscript` (`dashboard-server.mjs:2393`) renders the crumb (title,
+`renderTranscript` (`dashboard-server.mjs:2401`) renders the crumb (title,
 project, duration, `prompts/responses`, tokens, cost — all from masked
 `meta`) and the turn list. **The label comes from `kind`, never from role**
-(`dashboard-server.mjs:2409-2426`):
+(`dashboard-server.mjs:2417-2434`):
 
 | Turn | Label | Styling |
 |---|---|---|
-| user, `kind: 'prompt'` | `you` | accent — reserved for the person (`.t-user .t-who`, `dashboard-server.mjs:1311`) |
-| user, `kind: 'tool-result'` | `tool result` | purple, rhyming with the tool chips (`.t-tool .t-who`, `dashboard-server.mjs:1315`); hover title states the harness — not the person — sent it |
+| user, `kind: 'prompt'` | `you` | accent — reserved for the person (`.t-user .t-who`, `dashboard-server.mjs:1317`) |
+| user, `kind: 'tool-result'` | `tool result` | purple, rhyming with the tool chips (`.t-tool .t-who`, `dashboard-server.mjs:1321`); hover title states the harness — not the person — sent it |
 | user, `kind: 'context'` | `context` | same purple + hover title |
 | assistant | the model id | dim mono (`exception` placeholder turns label as `exception`) |
 
@@ -299,8 +299,8 @@ blocks (envelope census on the real corpus: task-notification 550,
 local-command-caveat 183, command-name 180, bash-input 85, bash-stdout 85,
 local-command-stdout 60; the stderr variants are the symmetric error-path
 siblings). Rendered literally they read as angle-bracket soup, so
-`fmtHarness` (`dashboard-server.mjs:2346-2365`; CSS
-`dashboard-server.mjs:1316-1328`) reformats them client-side: the command
+`fmtHarness` (`dashboard-server.mjs:2354-2373`; CSS
+`dashboard-server.mjs:1322-1334`) reformats them client-side: the command
 triple and `bash-input`
 become chips (`/clear`-style; the bash chip prefixed `!` so it reads as the
 shell invocation it was), and the block wrappers become quiet labelled
@@ -312,8 +312,8 @@ verbatim; only the wrapper tags become styling.** It runs on escaped text
 turn truncation — is left raw rather than half-formatted.
 
 Deep links: `#usage/<sessionId>` opens the Transcript view directly
-(`syncHash`, `dashboard-server.mjs:1444-1445`); the view lazy-fetches via
-`loadTranscript` (`dashboard-server.mjs:1918`).
+(`syncHash`, `dashboard-server.mjs:1450-1451`); the view lazy-fetches via
+`loadTranscript` (`dashboard-server.mjs:1924`).
 
 ---
 

--- a/docs/USAGE-SCORECARD-METRICS.md
+++ b/docs/USAGE-SCORECARD-METRICS.md
@@ -135,12 +135,12 @@ cost = (inputUnits × rate_in + output × rate_out) / 1,000,000
 
 summed across every row in the window.
 
-**Source:** `costOf()`, `src/lib/pricing.mjs:169-176`, reproduced verbatim:
+**Source:** `costOf()`, `src/lib/pricing.mjs:247-253`, reproduced verbatim:
 
 ```js
 export function costOf(usage) {
-  const { model, provider, input, output, cacheRead, cacheWrite } = usage ?? {};
-  const { in: rin, out: rout } = priceFor(model, provider);
+  const { model, provider, input, output, cacheRead, cacheWrite, day } = usage ?? {};
+  const { in: rin, out: rout } = priceFor(model, provider, day);
   const inputUnits = tokens(input)
     + tokens(cacheWrite) * CACHE_WRITE_MULTIPLIER
     + tokens(cacheRead) * CACHE_READ_MULTIPLIER;
@@ -149,19 +149,65 @@ export function costOf(usage) {
 ```
 
 `CACHE_READ_MULTIPLIER = 0.1`, `CACHE_WRITE_MULTIPLIER = 1.25`
-(`pricing.mjs:112-113`) — see §13 for why these two numbers are correct for
+(`pricing.mjs:154-155`) — see §13 for why these two numbers are correct for
 **both** Anthropic and OpenAI, which is why `costOf` needs no per-provider
 branch on the multiplier (only on the base `rate_in`/`rate_out`, resolved by
-`priceFor`, `pricing.mjs:141-152`).
+`priceFor`, `pricing.mjs:214-227`).
 
 Rate resolution is **longest-prefix match** on a normalized model id
-(`pricing.mjs:121-130`), so a dated release (`claude-haiku-4-5-20251001`)
+(`pricing.mjs:163-172`), so a dated release (`claude-haiku-4-5-20251001`)
 resolves to the same entry as its bare alias, and a more specific entry
 (`gpt-5.6-sol`) is never shadowed by a shorter one (`gpt-5.6`). An id matching
 nothing gets `FALLBACK_PRICE` — Sonnet-class rate, `$3`/`$15`
-(`pricing.mjs:109`) — rather than `$0`, so an unrecognized model can never be
+(`pricing.mjs:151`) — rather than `$0`, so an unrecognized model can never be
 silently free; `matched: false` travels with the result so a maintainer can
 find fallback-priced rows if the table needs a new entry.
+
+### 3a. Rates are dated, and a row is priced on the day it was spent
+
+Each table entry is a **schedule** — an ordered list of periods, each with the
+day it takes effect. Nearly every entry has exactly one period that has always
+applied (`anthropic(5, 25)` builds that shape); an entry whose rate the vendor
+has *published* a change to carries more than one (`schedule`,
+`pricing.mjs:41-55`). `periodOn` (`pricing.mjs:187`) picks the last period
+already in effect on the given day, comparing ISO date strings
+lexicographically so no `Date` parsing is involved and the module stays
+clock-free.
+
+`aggregate()` passes each usage row's own `day` (`usage-index.mjs:832`), which
+it already has because rows are keyed by `(day, model)`. **This is the whole
+point:** tokens metered in August must still read as August's rate when the
+panel is opened in December. Pricing by *today's* date instead would restate a
+finished window the moment a published rate changed — a 50% jump in a
+Sonnet-heavy August, with no session having changed. A panel whose claim is
+"what these tokens would cost metered" cannot do that.
+
+Two rules bound the mechanism:
+
+- **Only published changes are encoded.** Anthropic announced that Sonnet 5's
+  introductory rate ends 2026-08-31, so that boundary is a recorded fact.
+  Encoding a *forecast* of some future repricing would fabricate data — the
+  same error as an invented denominator (§14).
+- **The mechanism is identical for both providers.** A date range is a fact
+  about a price, not about a vendor. As of the verification date OpenAI
+  publishes no promotional rates or expiry dates, so every OpenAI entry is a
+  single always-applied period — but that is a fact about the *data*, not a gap
+  in the table: `openai.dated([...])` exists and behaves identically, so a
+  Codex promo would be a one-line edit rather than new machinery. Rates that
+  vary by *how* a request was served — regional uplift, large-prompt surcharge,
+  service tiers — are a different axis, are deliberately **not** expressible
+  here, and remain in `UNMODELLED_PRICING_FACTORS` (`pricing.mjs:142-144`)
+  because a transcript does not record the endpoint or tier.
+
+A `priceFor` call with no day prices as of `PRICES_AS_OF`, the table's
+verification date — **not** the newest period. "Newest" only means "current"
+once every published change has landed, and deciding that requires a clock this
+module does not read. Using the verification date also means the default can
+never disagree with the `rates as of <date>` label the UI already prints.
+
+Boundary behavior is pinned by `tests/kit/pricing-revert.test.mjs`, including
+the property that matters most: a finished window is not restated when a later
+rate change takes effect.
 
 **Worked example** (from the Anthropic pricing page's own published example,
 [C1] below — reproduced here because it is the cleanest independent check of
@@ -670,8 +716,11 @@ own published table, not a transcription from a secondary source:
 | Claude Sonnet 4.6 / 4.5 | $3/MTok | $3.75/MTok | $6/MTok | $0.30/MTok | $15/MTok |
 | Claude Haiku 4.5 | $1/MTok | $1.25/MTok | $2/MTok | $0.10/MTok | $5/MTok |
 
-Every value in `pricing.mjs`'s Anthropic entries (`pricing.mjs:32-50`) matches
-this table's "Base input" and "Output" columns exactly. The cache-write and
+Every value in `pricing.mjs`'s Anthropic entries (`pricing.mjs:74-108`) matches
+this table's "Base input" and "Output" columns exactly. Note that the two Sonnet
+5 rows above are not a documentation convenience — they are exactly what the
+code encodes, as the two periods of that entry's schedule (§3a), so the table
+and the implementation state the same published change in the same shape. The cache-write and
 cache-read *columns* in this table are provider-published absolute rates; the
 kit's `pricing.mjs` instead stores the two **multipliers** (0.1× and 1.25×,
 5-minute TTL only — the kit does not currently distinguish 5-minute from
@@ -688,7 +737,7 @@ Anthropic's own prompt-caching documentation **[C2]** states the multipliers
 in prose, independent of the pricing table: *"5-minute cache write tokens are
 1.25 times the base input tokens price... Cache read tokens are 0.1 times the
 base input tokens price."* This is the second, independent confirmation of
-`CACHE_READ_MULTIPLIER`/`CACHE_WRITE_MULTIPLIER` (`pricing.mjs:112-113`).
+`CACHE_READ_MULTIPLIER`/`CACHE_WRITE_MULTIPLIER` (`pricing.mjs:154-155`).
 
 ### 13.2 OpenAI (Codex) — hand-maintained, no canonical machine-readable source
 
@@ -737,8 +786,8 @@ hand-maintained and drift-prone, not vendor-confirmed via automated fetch.
 
 ### 13.3 What the pricing table deliberately does not model
 
-Recorded verbatim from `pricing.mjs:82-99` (`UNMODELLED_PRICING_FACTORS`,
-`pricing.mjs:100-102`) because listing known gaps is what makes the
+Recorded verbatim from `pricing.mjs:125-141` (`UNMODELLED_PRICING_FACTORS`,
+`pricing.mjs:142-144`) because listing known gaps is what makes the
 *modelled* factors credible:
 
 - **Regional-processing uplift.** OpenAI charges +10% on data-residency

--- a/docs/USAGE-SCORECARD-METRICS.md
+++ b/docs/USAGE-SCORECARD-METRICS.md
@@ -57,15 +57,15 @@ Every metric section below follows the same shape:
 
 Two transcript stores, read-only, parsed at most once per file (cache keyed by
 `(path, mtime, size)`; `SCHEMA_VERSION` invalidates the whole cache on a
-schema change — `src/lib/usage-index.mjs:50`):
+schema change — `src/lib/usage-index.mjs:51`):
 
 | Provider | Store | Format |
 |---|---|---|
 | Claude Code | `~/.claude/projects/<project>/<sessionId>.jsonl` | one JSON object per line: `user`/`assistant` turns, each assistant turn carrying its own `usage` object |
 | Codex CLI | `~/.codex/sessions/<yyyy>/<mm>/<dd>/rollout-<ts>-<sessionId>.jsonl` | one JSON object per line: `session_meta`, `turn_context`, and `event_msg` records, the latter carrying **cumulative** `token_count` snapshots, not per-turn deltas |
 
-The parsers are `parseClaude` (`usage-index.mjs:417-500`) and `parseCodex`
-(`usage-index.mjs:517-587`). Both are pure functions over the raw file bytes —
+The parsers are `parseClaude` (`usage-index.mjs:427-510`) and `parseCodex`
+(`usage-index.mjs:527-628`). Both are pure functions over the raw file bytes —
 no network, no clock dependency beyond the transcript's own timestamps — so
 every downstream number traces back to bytes already on the user's disk.
 Nothing in this pipeline calls a provider API or a billing endpoint; **no
@@ -89,16 +89,16 @@ responses = Σ over included sessions of session.responses
 **Source:**
 
 - Filter: a parsed record with zero assistant turns is dropped entirely — "no
-  assistant turn → not a session" (`usage-index.mjs:768`) — and a record whose
+  assistant turn → not a session" (`usage-index.mjs:809`) — and a record whose
   last activity falls outside the requested window is dropped too
-  (`usage-index.mjs:769`).
+  (`usage-index.mjs:810`).
 - `responses` accumulation: Claude increments per assistant message
-  (`usage-index.mjs:447`); Codex increments per `agent_message` event
-  (`usage-index.mjs:558`).
+  (`usage-index.mjs:457`); Codex increments per `agent_message` event
+  (`usage-index.mjs:595`).
 - Totals: `totals.responses += s.responses` per included session
-  (`usage-index.mjs:839`).
+  (`usage-index.mjs:884`).
 - Render: `kpi("sessions", fmtNum(t.sessions), fmtNum(t.responses)+" assistant
-  turns", "")` (`dashboard-server.mjs:1933`).
+  turns", "")` (`dashboard-server.mjs:1977`).
 
 **Worked example.** A session with 3 user turns and 2 assistant turns
 contributes `sessions += 1, responses += 2` — prompts (user turns) are tracked
@@ -210,23 +210,23 @@ tokens = input + output + cacheRead + cacheWrite   (summed across all rows in wi
 ```
 
 **Source:** `t.tokens` from `totals`, accumulated per row at
-`usage-index.mjs:783` (`rowTokens = row.input + row.output + row.cacheRead +
+`usage-index.mjs:824` (`rowTokens = row.input + row.output + row.cacheRead +
 row.cacheWrite`) and rolled into `totals.tokens` via `addTo`
-(`usage-index.mjs:738`). Rendered with `fmtTok()`
-(`dashboard-server.mjs:1843-1849`): `≥1e9` → `"X.XB"`, `≥1e6` → `"X.XM"`,
+(`usage-index.mjs:779`). Rendered with `fmtTok()`
+(`dashboard-server.mjs:1884-1890`): `≥1e9` → `"X.XB"`, `≥1e6` → `"X.XM"`,
 `≥1e3` → `"X.XK"`, else the rounded integer.
 
 The **token composition bar** immediately below the hero row (cache read /
 cache write / output / input, as four coloured segments) is the same four
-numbers as percentages of `t.tokens` (`dashboard-server.mjs:1969-1976`,
-`pct(a,b) = b ? a/b*100 : 0`, `dashboard-server.mjs:1857`).
+numbers as percentages of `t.tokens` (`dashboard-server.mjs:2013-2020`,
+`pct(a,b) = b ? a/b*100 : 0`, `dashboard-server.mjs:1898`).
 
 **What "input" excludes.** For both providers, the `input` counter recorded
 per row is **gross input minus cached input** — Claude's parser reads
 `cache_read_input_tokens` and `cache_creation_input_tokens` as separate fields
-the provider already reports separately (`usage-index.mjs:475-478`); Codex's
+the provider already reports separately (`usage-index.mjs:485-488`); Codex's
 parser subtracts `cached_input_tokens` from `input_tokens` explicitly
-(`usage-index.mjs:573-577`, `input: Math.max(0, gross - cacheRead)`) because
+(`usage-index.mjs:610-614`, `input: Math.max(0, gross - cacheRead)`) because
 Codex's own `input_tokens` field **includes** cached tokens and would
 double-count them against the separately-reported `cacheRead` figure if left
 as-is. This is asserted by test:
@@ -262,8 +262,8 @@ cacheRead + cacheWrite), **not** as a share of input alone. On the reference
 figures (`cacheRead = 1464.3B`, `tokens = 1495.2B`): `1464.3 / 1495.2 × 100 =
 97.93%`, which rounds to the displayed `97.9%` — confirming the denominator.
 
-**Source:** `dashboard-server.mjs:1931` (`cacheShare = pct(t.cacheRead,
-t.tokens)`), rendered `dashboard-server.mjs:1939`.
+**Source:** `dashboard-server.mjs:1975` (`cacheShare = pct(t.cacheRead,
+t.tokens)`), rendered `dashboard-server.mjs:1983`.
 
 **Why this number matters more than it looks like it should.** On the
 reference corpus, 96.3% of tokens were cache reads — pricing them as fresh
@@ -280,7 +280,7 @@ Codex CLI do by default.
 
 **Displayed as:** `ENGAGED TIME` hero tile — `403h`, subtitle `3286h summed`
 plus a `sessions overlap` note. Hovering the tile reveals a tooltip with all
-three tiers (the "ladder," `dashboard-server.mjs:1921-1927`).
+three tiers (the "ladder," `dashboard-server.mjs:1965-1971`).
 
 This is the single most heavily-caveated metric on the tab, because a naive
 version of it is **wrong by roughly 3×** on the reference corpus — worth
@@ -311,27 +311,27 @@ session data, and each needs its own fix:
    human, or genuinely idle) donates its *entire* idle stretch to the span,
    even though no work happened during it. Fix: split each session into
    active sub-intervals wherever the gap between two consecutive timestamps
-   exceeds `IDLE_GAP_MS` (15 minutes, `usage-index.mjs:56`), then union
+   exceeds `IDLE_GAP_MS` (15 minutes, `usage-index.mjs:62`), then union
    *those* sub-intervals — this is `engagedSeconds`.
 
 **Source:**
 
-- `mergeIntervals()` (`usage-index.mjs:83-108`) — the pure union primitive,
+- `mergeIntervals()` (`usage-index.mjs:89-114`) — the pure union primitive,
   sorts intervals and merges any two that overlap **or exactly touch**
-  (`s <= curEnd`, `usage-index.mjs:99`), returning total covered seconds
+  (`s <= curEnd`, `usage-index.mjs:105`), returning total covered seconds
   rounded to the nearest second.
-- `activeIntervals()` (`usage-index.mjs:306-318`) — splits one session's
+- `activeIntervals()` (`usage-index.mjs:316-328`) — splits one session's
   sorted timestamp list into sub-intervals wherever a gap exceeds
   `IDLE_GAP_MS`; "a run of one timestamp yields a zero-length interval and so
-  contributes nothing" (comment, `usage-index.mjs:304`).
+  contributes nothing" (comment, `usage-index.mjs:314`).
 - Aggregation: `totals.engagedSeconds = mergeIntervals(sessions.flatMap(s =>
-  s._active))` (`usage-index.mjs:882`); `totals.spanUnionSeconds =
-  mergeIntervals(sessions.map(s => s._span))` (`usage-index.mjs:881`);
+  s._active))` (`usage-index.mjs:927`); `totals.spanUnionSeconds =
+  mergeIntervals(sessions.map(s => s._span))` (`usage-index.mjs:926`);
   `totals.spanMinutes` is a running sum of `s._span[1] - s._span[0]` across
-  the loop (`usage-index.mjs:843`, finalized `usage-index.mjs:880`).
-- Render: `fmtHours()` (`dashboard-server.mjs:1850`, `≥10h` rounds to the
+  the loop (`usage-index.mjs:888`, finalized `usage-index.mjs:925`).
+- Render: `fmtHours()` (`dashboard-server.mjs:1891`, `≥10h` rounds to the
   nearest hour, else one decimal place) and `fmtMins()`
-  (`dashboard-server.mjs:1851`, `≥60min` rounds to hours, else whole
+  (`dashboard-server.mjs:1892`, `≥60min` rounds to hours, else whole
   minutes).
 
 **Worked example**, the reference-corpus measurement (14-day window, 582–584
@@ -377,13 +377,13 @@ byDay[day].cost = Σ costOf(row) for every usage row whose day == that key
 
 **Source:** the day key is the row's own `row.day`, computed once at parse
 time as **local calendar day**, not UTC
-(`usage-index.mjs:474`/`usage-index.mjs:576` call `localDay(at)`) — so a
+(`usage-index.mjs:484`/`usage-index.mjs:613` call `localDay(at)`) — so a
 session that runs from 23:58 local to 00:05 local is billed to the day its
 *first* row landed on (test:
 `tests/kit/usage-index.test.mjs:608`, "a session that opens before midnight
 is counted on its first billed day"). Accumulation:
-`byDay[row.day].cost += rowCost` (`usage-index.mjs:786`). Bar height:
-`h = maxDay ? max(2, cost/maxDay*100) : 2` (`dashboard-server.mjs:1950`) —
+`byDay[row.day].cost += rowCost` (`usage-index.mjs:827`). Bar height:
+`h = maxDay ? max(2, cost/maxDay*100) : 2` (`dashboard-server.mjs:1994`) —
 every non-empty day gets a visually nonzero bar (floor of 2%), so a very
 cheap day is never rendered as invisible.
 
@@ -400,14 +400,14 @@ rather than a continuous 30-day series.
 **Displayed as:** two cards, `claude` and `codex`, each showing cost,
 session count, and total tokens; an idle host (`sessions == 0 && cost == 0`)
 renders "no sessions in window" instead of zeroed figures
-(`dashboard-server.mjs:1962-1966`).
+(`dashboard-server.mjs:2006-2010`).
 
 **Formula:** identical aggregation to every other bucket
-(`byProvider[s.provider]`, populated via `addTo()`, `usage-index.mjs:734-743`,
-called once per session at `usage-index.mjs:845`), keyed by the literal string
+(`byProvider[s.provider]`, populated via `addTo()`, `usage-index.mjs:775-784`,
+called once per session at `usage-index.mjs:890`), keyed by the literal string
 `"claude"` or `"codex"` assigned at parse time
 (`blankSession(id, 'claude')` / `blankSession(id, 'codex')`,
-`usage-index.mjs:285-291`, `parseClaude`/`parseCodex` entry points).
+`usage-index.mjs:291-301`, `parseClaude`/`parseCodex` entry points).
 
 **Why this pairing is the one under the most scrutiny.** Both providers'
 tokens are summed into the *same* `tokens`/`cost` fields using the *same*
@@ -442,11 +442,11 @@ punchcard[dow + "-" + hour] += 1   per assistant/agent_message response, at its 
 ```
 
 **Source:** incremented once per Claude assistant turn
-(`usage-index.mjs:449-450`, keyed by `punchKey(at)`) and once per Codex
-`agent_message` (`usage-index.mjs:560-561`), merged into the window-level
-`punchcard` object per session (`usage-index.mjs:860`). Cell intensity is
+(`usage-index.mjs:459-460`, keyed by `punchKey(at)`) and once per Codex
+`agent_message` (`usage-index.mjs:597-598`), merged into the window-level
+`punchcard` object per session (`usage-index.mjs:905`). Cell intensity is
 linear against the single busiest cell in the window:
-`v = pcMax ? n/pcMax : 0` (`dashboard-server.mjs:1986`) — this is a
+`v = pcMax ? n/pcMax : 0` (`dashboard-server.mjs:2030`) — this is a
 **relative**, not absolute, scale, so the heatmap's brightest cell is always
 "the busiest hour-of-week in *this* window," not a fixed response-count
 threshold, and comparing brightness across two different date-range views is
@@ -477,9 +477,9 @@ byModel[model].sessions  = count of DISTINCT sessions whose s.models includes th
 ```
 
 **Source:** cost/tokens/responses accumulate inside the usage-row loop
-(`usage-index.mjs:773-790`); the `sessions` count is deliberately computed
+(`usage-index.mjs:814-831`); the `sessions` count is deliberately computed
 **separately**, once per session over its `s.models` array
-(`usage-index.mjs:853-858`) rather than inside the cost loop, precisely
+(`usage-index.mjs:898-903`) rather than inside the cost loop, precisely
 **so that a model can appear in `byModel` — with a nonzero session count —
 even in a session that contributed zero cost/tokens/responses for that
 model.** This is not an edge case invented for this document: it is the
@@ -489,16 +489,16 @@ excluded subagent-replay session still shows up as "used," at zero cost,
 rather than vanishing.
 
 `byModel[...].responses` is populated from `row.responses`
-(`usage-index.mjs:788`), which in turn comes from the `responses` field
+(`usage-index.mjs:829`), which in turn comes from the `responses` field
 passed into `addUsage()` at the call site — `1` per Claude assistant turn
-(`usage-index.mjs:474-480`), or `rec.responses` (the session's whole response
+(`usage-index.mjs:484-490`), or `rec.responses` (the session's whole response
 count) once per Codex session, passed at the single point Codex calls
-`addUsage` (`usage-index.mjs:576-583`).
+`addUsage` (`usage-index.mjs:613-624`).
 
 **Render:** `bar(name, fmtUsd(cost), fmtTok(tokens)+" · "+fmtNum(responses)+"
-resp", pct(cost, topModelCost), false)` (`dashboard-server.mjs:1999-2002`),
+resp", pct(cost, topModelCost), false)` (`dashboard-server.mjs:2043-2046`),
 list itself sorted cost-descending by the shared `entries()` helper
-(`dashboard-server.mjs:1858-1863`).
+(`dashboard-server.mjs:1899-1904`).
 
 **Exceptions — a turn that never resolved to a model is excluded here, not
 shown as a $0 row.** A dropped connection, rate limit, or authentication
@@ -509,17 +509,17 @@ split `server_error` 27, `authentication_failed` 3, `rate_limit` 3 — three
 distinct underlying causes, one placeholder shape).
 
 The parser branches on `isApiErrorMessage === true`
-(`usage-index.mjs:459-468`): the turn still increments `rec.responses`
-and the punchcard (`usage-index.mjs:447-450`) — it *is* real engaged
+(`usage-index.mjs:469-478`): the turn still increments `rec.responses`
+and the punchcard (`usage-index.mjs:457-460`) — it *is* real engaged
 time, someone was genuinely waiting on it — but it is never pushed into
 `rec.models` and `addUsage()` is never called for it, so it can no longer
 create a `byModel` row of any kind. It increments a separate
-`rec.exceptions` counter instead (`usage-index.mjs:460`), rolled up into
-`totals.exceptions` (`usage-index.mjs:828-839`) and surfaced per-session
-(`usage-index.mjs:803`, alongside the existing `sidechain`/`threadSource`
+`rec.exceptions` counter instead (`usage-index.mjs:470`), rolled up into
+`totals.exceptions` (`usage-index.mjs:873-884`) and surfaced per-session
+(`usage-index.mjs:844`, alongside the existing `sidechain`/`threadSource`
 flags — inspectable in the Sessions tab, never hidden). When
 `totals.exceptions > 0`, the panel header shows a small `"· N
-dropped/errored turns excluded"` note (`dashboard-server.mjs:2003-2008`);
+dropped/errored turns excluded"` note (`dashboard-server.mjs:2047-2052`);
 when it's zero, the note renders empty rather than always claiming a
 count of zero.
 
@@ -545,7 +545,7 @@ N"` when more exist; each row shows `cost`, `N sess · minutes`.
 it masquerade as a sibling project. (The mislabelling this rule corrected is
 recorded in [Appendix A](#appendix-a--fix-history).)
 
-**Source:** ranking and truncation, `dashboard-server.mjs:2010-2017`
+**Source:** ranking and truncation, `dashboard-server.mjs:2054-2061`
 (`shown = projects.slice(0,8)`); accumulation via the same `addTo()`/
 `entries()` machinery as §10, keyed by `s.project` instead of `s.models`.
 
@@ -561,7 +561,7 @@ rather than silently absent from the total.
 **Displayed as:** a ranked bar list of categories, bar width relative to
 the top category's cost; each row shows `cost`, `N sess · $/sess`; a small
 confidence dot on classified rows (opacity `0.5 + confidence×0.5`,
-`dashboard-server.mjs:2024-2025`); `Unclassified` is always shown, never
+`dashboard-server.mjs:2068-2069`); `Unclassified` is always shown, never
 hidden, and carries no confidence dot.
 
 This is the only Scorecard metric that is **not** pure arithmetic over
@@ -632,9 +632,9 @@ coverage was `ai-title` 93%, tool mix 100%,
 cannot classify most sessions and layer 2 (title + tool-mix rules) carries
 the bulk of the load.
 
-**Render:** `dashboard-server.mjs:2020-2031`, sorted cost-descending via the
+**Render:** `dashboard-server.mjs:2064-2075`, sorted cost-descending via the
 shared `entries()` helper, with `$/sess = cost / max(sessions, 1)` guarding
-the zero-session edge case (`dashboard-server.mjs:2022`).
+the zero-session edge case (`dashboard-server.mjs:2066`).
 
 **What this does not model:** the classifier reads only the session's
 *title* (Claude's own `ai-title`, written by the model itself at session
@@ -699,7 +699,7 @@ Anthropic which publishes a fetchable pricing document. OpenAI's rates in
 this table are therefore maintained by hand against OpenAI's own developer
 documentation and are the most drift-prone entries in the file — this is
 explicitly why `PRICES_AS_OF` is surfaced in the UI (`u-asof`,
-`dashboard-server.mjs:1940`) rather than assumed current.
+`dashboard-server.mjs:1984`) rather than assumed current.
 
 | Model (kit key) | Input | Output | Cache read (0.1×, derived) |
 |---|---|---|---|
@@ -770,6 +770,67 @@ Recorded verbatim from `pricing.mjs:82-99` (`UNMODELLED_PRICING_FACTORS`,
 
 ---
 
+## 13b. Limits view — vendor-reported plan utilization (ADR-0010)
+
+Every other figure in this document is computed locally from transcripts. The
+Limits sub-view is different by design: its percentages are **vendor-reported**
+— the plan's own denominator, which ADR-0009 §3 correctly said local parsing
+could never honestly invent. ADR-0010 defines the only two admissible channels,
+both credential-free for ak:
+
+- **Claude** — Claude Code pushes `rate_limits` (session/weekly/per-model
+  `used_percentage` + `resets_at`) into every statusLine invocation on Pro/Max.
+  The kit's managed statusline footer tees that JSON to
+  `~/.config/agentic-kit/claude-rate-limits.json` (throttled, atomic, 0600) —
+  the `quota tee` block in `statusline-footer.cjs:9`. The dashboard reads the
+  tee via `normalizeClaudeLimits` (`quota.mjs:62`), which maps `five_hour` /
+  `seven_day` / `seven_day_<model>` keys to duration-labelled windows.
+- **Codex** — one `initialize` → `account/rateLimits/read` JSON-RPC exchange
+  with a spawned `codex app-server`, implemented by `codexAppServerRateLimits`
+  (`quota.mjs:165`) and TTL-cached (`CODEX_TTL_MS`, `:36`) by
+  `collectCodexLimits` (`:220`). Lanes come from `rateLimitsByLimitId` in
+  `normalizeCodexLimits` (`:106`), including per-model pools and
+  rate-limit reset credits.
+
+**The primary/secondary trap.** Codex's `primary` window is *not* reliably the
+5-hour window — a live `prolite` account reported `primary` with
+`windowDurationMins: 10080` (the weekly). Windows are therefore keyed and
+labelled by duration (`windowLabel`, `quota.mjs:44`), never by slot name. The
+same rule applies to the historical snapshots parsed out of rollouts: the
+normalizer at `usage-index.mjs:560` keeps a flat `windows` list keyed by
+`window_minutes`.
+
+**Freshness is part of the number.** Both sides carry `fetchedAt`; the view
+renders "as of Nm ago" and a `stale` badge (Claude's tee is push-only, so it
+ages the moment sessions stop). Served by the `/api/limits` route
+(`dashboard-server.mjs:363`) and rendered by `renderLimits` (`:2120`), with
+`limRow` (`:2111`) coloring each bar by proximity to its cap.
+
+**Limit-aware findings.** `detectLimitInsights` (`usage-insights.mjs:625`)
+applies the same evidence rules as every other detector — vendor percentages
+are the user's own data; no dollar impact is ever claimed from a percentage;
+"now" is the payload's `generatedAt`, never a clock. Detectors: pacing
+against the window's own elapsed share, cross-host arbitrage between the two
+plan pools, and expiring Codex reset credits (reported, never auto-consumed).
+
+**What still has no supported channel:** Claude extra-usage credit balance and
+subscription tier. They stay absent rather than approximated.
+
+## 13c. Codex thread ledger — authoritative subagent attribution
+
+Codex ≥0.140 maintains its own SQLite thread ledger (`~/.codex/state_N.sqlite`
+— the `N` is a migration generation, so `codexStateDb` (`codex-state.mjs:30`)
+globs and takes the newest). `readCodexState` (`:49`) reads per-thread
+`thread_source` (`user` vs `subagent`) plus `thread_spawn_edges`, and
+`applyCodexLedger` (`usage-index.mjs:1090`) overlays that onto parsed
+sessions: a ledger-identified subagent has its token usage stripped — its
+rollout replays the parent's entire token history (ccusage/ccusage#950
+measured up to 91× inflation) — while the session record stays visible. The
+rollout's own `session_meta.thread_source` sniff remains as the fallback when
+the ledger is absent or migrated beyond recognition. Codex sessions also carry
+`reasoningOutput` (`usage-index.mjs:623`) — reasoning tokens are a **subset**
+of output tokens and are annotation only, never added to any sum.
+
 ## 14. Known limitations, restated as a single checklist
 
 For a reviewer who wants the "does this number lie to me" answer without
@@ -812,14 +873,14 @@ commit `540be18` on this branch.
 
 `parseCodex`'s single `addUsage()` call never included a `responses` field —
 Claude's parser passes `responses: 1` per assistant turn
-(`usage-index.mjs:479`, as it existed before this fix), but Codex's call
+(`usage-index.mjs:489`, as it existed before this fix), but Codex's call
 passed no such field at all. Because `byModel[model].responses` is summed
-directly from each usage row's `responses` field (`usage-index.mjs:788`,
+directly from each usage row's `responses` field (`usage-index.mjs:829`,
 `m.responses += row.responses`), **every** Codex model in §10's "Models in
 Play" list displayed `0 resp` regardless of real token/cost volume or actual
 `agent_message` count. **Fix:** `parseCodex` now passes `responses:
 rec.responses` (the session's own tallied response count,
-`usage-index.mjs:558`) on its `addUsage()` call.
+`usage-index.mjs:595`) on its `addUsage()` call.
 
 #### Bug B — subagent thread-replay could double-bill tokens
 
@@ -839,13 +900,13 @@ at face value (correctly avoiding the separate naive-summing bug **[C5]**
 documents, since it already used last-event-only logic — see §4's worked
 example) but performed **no de-duplication** against a parent session a
 subagent file might be replaying. **Fix:** the parser now reads
-`session_meta.thread_source` (`usage-index.mjs:532`, confirmed as a real
+`session_meta.thread_source` (`usage-index.mjs:542`, confirmed as a real
 Codex rollout field by **[C7]**) and skips the `addUsage()` call entirely
-when its value is `'subagent'` (`usage-index.mjs:572`, guard condition
+when its value is `'subagent'` (`usage-index.mjs:609`, guard condition
 `rec.threadSource !== 'subagent'`). The session record itself is **not**
 dropped — it remains visible in the Sessions tab with `threadSource`
 surfaced (mirroring the existing `sidechain` flag Claude sessions already
-carry, `usage-index.mjs:288`), so a maintainer auditing the raw data can
+carry, `usage-index.mjs:294`), so a maintainer auditing the raw data can
 still see it; it simply contributes zero tokens/cost, exactly as intended by
 the "models still shows up in §10's list, with zero cost" mechanism §10
 describes.
@@ -907,7 +968,7 @@ promise.
   `totals.exceptions: null` and still showed the `<synthetic>` row in
   `byModel` on the first run after the change, purely because the cache
   predated it; every unit test still passed, since tests only exercise a
-  fresh parse. `SCHEMA_VERSION` went to `4` (`usage-index.mjs:35-50`; since
+  fresh parse. `SCHEMA_VERSION` went to `4` (`usage-index.mjs:36-51`; since
   superseded by `5`, above) specifically to force the one-time re-parse.
   Re-querying the same live server after the bump returned
   `totals.exceptions: 20` with `<synthetic>` absent from `byModel` —

--- a/docs/USAGE-SCORECARD-METRICS.md
+++ b/docs/USAGE-SCORECARD-METRICS.md
@@ -98,7 +98,7 @@ responses = Σ over included sessions of session.responses
 - Totals: `totals.responses += s.responses` per included session
   (`usage-index.mjs:884`).
 - Render: `kpi("sessions", fmtNum(t.sessions), fmtNum(t.responses)+" assistant
-  turns", "")` (`dashboard-server.mjs:1977`).
+  turns", "")` (`dashboard-server.mjs:1983`).
 
 **Worked example.** A session with 3 user turns and 2 assistant turns
 contributes `sessions += 1, responses += 2` — prompts (user turns) are tracked
@@ -213,13 +213,13 @@ tokens = input + output + cacheRead + cacheWrite   (summed across all rows in wi
 `usage-index.mjs:824` (`rowTokens = row.input + row.output + row.cacheRead +
 row.cacheWrite`) and rolled into `totals.tokens` via `addTo`
 (`usage-index.mjs:779`). Rendered with `fmtTok()`
-(`dashboard-server.mjs:1884-1890`): `≥1e9` → `"X.XB"`, `≥1e6` → `"X.XM"`,
+(`dashboard-server.mjs:1890-1896`): `≥1e9` → `"X.XB"`, `≥1e6` → `"X.XM"`,
 `≥1e3` → `"X.XK"`, else the rounded integer.
 
 The **token composition bar** immediately below the hero row (cache read /
 cache write / output / input, as four coloured segments) is the same four
-numbers as percentages of `t.tokens` (`dashboard-server.mjs:2013-2020`,
-`pct(a,b) = b ? a/b*100 : 0`, `dashboard-server.mjs:1898`).
+numbers as percentages of `t.tokens` (`dashboard-server.mjs:2019-2026`,
+`pct(a,b) = b ? a/b*100 : 0`, `dashboard-server.mjs:1904`).
 
 **What "input" excludes.** For both providers, the `input` counter recorded
 per row is **gross input minus cached input** — Claude's parser reads
@@ -262,8 +262,8 @@ cacheRead + cacheWrite), **not** as a share of input alone. On the reference
 figures (`cacheRead = 1464.3B`, `tokens = 1495.2B`): `1464.3 / 1495.2 × 100 =
 97.93%`, which rounds to the displayed `97.9%` — confirming the denominator.
 
-**Source:** `dashboard-server.mjs:1975` (`cacheShare = pct(t.cacheRead,
-t.tokens)`), rendered `dashboard-server.mjs:1983`.
+**Source:** `dashboard-server.mjs:1981` (`cacheShare = pct(t.cacheRead,
+t.tokens)`), rendered `dashboard-server.mjs:1989`.
 
 **Why this number matters more than it looks like it should.** On the
 reference corpus, 96.3% of tokens were cache reads — pricing them as fresh
@@ -280,7 +280,7 @@ Codex CLI do by default.
 
 **Displayed as:** `ENGAGED TIME` hero tile — `403h`, subtitle `3286h summed`
 plus a `sessions overlap` note. Hovering the tile reveals a tooltip with all
-three tiers (the "ladder," `dashboard-server.mjs:1965-1971`).
+three tiers (the "ladder," `dashboard-server.mjs:1971-1977`).
 
 This is the single most heavily-caveated metric on the tab, because a naive
 version of it is **wrong by roughly 3×** on the reference corpus — worth
@@ -329,9 +329,9 @@ session data, and each needs its own fix:
   mergeIntervals(sessions.map(s => s._span))` (`usage-index.mjs:926`);
   `totals.spanMinutes` is a running sum of `s._span[1] - s._span[0]` across
   the loop (`usage-index.mjs:888`, finalized `usage-index.mjs:925`).
-- Render: `fmtHours()` (`dashboard-server.mjs:1891`, `≥10h` rounds to the
+- Render: `fmtHours()` (`dashboard-server.mjs:1897`, `≥10h` rounds to the
   nearest hour, else one decimal place) and `fmtMins()`
-  (`dashboard-server.mjs:1892`, `≥60min` rounds to hours, else whole
+  (`dashboard-server.mjs:1898`, `≥60min` rounds to hours, else whole
   minutes).
 
 **Worked example**, the reference-corpus measurement (14-day window, 582–584
@@ -383,7 +383,7 @@ session that runs from 23:58 local to 00:05 local is billed to the day its
 `tests/kit/usage-index.test.mjs:608`, "a session that opens before midnight
 is counted on its first billed day"). Accumulation:
 `byDay[row.day].cost += rowCost` (`usage-index.mjs:827`). Bar height:
-`h = maxDay ? max(2, cost/maxDay*100) : 2` (`dashboard-server.mjs:1994`) —
+`h = maxDay ? max(2, cost/maxDay*100) : 2` (`dashboard-server.mjs:2000`) —
 every non-empty day gets a visually nonzero bar (floor of 2%), so a very
 cheap day is never rendered as invisible.
 
@@ -400,7 +400,7 @@ rather than a continuous 30-day series.
 **Displayed as:** two cards, `claude` and `codex`, each showing cost,
 session count, and total tokens; an idle host (`sessions == 0 && cost == 0`)
 renders "no sessions in window" instead of zeroed figures
-(`dashboard-server.mjs:2006-2010`).
+(`dashboard-server.mjs:2012-2016`).
 
 **Formula:** identical aggregation to every other bucket
 (`byProvider[s.provider]`, populated via `addTo()`, `usage-index.mjs:775-784`,
@@ -446,7 +446,7 @@ punchcard[dow + "-" + hour] += 1   per assistant/agent_message response, at its 
 `agent_message` (`usage-index.mjs:597-598`), merged into the window-level
 `punchcard` object per session (`usage-index.mjs:905`). Cell intensity is
 linear against the single busiest cell in the window:
-`v = pcMax ? n/pcMax : 0` (`dashboard-server.mjs:2030`) — this is a
+`v = pcMax ? n/pcMax : 0` (`dashboard-server.mjs:2036`) — this is a
 **relative**, not absolute, scale, so the heatmap's brightest cell is always
 "the busiest hour-of-week in *this* window," not a fixed response-count
 threshold, and comparing brightness across two different date-range views is
@@ -496,9 +496,9 @@ count) once per Codex session, passed at the single point Codex calls
 `addUsage` (`usage-index.mjs:613-624`).
 
 **Render:** `bar(name, fmtUsd(cost), fmtTok(tokens)+" · "+fmtNum(responses)+"
-resp", pct(cost, topModelCost), false)` (`dashboard-server.mjs:2043-2046`),
+resp", pct(cost, topModelCost), false)` (`dashboard-server.mjs:2049-2052`),
 list itself sorted cost-descending by the shared `entries()` helper
-(`dashboard-server.mjs:1899-1904`).
+(`dashboard-server.mjs:1905-1910`).
 
 **Exceptions — a turn that never resolved to a model is excluded here, not
 shown as a $0 row.** A dropped connection, rate limit, or authentication
@@ -519,7 +519,7 @@ create a `byModel` row of any kind. It increments a separate
 (`usage-index.mjs:844`, alongside the existing `sidechain`/`threadSource`
 flags — inspectable in the Sessions tab, never hidden). When
 `totals.exceptions > 0`, the panel header shows a small `"· N
-dropped/errored turns excluded"` note (`dashboard-server.mjs:2047-2052`);
+dropped/errored turns excluded"` note (`dashboard-server.mjs:2053-2058`);
 when it's zero, the note renders empty rather than always claiming a
 count of zero.
 
@@ -545,7 +545,7 @@ N"` when more exist; each row shows `cost`, `N sess · minutes`.
 it masquerade as a sibling project. (The mislabelling this rule corrected is
 recorded in [Appendix A](#appendix-a--fix-history).)
 
-**Source:** ranking and truncation, `dashboard-server.mjs:2054-2061`
+**Source:** ranking and truncation, `dashboard-server.mjs:2060-2069`
 (`shown = projects.slice(0,8)`); accumulation via the same `addTo()`/
 `entries()` machinery as §10, keyed by `s.project` instead of `s.models`.
 
@@ -561,7 +561,7 @@ rather than silently absent from the total.
 **Displayed as:** a ranked bar list of categories, bar width relative to
 the top category's cost; each row shows `cost`, `N sess · $/sess`; a small
 confidence dot on classified rows (opacity `0.5 + confidence×0.5`,
-`dashboard-server.mjs:2068-2069`); `Unclassified` is always shown, never
+`dashboard-server.mjs:2076-2077`); `Unclassified` is always shown, never
 hidden, and carries no confidence dot.
 
 This is the only Scorecard metric that is **not** pure arithmetic over
@@ -632,9 +632,9 @@ coverage was `ai-title` 93%, tool mix 100%,
 cannot classify most sessions and layer 2 (title + tool-mix rules) carries
 the bulk of the load.
 
-**Render:** `dashboard-server.mjs:2064-2075`, sorted cost-descending via the
+**Render:** `dashboard-server.mjs:2072-2083`, sorted cost-descending via the
 shared `entries()` helper, with `$/sess = cost / max(sessions, 1)` guarding
-the zero-session edge case (`dashboard-server.mjs:2066`).
+the zero-session edge case (`dashboard-server.mjs:2074`).
 
 **What this does not model:** the classifier reads only the session's
 *title* (Claude's own `ai-title`, written by the model itself at session
@@ -699,7 +699,7 @@ Anthropic which publishes a fetchable pricing document. OpenAI's rates in
 this table are therefore maintained by hand against OpenAI's own developer
 documentation and are the most drift-prone entries in the file — this is
 explicitly why `PRICES_AS_OF` is surfaced in the UI (`u-asof`,
-`dashboard-server.mjs:1984`) rather than assumed current.
+`dashboard-server.mjs:1990`) rather than assumed current.
 
 | Model (kit key) | Input | Output | Cache read (0.1×, derived) |
 |---|---|---|---|
@@ -803,8 +803,8 @@ normalizer at `usage-index.mjs:560` keeps a flat `windows` list keyed by
 **Freshness is part of the number.** Both sides carry `fetchedAt`; the view
 renders "as of Nm ago" and a `stale` badge (Claude's tee is push-only, so it
 ages the moment sessions stop). Served by the `/api/limits` route
-(`dashboard-server.mjs:363`) and rendered by `renderLimits` (`:2120`), with
-`limRow` (`:2111`) coloring each bar by proximity to its cap.
+(`dashboard-server.mjs:363`) and rendered by `renderLimits` (`:2128`), with
+`limRow` (`:2119`) coloring each bar by proximity to its cap.
 
 **Limit-aware findings.** `detectLimitInsights` (`usage-insights.mjs:625`)
 applies the same evidence rules as every other detector — vendor percentages

--- a/docs/adr/0009-usage-scorecard-local-transcript-analytics.md
+++ b/docs/adr/0009-usage-scorecard-local-transcript-analytics.md
@@ -65,6 +65,28 @@ single-flight: a refresh already in progress is joined, not duplicated.
 `src/lib/pricing.mjs` holds dated per-model rates and computes
 `input×rate + cacheWrite×rate×1.25 + cacheRead×rate×0.1 + output×outRate`.
 
+**Rates are a schedule, and a row is priced on the day it was spent.** Every table entry is an
+ordered list of periods (the common case being one period that has always applied), and
+`priceFor(model, provider, day)` selects the period in effect on that day. Cost attribution is
+historical: tokens metered in August must still read as August's rate in December. Switching rates
+by *today's* date instead would retroactively restate finished windows the moment a published rate
+changed — which a panel claiming "what these tokens would cost metered" cannot do. Two constraints
+follow, both enforced in code:
+
+- **Only published changes may be encoded.** A schedule records a rate change the vendor has
+  announced (Anthropic's Sonnet 5 introductory period ending 2026-08-31). Encoding a *forecast*
+  would fabricate data, the same error as the invented denominator above.
+- **The mechanism is identical for both providers**, because a date range is a fact about a price,
+  not about a vendor. That OpenAI currently publishes no dated promos is a fact about the data, not
+  a reason for a second code path — mirroring how `costOf` needs no per-provider branch. Rates that
+  vary by *how* a request was served (regional uplift, large-prompt surcharge, service tiers) are a
+  different axis, are not expressible as a schedule, and stay in `UNMODELLED_PRICING_FACTORS`
+  because transcripts do not record the endpoint or tier.
+
+A dateless `priceFor` prices as of `PRICES_AS_OF`, the table's verification date — not the newest
+period, which only becomes "current" once every published change has landed, a judgement requiring
+a clock this module deliberately does not read.
+
 On a Max/Pro subscription the user is **not billed per token**, and Codex-via-ChatGPT likewise. The
 panel therefore labels every figure **"API-equivalent — not your plan billing"** as a first-class UI
 element, not a footnote. We do not model plan utilisation: Anthropic does not publish the limits that

--- a/docs/adr/0009-usage-scorecard-local-transcript-analytics.md
+++ b/docs/adr/0009-usage-scorecard-local-transcript-analytics.md
@@ -70,6 +70,13 @@ panel therefore labels every figure **"API-equivalent — not your plan billing"
 element, not a footnote. We do not model plan utilisation: Anthropic does not publish the limits that
 would make such a percentage honest, and an invented denominator is worse than no number.
 
+> **Amended by [ADR-0010](0010-provider-mediated-quota-reads.md) (2026-07-27):** the exclusion above
+> was about denominators the kit would have to *invent*. Both vendors now hand over their own
+> percentages through supported channels (Claude Code's statusLine `rate_limits` push; Codex's
+> `app-server` RPC), and the Limits sub-view renders those vendor-reported figures — with
+> provenance and freshness — under ADR-0010's provider-mediated rules. Locally *computed*
+> plan percentages remain excluded, exactly as stated here.
+
 OpenAI publishes no pricing in `~/.codex/models_cache.json` (verified), so Codex rates are a
 maintained table and are **date-stamped** in the UI so staleness is visible rather than silent.
 

--- a/docs/adr/0010-provider-mediated-quota-reads.md
+++ b/docs/adr/0010-provider-mediated-quota-reads.md
@@ -1,0 +1,98 @@
+# ADR-0010 — Provider-mediated quota reads (the Limits view)
+
+Date: 2026-07-27 · Status: **Accepted** · Amends: ADR-0009 §3
+
+## Context
+
+ADR-0009 §3 deliberately excluded plan/limit modeling from the usage scorecard:
+Anthropic and OpenAI publish no limit values, so any locally computed
+"percentage of plan used" would rest on an invented denominator — and "an
+invented denominator is worse than no number". That reasoning was about
+denominators the kit would have to *fabricate*. Research (2026-07-27, cited in
+§Research below) established that both vendors now *hand over* their own
+percentages through supported channels:
+
+- **Claude Code** pushes a `rate_limits` object — `five_hour` / `seven_day`
+  (and per-model weekly buckets) with `used_percentage` and `resets_at` — into
+  every statusLine invocation for Pro/Max subscribers. This is documented
+  behavior, not an internal.
+- **Codex** answers `account/rateLimits/read` over its `codex app-server`
+  JSON-RPC surface with per-lane (`rateLimitsByLimitId`) used-percent, window
+  duration, reset time, plan type, and rate-limit reset credits.
+
+A vendor-reported percentage IS an honest denominator. What remains dishonest —
+and stays excluded — is fetching those numbers through channels the vendors
+prohibit or do not support.
+
+## Decision
+
+Quota data enters the kit **only through the vendors' own software**, with ak
+never reading, storing, or refreshing a vendor credential:
+
+1. **Claude — statusline tee.** The kit's managed statusline footer tees the
+   pushed `rate_limits` (plus `context_window` and `cost`) to
+   `~/.config/agentic-kit/claude-rate-limits.json` (0600, atomic, throttled to
+   one write per minute). Push, not pull: with no recent Claude session the
+   file goes stale, and the UI labels it stale rather than hiding it.
+2. **Codex — app-server subprocess.** `src/lib/quota.mjs` spawns
+   `codex -s read-only -a untrusted app-server` (codex authenticates itself),
+   performs one `initialize` → `account/rateLimits/read` exchange with a hard
+   timeout and kill, and caches the normalized answer for `CODEX_TTL_MS`.
+   This is the same shell-out trust model the dashboard already uses for
+   `ak status --json`.
+3. **The dashboard server itself still opens no sockets to the internet.**
+   ADR-0005/0007's egress split is unchanged: the Codex subprocess is vendor
+   code using vendor auth, and the Claude path is a local file read.
+
+Normalization rules (all in `quota.mjs`, all pinned by tests):
+
+- **Windows are keyed by duration, never by slot.** Codex's `primary` /
+  `secondary` fields do not reliably mean "5-hour" / "weekly" — a live
+  `prolite` account answered with `primary.windowDurationMins = 10080`.
+- `null` timestamps stay `null`; they are never coerced to epoch 0.
+- Every payload carries `fetchedAt`, and the UI renders freshness ("as of Nm
+  ago") next to every number.
+
+### Explicit non-paths
+
+- **No `api.anthropic.com/api/oauth/usage`.** Undocumented; hostile
+  rate-limiting to unrecognized clients; and Anthropic's consumer ToS bars
+  subscription OAuth tokens "in any other product, tool, or service", enforced
+  server-side since January 2026.
+- **No Keychain or credential-file reads** (the macOS item stopped carrying
+  the OAuth token in Claude Code 2.1.x; refresh tokens rotate destructively).
+- **No `chatgpt.com/backend-api/wham/*`** — private endpoints that would
+  require ak to hold and refresh the user's bearer token.
+- **No auto-consumption of Codex reset credits.** The panel reports them;
+  redeeming a finite grant is the user's action in codex's own `/usage`.
+
+## Consequences
+
+- The Limits sub-view can show authoritative, cross-device session/weekly
+  utilization — data local transcript parsing can never produce (ADR-0009 §3's
+  table of unknowables shrinks to: extra-usage credit balance and subscription
+  tier, which have no supported channel).
+- `usage-insights.mjs` gains limit-aware detectors (`detectLimitInsights`)
+  under the same evidence rules; vendor percentages count as the user's own
+  data, and no dollar impact is ever claimed from a percentage.
+- Codex attribution stops being heuristic: `codex-state.mjs` reads Codex's own
+  SQLite thread ledger (`state_*.sqlite`, glob — the numeric suffix is a
+  migration generation) for `thread_source` and spawn edges, demoting the
+  rollout-sniffing subagent guard to a fallback.
+- Two new 0600 cache files exist under `~/.config/agentic-kit/`; both are
+  derived, deletable, and self-healing.
+- The `codex app-server` surface is flagged experimental upstream; the client
+  pins nothing beyond two method names and degrades to "no data" with the
+  stale cache visible if the protocol shifts.
+
+## Research
+
+Grounded findings behind this ADR (full citations in the planning record):
+statusLine `rate_limits` — code.claude.com/docs/en/statusline.md; Admin
+Usage/Cost + Claude Code Analytics APIs are org-only —
+platform.claude.com/docs/en/manage-claude/usage-cost-api; consumer-OAuth
+prohibition — code.claude.com/docs/en/legal-and-compliance; Codex app-server
+schema — `codex app-server generate-json-schema` (verified live on codex
+0.145.0, 2026-07-27); Codex reset-credit detail — openai/codex#29618 (shipped
+via PR #30488); subagent rollout replay inflation — ccusage/ccusage#950;
+wham endpoint traffic complaints — openai/codex#10869, #27952.

--- a/src/lib/codex-state.mjs
+++ b/src/lib/codex-state.mjs
@@ -1,0 +1,79 @@
+// Codex's own thread ledger (~/.codex/state_N.sqlite) — the authoritative
+// source for per-thread attribution that the rollout JSONL can only guess at.
+//
+// Codex ≥0.140 maintains a `threads` table with a pre-aggregated `tokens_used`
+// column plus `thread_source` ('user' | 'subagent') and `source`
+// ('cli' | 'exec' | 'subagent'), and a `thread_spawn_edges` table recording
+// parent→child delegation. That replaces the kit's heuristic subagent-replay
+// guard (a `session_meta.thread_source` sniff, PR #60) with Codex's own
+// bookkeeping: a subagent rollout replays its parent's ENTIRE token history
+// (ccusage/ccusage#950 measured up to 91x inflation), so knowing which threads
+// are subagents is what keeps the totals honest.
+//
+// Deliberate limits:
+//   - READ-ONLY, always. `withDb` opens readonly and swallows every error —
+//     a locked or half-migrated db yields null, never a crash and never a lock
+//     held against the codex CLI itself.
+//   - The filename suffix (`state_5`) is a MIGRATION GENERATION, not a stable
+//     name. We glob `state_*.sqlite` and take the highest generation rather
+//     than hardcoding today's.
+//   - Column names are probed before use: a future migration that drops or
+//     renames a column degrades this module to null (callers fall back to the
+//     JSONL heuristic), not to a throw.
+import fs from 'node:fs';
+import path from 'node:path';
+import { codexDir } from './paths.mjs';
+import { withDb } from './sqlite.mjs';
+
+/** Newest-generation state db file under ~/.codex, or null. Exported for test
+ *  via the `dir` override. */
+export function codexStateDb(dir = codexDir()) {
+  let names;
+  try { names = fs.readdirSync(dir); } catch { return null; }
+  const gens = names
+    .map((n) => /^state_(\d+)\.sqlite$/.exec(n))
+    .filter(Boolean)
+    .map((m) => ({ name: m[0], gen: Number(m[1]) }))
+    .sort((a, b) => b.gen - a.gen);
+  return gens.length ? path.join(dir, gens[0].name) : null;
+}
+
+/**
+ * Read Codex's thread ledger. Returns
+ *   { threads: Map<id, {tokensUsed, threadSource, source, model, gitBranch}>,
+ *     parents: Map<childId, parentId> }
+ * or null when the db is absent, unreadable, or shaped unexpectedly.
+ *
+ * @param {{ dir?: string, file?: string }} [opts] test seams
+ */
+export function readCodexState(opts = {}) {
+  const file = opts.file ?? codexStateDb(opts.dir);
+  if (!file) return null;
+  return withDb(file, (db) => {
+    const cols = new Set(db.prepare('PRAGMA table_info(threads)').all().map((c) => c.name));
+    // id + thread_source are what the attribution fix rests on; without them
+    // this ledger cannot answer the question and the caller must fall back.
+    if (!cols.has('id') || !cols.has('thread_source')) return null;
+    const pick = ['id', 'thread_source']
+      .concat(['tokens_used', 'source', 'model', 'git_branch'].filter((c) => cols.has(c)));
+    const threads = new Map();
+    for (const row of db.prepare(`SELECT ${pick.join(', ')} FROM threads`).all()) {
+      threads.set(String(row.id), {
+        tokensUsed: Number(row.tokens_used) || 0,
+        threadSource: typeof row.thread_source === 'string' ? row.thread_source : null,
+        source: typeof row.source === 'string' ? row.source : null,
+        model: typeof row.model === 'string' ? row.model : null,
+        gitBranch: typeof row.git_branch === 'string' ? row.git_branch : null,
+      });
+    }
+    const parents = new Map();
+    try {
+      for (const e of db.prepare('SELECT parent_thread_id, child_thread_id FROM thread_spawn_edges').all()) {
+        if (e.child_thread_id != null && e.parent_thread_id != null) {
+          parents.set(String(e.child_thread_id), String(e.parent_thread_id));
+        }
+      }
+    } catch { /* the edges table is additive detail — attribution works without it */ }
+    return { threads, parents };
+  }, null);
+}

--- a/src/lib/dashboard-server.mjs
+++ b/src/lib/dashboard-server.mjs
@@ -262,12 +262,16 @@ function sendJson(res, status, payload) {
 
 /**
  * Start the dashboard HTTP server, bound to loopback only.
- * @param {{ port?: number, cwd?: string, fetchStatus?: () => Promise<any>, usage?: any }} [opts]
+ * @param {{ port?: number, cwd?: string, fetchStatus?: () => Promise<any>, usage?: any,
+ *           limits?: () => Promise<any> }} [opts]
  * @returns {Promise<{ url: string, port: number, close: () => Promise<void> }>}
  */
-export function startDashboard({ port = 7431, cwd = process.cwd(), fetchStatus, usage } = {}) {
+export function startDashboard({ port = 7431, cwd = process.cwd(), fetchStatus, usage, limits } = {}) {
   const provide = fetchStatus || shellOutStatus(cwd);
   const usageApi = usage || lazyUsage();
+  // Injectable like `usage`: tests must never spawn a real codex or read the
+  // real ~/.config through this route. Lazy for the same reason lazyUsage is.
+  const provideLimits = limits || (async () => (await import('./quota.mjs')).readLimits());
   const html = renderPage({ name: '@pacphi/agentic-kit', version: kitVersion() });
 
   const server = http.createServer(async (req, res) => {
@@ -346,6 +350,22 @@ export function startDashboard({ port = 7431, cwd = process.cwd(), fetchStatus, 
             rows: Array.isArray(n.rows) ? n.rows.slice(0, USAGE_TREE_PREVIEW) : [],
           })),
         });
+      } catch (e) {
+        sendJson(res, 500, { error: String(e && e.message || e) });
+      }
+      return;
+    }
+
+    // Plan-limit utilization (ADR-0010). Claude side is a pure file read (the
+    // statusline tee); Codex side may spawn ONE vendor subprocess (`codex
+    // app-server`), TTL-cached — the same shell-out trust model as
+    // `ak status --json` above. No vendor credential is ever read here.
+    if (url === '/api/limits') {
+      try {
+        const agg = await usageApi.readIndex({ days: clampDays(query.get('days')) }).catch(() => null);
+        const payload = await provideLimits();
+        const { detectLimitInsights } = await import('./usage-insights.mjs');
+        sendJson(res, 200, { ...payload, insights: detectLimitInsights(payload, agg) ?? [] });
       } catch (e) {
         sendJson(res, 500, { error: String(e && e.message || e) });
       }
@@ -517,9 +537,16 @@ function renderPage({ name, version }) {
     <div id="cards-providers"></div>
     <section class="strip" id="models" hidden>
       <div class="strip-head">
-        <h2 class="strip-title">models in play</h2>
+        <h2 class="strip-title">routed models</h2>
         <span class="mono strip-note" id="models-note"></span>
       </div>
+      <div class="note"><span class="i">&#8505;</span><span>This is your <b>per-activity routing policy</b> &mdash;
+        which host and model ak <i>assigns</i> to each kind of work. It is projected into
+        <b>agentic-qe</b> agent overrides and <b>ak dual run</b> pipelines; agentic-qe also has its own
+        model router, so a route here is the assignment, not a guarantee.
+        It does <b>not</b> govern the model an interactive Claude Code or codex CLI session uses &mdash;
+        you choose that per session with <span class="mono">/model</span>.
+        For the models that <b>actually ran</b>, see <b>Usage &rarr; Scorecard</b>.</span></div>
       <div class="model-list" id="model-list"></div>
     </section>
   </section>
@@ -552,6 +579,7 @@ function renderPage({ name, version }) {
     <div class="usage-bar">
       <div class="seg subseg" role="tablist" aria-label="usage views" id="usage-seg">
         <button class="seg-btn" role="tab" data-view="score" aria-selected="true" type="button">Scorecard</button>
+        <button class="seg-btn" role="tab" data-view="limits" aria-selected="false" type="button">Limits</button>
         <button class="seg-btn" role="tab" data-view="findings" aria-selected="false" type="button">Findings<span class="segbadge" id="u-findings-n" hidden></span></button>
         <button class="seg-btn" role="tab" data-view="sessions" aria-selected="false" type="button">Sessions<span class="mono seg-n" id="u-sessions-n"></span></button>
         <button class="seg-btn" role="tab" data-view="transcript" aria-selected="false" type="button">Transcript</button>
@@ -587,7 +615,7 @@ function renderPage({ name, version }) {
       </div>
       <div class="two">
         <section class="strip">
-          <div class="sh"><h2>models in play</h2><span class="n mono">by api-equivalent cost<span id="u-models-note"></span></span></div>
+          <div class="sh"><h2>models in play</h2><span class="n mono">observed in transcripts &middot; by api-equivalent cost<span id="u-models-note"></span></span></div>
           <div id="u-models"></div>
         </section>
         <section class="strip">
@@ -604,6 +632,26 @@ function renderPage({ name, version }) {
           <span class="lg">Unclassified is shown, never force-fit</span>
         </div>
       </section>
+    </section>
+
+    <section class="view" id="v-limits" hidden>
+      <div class="note"><span class="i">&#8505;</span><span>Utilization here is <b>vendor-reported</b> &mdash;
+        the plan&rsquo;s own percentages, a denominator local transcripts cannot compute.
+        Claude&rsquo;s numbers arrive via the managed statusLine while a session runs; Codex&rsquo;s come from
+        <b>codex app-server</b> using codex&rsquo;s own login. This panel reads no vendor credential.</span></div>
+      <div class="two">
+        <section class="strip">
+          <div class="sh"><h2>claude plan limits</h2><span class="n mono" id="u-lim-claude-note"></span></div>
+          <div class="lim" id="u-lim-claude"></div>
+        </section>
+        <section class="strip">
+          <div class="sh"><h2>codex plan limits</h2><span class="n mono" id="u-lim-codex-note"></span></div>
+          <div class="lim" id="u-lim-codex"></div>
+        </section>
+      </div>
+      <div class="ins-grid" id="u-lim-insights"></div>
+      <div class="foot">windows are keyed by their duration, never by the vendor&rsquo;s primary/secondary slot &middot;
+        stale data is labelled stale, not hidden</div>
     </section>
 
     <section class="view" id="v-findings" hidden>
@@ -1376,7 +1424,7 @@ const JS = `
   // subsystems fall back to Runtime so nothing is ever dropped. Overview
   // aggregates all attention cards regardless of category.
   var TABS=["overview","hosts","providers","runtime","intel","usage"];
-  var VIEWS=["score","findings","sessions","transcript"];
+  var VIEWS=["score","limits","findings","sessions","transcript"];
   var CAT={
     hosts:"hosts", mcp:"hosts", "codex-mcp":"hosts", routing:"hosts",
     providers:"providers",
@@ -1893,6 +1941,9 @@ const JS = `
     if(v==="transcript"&&usageSession&&(!TRANSCRIPT||TRANSCRIPT.id!==usageSession)){
       loadTranscript(usageSession).then(renderTranscript);
     }
+    // Limits is LAZY like the tab itself: the Codex side may spawn one vendor
+    // subprocess server-side, so it runs when the view is opened, not on poll.
+    if(v==="limits"&&!LIMITS)loadLimits();
   }
 
   // titleTxt is optional and goes on the OUTER .kpi, so the whole card is the
@@ -2031,6 +2082,102 @@ const JS = `
     }).join(""):'<div class="empty">nothing classified in window.</div>';
   }
 
+  // ══ Limits view (ADR-0010) ═════════════════════════════════════════════════
+  var LIMITS=null, limitsBusy=false;
+
+  function loadLimits(){
+    if(limitsBusy)return;
+    limitsBusy=true;
+    fetch("/api/limits?days="+usageDays,{cache:"no-store"})
+      .then(function(r){return r.json();})
+      .then(function(d){LIMITS=d&&!d.error?d:{error:(d&&d.error)||"limits unavailable"};})
+      .catch(function(){LIMITS={error:"limits unavailable"};})
+      .then(function(){limitsBusy=false; renderLimits();});
+  }
+
+  // "as of 3m ago" — an epoch-ms fetchedAt against the browser clock. Stale is
+  // LABELLED, never hidden: a yesterday's-number bar with no timestamp is a lie
+  // of omission.
+  function limAge(ms){
+    if(!ms||!isFinite(ms))return "";
+    var m=Math.max(0,Math.round((Date.now()-ms)/60000));
+    if(m<1)return "just now";
+    if(m<60)return m+"m ago";
+    var h=Math.round(m/60);
+    return h<48?h+"h ago":Math.round(h/24)+"d ago";
+  }
+  function limStale(ms,freshMs){return !ms||!isFinite(ms)||(Date.now()-ms)>freshMs;}
+  function resetTxt(sec){
+    if(!sec||!isFinite(sec))return "";
+    var d=new Date(sec*1000);
+    if(isNaN(d))return "";
+    return "resets "+d.toLocaleString(undefined,{month:"short",day:"numeric",hour:"2-digit",minute:"2-digit"});
+  }
+  // One utilization row on the shared .mrow grid; fill color says how close to
+  // the cap this window is (ok <70, warn ≥70, fail ≥90).
+  function limRow(label,usedPercent,resetSec,sub){
+    var p=Math.max(0,Math.min(100,Number(usedPercent)||0));
+    var col=p>=90?"var(--fail)":(p>=70?"var(--warn)":"var(--ok)");
+    return '<div class="mrow"><span class="mname">'+esc(label)+"</span>"
+      +'<span class="mbar"><i style="width:'+p.toFixed(1)+"%;background:"+col+'"></i></span>'
+      +'<span class="mval mono">'+p.toFixed(0)+"%</span>"
+      +'<span class="msub mono">'+esc(sub||resetTxt(resetSec))+"</span></div>";
+  }
+
+  function renderLimits(){
+    var claudeEl=document.getElementById("u-lim-claude");
+    var codexEl=document.getElementById("u-lim-codex");
+    if(!claudeEl||!codexEl)return;
+    if(!LIMITS){claudeEl.innerHTML='<div class="empty">loading&hellip;</div>'; codexEl.innerHTML='<div class="empty">loading&hellip;</div>'; return;}
+    if(LIMITS.error){claudeEl.innerHTML='<div class="empty">'+esc(LIMITS.error)+"</div>"; codexEl.innerHTML=""; return;}
+
+    var c=LIMITS.claude;
+    var cn=document.getElementById("u-lim-claude-note");
+    if(c&&c.windows&&c.windows.length){
+      // Claude's tee is push-only: FRESH means a session wrote it in the last
+      // 10 minutes; anything older gets the stale badge rather than silence.
+      if(cn)cn.textContent="statusline tee · "+limAge(c.fetchedAt)+(limStale(c.fetchedAt,600000)?" · stale":"");
+      claudeEl.innerHTML=c.windows.map(function(w){
+        return limRow("claude · "+(w.label||w.id),w.usedPercent,w.resetsAt);
+      }).join("");
+    }else{
+      if(cn)cn.textContent="no data";
+      claudeEl.innerHTML='<div class="empty">no Claude limit data yet &mdash; it arrives while a Claude Code session runs '
+        +"with the kit's managed statusline (Pro/Max plans only). Run one session, then revisit.</div>";
+    }
+
+    var x=LIMITS.codex;
+    var xn=document.getElementById("u-lim-codex-note");
+    if(x&&x.lanes&&x.lanes.length){
+      if(xn)xn.textContent=(x.planType?("plan "+x.planType+" · "):"")+"app-server · "+limAge(x.fetchedAt);
+      var html="";
+      for(var i=0;i<x.lanes.length;i++){
+        var lane=x.lanes[i];
+        for(var j=0;j<(lane.windows||[]).length;j++){
+          var w=lane.windows[j];
+          html+=limRow(lane.name+" · "+(w.label||""),w.usedPercent,w.resetsAt);
+        }
+        if(!(lane.windows||[]).length)html+=limRow(lane.name,0,null,"no window reported");
+      }
+      var rc=x.resetCredits;
+      if(rc&&rc.availableCount>0){
+        html+='<div class="legend" style="margin-top:11px"><span class="lg"><i style="background:var(--ok)"></i>'
+          +esc(fmtNum(rc.availableCount))+" rate-limit reset credit"+(rc.availableCount===1?"":"s")
+          +" available &middot; redeem via codex /usage</span></div>";
+      }
+      codexEl.innerHTML=html;
+    }else{
+      if(xn)xn.textContent="no data";
+      codexEl.innerHTML='<div class="empty">no Codex limit data &mdash; codex is not installed, not logged in, '
+        +"or app-server did not answer.</div>";
+    }
+
+    var ins=Array.isArray(LIMITS.insights)?LIMITS.insights:[];
+    document.getElementById("u-lim-insights").innerHTML=ins.length
+      ?ins.map(insightCard).join("")
+      :'<div class="empty">no limit findings &mdash; nothing is ahead of pace and no arbitrage is open.</div>';
+  }
+
   function renderFindings(d){
     var ins=Array.isArray(d.insights)?d.insights:[];
     var badge=document.getElementById("u-findings-n");
@@ -2040,28 +2187,34 @@ const JS = `
       ins.length+" finding"+(ins.length===1?"":"s")+", ranked by estimated impact. A finding only claims a "
       +"dollar figure when it can compute one from your data &mdash; the rest say <b>no $ claimed</b> rather "
       +"than inventing a number. Recommendations that depend on model-capability claims carry their sources.";
-    document.getElementById("u-insights").innerHTML=ins.length?ins.map(function(f,i){
-      var imp=(typeof f.impact==="number")
-        ? '<span class="i-imp mono">~'+esc(fmtUsd(f.impact))+"/window</span>"
-        : '<span class="i-imp mono soft">no $ claimed</span>';
-      var cmd=f.command?' <code class="i-cmd">'+esc(f.command)+"</code>":"";
-      var src="";
-      if(f.sources&&f.sources.length){
-        src='<details class="i-src"><summary>grounding &mdash; '+f.sources.length+" source"
-          +(f.sources.length===1?"":"s")+"</summary><ul>"
-          +f.sources.map(function(sc){
-            return "<li><a href=\\""+esc(sc.url)+"\\" target=\\"_blank\\" rel=\\"noreferrer noopener\\">"+esc(sc.label)+"</a></li>";
-          }).join("")+"</ul></details>";
-      }
-      return '<article class="icard" data-sev="'+esc(f.severity||"info")+'">'
-        +'<div class="i-top"><span class="i-n">'+(i+1)+"</span>"
-        +'<span class="i-title">'+esc(f.title)+"</span>"
-        +'<span class="i-kind">'+esc(f.kind==="trend"?"trend":"coaching")+"</span>"+imp+"</div>"
-        +'<p class="i-find">'+esc(f.finding)+"</p>"
-        +(f.evidence?'<p class="i-ev">'+esc(f.evidence)+"</p>":"")
-        +'<div class="i-act"><span class="i-arrow">&rarr;</span><span>'+esc(f.action)+cmd+"</span></div>"
-        +src+"</article>";
-    }).join(""):'<div class="empty">no findings — nothing in this window crossed a detector threshold.</div>';
+    document.getElementById("u-insights").innerHTML=ins.length
+      ?ins.map(insightCard).join("")
+      :'<div class="empty">no findings — nothing in this window crossed a detector threshold.</div>';
+  }
+
+  // One finding card. Shared by the Findings view and the Limits view — both
+  // render the same Insight contract, so they must render it the same way.
+  function insightCard(f,i){
+    var imp=(typeof f.impact==="number")
+      ? '<span class="i-imp mono">~'+esc(fmtUsd(f.impact))+"/window</span>"
+      : '<span class="i-imp mono soft">no $ claimed</span>';
+    var cmd=f.command?' <code class="i-cmd">'+esc(f.command)+"</code>":"";
+    var src="";
+    if(f.sources&&f.sources.length){
+      src='<details class="i-src"><summary>grounding &mdash; '+f.sources.length+" source"
+        +(f.sources.length===1?"":"s")+"</summary><ul>"
+        +f.sources.map(function(sc){
+          return "<li><a href=\\""+esc(sc.url)+"\\" target=\\"_blank\\" rel=\\"noreferrer noopener\\">"+esc(sc.label)+"</a></li>";
+        }).join("")+"</ul></details>";
+    }
+    return '<article class="icard" data-sev="'+esc(f.severity||"info")+'">'
+      +'<div class="i-top"><span class="i-n">'+(i+1)+"</span>"
+      +'<span class="i-title">'+esc(f.title)+"</span>"
+      +'<span class="i-kind">'+esc(f.kind==="trend"?"trend":"coaching")+"</span>"+imp+"</div>"
+      +'<p class="i-find">'+esc(f.finding)+"</p>"
+      +(f.evidence?'<p class="i-ev">'+esc(f.evidence)+"</p>":"")
+      +'<div class="i-act"><span class="i-arrow">&rarr;</span><span>'+esc(f.action)+cmd+"</span></div>"
+      +src+"</article>";
   }
 
   // A missing signal renders as an em dash and is NEVER omitted: a line that
@@ -2080,7 +2233,10 @@ const JS = `
       ? ' <span class="sd-conf">(conf '+esc(sx.confidence.toFixed(2))+")</span>" : "";
     var models=(Array.isArray(sx.models)&&sx.models.length)?sx.models.join(", "):"—";
     var toks="in "+fmtTok(sx.input)+" · out "+fmtTok(sx.output)
-      +" · cache r "+fmtTok(sx.cacheRead)+" / w "+fmtTok(sx.cacheWrite);
+      +" · cache r "+fmtTok(sx.cacheRead)+" / w "+fmtTok(sx.cacheWrite)
+      // Codex-only detail: reasoning tokens are a SUBSET of output (they bill
+      // as output), so this annotates the split without changing any sum.
+      +((Number(sx.reasoningOutput)||0)>0?" · reasoning "+fmtTok(sx.reasoningOutput)+" (in out)":"");
     var tmap=(sx.tools&&typeof sx.tools==="object"&&!Array.isArray(sx.tools))?sx.tools:{};
     var tl=[],tk;
     for(tk in tmap)tl.push({n:tk,c:Number(tmap[tk])||0});
@@ -2114,7 +2270,7 @@ const JS = `
     // Session ids are validated against [A-Za-z0-9._-]{1,128} by parseSessionId
     // before they are ever indexed, so they are safe AND unique as DOM ids.
     var sid=esc(sx.id);
-    var wt=sx.worktree!=null?'<span class="s-wt" title="git worktree — the repo is the project (ADR-0009 §4b)">⑂'+esc(sx.worktree)+"</span>":"";
+    var wt=sx.worktree!=null?'<span class="s-wt" title="git worktree — the repo is the project">⑂'+esc(sx.worktree)+"</span>":"";
     return '<div class="srow" data-id="'+sid+'" title="open transcript">'
       +'<button class="s-exp" type="button" aria-expanded="false" aria-controls="sd-'+sid+'"'
         +' title="show session detail" aria-label="show session detail">&rsaquo;</button>'
@@ -2308,6 +2464,8 @@ const JS = `
       var all=chips.querySelectorAll("[data-days]");
       for(var i=0;i<all.length;i++)all[i].classList.toggle("on",all[i]===b);
       usageLoaded=false; loadUsage(true);
+      // limit findings are computed against the same window; refetch on change.
+      LIMITS=null; if(usageView==="limits")loadLimits();
     });
     var panel=document.getElementById("panel-usage");
     if(panel)panel.addEventListener("click",function(e){

--- a/src/lib/dashboard-server.mjs
+++ b/src/lib/dashboard-server.mjs
@@ -615,7 +615,7 @@ function renderPage({ name, version }) {
       </div>
       <div class="two">
         <section class="strip">
-          <div class="sh"><h2>models in play</h2><span class="n mono">observed in transcripts &middot; by api-equivalent cost<span id="u-models-note"></span></span></div>
+          <div class="sh"><h2>models in play</h2><span class="n mono">observed in transcripts &middot; by api-equivalent cost<span class="n-sub" id="u-models-note"></span></span></div>
           <div id="u-models"></div>
         </section>
         <section class="strip">
@@ -1075,6 +1075,12 @@ body{
 .sh{display:flex; align-items:baseline; justify-content:space-between; gap:12px; margin-bottom:14px}
 .sh h2{font-size:15px; font-weight:600; letter-spacing:-.014em; margin:0}
 .sh .n{color:var(--ink-dim); font-size:11.5px}
+/* A qualifier that must not share a line with the caption it qualifies: as an
+   inline tail it wrapped mid-phrase, leaving "· 4" dangling at the end of one
+   line and "dropped/errored turns excluded" orphaned on the next — the count
+   read as part of the caption rather than as its own fact. */
+.sh .n-sub{display:block}
+.sh .n-sub:empty{display:none}
 .two{display:grid; gap:16px; grid-template-columns:repeat(auto-fit,minmax(330px,1fr))}
 #panel-usage .strip{margin-top:0; margin-bottom:16px}
 
@@ -2055,8 +2061,10 @@ const JS = `
     // model — excluded from this list entirely rather than shown as a $0 row
     // (see docs/USAGE-SCORECARD-METRICS.md §10). Surfaced here instead, only
     // when nonzero, so they stay visible rather than silently vanishing.
+    // On its own line (.n-sub), so no leading separator — a "·" would read as a
+    // continuation of the caption above rather than the start of a new fact.
     var exc=fld(t,"exceptions");
-    document.getElementById("u-models-note").textContent=exc?(" · "+fmtNum(exc)+" dropped/errored turn"+(exc===1?"":"s")+" excluded"):"";
+    document.getElementById("u-models-note").textContent=exc?(fmtNum(exc)+" dropped/errored turn"+(exc===1?"":"s")+" excluded"):"";
 
     var projects=entries(d.byProject), pMax=projects.length?projects[0].cost:0;
     var shown=projects.slice(0,8);

--- a/src/lib/pricing.mjs
+++ b/src/lib/pricing.mjs
@@ -17,8 +17,43 @@
 /** The date the whole table was last verified — date-stamped in the UI. */
 export const PRICES_AS_OF = '2026-07-25';
 
-const anthropic = (i, o) => ({ in: i, out: o, provider: 'anthropic', asOf: PRICES_AS_OF });
-const openai = (i, o) => ({ in: i, out: o, provider: 'openai', asOf: PRICES_AS_OF });
+// ── Rate constructors ────────────────────────────────────────────────────────
+// A rate entry is always a SCHEDULE — an ordered list of periods, each with the
+// day it takes effect. The overwhelmingly common case is one period that has
+// always applied, so `anthropic(3, 15)` stays the terse form and builds a
+// single-period schedule; `.dated([...])` is for the rare entry whose rate the
+// vendor has PUBLISHED a change to.
+//
+// The mechanism is deliberately IDENTICAL for both vendors. A date range is a
+// fact about a price, not about a provider, and today's asymmetry — Anthropic
+// has published a dated change, OpenAI has not — is a fact about the DATA, not
+// about the mechanics. Encoding it in the shape of the table would mean that
+// the day OpenAI ships a promo rate, someone has to build a second mechanism
+// under deadline pressure and then keep two sets of boundary tests from
+// drifting apart. This mirrors `costOf`, which has no per-provider branch for
+// exactly the same reason (see the multiplier note below).
+//
+// NOT expressible here, on purpose: rates that vary by HOW a request was served
+// rather than WHEN — regional uplift, the large-prompt surcharge, service
+// tiers. Those are a different axis, transcripts do not record the endpoint or
+// tier, and stretching this into a general modifier system would manufacture
+// precision the data cannot support. They stay in UNMODELLED_PRICING_FACTORS.
+const schedule = (provider) => {
+  // `from` absent on the first period = "has always applied". Periods are kept
+  // sorted so selection is a scan for the last one already in effect.
+  const build = (periods) => ({
+    provider,
+    asOf: PRICES_AS_OF,
+    periods: [...periods]
+      .map((p) => ({ from: p.from ?? null, in: p.in, out: p.out }))
+      .sort((a, b) => String(a.from ?? '').localeCompare(String(b.from ?? ''))),
+  });
+  const make = (i, o) => build([{ in: i, out: o }]);
+  make.dated = build;
+  return make;
+};
+const anthropic = schedule('anthropic');
+const openai = schedule('openai');
 
 /**
  * Model-id PREFIX → { in, out, provider, asOf }, in $ per 1M tokens.
@@ -38,12 +73,16 @@ export const PRICES = {
   'claude-opus-4-6': anthropic(5, 25),
   'claude-opus-4-5': anthropic(5, 25),
   // Anthropic — Sonnet line.
-  // Sonnet 5 is on INTRODUCTORY pricing ($2/$10) through 2026-08-31; the
-  // standard rate is $3/$15. We carry the rate actually billed today, because
-  // the panel's claim is "what these tokens would cost metered" — using the
-  // standard rate would overstate a Sonnet-heavy window by 50%.
-  // ⚠ ON 2026-09-01 THIS MUST REVERT TO anthropic(3, 15).
-  'claude-sonnet-5': anthropic(2, 10),
+  // Sonnet 5 launched on INTRODUCTORY pricing ($2/$10) through 2026-08-31,
+  // reverting to the standard $3/$15 on 2026-09-01. Anthropic PUBLISHED that
+  // end date, so it is a recorded fact rather than a forecast — which is the
+  // bar for putting anything in a `dated` schedule. Tokens spent before the
+  // boundary stay priced at the rate they were metered at, forever; only
+  // tokens spent on or after it price at the standard rate.
+  'claude-sonnet-5': anthropic.dated([
+    { in: 2, out: 10 },                      // introductory, from launch
+    { from: '2026-09-01', in: 3, out: 15 },  // standard
+  ]),
   'claude-sonnet-4-6': anthropic(3, 15),
   'claude-sonnet-4-5': anthropic(3, 15),
   // Anthropic — Haiku line
@@ -54,9 +93,12 @@ export const PRICES = {
   // ~/.codex/models_cache.json (checked: zero price/pricing/usd keys), so this
   // table is maintained by hand and is the most drift-prone thing in this file.
   //
-  // UNLIKE ANTHROPIC, OpenAI publishes no introductory or promotional rates —
-  // the pricing page carries no promo tiers and no expiry dates. So there is no
-  // OpenAI equivalent of the Sonnet 5 intro caveat above; these are simply list.
+  // As of the verification date OpenAI publishes no introductory or promotional
+  // rates — the pricing page carries no promo tiers and no expiry dates — so
+  // every entry below is a single always-applied period. That is a fact about
+  // the DATA, not a limitation of the table: `openai.dated([...])` is available
+  // and behaves identically to the Anthropic case, so if OpenAI ships a dated
+  // promo it is a one-line edit here rather than new machinery.
   //
   // OpenAI's cached-input rate is a 90% discount (0.1x) and cache writes are
   // 1.25x — the SAME multipliers as Anthropic, which is why costOf() needs no
@@ -130,6 +172,30 @@ const KEYS_BY_LENGTH = Object.keys(PRICES)
   .sort((a, b) => b.norm.length - a.norm.length);
 
 /**
+ * The period of a schedule in effect on `day` — the last one whose `from` has
+ * already arrived. `day` is an ISO date string (`YYYY-MM-DD`), compared
+ * lexicographically, which is exact for that format and needs no Date parsing.
+ *
+ * A missing/invalid `day` falls back to **PRICES_AS_OF**, the date this table
+ * was last verified — deliberately NOT the newest period. "Newest" only means
+ * "current" once every published change has taken effect, and deciding whether
+ * one has requires a clock this module does not read (its purity is what makes
+ * the arithmetic testable). Verification date is the honest answer to a
+ * dateless query, and it is the same date the UI already prints as
+ * "rates as of …", so the default and the label can never disagree.
+ */
+function periodOn(periods, day) {
+  const raw = typeof day === 'string' && /^\d{4}-\d{2}-\d{2}/.test(day) ? day : PRICES_AS_OF;
+  const when = raw.slice(0, 10);
+  let chosen = periods[0];
+  for (const p of periods) {
+    if (p.from === null || p.from <= when) chosen = p;
+    else break;
+  }
+  return chosen;
+}
+
+/**
  * Resolve a model id to its rates: `{ in, out, provider, key, matched }`.
  *
  * Longest-prefix match over `PRICES`. `provider` is a HINT used only to break a
@@ -137,15 +203,23 @@ const KEYS_BY_LENGTH = Object.keys(PRICES)
  * because the id is the stronger signal. An unrecognised (or absent, or
  * non-string) model yields `FALLBACK_PRICE` with `matched:false`; this function
  * never throws.
+ *
+ * `day` (ISO `YYYY-MM-DD`) selects the rate IN EFFECT ON THAT DAY. Cost
+ * attribution is historical: tokens spent in August were metered at August's
+ * rate and must still read that way in October. Pricing by "now" instead would
+ * retroactively restate finished windows the moment a published rate changed —
+ * a panel whose claim is "what these tokens would cost metered" cannot do that.
+ * Omitting `day` prices as of `PRICES_AS_OF` (see `periodOn`).
  */
-export function priceFor(model, provider) {
+export function priceFor(model, provider, day) {
   const id = typeof model === 'string' ? normalize(model) : '';
   if (id) {
     const hits = KEYS_BY_LENGTH.filter(({ norm }) => isPrefixOf(norm, id));
     if (hits.length) {
       const best = (provider && hits.find(({ key }) => PRICES[key].provider === provider)) || hits[0];
       const p = PRICES[best.key];
-      return { in: p.in, out: p.out, provider: p.provider, key: best.key, matched: true };
+      const r = periodOn(p.periods, day);
+      return { in: r.in, out: r.out, provider: p.provider, key: best.key, matched: true };
     }
   }
   return { ...FALLBACK_PRICE, key: null, matched: false };
@@ -165,10 +239,14 @@ const tokens = (v) => (Number.isFinite(v) && v > 0 ? v : 0);
  * `0`. An unknown model is priced at the fallback rate rather than zeroed, and
  * junk input is coerced rather than thrown on — this runs over transcripts the
  * kit did not write.
+ *
+ * `usage.day` (ISO `YYYY-MM-DD`) prices the row at the rate in effect that day.
+ * Usage rows are already keyed by day upstream, so the caller has it in hand;
+ * omitting it falls back to the current standing rate.
  */
 export function costOf(usage) {
-  const { model, provider, input, output, cacheRead, cacheWrite } = usage ?? {};
-  const { in: rin, out: rout } = priceFor(model, provider);
+  const { model, provider, input, output, cacheRead, cacheWrite, day } = usage ?? {};
+  const { in: rin, out: rout } = priceFor(model, provider, day);
   const inputUnits = tokens(input)
     + tokens(cacheWrite) * CACHE_WRITE_MULTIPLIER
     + tokens(cacheRead) * CACHE_READ_MULTIPLIER;

--- a/src/lib/quota.mjs
+++ b/src/lib/quota.mjs
@@ -1,0 +1,258 @@
+// Provider-mediated quota reads (ADR-0010). The ONLY honest denominators for
+// "how much of my plan have I used" are the vendors' own percentages, and both
+// vendors expose them without ak ever touching a credential:
+//
+//   Claude — Claude Code PUSHES a `rate_limits` object (session/weekly/
+//     per-model used-percentage + reset epochs) into every statusLine
+//     invocation (code.claude.com/docs/en/statusline.md). The kit's managed
+//     statusline tees that JSON to claude-rate-limits.json; this module only
+//     READS the tee. Push, not pull: with no recent Claude session the file
+//     goes stale, and staleness is REPORTED, never papered over.
+//   Codex — `codex app-server` (JSON-RPC over stdio) answers
+//     `account/rateLimits/read` using codex's own auth. ak spawns the vendor's
+//     CLI read-only (same trust model as the dashboard's `ak status` shell-out)
+//     and caches the normalized answer with a TTL.
+//
+// Explicit NON-paths, per the research behind ADR-0010: no `/api/oauth/usage`
+// (undocumented; consumer-OAuth use outside Claude Code is ToS-prohibited and
+// server-enforced), no Keychain/credentials reads, no chatgpt.com backend
+// endpoints (private; requires bearer-token handling ak must not do).
+//
+// Field-name trap, load-bearing: Codex's `primary`/`secondary` window fields do
+// NOT reliably mean "5-hour"/"weekly" — a live prolite account answered with
+// `primary.windowDurationMins = 10080` (the weekly) and `secondary = null`.
+// Everything here therefore keys windows on their DURATION, never their slot.
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import { configDir } from './paths.mjs';
+
+export const claudeLimitsFile = () => path.join(configDir(), 'claude-rate-limits.json');
+export const codexLimitsFile = () => path.join(configDir(), 'codex-rate-limits.json');
+
+/** How long a cached Codex answer stays fresh, and how long a Claude tee stays
+ *  fresh enough to show without a stale badge. Named because the UI's honesty
+ *  ("as of Nm ago") depends on them. */
+export const CODEX_TTL_MS = 5 * 60 * 1000;
+export const CLAUDE_FRESH_MS = 10 * 60 * 1000;
+
+// null/undefined must stay null — Number(null) is 0, and a null resets_at
+// coerced to 0 would render as an epoch-1970 reset time.
+const num = (v) => (v == null ? null : (Number.isFinite(Number(v)) ? Number(v) : null));
+
+/** minutes → the label a person would use. Duration-derived, never slot-derived. */
+export function windowLabel(minutes) {
+  if (!Number.isFinite(minutes)) return 'window';
+  if (minutes === 300) return '5h';
+  if (minutes === 10080) return 'weekly';
+  if (minutes % 1440 === 0) return `${minutes / 1440}d`;
+  if (minutes % 60 === 0) return `${minutes / 60}h`;
+  return `${minutes}m`;
+}
+
+// ── Claude (statusline tee) ─────────────────────────────────────────────────
+
+/**
+ * Normalize the tee'd statusLine payload. The documented shape is
+ * `rate_limits.{five_hour,seven_day}.{used_percentage,resets_at}` with
+ * resets_at in EPOCH SECONDS; per-model weekly buckets (`seven_day_opus`, …)
+ * appear for some plans, and each window may be independently absent. Pure;
+ * returns null when there is nothing usable.
+ */
+export function normalizeClaudeLimits(raw) {
+  const rl = raw?.rate_limits;
+  if (!rl || typeof rl !== 'object') return null;
+  const KNOWN_MINUTES = { five_hour: 300, seven_day: 10080 };
+  const windows = [];
+  for (const [key, w] of Object.entries(rl)) {
+    if (!w || typeof w !== 'object') continue;
+    const usedPercent = num(w.used_percentage);
+    if (usedPercent === null) continue;
+    windows.push({
+      id: key,
+      label: key.startsWith('seven_day_')
+        ? `weekly · ${key.slice('seven_day_'.length)}`
+        : windowLabel(KNOWN_MINUTES[key] ?? NaN),
+      usedPercent,
+      windowMinutes: KNOWN_MINUTES[key] ?? (key.startsWith('seven_day') ? 10080 : null),
+      resetsAt: num(w.resets_at),
+    });
+  }
+  if (!windows.length) return null;
+  return {
+    provider: 'claude',
+    source: 'statusline',
+    fetchedAt: num(raw.teedAt) ?? null,
+    sessionId: typeof raw.session_id === 'string' ? raw.session_id : null,
+    windows,
+  };
+}
+
+/** Read the statusline tee. Absent/unparseable → null (the UI's empty state
+ *  explains how to produce one — run a Claude session with the managed
+ *  statusline — rather than pretending the measurement failed). */
+export function readClaudeLimits({ file = claudeLimitsFile() } = {}) {
+  try { return normalizeClaudeLimits(JSON.parse(fs.readFileSync(file, 'utf8'))); }
+  catch { return null; }
+}
+
+// ── Codex (app-server) ──────────────────────────────────────────────────────
+
+/**
+ * Normalize a GetAccountRateLimitsResponse. Lanes come from
+ * `rateLimitsByLimitId` (per-model pools, e.g. `codex` + `codex_bengalfox`)
+ * with the legacy single-bucket `rateLimits` as fallback. Pure.
+ */
+export function normalizeCodexLimits(resp, { fetchedAt = null } = {}) {
+  if (!resp || typeof resp !== 'object') return null;
+  const byId = resp.rateLimitsByLimitId && typeof resp.rateLimitsByLimitId === 'object'
+    ? resp.rateLimitsByLimitId
+    : (resp.rateLimits ? { [resp.rateLimits.limitId ?? 'codex']: resp.rateLimits } : {});
+  const lanes = [];
+  for (const [id, snap] of Object.entries(byId)) {
+    if (!snap || typeof snap !== 'object') continue;
+    const windows = [];
+    for (const w of [snap.primary, snap.secondary]) {
+      if (!w || typeof w !== 'object') continue;
+      const usedPercent = num(w.usedPercent);
+      if (usedPercent === null) continue;
+      const windowMinutes = num(w.windowDurationMins);
+      windows.push({
+        id: `${id}:${windowMinutes ?? 'window'}`,
+        label: windowLabel(windowMinutes ?? NaN),
+        usedPercent, windowMinutes,
+        resetsAt: num(w.resetsAt),
+      });
+    }
+    lanes.push({
+      id,
+      name: typeof snap.limitName === 'string' && snap.limitName ? snap.limitName : id,
+      planType: typeof snap.planType === 'string' ? snap.planType : null,
+      windows,
+    });
+  }
+  if (!lanes.length) return null;
+  const rc = resp.rateLimitResetCredits;
+  const resetCredits = rc && typeof rc === 'object' && Number.isFinite(Number(rc.availableCount))
+    ? {
+      availableCount: Number(rc.availableCount),
+      credits: (Array.isArray(rc.credits) ? rc.credits : [])
+        .filter((c) => c && typeof c === 'object')
+        .map((c) => ({
+          status: typeof c.status === 'string' ? c.status : null,
+          title: typeof c.title === 'string' ? c.title : null,
+          expiresAt: num(c.expiresAt),
+        })),
+    }
+    : null;
+  return {
+    provider: 'codex',
+    source: 'app-server',
+    fetchedAt,
+    planType: lanes.find((l) => l.planType)?.planType ?? null,
+    lanes,
+    resetCredits,
+  };
+}
+
+/**
+ * One JSON-RPC exchange with `codex app-server`: initialize, then
+ * account/rateLimits/read, then kill the child (it does not exit on EOF —
+ * verified live — so the timeout and the kill are both load-bearing).
+ * Read-only, untrusted sandbox flags; codex handles its own auth and refresh.
+ * Resolves the raw response object, or null on any failure.
+ */
+export function codexAppServerRateLimits({ timeoutMs = 15_000, spawnImpl = spawn, bin = 'codex' } = {}) {
+  return new Promise((resolve) => {
+    let child;
+    try {
+      child = spawnImpl(bin, ['-s', 'read-only', '-a', 'untrusted', 'app-server'],
+        { stdio: ['pipe', 'pipe', 'ignore'] });
+    } catch { resolve(null); return; }
+    let buf = '';
+    let settled = false;
+    const done = (value) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      try { child.kill(); } catch { /* already gone */ }
+      resolve(value);
+    };
+    const timer = setTimeout(() => done(null), timeoutMs);
+    child.on('error', () => done(null));
+    child.on('exit', () => done(null));
+    child.stdout.on('data', (chunk) => {
+      buf += String(chunk);
+      let nl;
+      while ((nl = buf.indexOf('\n')) >= 0) {
+        const line = buf.slice(0, nl); buf = buf.slice(nl + 1);
+        let msg;
+        try { msg = JSON.parse(line); } catch { continue; }
+        if (msg?.id === 1) {
+          // initialized → notify per protocol, then ask the real question.
+          try {
+            child.stdin.write(`${JSON.stringify({ jsonrpc: '2.0', method: 'initialized' })}\n`);
+            child.stdin.write(`${JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'account/rateLimits/read', params: {} })}\n`);
+          } catch { done(null); }
+        } else if (msg?.id === 2) {
+          done(msg.result && typeof msg.result === 'object' ? msg.result : null);
+        }
+      }
+    });
+    try {
+      child.stdin.write(`${JSON.stringify({
+        jsonrpc: '2.0', id: 1, method: 'initialize',
+        params: { clientInfo: { name: 'agentic-kit', title: 'agentic-kit dashboard', version: '0' } },
+      })}\n`);
+    } catch { done(null); }
+  });
+}
+
+/**
+ * Cached Codex quota. Fresh cache → served as-is; stale → one app-server call,
+ * cache rewritten on success; failure → the stale cache (age visible via
+ * `fetchedAt`) rather than nothing, or null when there has never been an
+ * answer (codex absent / logged out).
+ *
+ * @param {{ ttlMs?: number, cacheFile?: string, now?: number,
+ *           timeoutMs?: number, spawnImpl?: any, bin?: string }} [o]
+ */
+export async function collectCodexLimits({
+  ttlMs = CODEX_TTL_MS, cacheFile = codexLimitsFile(), now = Date.now(),
+  timeoutMs, spawnImpl, bin,
+} = {}) {
+  let cached = null;
+  try { cached = JSON.parse(fs.readFileSync(cacheFile, 'utf8')); } catch { /* first run */ }
+  if (cached && Number.isFinite(cached.fetchedAt) && now - cached.fetchedAt < ttlMs) return cached;
+
+  const resp = await codexAppServerRateLimits({ timeoutMs, spawnImpl, bin });
+  const fresh = normalizeCodexLimits(resp, { fetchedAt: now });
+  if (!fresh) return cached; // stale beats silent-nothing; null when never answered
+  try {
+    fs.mkdirSync(path.dirname(cacheFile), { recursive: true });
+    const tmp = `${cacheFile}.${process.pid}.tmp`;
+    // 0600 like the usage cache: plan type and utilization are the user's own
+    // account details, not world-readable material.
+    fs.writeFileSync(tmp, JSON.stringify(fresh), { mode: 0o600 });
+    fs.renameSync(tmp, cacheFile);
+  } catch { /* an unwritable cache costs a refetch, never the answer */ }
+  return fresh;
+}
+
+// ── Combined read (the /api/limits payload) ─────────────────────────────────
+
+/**
+ * Both providers, plus the freshness contract the UI renders: `fetchedAt` on
+ * each side and `generatedAt` overall. Claude is a pure file read (push
+ * model); Codex may spawn one vendor subprocess, TTL-bounded.
+ *
+ * @param {{ now?: number, claudeFile?: string, codexCacheFile?: string, ttlMs?: number,
+ *           timeoutMs?: number, spawnImpl?: any, bin?: string }} [o]
+ */
+export async function readLimits({ now = Date.now(), claudeFile, codexCacheFile, ttlMs, timeoutMs, spawnImpl, bin } = {}) {
+  const claude = readClaudeLimits({ file: claudeFile ?? claudeLimitsFile() });
+  const codex = await collectCodexLimits({
+    ttlMs, cacheFile: codexCacheFile ?? codexLimitsFile(), now, timeoutMs, spawnImpl, bin,
+  });
+  return { generatedAt: new Date(now).toISOString(), claude, codex };
+}

--- a/src/lib/usage-index.mjs
+++ b/src/lib/usage-index.mjs
@@ -813,8 +813,13 @@ function aggregate(records, { days, now, cutoff, deps }) {
     let firstDay = null;
     for (const row of rec.usage) {
       if (firstDay === null || row.day < firstDay) firstDay = row.day;
+      // `day` prices the row at the rate in effect WHEN THOSE TOKENS WERE
+      // SPENT, not today's. A published rate change (Sonnet 5's introductory
+      // period ending 2026-09-01) must not retroactively restate a finished
+      // window — August's spend was metered at August's rate and has to keep
+      // reading that way. Rows are already keyed by day, so this costs nothing.
       const rowCost = deps.costOf({
-        model: row.model, provider: rec.provider,
+        model: row.model, provider: rec.provider, day: row.day,
         input: row.input, output: row.output, cacheRead: row.cacheRead, cacheWrite: row.cacheWrite,
       }) || 0;
       input += row.input; output += row.output;

--- a/src/lib/usage-index.mjs
+++ b/src/lib/usage-index.mjs
@@ -31,6 +31,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { configDir, claudeDir, codexDir } from './paths.mjs';
+import { readCodexState } from './codex-state.mjs';
 
 /** Bump to invalidate every cached entry wholesale.
  *  v2: cached records carry `active` sub-intervals for the idle-gap split.
@@ -46,8 +47,13 @@ import { configDir, claudeDir, codexDir } from './paths.mjs';
  *  v5: harness-output envelopes (task-notification, bash-stdout,
  *      local-command-stdout, …) no longer count as human prompts, so the
  *      cached `prompts` figure on every session parsed before this rule is
- *      inflated and must be re-derived. */
-export const SCHEMA_VERSION = 5;
+ *      inflated and must be re-derived.
+ *  v6: Codex sessions grow `reasoningOutput` (reasoning tokens inside output)
+ *      and `rateLimits` (the LAST rate-limit snapshot embedded in the
+ *      rollout's token_count events). A v5-cached Codex session carries
+ *      neither and must be re-derived, or the Limits history reads as empty
+ *      for exactly the sessions that have data. */
+export const SCHEMA_VERSION = 6;
 
 /** Silence longer than this ends a stretch of engagement. A session is split
  *  into active sub-intervals at gaps ABOVE this bound (exactly this much is not
@@ -287,6 +293,10 @@ function blankSession(id, provider) {
     id, provider, title: '', project: 'unknown', start: null, end: null,
     prompts: 0, responses: 0, exceptions: 0, sidechain: false, threadSource: null, models: [], tools: {},
     skill: null, plugin: null, worktree: null, usage: [], punchcard: {}, active: [], stamps: [],
+    // Codex-only detail (v6): reasoning tokens inside output, and the last
+    // rate-limit snapshot the rollout carried. Claude sessions keep the zero
+    // and the null — absent, not unknown.
+    reasoningOutput: 0, rateLimits: null,
   };
 }
 
@@ -542,6 +552,33 @@ function parseCodex(raw, { id, withTurns = false }) {
     if (p.type === 'token_count') {
       const t = p.info?.total_token_usage;
       if (t && typeof t === 'object') { lastUsage = t; lastUsageAt = ms; }
+      // Every token_count also carries a live rate-limit snapshot — keep the
+      // LAST one, normalized. Field names are a trap upstream: `primary` is
+      // whichever window the server listed first, NOT reliably the 5-hour one
+      // (observed live: primary = the 10080-minute weekly). So windows are
+      // kept as a flat list keyed by window_minutes and never by field name.
+      const rl = p.rate_limits;
+      if (rl && typeof rl === 'object') {
+        const windows = [];
+        for (const w of [rl.primary, rl.secondary]) {
+          if (!w || typeof w !== 'object') continue;
+          const usedPercent = Number(w.used_percent);
+          const windowMinutes = Number(w.window_minutes);
+          if (!Number.isFinite(usedPercent) || !Number.isFinite(windowMinutes)) continue;
+          windows.push({
+            usedPercent, windowMinutes,
+            resetsAt: Number.isFinite(Number(w.resets_at)) ? Number(w.resets_at) : null,
+          });
+        }
+        if (windows.length) {
+          rec.rateLimits = {
+            at: Number.isFinite(ms) ? ms : null,
+            limitId: typeof rl.limit_id === 'string' ? rl.limit_id : null,
+            planType: typeof rl.plan_type === 'string' ? rl.plan_type : null,
+            windows,
+          };
+        }
+      }
       continue;
     }
     if (p.type === 'user_message') {
@@ -580,6 +617,10 @@ function parseCodex(raw, { id, withTurns = false }) {
       cacheWrite: 0,
       responses: rec.responses,
     });
+    // Reasoning tokens are a SUBSET of output_tokens (they bill as output) —
+    // recorded as detail, never added into any token sum, or the total would
+    // double-count exactly the reasoning share.
+    rec.reasoningOutput = Number(lastUsage.reasoning_output_tokens) || 0;
   }
 
   rec.title = maskSecrets(clip(firstPrompt)) || '(untitled)';
@@ -811,6 +852,10 @@ function aggregate(records, { days, now, cutoff, deps }) {
       confidence: verdict.confidence ?? 0,
       basis: verdict.basis ?? 'no signal',
       skill: rec.skill, plugin: rec.plugin,
+      // Codex-only detail (v6); zero / null on Claude sessions and on v5-cached
+      // records (the schema bump re-derives those).
+      reasoningOutput: rec.reasoningOutput ?? 0,
+      rateLimits: rec.rateLimits ?? null,
       _span: [rec.start ?? rec.end, rec.end],
       // Pre-v2 cache entries have no `active`; fall back to the whole span so a
       // stale record degrades to the old figure instead of vanishing.
@@ -891,12 +936,22 @@ function aggregate(records, { days, now, cutoff, deps }) {
 
   for (const s of sessions) { delete s._span; delete s._active; delete s._punchcard; delete s._day; }
 
+  // Local rate-limit history: every Codex rollout embeds live quota snapshots
+  // in its token_count events, so a utilization time series is reconstructable
+  // retroactively with ZERO network — one point per session (its last
+  // snapshot), oldest first. Claude has no local analogue (its quota arrives
+  // via the statusline push — see quota.mjs), hence codex-prefixed.
+  const codexRateLimits = sessions
+    .filter((s) => s.provider === 'codex' && s.rateLimits && Number.isFinite(s.rateLimits.at))
+    .map((s) => s.rateLimits)
+    .sort((x, y) => x.at - y.at);
+
   const agg = {
     generatedAt: new Date(now).toISOString(),
     windowDays: days,
     pricesAsOf: deps.pricesAsOf ?? null,
     totals, byDay, byModel, byProvider, byProject, byCategory,
-    punchcard, projectTree, sessions, insights: [],
+    punchcard, projectTree, sessions, codexRateLimits, insights: [],
   };
   agg.insights = deps.detectInsights(agg) ?? [];
   return agg;
@@ -936,6 +991,8 @@ function notify(onProgress, payload) {
  * @property {string} [cachePath]   override the index cache location (tests)
  * @property {number} [now]         override "now" (tests)
  * @property {number} [maxAgeMs]    readIndex only: memo TTL
+ * @property {object|null} [codexState] override the Codex SQLite thread ledger
+ *           (tests); null skips the read entirely, undefined reads the real db
  * @property {{costOf: Function, pricesAsOf?: string, classify: Function, detectInsights: Function}} [deps]
  *           inject the pricing/classification/insights seam (tests)
  */
@@ -1003,7 +1060,45 @@ async function scan(o = {}) {
   writeCache(cacheFile, { schemaVersion: SCHEMA_VERSION, updatedAt: new Date(now).toISOString(), entries });
   notify(onProgress, { scanned: total, total, phase: 'aggregate' });
 
-  return aggregate(records, { days, now, cutoff, deps });
+  // Codex's own thread ledger outranks the rollout heuristic (`undefined` →
+  // read the real db; tests pass an object, or null to skip). Applied AFTER the
+  // cache write, on copies: the cache stores what the FILE said, the aggregate
+  // reflects what Codex's ledger knows — a ledger that arrives later (or gets
+  // repaired) corrects old sessions without a cache invalidation.
+  // Overridden roots (tests, sandboxes) imply the REAL ~/.codex ledger is the
+  // wrong ledger for these records — reading it would break test hermeticity
+  // and mis-attribute fixture sessions. Only default roots read the real db.
+  const ledger = o.codexState !== undefined
+    ? o.codexState
+    : (roots?.codex ? null : readCodexState());
+  return aggregate(applyCodexLedger(records, ledger), { days, now, cutoff, deps });
+}
+
+/**
+ * Overlay Codex's SQLite thread ledger onto parsed session records. Pure —
+ * returns copies where anything changes, never mutates a (possibly cached)
+ * record. Two corrections, both attribution-only:
+ *   - a session whose rollout carried no `thread_source` is backfilled from
+ *     the ledger's `threads.thread_source` (or marked `subagent` when a
+ *     spawn edge names it as a child);
+ *   - a session the ledger says is a subagent has its token usage STRIPPED,
+ *     mirroring the parse-time exclusion: its rollout replays the parent's
+ *     entire token history, so keeping the tokens double-counts the parent
+ *     (ccusage/ccusage#950). The record itself stays visible/auditable.
+ * Exported for test.
+ */
+export function applyCodexLedger(records, ledger) {
+  if (!ledger || !(ledger.threads instanceof Map)) return records;
+  return records.map((rec) => {
+    if (!rec || rec.provider !== 'codex') return rec;
+    const t = ledger.threads.get(rec.id);
+    const fromEdges = ledger.parents instanceof Map && ledger.parents.has(rec.id) ? 'subagent' : null;
+    const source = rec.threadSource ?? t?.threadSource ?? fromEdges;
+    if (source === rec.threadSource && (source !== 'subagent' || !rec.usage.length)) return rec;
+    const out = { ...rec, threadSource: source };
+    if (source === 'subagent' && out.usage.length) out.usage = [];
+    return out;
+  });
 }
 
 /**

--- a/src/lib/usage-insights.mjs
+++ b/src/lib/usage-insights.mjs
@@ -86,6 +86,29 @@ export const THRESHOLDS = {
   // corpus's value of exactly this — an absolute floor would violate rule 2).
   automationMinSessions: 100,
   automationMaxAvgShare: 0.5,
+
+  // parallel-sessions: summed span ÷ union span — how many sessions were open
+  // at once, on average, while anything was open. All parallel sessions draw on
+  // ONE plan limit, which is why the factor matters at all.
+  parallelMinFactor: 2,
+
+  // subagent-share / long-session-share: cost share of sidechain (subagent)
+  // transcripts, and of sessions spanning 8+ hours. Both mirror characteristics
+  // Claude Code's own /usage panel reports, computed here from local data.
+  sidechainMinShare: 0.25,
+  longSessionMinutes: 480,
+  longSessionMinShare: 0.25,
+
+  // limit-pacing (detectLimitInsights): fires only past this utilization, and
+  // only when consumption is running ahead of the window's own elapsed share by
+  // this lead factor — pace alone at 5% used is noise, pace at 60% is a fact.
+  pacingMinUsedPercent: 50,
+  pacingLeadFactor: 1.25,
+
+  // cross-host-arbitrage (detectLimitInsights): one host's weekly window above
+  // the high mark while the other host has a lane under the low mark.
+  arbitrageHighPercent: 75,
+  arbitrageLowPercent: 25,
 };
 
 // ── Grounding for `model-routing` (ADR-0009 §6) ──────────────────────────────
@@ -386,9 +409,12 @@ export function detectInsights(agg) {
         evidence: 'Categories come from session provenance, titles and tool mix; short or '
           + 'generically-titled sessions carry little signal, and a forced label would make the '
           + 'other categories untrustworthy too.',
-        action: 'Enable optional LLM labelling to classify the residue once — results cache '
-          + 'permanently per session id.',
-        command: 'ak x usage classify --enrich',
+        // No command: the optional LLM-labelling pass (ADR-0009 §5 Layer 3) is
+        // designed but not shipped, and a dead command in a diagnostic is worse
+        // than none.
+        action: 'Short or generically-titled sessions are the usual cause — descriptive first '
+          + 'prompts and skill-invoked sessions classify well. An optional LLM labelling pass '
+          + 'is planned but not yet available.',
       });
     }
   }
@@ -489,8 +515,193 @@ export function detectInsights(agg) {
     }
   }
 
+  // 11 ── parallel-sessions. Summed span ÷ union span = mean concurrency while
+  // anything was open. Every parallel session draws on the SAME plan limit
+  // (Claude Code's own /usage panel makes the same point), so sustained
+  // parallelism is how a week's allowance disappears in two days. No dollar
+  // claim: parallelism shifts WHEN tokens are spent, not directly how many.
+  const spanSum = num(totals.spanMinutes) * 60;
+  const spanUnion = num(totals.spanUnionSeconds);
+  if (spanUnion > 0 && sessionCount >= 2) {
+    const factor = spanSum / spanUnion;
+    if (factor >= THRESHOLDS.parallelMinFactor) {
+      push({
+        id: 'parallel-sessions', kind: 'trend', severity: 'info',
+        title: `Sessions ran ~${factor.toFixed(1)}× in parallel`,
+        finding: `Summed session time is ${Math.round(spanSum / 3600)}h against ${Math.round(spanUnion / 3600)}h `
+          + `of wall-clock with anything open — on average ${factor.toFixed(1)} sessions at once.`,
+        evidence: 'All sessions on a subscription share one rate-limit pool, so parallel work '
+          + 'consumes the same allowance faster; queueing spreads it more evenly.',
+        action: 'Keep parallelism for genuinely independent work; queue the rest, or route some '
+          + 'lanes to the other host so the two pools share the load.',
+        command: 'ak x provider pick',
+      });
+    }
+  }
+
+  // 12 ── subagent-share. Sidechain/subagent transcripts as a share of spend —
+  // the local computation of the "subagent-heavy sessions" characteristic
+  // Claude Code's /usage panel reports. The dollar figure is measured, but NOT
+  // claimed as impact: subagent work is not waste, it is a composition fact.
+  const side = sessions.filter((s) => s.sidechain === true || s.threadSource === 'subagent');
+  if (side.length && windowCost > 0) {
+    const spend = sumBy(side, 'cost');
+    const share = spend / windowCost;
+    if (share >= THRESHOLDS.sidechainMinShare) {
+      push({
+        id: 'subagent-share', kind: 'trend', severity: 'info',
+        title: `Subagent transcripts carry ${pct(share)} of spend`,
+        finding: `${count(side.length)} sidechain/subagent transcripts account for ${usd(spend)} of `
+          + `this window's ${usd(windowCost)}.`,
+        evidence: 'Each spawned agent runs its own requests with its own context load, so '
+          + 'delegation multiplies token volume even when the main thread stays small.',
+        action: 'Be deliberate about fan-out: fewer, better-briefed subagents — and a cheaper '
+          + 'model for mechanical subagent roles — keep the leverage without the volume.',
+      });
+    }
+  }
+
+  // 13 ── long-session-share. Sessions spanning 8+ hours are usually loops,
+  // daemons, or forgotten terminals rather than a sitting; their spend share
+  // says how much of the window rides on unattended context.
+  const long = sessions.filter((s) => num(s.minutes) >= THRESHOLDS.longSessionMinutes);
+  if (long.length && windowCost > 0) {
+    const spend = sumBy(long, 'cost');
+    const share = spend / windowCost;
+    if (share >= THRESHOLDS.longSessionMinShare) {
+      push({
+        id: 'long-session-share', kind: 'trend', severity: 'info',
+        title: `${pct(share)} of spend sits in 8h+ sessions`,
+        finding: `${count(long.length)} sessions spanned ${Math.round(THRESHOLDS.longSessionMinutes / 60)}+ hours `
+          + `and carried ${usd(spend)} (${pct(share)}) of the window.`,
+        evidence: 'Very long spans are the signature of background loops and left-open sessions; '
+          + 'long-lived context is also the expensive kind — every turn re-reads it.',
+        action: 'Confirm the long-runners are intentional; close or /clear sessions that have '
+          + 'become idle context holders.',
+        command: 'ak x daemon-gc',
+      });
+    }
+  }
+
   // Ranked: measured dollars first (descending), then $-free findings by severity.
   // `Array.prototype.sort` is stable, so detector order breaks remaining ties.
+  return found.sort((x, y) => (num(y.impact) - num(x.impact))
+    || (SEVERITY_RANK[x.severity] - SEVERITY_RANK[y.severity]));
+}
+
+// ── Limit-aware findings (ADR-0010) ──────────────────────────────────────────
+// Same contract and rules as detectInsights, over the /api/limits payload from
+// quota.mjs instead of the transcript aggregate. Still PURE: "now" is
+// `limits.generatedAt` — data, not a clock — so every firing is reproducible
+// from its input. Vendor-reported percentages ARE the user's own data (rule 1):
+// they are the one denominator ADR-0009 §3 said local parsing could never
+// honestly invent.
+
+/** Flatten both providers' windows into rows detectors can iterate:
+ *  { host, lane, label, usedPercent, windowMinutes, resetsAt }. */
+function limitWindows(limits) {
+  const rows = [];
+  for (const w of limits?.claude?.windows ?? []) {
+    rows.push({ host: 'claude', lane: null, label: w.label ?? w.id, usedPercent: num(w.usedPercent), windowMinutes: w.windowMinutes ?? null, resetsAt: w.resetsAt ?? null });
+  }
+  for (const lane of limits?.codex?.lanes ?? []) {
+    for (const w of lane.windows ?? []) {
+      rows.push({ host: 'codex', lane: lane.name ?? lane.id, label: w.label ?? w.id, usedPercent: num(w.usedPercent), windowMinutes: w.windowMinutes ?? null, resetsAt: w.resetsAt ?? null });
+    }
+  }
+  return rows.filter((r) => Number.isFinite(r.usedPercent));
+}
+
+// "codex codex" reads as a stutter when the default lane carries the host's
+// own name — the lane is only worth naming when it distinguishes.
+const hostLane = (r) => r.host + (r.lane && r.lane !== r.host ? ` ${r.lane}` : '');
+
+/**
+ * Rank findings over vendor-reported plan limits (the /api/limits payload).
+ *
+ * @param {{ generatedAt?: string, claude?: any, codex?: any }} [limits]
+ * @param {UsageAggregate} [agg] optional transcript aggregate for composition
+ *   context (currently unused by the firing rules; reserved for evidence).
+ * @returns same Insight contract as detectInsights.
+ */
+export function detectLimitInsights(limits, agg) { // eslint-disable-line no-unused-vars
+  const rows = limitWindows(limits);
+  const nowMs = Date.parse(limits?.generatedAt ?? '') || null;
+  const found = [];
+  const push = (insight) => found.push({ command: null, impact: null, ...insight });
+
+  // A ── limit-pacing: consumption running ahead of the window's own clock.
+  // elapsedShare needs both resetsAt and the window duration; a window missing
+  // either stays silent rather than pacing against a guess.
+  for (const r of rows) {
+    if (!nowMs || !Number.isFinite(r.resetsAt) || !Number.isFinite(r.windowMinutes) || r.windowMinutes <= 0) continue;
+    const windowMs = r.windowMinutes * 60_000;
+    const remainingMs = r.resetsAt * 1000 - nowMs;
+    if (remainingMs <= 0 || remainingMs > windowMs) continue; // reset passed, or clock skew
+    const elapsedShare = 1 - remainingMs / windowMs;
+    const usedShare = r.usedPercent / 100;
+    if (r.usedPercent < THRESHOLDS.pacingMinUsedPercent || elapsedShare <= 0) continue;
+    if (usedShare < elapsedShare * THRESHOLDS.pacingLeadFactor) continue;
+    const remainH = Math.round(remainingMs / 3_600_000);
+    const projected = Math.round((usedShare / elapsedShare) * 100);
+    push({
+      id: `limit-pacing-${r.host}${r.lane ? `-${String(r.lane).toLowerCase().replace(/[^a-z0-9]+/g, '-')}` : ''}-${r.windowMinutes}`.replace(/-+$/, ''),
+      kind: 'trend', severity: usedShare >= 0.9 ? 'warn' : 'info',
+      title: `${hostLane(r)} ${r.label} window is ahead of pace at ${Math.round(r.usedPercent)}%`,
+      finding: `${Math.round(r.usedPercent)}% used with ${pct(1 - elapsedShare)} of the window still to run `
+        + `(${remainH}h to reset) — on current pace that projects to ~${projected}% of the limit.`,
+      evidence: `Vendor-reported utilization against the window's own elapsed time: `
+        + `${Math.round(r.usedPercent)}% consumed vs ${pct(elapsedShare)} elapsed.`,
+      action: 'Front-load what matters before the cap, shift routine work to the other host or a '
+        + 'cheaper lane, and let non-urgent automation wait for the reset.',
+      command: 'ak x provider pick',
+    });
+  }
+
+  // B ── cross-host-arbitrage: one host's window high while the other host has
+  // clear headroom. This is the dual-host case ak exists for.
+  const high = rows.filter((r) => r.usedPercent >= THRESHOLDS.arbitrageHighPercent);
+  for (const h of high) {
+    const spare = rows.filter((r) => r.host !== h.host && r.usedPercent <= THRESHOLDS.arbitrageLowPercent);
+    if (!spare.length) continue;
+    const best = spare.sort((x, y) => x.usedPercent - y.usedPercent)[0];
+    push({
+      id: `cross-host-arbitrage-${h.host}`,
+      kind: 'coach', severity: h.usedPercent >= 90 ? 'warn' : 'info',
+      title: `${hostLane(h)} is at ${Math.round(h.usedPercent)}% while ${hostLane(best)} sits at ${Math.round(best.usedPercent)}%`,
+      finding: `The ${h.label} window on ${hostLane(h)} has ${Math.round(100 - h.usedPercent)}% headroom left; `
+        + `${hostLane(best)} (${best.label}) is ${Math.round(best.usedPercent)}% used.`,
+      evidence: 'Both hosts are enabled on this machine and their plan pools are independent — '
+        + 'work routed to the idle pool costs nothing against the strained one.',
+      action: 'Shift routine and mechanical activities to the host with headroom in the '
+        + 'per-activity routing policy; reasoning-critical work can stay put.',
+      command: 'ak x provider pick',
+    });
+    break; // one arbitrage finding is guidance; one per hot window is nagging
+  }
+
+  // C ── codex-reset-credits: a granted, expiring resource the user may not
+  // know they hold. Redemption is deliberately left to codex's own /usage UI —
+  // consuming a finite grant is not a diagnostic's call to make.
+  const rc = limits?.codex?.resetCredits;
+  if (rc && Number.isFinite(rc.availableCount) && rc.availableCount > 0) {
+    const expiries = (rc.credits ?? [])
+      .filter((c) => c && c.status === 'available' && Number.isFinite(c.expiresAt))
+      .map((c) => c.expiresAt)
+      .sort((a, b) => a - b);
+    const soonest = expiries.length && nowMs ? Math.max(0, Math.round((expiries[0] * 1000 - nowMs) / 86_400_000)) : null;
+    push({
+      id: 'codex-reset-credits', kind: 'coach', severity: 'info',
+      title: `${count(rc.availableCount)} Codex rate-limit reset credit${rc.availableCount === 1 ? '' : 's'} available`,
+      finding: `Codex has granted ${count(rc.availableCount)} full rate-limit reset${rc.availableCount === 1 ? '' : 's'}`
+        + `${soonest !== null ? `; the soonest expires in ~${count(soonest)} day${soonest === 1 ? '' : 's'}` : ''}.`,
+      evidence: 'Reported by codex app-server (account/rateLimits/read → rateLimitResetCredits); '
+        + 'an unredeemed credit that expires is simply lost.',
+      action: 'If a Codex window is pinned at its cap, redeem a reset from codex’s own /usage '
+        + 'screen. This panel never consumes one on your behalf.',
+    });
+  }
+
   return found.sort((x, y) => (num(y.impact) - num(x.impact))
     || (SEVERITY_RANK[x.severity] - SEVERITY_RANK[y.severity]));
 }

--- a/src/templates/statusline-footer.cjs
+++ b/src/templates/statusline-footer.cjs
@@ -6,6 +6,39 @@ function rufloActivationSegments(cwd){
     var DIM = "[2m", G = "[1;32m", Y = "[1;33m", C = "[1;36m", R = "[0m";
     // execFileSync (no shell) — db path / sql are passed as argv, never interpolated into a command line.
     function q(db, sql){ try { return cp.execFileSync("sqlite3", [db, sql], {stdio:["ignore","pipe","ignore"], timeout:1500}).toString().trim(); } catch(e){ return ""; } }
+    // ── quota tee (ADR-0010): Claude Code pushes plan utilization into every
+    // statusline invocation (rate_limits: five_hour/seven_day used_percentage +
+    // reset epochs — code.claude.com/docs/en/statusline.md). This is the ONLY
+    // supported channel for those numbers on a Pro/Max plan, and it is push-
+    // only, so the kit persists the latest payload for the dashboard's Limits
+    // view to read (quota.mjs). Throttled to one write/min (the statusline
+    // refreshes every ~5s); atomic tmp+rename at 0600 — account utilization is
+    // the user's own business. Failure is silent by design: a broken tee must
+    // never cost a statusline render.
+    try {
+      if (typeof getStdinData === "function") {
+        var _qsd = getStdinData();
+        if (_qsd && _qsd.rate_limits && typeof _qsd.rate_limits === "object") {
+          var _qdir = path.join(process.env.XDG_CONFIG_HOME || path.join(require("os").homedir(), ".config"), "agentic-kit");
+          var _qf = path.join(_qdir, "claude-rate-limits.json");
+          var _qold = 0;
+          try { _qold = fs.statSync(_qf).mtimeMs; } catch(e){}
+          if (Date.now() - _qold > 60000) {
+            fs.mkdirSync(_qdir, { recursive: true });
+            var _qtmp = _qf + "." + process.pid + ".tmp";
+            fs.writeFileSync(_qtmp, JSON.stringify({
+              teedAt: Date.now(),
+              session_id: _qsd.session_id || null,
+              model: (_qsd.model && _qsd.model.id) || null,
+              rate_limits: _qsd.rate_limits,
+              context_window: _qsd.context_window || null,
+              cost: _qsd.cost || null
+            }), { mode: 0o600 });
+            fs.renameSync(_qtmp, _qf);
+          }
+        }
+      }
+    } catch(e){}
     function bar(n, max){ n = Math.max(0, Math.min(max, n)); return "[" + "●".repeat(n) + "○".repeat(max - n) + "]"; }
     // ── self-learning (SONA): own line with a volume bar (patterns/traj/HNSW) plus a
     // LIVE micro-LoRA adaptation field (Δ‖W‖, appended further below). The Δ‖W‖ tracker

--- a/tests/dashboard.test.cjs
+++ b/tests/dashboard.test.cjs
@@ -371,6 +371,50 @@ async function main() {
     await usageSrv.close();
   }
 
+  // ── /api/limits (ADR-0010): injected provider, insights computed server-side ──
+  const limitsSrv = await startDashboard({
+    port: 0, cwd: fixture, fetchStatus: async () => STUB_STATUS, usage: spyUsage().api,
+    limits: async () => ({
+      generatedAt: '2026-07-27T12:00:00.000Z',
+      claude: {
+        provider: 'claude', source: 'statusline', fetchedAt: 1785000000000,
+        windows: [{ id: 'seven_day', label: 'weekly', usedPercent: 89, windowMinutes: 10080, resetsAt: 1785600000 }],
+      },
+      codex: {
+        provider: 'codex', source: 'app-server', fetchedAt: 1785000000000, planType: 'prolite',
+        lanes: [{ id: 'codex', name: 'codex', windows: [{ label: 'weekly', usedPercent: 3, windowMinutes: 10080, resetsAt: 1785694902 }] }],
+        resetCredits: { availableCount: 2, credits: [] },
+      },
+    }),
+  });
+  try {
+    await test('GET /api/limits → both providers plus server-computed limit insights', async () => {
+      const r = await get(limitsSrv.url + 'api/limits');
+      assert(r.status === 200, 'expected 200, got ' + r.status);
+      const j = JSON.parse(r.body);
+      assert(j.claude && j.claude.windows[0].usedPercent === 89, 'claude windows must survive');
+      assert(j.codex && j.codex.planType === 'prolite', 'codex plan must survive');
+      assert(Array.isArray(j.insights), 'insights must be an array');
+      assert(j.insights.some((i) => i.id === 'cross-host-arbitrage-claude'),
+        'claude 89% vs codex 3% must yield the arbitrage finding, got ' + JSON.stringify(j.insights.map((i) => i.id)));
+      assert(j.insights.some((i) => i.id === 'codex-reset-credits'),
+        '2 reset credits must yield the credits finding');
+    });
+    await test('GET /api/limits degrades to 500 JSON when the provider throws', async () => {
+      const broken = await startDashboard({
+        port: 0, cwd: fixture, fetchStatus: async () => STUB_STATUS, usage: spyUsage().api,
+        limits: async () => { throw new Error('quota backend down'); },
+      });
+      try {
+        const r = await get(broken.url + 'api/limits');
+        assert(r.status === 500, 'expected 500, got ' + r.status);
+        contains(r.body, 'quota backend down');
+      } finally { await broken.close(); }
+    });
+  } finally {
+    await limitsSrv.close();
+  }
+
   // Masking is not optional: a usage module that cannot mask must fail the
   // request, never serve an unmasked transcript.
   const noMask = spyUsage({ maskSecrets: undefined });
@@ -388,12 +432,12 @@ async function main() {
   // ── the served page: sixth segment, four views, poll control ──
   const uiSrv = await startDashboard({ port: 0, cwd: fixture, fetchStatus: async () => STUB_STATUS, usage: spyUsage().api });
   try {
-    await test('served HTML carries the sixth "Usage" segment and its four sub-views', async () => {
+    await test('served HTML carries the sixth "Usage" segment and its five sub-views', async () => {
       const r = await get(uiSrv.url);
       contains(r.body, 'data-tab="usage"');
       contains(r.body, '>Usage<');
       contains(r.body, 'id="panel-usage"');
-      for (const v of ['score', 'findings', 'sessions', 'transcript']) {
+      for (const v of ['score', 'limits', 'findings', 'sessions', 'transcript']) {
         contains(r.body, 'id="v-' + v + '"');
         contains(r.body, 'data-view="' + v + '"');
       }

--- a/tests/kit/codex-state.test.mjs
+++ b/tests/kit/codex-state.test.mjs
@@ -1,0 +1,121 @@
+// codex-state.mjs — Codex's SQLite thread ledger, tested against fixture dbs
+// built with the same node:sqlite the reader uses. Plus applyCodexLedger from
+// usage-index.mjs: the attribution overlay the ledger exists to power.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+import { codexStateDb, readCodexState } from '../../src/lib/codex-state.mjs';
+import { applyCodexLedger } from '../../src/lib/usage-index.mjs';
+
+const tmp = () => fs.mkdtempSync(path.join(os.tmpdir(), 'ak-codex-state-'));
+
+/** Build a fixture ledger shaped like the real state_5.sqlite (verified live
+ *  2026-07-27: threads has id/thread_source/source/model/git_branch/tokens_used
+ *  among 32 columns; thread_spawn_edges has parent/child/status). */
+function fixtureDb(dir, name = 'state_5.sqlite') {
+  const file = path.join(dir, name);
+  const db = new DatabaseSync(file);
+  db.exec(`CREATE TABLE threads (
+    id TEXT PRIMARY KEY, thread_source TEXT, source TEXT, model TEXT,
+    git_branch TEXT, tokens_used INTEGER);`);
+  db.exec(`CREATE TABLE thread_spawn_edges (
+    parent_thread_id TEXT, child_thread_id TEXT, status TEXT);`);
+  db.prepare('INSERT INTO threads VALUES (?,?,?,?,?,?)').run('parent-1', 'user', 'cli', 'gpt-5.6', 'main', 21_500_000);
+  db.prepare('INSERT INTO threads VALUES (?,?,?,?,?,?)').run('child-1', 'subagent', 'subagent', 'gpt-5.6', 'main', 1_000_000);
+  db.prepare('INSERT INTO thread_spawn_edges VALUES (?,?,?)').run('parent-1', 'child-1', 'open');
+  db.close();
+  return file;
+}
+
+test('codexStateDb picks the HIGHEST migration generation, never a hardcoded name', () => {
+  const dir = tmp();
+  fixtureDb(dir, 'state_5.sqlite');
+  fixtureDb(dir, 'state_12.sqlite');
+  fs.writeFileSync(path.join(dir, 'state_x.sqlite'), 'not a generation');
+  assert.equal(codexStateDb(dir), path.join(dir, 'state_12.sqlite'));
+});
+
+test('codexStateDb returns null for an absent dir or no state db', () => {
+  assert.equal(codexStateDb(path.join(tmp(), 'nope')), null);
+  assert.equal(codexStateDb(tmp()), null);
+});
+
+test('readCodexState reads threads and spawn edges', () => {
+  const dir = tmp();
+  fixtureDb(dir);
+  const ledger = readCodexState({ dir });
+  assert.equal(ledger.threads.get('parent-1').threadSource, 'user');
+  assert.equal(ledger.threads.get('parent-1').tokensUsed, 21_500_000);
+  assert.equal(ledger.threads.get('child-1').threadSource, 'subagent');
+  assert.equal(ledger.parents.get('child-1'), 'parent-1');
+});
+
+test('readCodexState degrades to null when the load-bearing columns are missing', () => {
+  const dir = tmp();
+  const file = path.join(dir, 'state_9.sqlite');
+  const db = new DatabaseSync(file);
+  db.exec('CREATE TABLE threads (id TEXT, tokens_used INTEGER);'); // no thread_source
+  db.close();
+  assert.equal(readCodexState({ dir }), null);
+});
+
+test('readCodexState returns null for a corrupt file rather than throwing', () => {
+  const dir = tmp();
+  fs.writeFileSync(path.join(dir, 'state_5.sqlite'), 'garbage bytes, not sqlite');
+  assert.equal(readCodexState({ dir }), null);
+});
+
+// ── applyCodexLedger — the overlay ───────────────────────────────────────────
+
+const rec = (over = {}) => ({
+  id: 'child-1', provider: 'codex', threadSource: null,
+  usage: [{ day: '2026-07-26', model: 'gpt-5.6', input: 10, output: 5, cacheRead: 0, cacheWrite: 0, responses: 2 }],
+  ...over,
+});
+const ledgerOf = (threads, parents = []) => ({
+  threads: new Map(Object.entries(threads)),
+  parents: new Map(parents),
+});
+
+test('applyCodexLedger backfills thread_source and STRIPS a subagent’s usage', () => {
+  const [out] = applyCodexLedger([rec()], ledgerOf({ 'child-1': { threadSource: 'subagent' } }));
+  assert.equal(out.threadSource, 'subagent');
+  assert.deepEqual(out.usage, []); // replayed parent history must not double-bill
+});
+
+test('applyCodexLedger marks a spawn-edge child subagent even without a thread row', () => {
+  const [out] = applyCodexLedger([rec()], ledgerOf({}, [['child-1', 'parent-1']]));
+  assert.equal(out.threadSource, 'subagent');
+  assert.deepEqual(out.usage, []);
+});
+
+test('applyCodexLedger never overrides what the rollout already said', () => {
+  const r = rec({ threadSource: 'user' });
+  const [out] = applyCodexLedger([r], ledgerOf({ 'child-1': { threadSource: 'subagent' } }));
+  assert.equal(out.threadSource, 'user');
+  assert.equal(out.usage.length, 1);
+});
+
+test('applyCodexLedger does not mutate the (possibly cached) input record', () => {
+  const r = rec();
+  applyCodexLedger([r], ledgerOf({ 'child-1': { threadSource: 'subagent' } }));
+  assert.equal(r.threadSource, null);
+  assert.equal(r.usage.length, 1);
+});
+
+test('applyCodexLedger leaves claude records and unmatched ids untouched', () => {
+  const claude = { id: 'c1', provider: 'claude', threadSource: null, usage: [{}] };
+  const unmatched = rec({ id: 'not-in-ledger' });
+  const out = applyCodexLedger([claude, unmatched], ledgerOf({ 'child-1': { threadSource: 'subagent' } }));
+  assert.equal(out[0], claude);
+  assert.equal(out[1], unmatched);
+});
+
+test('applyCodexLedger is a no-op for a null/absent ledger', () => {
+  const rows = [rec()];
+  assert.equal(applyCodexLedger(rows, null), rows);
+  assert.equal(applyCodexLedger(rows, {}), rows);
+});

--- a/tests/kit/pricing-revert.test.mjs
+++ b/tests/kit/pricing-revert.test.mjs
@@ -1,0 +1,28 @@
+// The Sonnet 5 introductory-pricing time bomb, armed as a TEST instead of a
+// comment. pricing.mjs carries Sonnet 5 at the launch $2/$10 with a note that
+// it must revert to the standard $3/$15 on 2026-09-01 — a promise nothing
+// enforced. This test is the enforcement: it passes while the promo window is
+// open, and FAILS THE SUITE from 2026-09-01 onward until the table is updated
+// (at which point the assertion flips to pinning the standard rate).
+//
+// Deliberately reads the real clock — that is the entire point of the test.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { priceFor } from '../../src/lib/pricing.mjs';
+
+const REVERT_DATE = Date.parse('2026-09-01T00:00:00Z');
+
+test('sonnet-5 pricing matches its calendar: intro $2/$10 before 2026-09-01, standard $3/$15 after', () => {
+  const p = priceFor('claude-sonnet-5', 'claude');
+  assert.ok(p && p.matched, 'sonnet-5 must have a real price row');
+  if (Date.now() < REVERT_DATE) {
+    assert.equal(p.in, 2, 'intro input rate while the launch window is open');
+    assert.equal(p.out, 10, 'intro output rate while the launch window is open');
+  } else {
+    assert.equal(p.in, 3,
+      'the Sonnet 5 introductory price expired 2026-09-01 — update PRICES in pricing.mjs '
+      + '(anthropic(3, 15)) and PRICES_AS_OF, then keep this assertion as the pin');
+    assert.equal(p.out, 15,
+      'the Sonnet 5 introductory price expired 2026-09-01 — update PRICES in pricing.mjs');
+  }
+});

--- a/tests/kit/pricing-revert.test.mjs
+++ b/tests/kit/pricing-revert.test.mjs
@@ -1,28 +1,103 @@
-// The Sonnet 5 introductory-pricing time bomb, armed as a TEST instead of a
-// comment. pricing.mjs carries Sonnet 5 at the launch $2/$10 with a note that
-// it must revert to the standard $3/$15 on 2026-09-01 — a promise nothing
-// enforced. This test is the enforcement: it passes while the promo window is
-// open, and FAILS THE SUITE from 2026-09-01 onward until the table is updated
-// (at which point the assertion flips to pinning the standard rate).
+// Published rate changes, pinned at their BOUNDARIES.
 //
-// Deliberately reads the real clock — that is the entire point of the test.
+// This file used to be a time bomb: it read the wall clock and failed the suite
+// from 2026-09-01 onward until a human edited the Sonnet 5 rate. That worked as
+// a reminder but was a bad test — it would go red on a calendar date with no
+// code change, and CI red-for-a-reason-that-is-not-a-defect trains people to
+// ignore CI.
+//
+// The dated schedule in pricing.mjs removes the need for it. A published change
+// is DATA now, so what needs proving is that the boundary behaves: the day
+// before takes the old rate, the day of takes the new one, and — the part that
+// actually matters for a usage panel — a finished window keeps the rate it was
+// metered at forever, rather than being restated the moment the change lands.
+//
+// Nothing here reads a clock, so these assertions are stable for all time.
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { priceFor } from '../../src/lib/pricing.mjs';
+import { priceFor, costOf, PRICES, PRICES_AS_OF } from '../../src/lib/pricing.mjs';
 
-const REVERT_DATE = Date.parse('2026-09-01T00:00:00Z');
+// ── Sonnet 5: introductory $2/$10 → standard $3/$15 on 2026-09-01 ────────────
+// Anthropic published this end date; that is the bar for encoding a schedule.
 
-test('sonnet-5 pricing matches its calendar: intro $2/$10 before 2026-09-01, standard $3/$15 after', () => {
-  const p = priceFor('claude-sonnet-5', 'claude');
-  assert.ok(p && p.matched, 'sonnet-5 must have a real price row');
-  if (Date.now() < REVERT_DATE) {
-    assert.equal(p.in, 2, 'intro input rate while the launch window is open');
-    assert.equal(p.out, 10, 'intro output rate while the launch window is open');
-  } else {
-    assert.equal(p.in, 3,
-      'the Sonnet 5 introductory price expired 2026-09-01 — update PRICES in pricing.mjs '
-      + '(anthropic(3, 15)) and PRICES_AS_OF, then keep this assertion as the pin');
-    assert.equal(p.out, 15,
-      'the Sonnet 5 introductory price expired 2026-09-01 — update PRICES in pricing.mjs');
+test('sonnet-5 prices at the introductory rate on the last day of the promo', () => {
+  const p = priceFor('claude-sonnet-5', 'claude', '2026-08-31');
+  assert.deepEqual([p.in, p.out], [2, 10]);
+});
+
+test('sonnet-5 prices at the standard rate on the first day after it', () => {
+  const p = priceFor('claude-sonnet-5', 'claude', '2026-09-01');
+  assert.deepEqual([p.in, p.out], [3, 15]);
+});
+
+test('sonnet-5 stays on the standard rate well beyond the boundary', () => {
+  const p = priceFor('claude-sonnet-5', 'claude', '2027-03-14');
+  assert.deepEqual([p.in, p.out], [3, 15]);
+});
+
+test('a day before any dated period falls to the opening rate', () => {
+  const p = priceFor('claude-sonnet-5', 'claude', '2026-01-01');
+  assert.deepEqual([p.in, p.out], [2, 10]);
+});
+
+// ── The property the schedule exists to protect ──────────────────────────────
+
+test('a finished window is NOT restated when a later rate change takes effect', () => {
+  // Same tokens, same model. Priced on the day they were spent, an August row
+  // must read identically whether the reader opens the panel in August or in
+  // December. A clock-driven table would inflate this by 50% on 2026-09-01.
+  const august = { model: 'claude-sonnet-5', provider: 'claude', day: '2026-08-15', input: 1_000_000, output: 1_000_000 };
+  assert.equal(costOf(august), 2 + 10);
+  // ...while tokens genuinely spent after the boundary carry the new rate.
+  assert.equal(costOf({ ...august, day: '2026-09-15' }), 3 + 15);
+});
+
+test('the day is what selects the rate — not the order rows are priced in', () => {
+  const rows = ['2026-09-15', '2026-08-15', '2026-09-01', '2026-08-31']
+    .map((day) => costOf({ model: 'claude-sonnet-5', provider: 'claude', day, input: 1_000_000 }));
+  assert.deepEqual(rows, [3, 2, 3, 2]);
+});
+
+// ── The dateless default ─────────────────────────────────────────────────────
+
+test('a dateless query prices as of the table verification date, not the newest period', () => {
+  // The subtle one. "Newest period" only means "current" once every published
+  // change has landed; on a table verified before the boundary it would price
+  // Sonnet at a rate nobody is paying yet. PRICES_AS_OF is the honest answer
+  // and is the same date the UI prints as "rates as of …".
+  const dateless = priceFor('claude-sonnet-5', 'claude');
+  const asOf = priceFor('claude-sonnet-5', 'claude', PRICES_AS_OF);
+  assert.deepEqual([dateless.in, dateless.out], [asOf.in, asOf.out]);
+  const last = PRICES['claude-sonnet-5'].periods.at(-1);
+  assert.ok(PRICES_AS_OF < last.from,
+    'this assertion is only meaningful while the table predates the boundary — '
+    + 'once PRICES_AS_OF passes 2026-09-01 the two coincide and the case is moot');
+  assert.notDeepEqual([dateless.in, dateless.out], [last.in, last.out]);
+});
+
+test('junk or missing day never throws and never yields a zero rate', () => {
+  for (const day of [null, undefined, '', 'not-a-date', 42, {}, 'ate-2026-09-01']) {
+    const p = priceFor('claude-sonnet-5', 'claude', day);
+    assert.ok(p.in > 0 && p.out > 0, `day=${JSON.stringify(day)} produced ${p.in}/${p.out}`);
   }
+});
+
+// ── The mechanism is uniform across providers ────────────────────────────────
+
+test('an undated entry is a one-period schedule and ignores the day entirely', () => {
+  // Both vendors: no schedule means the rate is the same on any date. This is
+  // what makes the OpenAI table a data question rather than a mechanism gap —
+  // if OpenAI ships a dated promo it is one edit, not new machinery.
+  for (const id of ['gpt-5.6-sol', 'claude-opus-5']) {
+    const early = priceFor(id, undefined, '2020-01-01');
+    const late = priceFor(id, undefined, '2030-01-01');
+    assert.deepEqual([early.in, early.out], [late.in, late.out], id);
+    assert.equal(PRICES[id].periods.length, 1, `${id} should carry a single period`);
+  }
+});
+
+test('both providers build schedules through the same constructor shape', () => {
+  const shapes = new Set(Object.values(PRICES).map((p) => (Array.isArray(p.periods) ? 'schedule' : typeof p)));
+  assert.deepEqual([...shapes], ['schedule'],
+    'a provider-specific rate shape would mean two code paths through priceFor');
 });

--- a/tests/kit/pricing.test.mjs
+++ b/tests/kit/pricing.test.mjs
@@ -17,11 +17,23 @@ test('every PRICES entry carries finite in/out rates, a provider, and asOf', () 
   const keys = Object.keys(PRICES);
   assert.ok(keys.length >= 8, 'table covers the shipped model lines');
   for (const [key, p] of Object.entries(PRICES)) {
-    assert.ok(Number.isFinite(p.in) && p.in > 0, `${key} in rate`);
-    assert.ok(Number.isFinite(p.out) && p.out > 0, `${key} out rate`);
-    assert.ok(p.out >= p.in, `${key} output is never cheaper than input`);
     assert.ok(['anthropic', 'openai'].includes(p.provider), `${key} provider`);
     assert.match(p.asOf, /^\d{4}-\d{2}(-\d{2})?$/, `${key} asOf`);
+    // Every entry is a SCHEDULE, uniformly — the single-rate case is a
+    // one-period schedule, so there is no second shape to special-case.
+    assert.ok(Array.isArray(p.periods) && p.periods.length >= 1, `${key} periods`);
+    for (const r of p.periods) {
+      assert.ok(Number.isFinite(r.in) && r.in > 0, `${key} in rate`);
+      assert.ok(Number.isFinite(r.out) && r.out > 0, `${key} out rate`);
+      assert.ok(r.out >= r.in, `${key} output is never cheaper than input`);
+      assert.ok(r.from === null || /^\d{4}-\d{2}-\d{2}$/.test(r.from), `${key} period from`);
+    }
+    // The first period is the open-ended one ("has always applied"); only
+    // later periods carry a start date, and they must be strictly ordered.
+    assert.equal(p.periods[0].from, null, `${key} first period must be open-ended`);
+    const dated = p.periods.slice(1).map((r) => r.from);
+    assert.deepEqual(dated, [...dated].sort(), `${key} periods are chronological`);
+    assert.equal(new Set(dated).size, dated.length, `${key} has no duplicate boundaries`);
   }
 });
 

--- a/tests/kit/quota.test.mjs
+++ b/tests/kit/quota.test.mjs
@@ -1,0 +1,194 @@
+// quota.mjs — provider-mediated quota reads (ADR-0010). Normalizers are pure
+// and pinned against LIVE-observed payload shapes; the collector is tested
+// through its injection seams (spawnImpl, cacheFile), never a real codex.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { EventEmitter } from 'node:events';
+import {
+  windowLabel, normalizeClaudeLimits, normalizeCodexLimits, readClaudeLimits,
+  collectCodexLimits, CODEX_TTL_MS,
+} from '../../src/lib/quota.mjs';
+
+const tmp = () => fs.mkdtempSync(path.join(os.tmpdir(), 'ak-quota-'));
+
+// ── windowLabel — duration-derived, never slot-derived ───────────────────────
+
+test('windowLabel names the two known windows and degrades sanely', () => {
+  assert.equal(windowLabel(300), '5h');
+  assert.equal(windowLabel(10080), 'weekly');
+  assert.equal(windowLabel(2880), '2d');
+  assert.equal(windowLabel(120), '2h');
+  assert.equal(windowLabel(90), '90m');
+  assert.equal(windowLabel(NaN), 'window');
+});
+
+// ── Claude normalizer (statusline tee shape, code.claude.com statusline docs) ─
+
+const CLAUDE_TEE = {
+  teedAt: 1785000000000,
+  session_id: 'abc-123',
+  rate_limits: {
+    five_hour: { used_percentage: 23.5, resets_at: 1785010000 },
+    seven_day: { used_percentage: 89, resets_at: 1785400000 },
+    seven_day_sonnet: { used_percentage: 46, resets_at: 1785400000 },
+  },
+};
+
+test('normalizeClaudeLimits maps documented windows, per-model buckets included', () => {
+  const n = normalizeClaudeLimits(CLAUDE_TEE);
+  assert.equal(n.provider, 'claude');
+  assert.equal(n.source, 'statusline');
+  assert.equal(n.fetchedAt, 1785000000000);
+  assert.equal(n.sessionId, 'abc-123');
+  const byId = Object.fromEntries(n.windows.map((w) => [w.id, w]));
+  assert.equal(byId.five_hour.usedPercent, 23.5);
+  assert.equal(byId.five_hour.label, '5h');
+  assert.equal(byId.five_hour.windowMinutes, 300);
+  assert.equal(byId.five_hour.resetsAt, 1785010000);
+  assert.equal(byId.seven_day.label, 'weekly');
+  assert.equal(byId.seven_day.windowMinutes, 10080);
+  assert.equal(byId.seven_day_sonnet.label, 'weekly · sonnet');
+  assert.equal(byId.seven_day_sonnet.windowMinutes, 10080);
+});
+
+test('normalizeClaudeLimits tolerates an independently absent window', () => {
+  const n = normalizeClaudeLimits({ rate_limits: { seven_day: { used_percentage: 41.2 } } });
+  assert.equal(n.windows.length, 1);
+  assert.equal(n.windows[0].resetsAt, null);
+});
+
+test('normalizeClaudeLimits returns null when nothing is usable', () => {
+  assert.equal(normalizeClaudeLimits(null), null);
+  assert.equal(normalizeClaudeLimits({}), null);
+  assert.equal(normalizeClaudeLimits({ rate_limits: {} }), null);
+  assert.equal(normalizeClaudeLimits({ rate_limits: { five_hour: { used_percentage: 'nope' } } }), null);
+});
+
+test('readClaudeLimits returns null for a missing or corrupt tee file', () => {
+  const dir = tmp();
+  assert.equal(readClaudeLimits({ file: path.join(dir, 'absent.json') }), null);
+  const bad = path.join(dir, 'bad.json');
+  fs.writeFileSync(bad, '{not json');
+  assert.equal(readClaudeLimits({ file: bad }), null);
+});
+
+// ── Codex normalizer (GetAccountRateLimitsResponse, pinned to a LIVE answer) ─
+
+const CODEX_RESP = {
+  rateLimits: {
+    limitId: 'codex', limitName: null, planType: 'prolite',
+    primary: { usedPercent: 3, windowDurationMins: 10080, resetsAt: 1785694902 },
+    secondary: null,
+  },
+  rateLimitsByLimitId: {
+    codex: {
+      limitId: 'codex', limitName: null, planType: 'prolite',
+      primary: { usedPercent: 3, windowDurationMins: 10080, resetsAt: 1785694902 },
+      secondary: null,
+    },
+    codex_bengalfox: {
+      limitId: 'codex_bengalfox', limitName: 'GPT-5.3-Codex-Spark', planType: 'prolite',
+      primary: { usedPercent: 0, windowDurationMins: 10080, resetsAt: 1785767166 },
+      secondary: null,
+    },
+  },
+  rateLimitResetCredits: {
+    availableCount: 2,
+    credits: [
+      { id: 'RateLimitResetCredit_x', resetType: 'codexRateLimits', status: 'available', grantedAt: 1782933074, expiresAt: 1785525074, title: 'Full reset' },
+      { id: 'RateLimitResetCredit_y', resetType: 'codexRateLimits', status: 'available', grantedAt: 1782933074, expiresAt: null, title: 'Full reset' },
+    ],
+  },
+};
+
+test('normalizeCodexLimits emits one lane per limit id with duration-labelled windows', () => {
+  const n = normalizeCodexLimits(CODEX_RESP, { fetchedAt: 42 });
+  assert.equal(n.provider, 'codex');
+  assert.equal(n.fetchedAt, 42);
+  assert.equal(n.planType, 'prolite');
+  const lanes = Object.fromEntries(n.lanes.map((l) => [l.id, l]));
+  assert.equal(lanes.codex.name, 'codex'); // null limitName falls back to id
+  assert.equal(lanes.codex_bengalfox.name, 'GPT-5.3-Codex-Spark');
+  // THE NAMING TRAP: primary here is the WEEKLY window; the label must come
+  // from windowDurationMins, never from the slot name.
+  assert.equal(lanes.codex.windows[0].label, 'weekly');
+  assert.equal(lanes.codex.windows[0].usedPercent, 3);
+  assert.equal(lanes.codex.windows[0].resetsAt, 1785694902);
+});
+
+test('normalizeCodexLimits carries reset credits with expiries', () => {
+  const n = normalizeCodexLimits(CODEX_RESP);
+  assert.equal(n.resetCredits.availableCount, 2);
+  assert.equal(n.resetCredits.credits.length, 2);
+  assert.equal(n.resetCredits.credits[0].expiresAt, 1785525074);
+  assert.equal(n.resetCredits.credits[1].expiresAt, null);
+});
+
+test('normalizeCodexLimits falls back to the legacy single-bucket view', () => {
+  const n = normalizeCodexLimits({ rateLimits: CODEX_RESP.rateLimits });
+  assert.equal(n.lanes.length, 1);
+  assert.equal(n.lanes[0].id, 'codex');
+});
+
+test('normalizeCodexLimits returns null on nothing usable', () => {
+  assert.equal(normalizeCodexLimits(null), null);
+  assert.equal(normalizeCodexLimits({}), null);
+});
+
+// ── collectCodexLimits — cache TTL + failure semantics ───────────────────────
+
+/** A spawnImpl whose child answers the JSON-RPC exchange with `resp`, or dies. */
+function fakeSpawn(resp) {
+  return () => {
+    const child = new EventEmitter();
+    child.stdout = new EventEmitter();
+    child.kill = () => {};
+    child.stdin = {
+      write(line) {
+        const msg = JSON.parse(line);
+        if (msg.id === 1) {
+          setImmediate(() => child.stdout.emit('data', `${JSON.stringify({ jsonrpc: '2.0', id: 1, result: {} })}\n`));
+        } else if (msg.id === 2) {
+          setImmediate(() => child.stdout.emit('data', `${JSON.stringify({ jsonrpc: '2.0', id: 2, result: resp })}\n`));
+        }
+        return true;
+      },
+    };
+    return child;
+  };
+}
+const failSpawn = () => { throw new Error('ENOENT'); };
+
+test('collectCodexLimits answers via the RPC seam and writes a 0600 cache', async () => {
+  const cacheFile = path.join(tmp(), 'codex-rate-limits.json');
+  const out = await collectCodexLimits({ cacheFile, spawnImpl: fakeSpawn(CODEX_RESP), now: 1000 });
+  assert.equal(out.planType, 'prolite');
+  assert.equal(out.fetchedAt, 1000);
+  const st = fs.statSync(cacheFile);
+  if (process.platform !== 'win32') assert.equal(st.mode & 0o777, 0o600);
+});
+
+test('collectCodexLimits serves a fresh cache without spawning at all', async () => {
+  const cacheFile = path.join(tmp(), 'codex-rate-limits.json');
+  fs.writeFileSync(cacheFile, JSON.stringify({ provider: 'codex', fetchedAt: 5000, lanes: [{ id: 'codex' }] }));
+  const out = await collectCodexLimits({
+    cacheFile, now: 5000 + CODEX_TTL_MS - 1,
+    spawnImpl: () => { throw new Error('must not spawn on a fresh cache'); },
+  });
+  assert.equal(out.fetchedAt, 5000);
+});
+
+test('collectCodexLimits falls back to the STALE cache when the spawn fails', async () => {
+  const cacheFile = path.join(tmp(), 'codex-rate-limits.json');
+  fs.writeFileSync(cacheFile, JSON.stringify({ provider: 'codex', fetchedAt: 1, lanes: [{ id: 'codex' }] }));
+  const out = await collectCodexLimits({ cacheFile, now: 10 + CODEX_TTL_MS, spawnImpl: failSpawn });
+  assert.equal(out.fetchedAt, 1); // stale beats silent-nothing; age stays visible
+});
+
+test('collectCodexLimits returns null when there has never been an answer', async () => {
+  const out = await collectCodexLimits({ cacheFile: path.join(tmp(), 'none.json'), spawnImpl: failSpawn });
+  assert.equal(out, null);
+});

--- a/tests/kit/usage-deps-contract.test.mjs
+++ b/tests/kit/usage-deps-contract.test.mjs
@@ -178,6 +178,20 @@ test('costOf returns a finite non-negative number for every call at the seam', a
   }
 });
 
+test('every costOf call at the seam carries the row day, so dated rates apply', async () => {
+  // The schedule in pricing.mjs is inert unless the caller says WHEN. This is
+  // the seam where that contract is kept or silently dropped: aggregate() holds
+  // `row.day` and must forward it, or every row would price at PRICES_AS_OF and
+  // a published rate change would never take effect on the panel.
+  const { log } = await seam();
+  assert.ok(log.cost.length > 0, 'the corpus must actually exercise pricing');
+  for (const { usage } of log.cost) {
+    assert.match(String(usage?.day), /^\d{4}-\d{2}-\d{2}$/,
+      `costOf(${usage?.model}) was called with day=${JSON.stringify(usage?.day)} — `
+      + 'the usage row is keyed by day, so dropping it here loses dated pricing');
+  }
+});
+
 test('a model absent from the rate table is still priced, not zeroed or NaN', async () => {
   // The fixture corpus emits `gpt-5.6`, which the table carries only as
   // `gpt-5.6-sol` / `-terra` / `-luna` — so the bare id falls to FALLBACK_PRICE.

--- a/tests/kit/usage-index-v6.test.mjs
+++ b/tests/kit/usage-index-v6.test.mjs
@@ -1,0 +1,132 @@
+// SCHEMA v6 additions to the Codex parse path: reasoning-output detail, the
+// embedded rate-limit snapshot (normalized, duration-keyed), the aggregate's
+// codexRateLimits history, and the ledger seam on buildIndex. Self-contained
+// fixtures — nothing here reads ~/.claude, ~/.codex or ~/.config.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { buildIndex, _resetForTest } from '../../src/lib/usage-index.mjs';
+
+const NOW = Date.parse('2026-07-25T12:00:00.000Z');
+const T0 = '2026-07-24T09:00:00.000Z';
+const T1 = '2026-07-24T09:10:00.000Z';
+
+const deps = () => ({
+  costOf: () => 1,
+  pricesAsOf: '2026-07-01',
+  classify: () => ({ category: 'Build', confidence: 0.9, basis: 'stub' }),
+  detectInsights: () => [],
+});
+
+/** One rollout with two token_count events: cumulative totals plus a live
+ *  rate_limits snapshot on each — the LAST of both must win. */
+function rollout(id, { threadSource = 'user' } = {}) {
+  const line = (o) => `${JSON.stringify(o)}\n`;
+  return line({ timestamp: T0, type: 'session_meta', payload: { id, cwd: '/Users/me/proj', thread_source: threadSource } })
+    + line({ timestamp: T0, type: 'turn_context', payload: { model: 'gpt-5.6' } })
+    + line({ timestamp: T0, type: 'event_msg', payload: { type: 'user_message', message: 'do the thing' } })
+    + line({
+      timestamp: T0, type: 'event_msg',
+      payload: {
+        type: 'token_count',
+        info: { total_token_usage: { input_tokens: 100, cached_input_tokens: 40, output_tokens: 20, reasoning_output_tokens: 5, total_tokens: 120 } },
+        rate_limits: {
+          limit_id: 'codex', plan_type: 'prolite',
+          primary: { used_percent: 5, window_minutes: 300, resets_at: 1785000000 },
+          secondary: { used_percent: 1, window_minutes: 10080, resets_at: 1785400000 },
+        },
+      },
+    })
+    + line({ timestamp: T1, type: 'event_msg', payload: { type: 'agent_message', message: 'done' } })
+    + line({
+      timestamp: T1, type: 'event_msg',
+      payload: {
+        type: 'token_count',
+        info: { total_token_usage: { input_tokens: 600000, cached_input_tokens: 500000, output_tokens: 4000, reasoning_output_tokens: 875, total_tokens: 604000 } },
+        rate_limits: {
+          limit_id: 'codex', plan_type: 'prolite',
+          // The NAMING TRAP, reproduced: primary is the WEEKLY window here.
+          primary: { used_percent: 9, window_minutes: 10080, resets_at: 1785649138 },
+          secondary: null,
+        },
+      },
+    });
+}
+
+function sandbox(files) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ak-usage-v6-'));
+  const day = path.join(dir, 'codex', '2026', '07', '24');
+  fs.mkdirSync(day, { recursive: true });
+  fs.mkdirSync(path.join(dir, 'claude'), { recursive: true });
+  for (const [name, body] of Object.entries(files)) {
+    fs.writeFileSync(path.join(day, name), body);
+  }
+  return {
+    roots: { claude: path.join(dir, 'claude'), codex: path.join(dir, 'codex') },
+    cachePath: path.join(dir, 'cache', 'usage-index.json'),
+  };
+}
+
+const opts = (sb, extra = {}) => ({
+  days: 14, now: NOW, roots: sb.roots, cachePath: sb.cachePath, deps: deps(), ...extra,
+});
+
+test('parseCodex captures reasoning output and the LAST rate-limit snapshot', async () => {
+  _resetForTest();
+  const sb = sandbox({ 'rollout-2026-07-24T09-00-00-aaaa1111.jsonl': rollout('aaaa1111') });
+  const agg = await buildIndex(opts(sb));
+  const s = agg.sessions.find((x) => x.id === 'aaaa1111');
+  assert.ok(s, 'session parsed');
+  assert.equal(s.reasoningOutput, 875, 'last cumulative reasoning figure, not a sum');
+  assert.equal(s.rateLimits.planType, 'prolite');
+  assert.equal(s.rateLimits.limitId, 'codex');
+  assert.equal(s.rateLimits.at, Date.parse(T1), 'the LAST snapshot wins');
+  // Duration-keyed, slot-agnostic: this last snapshot's primary IS the weekly.
+  assert.deepEqual(s.rateLimits.windows, [
+    { usedPercent: 9, windowMinutes: 10080, resetsAt: 1785649138 },
+  ]);
+  // And the aggregate exposes the window's snapshots as a history, oldest first.
+  assert.equal(agg.codexRateLimits.length, 1);
+  assert.equal(agg.codexRateLimits[0].windows[0].usedPercent, 9);
+});
+
+test('reasoning tokens are annotation only — token totals are unchanged by them', async () => {
+  _resetForTest();
+  const sb = sandbox({ 'rollout-2026-07-24T09-00-00-bbbb2222.jsonl': rollout('bbbb2222') });
+  const agg = await buildIndex(opts(sb));
+  const s = agg.sessions.find((x) => x.id === 'bbbb2222');
+  // input excludes cached; output is the full output figure, reasoning inside it.
+  assert.equal(s.input, 100000);
+  assert.equal(s.output, 4000);
+  assert.equal(s.cacheRead, 500000);
+  assert.equal(s.tokens, 604000);
+});
+
+test('a subagent rollout contributes no tokens but keeps its rate-limit snapshot out of nothing', async () => {
+  _resetForTest();
+  const sb = sandbox({ 'rollout-2026-07-24T09-00-00-cccc3333.jsonl': rollout('cccc3333', { threadSource: 'subagent' }) });
+  const agg = await buildIndex(opts(sb));
+  const s = agg.sessions.find((x) => x.id === 'cccc3333');
+  assert.ok(s, 'subagent session stays visible');
+  assert.equal(s.tokens, 0, 'replayed parent history is excluded');
+  assert.equal(s.threadSource, 'subagent');
+});
+
+test('buildIndex applies an injected Codex ledger: subagent stripped without a rollout marker', async () => {
+  _resetForTest();
+  const raw = rollout('dddd4444').replace('"thread_source":"user"', '"thread_source":null');
+  const sb = sandbox({ 'rollout-2026-07-24T09-00-00-dddd4444.jsonl': raw });
+  const withLedger = await buildIndex(opts(sb, {
+    codexState: { threads: new Map([['dddd4444', { threadSource: 'subagent' }]]), parents: new Map() },
+  }));
+  const s = withLedger.sessions.find((x) => x.id === 'dddd4444');
+  assert.equal(s.threadSource, 'subagent');
+  assert.equal(s.tokens, 0, 'ledger-identified subagent must not bill its replayed history');
+
+  // Same corpus, no ledger: the heuristic alone cannot know, tokens remain.
+  _resetForTest();
+  const without = await buildIndex(opts(sb, { force: true, codexState: null }));
+  assert.equal(without.sessions.find((x) => x.id === 'dddd4444').tokens, 604000);
+});

--- a/tests/kit/usage-insights.test.mjs
+++ b/tests/kit/usage-insights.test.mjs
@@ -421,7 +421,9 @@ test('classify-coverage: 26% unclassified fires', () => {
   const ins = byId(detectInsights(classifyAgg(26)), 'classify-coverage');
   assert.ok(ins);
   assert.equal(ins.impact, null);
-  assert.equal(ins.command, 'ak x usage classify --enrich');
+  // No command by design: the LLM-labelling pass (ADR-0009 §5 Layer 3) is not
+  // shipped, and the detector must not advertise a command that does not exist.
+  assert.equal(ins.command, null);
 });
 
 // model-routing

--- a/tests/kit/usage-limit-insights.test.mjs
+++ b/tests/kit/usage-limit-insights.test.mjs
@@ -1,0 +1,203 @@
+// detectLimitInsights (ADR-0010) and the local parity detectors added to
+// detectInsights alongside it. Purity is load-bearing: "now" is always
+// limits.generatedAt — data, not a clock — so every case here is reproducible.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { detectInsights, detectLimitInsights, THRESHOLDS } from '../../src/lib/usage-insights.mjs';
+
+const NOW = Date.parse('2026-07-27T12:00:00Z');
+const sec = (ms) => Math.round(ms / 1000);
+
+const limits = (over = {}) => ({
+  generatedAt: new Date(NOW).toISOString(),
+  claude: null,
+  codex: null,
+  ...over,
+});
+const claudeSide = (windows) => ({ provider: 'claude', source: 'statusline', fetchedAt: NOW, windows });
+const codexSide = (lanes, resetCredits = null) => ({ provider: 'codex', source: 'app-server', fetchedAt: NOW, planType: 'prolite', lanes, resetCredits });
+const byId = (list, id) => list.find((i) => i.id === id);
+const fired = (list, prefix) => list.some((i) => i.id.startsWith(prefix));
+
+// ── limit-pacing ─────────────────────────────────────────────────────────────
+
+// A weekly window 89% used with 48h of 168 still to run: elapsed 71%, used 89%
+// → ahead of pace by 1.24×… just under the 1.25 lead. Use 60h remaining
+// (elapsed 64%) so the lead is decisive.
+test('limit-pacing fires when consumption runs ahead of the window clock', () => {
+  const l = limits({
+    claude: claudeSide([{ id: 'seven_day', label: 'weekly', usedPercent: 89, windowMinutes: 10080, resetsAt: sec(NOW + 60 * 3600 * 1000) }]),
+  });
+  const ins = detectLimitInsights(l, null);
+  const f = ins.find((i) => i.id.startsWith('limit-pacing-claude'));
+  assert.ok(f, 'expected a pacing finding');
+  assert.equal(f.kind, 'trend');
+  assert.match(f.finding, /89%/);
+  assert.match(f.evidence, /elapsed/);
+});
+
+test('limit-pacing stays silent below the utilization floor', () => {
+  const l = limits({
+    claude: claudeSide([{ id: 'seven_day', label: 'weekly', usedPercent: THRESHOLDS.pacingMinUsedPercent - 1, windowMinutes: 10080, resetsAt: sec(NOW + 3600 * 1000) }]),
+  });
+  assert.equal(fired(detectLimitInsights(l, null), 'limit-pacing'), false);
+});
+
+test('limit-pacing stays silent when on or behind pace', () => {
+  // 60% used with 60% elapsed — exactly on pace, under the 1.25 lead factor.
+  const l = limits({
+    claude: claudeSide([{ id: 'seven_day', label: 'weekly', usedPercent: 60, windowMinutes: 10080, resetsAt: sec(NOW + 0.4 * 10080 * 60000) }]),
+  });
+  assert.equal(fired(detectLimitInsights(l, null), 'limit-pacing'), false);
+});
+
+test('limit-pacing needs generatedAt — no clock is ever read', () => {
+  const l = limits({
+    generatedAt: undefined,
+    claude: claudeSide([{ id: 'seven_day', label: 'weekly', usedPercent: 95, windowMinutes: 10080, resetsAt: sec(NOW + 3600 * 1000) }]),
+  });
+  assert.equal(fired(detectLimitInsights(l, null), 'limit-pacing'), false);
+});
+
+test('limit-pacing skips a window missing duration or reset', () => {
+  const l = limits({
+    claude: claudeSide([
+      { id: 'seven_day', label: 'weekly', usedPercent: 95, windowMinutes: null, resetsAt: sec(NOW + 3600 * 1000) },
+      { id: 'five_hour', label: '5h', usedPercent: 95, windowMinutes: 300, resetsAt: null },
+    ]),
+  });
+  assert.equal(fired(detectLimitInsights(l, null), 'limit-pacing'), false);
+});
+
+// ── cross-host-arbitrage ─────────────────────────────────────────────────────
+
+test('cross-host-arbitrage fires when one host is hot and the other idle', () => {
+  const l = limits({
+    claude: claudeSide([{ id: 'seven_day', label: 'weekly', usedPercent: 89, windowMinutes: 10080, resetsAt: null }]),
+    codex: codexSide([{ id: 'codex', name: 'codex', windows: [{ label: 'weekly', usedPercent: 3, windowMinutes: 10080, resetsAt: null }] }]),
+  });
+  const f = byId(detectLimitInsights(l, null), 'cross-host-arbitrage-claude');
+  assert.ok(f, 'expected an arbitrage finding');
+  assert.equal(f.command, 'ak x provider pick');
+  assert.match(f.title, /89%/);
+  assert.match(f.title, /3%/);
+});
+
+test('cross-host-arbitrage needs BOTH hosts — a hot host alone is not arbitrage', () => {
+  const l = limits({
+    claude: claudeSide([{ id: 'seven_day', label: 'weekly', usedPercent: 95, windowMinutes: 10080, resetsAt: null }]),
+  });
+  assert.equal(fired(detectLimitInsights(l, null), 'cross-host-arbitrage'), false);
+});
+
+test('cross-host-arbitrage stays silent when the other host is also busy', () => {
+  const l = limits({
+    claude: claudeSide([{ id: 'seven_day', label: 'weekly', usedPercent: 89, windowMinutes: 10080, resetsAt: null }]),
+    codex: codexSide([{ id: 'codex', name: 'codex', windows: [{ label: 'weekly', usedPercent: THRESHOLDS.arbitrageLowPercent + 1, windowMinutes: 10080, resetsAt: null }] }]),
+  });
+  assert.equal(fired(detectLimitInsights(l, null), 'cross-host-arbitrage'), false);
+});
+
+// ── codex-reset-credits ──────────────────────────────────────────────────────
+
+test('codex-reset-credits reports the count and the soonest expiry', () => {
+  const l = limits({
+    codex: codexSide([{ id: 'codex', name: 'codex', windows: [] }], {
+      availableCount: 2,
+      credits: [
+        { status: 'available', title: 'Full reset', expiresAt: sec(NOW + 4 * 86400 * 1000) },
+        { status: 'available', title: 'Full reset', expiresAt: sec(NOW + 30 * 86400 * 1000) },
+      ],
+    }),
+  });
+  const f = byId(detectLimitInsights(l, null), 'codex-reset-credits');
+  assert.ok(f);
+  assert.match(f.finding, /2/);
+  assert.match(f.finding, /4 days/);
+  assert.match(f.action, /never consumes/);
+});
+
+test('codex-reset-credits stays silent at zero credits', () => {
+  const l = limits({ codex: codexSide([], { availableCount: 0, credits: [] }) });
+  assert.equal(fired(detectLimitInsights(l, null), 'codex-reset-credits'), false);
+});
+
+test('empty input claims nothing', () => {
+  assert.deepEqual(detectLimitInsights(undefined, undefined), []);
+  assert.deepEqual(detectLimitInsights(limits(), null), []);
+});
+
+test('every limit insight satisfies the Insight contract', () => {
+  const l = limits({
+    claude: claudeSide([{ id: 'seven_day', label: 'weekly', usedPercent: 92, windowMinutes: 10080, resetsAt: sec(NOW + 60 * 3600 * 1000) }]),
+    codex: codexSide(
+      [{ id: 'codex', name: 'codex', windows: [{ label: 'weekly', usedPercent: 3, windowMinutes: 10080, resetsAt: null }] }],
+      { availableCount: 1, credits: [] },
+    ),
+  });
+  const list = detectLimitInsights(l, null);
+  assert.ok(list.length >= 3, `expected pacing + arbitrage + credits, got ${list.map((i) => i.id)}`);
+  for (const i of list) {
+    assert.ok(['coach', 'trend'].includes(i.kind), `${i.id} kind`);
+    assert.ok(['warn', 'info', 'ok'].includes(i.severity), `${i.id} severity`);
+    for (const k of ['title', 'finding', 'evidence', 'action']) {
+      assert.equal(typeof i[k], 'string', `${i.id}.${k}`);
+      assert.ok(i[k].trim().length > 0, `${i.id}.${k} non-empty`);
+    }
+    assert.equal(i.impact, null, `${i.id}: percentages are not dollars — no impact may be claimed`);
+  }
+});
+
+// ── parity detectors in detectInsights ───────────────────────────────────────
+
+const session = (over = {}) => ({
+  cost: 10, minutes: 30, prompts: 5, responses: 20, sidechain: false, threadSource: null,
+  input: 1000, output: 500, cacheRead: 0, cacheWrite: 0, models: { 'claude-sonnet-5': 1 },
+  ...over,
+});
+const agg = (sessions, totals = {}) => ({
+  totals: {
+    cost: sessions.reduce((a, s) => a + s.cost, 0),
+    sessions: sessions.length,
+    spanMinutes: 0, spanUnionSeconds: 0,
+    ...totals,
+  },
+  sessions,
+});
+
+test('parallel-sessions fires at 2× mean concurrency and names the factor', () => {
+  const a = agg([session(), session()], { spanMinutes: 240, spanUnionSeconds: 7200 }); // 4h summed vs 2h wall
+  const f = byId(detectInsights(a), 'parallel-sessions');
+  assert.ok(f);
+  assert.match(f.title, /2\.0×/);
+});
+
+test('parallel-sessions stays silent under the factor and with one session', () => {
+  assert.equal(fired(detectInsights(agg([session(), session()], { spanMinutes: 100, spanUnionSeconds: 6000 })), 'parallel-sessions'), false);
+  assert.equal(fired(detectInsights(agg([session()], { spanMinutes: 240, spanUnionSeconds: 3600 })), 'parallel-sessions'), false);
+});
+
+test('subagent-share fires on sidechain/subagent cost share ≥ threshold', () => {
+  const a = agg([session({ sidechain: true, cost: 30 }), session({ threadSource: 'subagent', cost: 20 }), session({ cost: 50 })]);
+  const f = byId(detectInsights(a), 'subagent-share');
+  assert.ok(f);
+  assert.match(f.title, /50%/);
+  assert.equal(f.impact, null, 'composition fact, not waste — no dollar claim');
+});
+
+test('subagent-share stays silent below the threshold', () => {
+  const a = agg([session({ sidechain: true, cost: 10 }), session({ cost: 90 })]);
+  assert.equal(fired(detectInsights(a), 'subagent-share'), false);
+});
+
+test('long-session-share fires on 8h+ sessions carrying the window', () => {
+  const a = agg([session({ minutes: 600, cost: 60 }), session({ cost: 40 })]);
+  const f = byId(detectInsights(a), 'long-session-share');
+  assert.ok(f);
+  assert.equal(f.command, 'ak x daemon-gc');
+});
+
+test('long-session-share stays silent when long sessions are cheap', () => {
+  const a = agg([session({ minutes: 600, cost: 10 }), session({ cost: 90 })]);
+  assert.equal(fired(detectInsights(a), 'long-session-share'), false);
+});

--- a/tests/ui/dashboard-ui.mjs
+++ b/tests/ui/dashboard-ui.mjs
@@ -60,6 +60,9 @@ const ARTIFACTS = [
   /\bInvalid Date\b/,
   /\$NaN/,
   /\bnull\b/,
+  // Internal design-record ids are for contributors, not the person reading
+  // the panel — an "ADR-0010" in visible text is documentation leaking into UI.
+  /\bADR-\d/,
 ];
 
 async function visibleText(page, selector) {
@@ -183,10 +186,35 @@ const TABS = [
 ];
 const USAGE_VIEWS = [
   ['score', '#v-score'],
+  ['limits', '#v-limits'],
   ['findings', '#v-findings'],
   ['sessions', '#v-sessions'],
   ['transcript', '#v-transcript'],
 ];
+
+// /api/limits stub (ADR-0010): injected so the harness never spawns a real
+// codex or reads ~/.config. Shape mirrors quota.mjs output, deliberately
+// including the null-heavy edges (missing resetsAt, credit without expiry)
+// that are exactly where fmtters leak "null"/"Invalid Date" into the DOM.
+const LIMITS_STUB = async () => ({
+  generatedAt: new Date().toISOString(),
+  claude: {
+    provider: 'claude', source: 'statusline', fetchedAt: Date.now() - 3 * 60_000,
+    sessionId: 'ui-stub', windows: [
+      { id: 'five_hour', label: '5h', usedPercent: 3, windowMinutes: 300, resetsAt: Math.round(Date.now() / 1000) + 7200 },
+      { id: 'seven_day', label: 'weekly', usedPercent: 89, windowMinutes: 10080, resetsAt: Math.round(Date.now() / 1000) + 172800 },
+      { id: 'seven_day_sonnet', label: 'weekly · sonnet', usedPercent: 46, windowMinutes: 10080, resetsAt: null },
+    ],
+  },
+  codex: {
+    provider: 'codex', source: 'app-server', fetchedAt: Date.now() - 60_000, planType: 'prolite',
+    lanes: [
+      { id: 'codex', name: 'codex', planType: 'prolite', windows: [{ label: 'weekly', usedPercent: 3, windowMinutes: 10080, resetsAt: Math.round(Date.now() / 1000) + 500000 }] },
+      { id: 'codex_bengalfox', name: 'GPT-5.3-Codex-Spark', planType: 'prolite', windows: [] },
+    ],
+    resetCredits: { availableCount: 2, credits: [{ status: 'available', title: 'Full reset', expiresAt: null }] },
+  },
+});
 
 async function main() {
   // The usage API is injected rather than reaching for the real stores, so the
@@ -215,6 +243,7 @@ async function main() {
       drift: [],
     }),
     usage,
+    limits: LIMITS_STUB,
   });
 
   const browser = await chromium.launch({ channel: 'chrome', headless: !HEADED });

--- a/tests/ui/dashboard-ui.mjs
+++ b/tests/ui/dashboard-ui.mjs
@@ -161,6 +161,28 @@ function extendedCorpus() {
     asst(TRUNC_ID, '/Users/me/proj', '2026-07-24T12:35:00.000Z', 'One warning.'),
   ));
 
+  // A dropped/rate-limited turn: model "<synthetic>", isApiErrorMessage, zero
+  // usage. Present so the "N dropped/errored turns excluded" qualifier under
+  // the models caption actually RENDERS here — with no exception in the corpus
+  // the element stayed empty, and the caption's line-wrap defect (the count
+  // orphaned onto the next line, reading as part of the caption) was invisible
+  // to this harness until it was seen by eye.
+  const EXC_ID = 'exc00001';
+  fs.writeFileSync(path.join(claude, '-Users-me-proj', `${EXC_ID}.jsonl`), jsonl(
+    { type: 'ai-title', aiTitle: 'Session that hit a rate limit', sessionId: EXC_ID },
+    usr(EXC_ID, '/Users/me/proj', '2026-07-24T13:00:00.000Z', 'keep going'),
+    asst(EXC_ID, '/Users/me/proj', '2026-07-24T13:01:00.000Z', 'Working on it.'),
+    {
+      type: 'assistant', sessionId: EXC_ID, cwd: '/Users/me/proj', isSidechain: false,
+      timestamp: '2026-07-24T13:02:00.000Z', isApiErrorMessage: true,
+      message: {
+        role: 'assistant', model: '<synthetic>',
+        usage: { input_tokens: 0, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
+        content: [{ type: 'text', text: 'API Error: 429 rate limit exceeded' }],
+      },
+    },
+  ));
+
   // <repo>/.git/worktrees/<rest> — collapses to project "proj" with worktree
   // "phase-1" (ADR-0009 §4b), so this row must render a chip and aaaa1111 must not.
   const wtCwd = `/Users/me/proj/.git/worktrees/${WT_NAME}`;
@@ -443,6 +465,53 @@ async function main() {
       check('KPI tooltip states the ORDERING, not just three numbers',
         (tip.match(/≤/g) || []).length >= 2,
         `title carried ${(tip.match(/≤/g) || []).length} "≤" — the invariant is the argument (ADR-0009 §4)`);
+    }
+
+    // ── the models caption's exclusion qualifier owns its own line ───────────
+    // Geometry, not markup: the defect was that "· 4" wrapped to the end of the
+    // caption line with "dropped/errored turns excluded" orphaned below, so the
+    // count read as part of the caption. A display:block sub-line is the fix,
+    // and only a rect comparison can prove the reader sees two distinct lines.
+    const modelsNote = await page.evaluate(() => {
+      const sub = document.getElementById('u-models-note');
+      if (!sub) return null;
+      const caption = sub.parentElement;
+      const s = sub.getBoundingClientRect();
+      const c = caption.getBoundingClientRect();
+      // The caption's own first line: measure a range over the text node that
+      // precedes the sub-element, so this is the rendered lead, not a guess.
+      const r = document.createRange();
+      r.setStart(caption, 0);
+      r.setEndBefore(sub);
+      const lead = r.getBoundingClientRect();
+      return {
+        text: sub.textContent.trim(),
+        leadText: r.toString().trim(),
+        display: getComputedStyle(sub).display,
+        startsBelowLead: s.top >= lead.bottom - 1,
+        sharesLeftEdge: Math.abs(s.left - c.left) <= 1,
+      };
+    });
+    await shoot(page, 'followup-models-caption');
+
+    check('the exclusion qualifier actually renders (fixture has an errored turn)',
+      !!modelsNote && modelsNote.text.length > 0,
+      'the corpus produced no exception, so this layout is untested — the fixture must carry one');
+    if (modelsNote && modelsNote.text) {
+      check('the qualifier is a block, not an inline tail',
+        modelsNote.display === 'block', `computed display was "${modelsNote.display}"`);
+      check('the qualifier begins on its own line, below the caption',
+        modelsNote.startsBelowLead,
+        `qualifier top is not below the caption's last line — it is sharing a line with `
+        + `${JSON.stringify(modelsNote.leadText)}, which is the wrap defect`);
+      check('the qualifier is a whole phrase, not a fragment split across lines',
+        /^\d[\d,]* dropped\/errored turns? excluded$/.test(modelsNote.text),
+        `read ${JSON.stringify(modelsNote.text)} — expected the count and its noun together`);
+      check('the qualifier carries no leading separator now that it owns a line',
+        !/^[·.\-–—]/.test(modelsNote.text),
+        `read ${JSON.stringify(modelsNote.text)} — a leading "·" reads as a continuation of the caption`);
+      check('the qualifier aligns with the caption it sits under',
+        modelsNote.sharesLeftEdge, 'the sub-line is indented away from its caption');
     }
 
     // ── ITEM 2 · a truncated turn announces itself, with BOTH figures ────────


### PR DESCRIPTION
Three related changes to the Usage panel, each with its own rationale below. All three share one theme: **stop guessing at facts the data can actually answer, and stop claiming precision it cannot.**

| # | Commit | What it does | Impact |
|---|---|---|---|
| 1 | `b78d4fd` | Vendor-reported plan limits + Codex thread-ledger attribution | New **Limits** sub-view; subagent double-counting fixed at the source; 18 files, +1910/−157 |
| 2 | `f720ac2` | Excluded-turns count gets its own line | Caption no longer wraps mid-phrase; layout now pinned by geometry, not markup; 4 files, +114/−37 |
| 3 | `e16867e` | Dated rate schedules, priced on the day tokens were spent | Removes a CI time bomb; historical windows stop being restated when a rate changes; 7 files, +309/−54 |

---

## 1 · Plan limits and Codex ledger attribution (`b78d4fd`)

**Why.** The scorecard could say what tokens *cost* but never how much of the *plan* they consumed. ADR-0009 §3 excluded that deliberately: a locally computed "percentage of plan used" needs a denominator no vendor publishes, and an invented denominator is worse than no number.

That reasoning was about denominators the kit would have to **fabricate**. Both vendors now hand over their own percentages through supported channels, so the denominator is no longer invented and the exclusion no longer applies. [ADR-0010](docs/adr/0010-provider-mediated-quota-reads.md) records the amendment.

**The two admissible channels — both credential-free for ak:**

| Vendor | Channel | Mechanism |
|---|---|---|
| Claude | statusLine push | Claude Code pushes `rate_limits` (session/weekly/per-model used-% + reset epochs) into every statusLine invocation on Pro/Max. The managed footer tees it to `claude-rate-limits.json`. |
| Codex | `codex app-server` | One `initialize` → `account/rateLimits/read` JSON-RPC exchange with a spawned codex, which authenticates itself. Same shell-out trust model as `ak status --json`, TTL-cached. |

The dashboard server still opens no sockets to the internet: the Claude path is a local file read, the Codex path is vendor code using vendor auth.

**Explicit non-paths.** No `api.anthropic.com/api/oauth/usage` — undocumented, hostile to unrecognized clients, and consumer-OAuth use outside Claude Code is ToS-prohibited and **server-enforced since January 2026**. No Keychain reads (the macOS item stopped carrying the token in Claude Code 2.1.x). No `chatgpt.com/backend-api/wham/*`. No auto-consumption of Codex reset credits — the panel reports them; redeeming a finite grant is the user's call.

**The trap that shaped the data model.** Codex's `primary`/`secondary` window fields do **not** reliably mean 5-hour/weekly. A live `prolite` account answered with `primary.windowDurationMins = 10080` — the weekly — and `secondary: null`. Every window is keyed and labelled by **duration**, never by slot. Trusting the field name would have mislabelled every bar.

**Codex attribution stops being heuristic.** Codex keeps its own thread ledger (`state_N.sqlite` — the suffix is a migration generation, so it is globbed) carrying `thread_source` and `thread_spawn_edges`. A ledger-identified subagent now has its usage stripped, because its rollout replays the parent's entire token history — ccusage/ccusage#950 measured up to **91× inflation**. The rollout sniff from #60 remains the fallback. Rollouts also yield reasoning tokens (a **subset** of output, annotation only) and embedded rate-limit snapshots, making a utilization history reconstructable with zero network calls.

**Findings.** Six new detectors under the existing evidence discipline — vendor percentages count as the user's own data, **no dollar impact is ever claimed from a percentage**, and "now" is the payload's `generatedAt` rather than a clock, so every firing is reproducible: `limit-pacing`, `cross-host-arbitrage`, `codex-reset-credits`, plus local parity with Claude's own `/usage` characteristics (`parallel-sessions`, `subagent-share`, `long-session-share`).

**Also fixed:** `classify-coverage` advertised `ak x usage classify --enrich`, **which does not exist**. A dead command in a diagnostic is worse than none.

**UI clarity.** The Providers strip is retitled **routed models** (it collided with Usage's "models in play") and explains itself: it is the per-activity policy projected into agentic-qe agent overrides and `ak dual run` — not a record of what ran. agentic-qe carries its own model router, so a route there is an assignment, not a guarantee. Internal ADR ids were removed from all visible text, and the UI net now fails on any that reappear.

## 2 · The excluded-turns count gets its own line (`f720ac2`)

As an inline tail on the models caption it wrapped mid-phrase, leaving `· 4` dangling at the end of one line and "dropped/errored turns excluded" orphaned on the next — the count read as part of the caption rather than as its own fact. It is now a block sub-line with no leading separator (a `·` starting a line reads as a continuation).

**The harness could not have caught this:** the fixture corpus contained no errored turn, so the element rendered empty and the wrap never happened. It now carries an `isApiErrorMessage` turn, and six assertions pin the layout by **geometry** — comparing the sub-line's rect against a `Range` measured over the caption text preceding it — because markup alone cannot prove a reader sees two distinct lines.

## 3 · Dated rate schedules (`e16867e`)

**Why.** Sonnet 5's introductory rate reverts to $3/$15 on 2026-09-01. That was a code comment promising a human would edit it, enforced by a test that read the wall clock and failed CI on a calendar date. A build that goes red for a reason that is not a defect teaches people to ignore builds.

**Clock-switching would have been the wrong fix.** Cost attribution is historical — tokens metered in August must still read as August's rate in December. Selecting by "now" restates finished windows the moment a published rate changes: a Sonnet-heavy August would jump 50% overnight with no session having changed, under a panel claiming to show "what these tokens would cost metered".

So the rate is selected by the **day the tokens were spent**, which `aggregate()` already had in hand and was simply not passing:

| Day | Sonnet 5 rate | 1M in + 1M out |
|---|---|---|
| 2026-08-31 | $2/$10 | $12.00 |
| 2026-09-01 | $3/$15 | $18.00 |

**Uniform across providers**, because a date range is a fact about a price, not about a vendor. `anthropic(5, 25)` and `openai(2.5, 15)` build one-period schedules and read exactly as before; `.dated([...])` exists identically on both. OpenAI publishes no dated promos today, so its entries are all single-period — a fact about the **data**, not the table's shape. A Codex promo is a one-line edit rather than a second mechanism built under deadline with its own boundary tests to drift. A test asserts no provider-specific rate shape exists.

**Deliberately not absorbed:** rates varying by *how* a request was served — regional uplift, large-prompt surcharge, service tiers. Transcripts record neither endpoint nor tier; a general modifier system would manufacture precision the data cannot support. They stay in `UNMODELLED_PRICING_FACTORS`.

**A subtlety a test caught.** A dateless `priceFor` prices as of `PRICES_AS_OF`, **not** the newest period. "Newest" only means "current" once every published change has landed, and judging that needs a clock this module does not read. The verification date is also what the UI prints as "rates as of …", so the default and the label cannot disagree. My first version defaulted to the newest period and an existing test expecting today's $2/$10 failed — the test doing its job.

---

## Verification

- `pnpm run check` exits 0 — 569 unit tests + all cjs suites, including **57 new tests** and the self-verifying `file:line` doc citations (re-anchored twice as these changes shifted them; the net caught both, which is its entire purpose).
- Playwright artifact net **108/108**, extended to the Limits view with a deliberately null-heavy stub — it caught a real bug where a null reset time rendered as an epoch-1970 date.
- `/api/limits` smoke-tested against real local state: `prolite` plan, both lanes, 2 reset credits, a genuine `codex-reset-credits` finding.

**Docs.** ADR-0010 is new; ADR-0009 §3 records both the quota amendment and the day-of-spend pricing decision; USAGE-SCORECARD-METRICS gains §3a, §13b, §13c. `PROVIDERS.md` is deliberately untouched — it covers host/provider configuration, not rate mechanics or quota reads.

**Note for reviewers:** Claude's limit bars read "no data" until `ak sync` injects the updated statusline footer and one Claude session runs — the tee is push-only by design, and the empty state says so. Codex's bars populate immediately.
