### PR TITLE
fix(court-remand): five bounded conditions from the #76 qe-court verdict

### DIFF
--- a/src/commands/run.mjs
+++ b/src/commands/run.mjs
@@ -65,7 +65,7 @@ function printResults(results) {
   }
 }
 
-export async function run({ flags, positionals, executePlan = executeRunPlan }) {
+export async function run({ flags, positionals, executePlan = executeRunPlan, cfg = loadKitConfig() }) {
   const template = positionals[0];
   const task = positionals.slice(1).join(' ').trim();
   if (!template || !DUAL_RUN_TEMPLATE_NAMES.includes(template)) {
@@ -76,7 +76,7 @@ export async function run({ flags, positionals, executePlan = executeRunPlan }) 
   let plan;
   let warnings;
   try {
-    ({ plan, warnings } = buildRunPlan(loadKitConfig(), template, task, flags.route ?? []));
+    ({ plan, warnings } = buildRunPlan(cfg, template, task, flags.route ?? []));
   } catch (error) {
     fail(error.message);
     return 2;

--- a/src/commands/run.mjs
+++ b/src/commands/run.mjs
@@ -65,7 +65,7 @@ function printResults(results) {
   }
 }
 
-export async function run({ flags, positionals }) {
+export async function run({ flags, positionals, executePlan = executeRunPlan }) {
   const template = positionals[0];
   const task = positionals.slice(1).join(' ').trim();
   if (!template || !DUAL_RUN_TEMPLATE_NAMES.includes(template)) {
@@ -94,10 +94,12 @@ export async function run({ flags, positionals }) {
     timeoutMs = positiveInt(flags.timeout, 'timeout');
   } catch (error) { fail(error.message); return 2; }
   if (!flags.json) printPlan(plan);
-  const results = await executeRunPlan(plan, { maxConcurrent, timeoutMs });
+  const results = await executePlan(plan, { maxConcurrent, timeoutMs });
   if (flags.json) console.log(JSON.stringify({ plan, results }, null, 2));
   else printResults(results);
-  if (results.every((result) => result.status === 'succeeded')) { ok('run complete'); return 0; }
-  fail('run finished with one or more non-successful workers');
-  return 1;
+  // The human status line is gated on !json — a trailing "✓ run complete"
+  // after the document makes `ak run --json` unparseable (qe-court B8).
+  const succeeded = results.every((result) => result.status === 'succeeded');
+  if (!flags.json) (succeeded ? ok : fail)(succeeded ? 'run complete' : 'run finished with one or more non-successful workers');
+  return succeeded ? 0 : 1;
 }

--- a/src/lib/adapters/registries.mjs
+++ b/src/lib/adapters/registries.mjs
@@ -176,6 +176,22 @@ export const OBSERVABILITY_REGISTRY = immutable(Object.values(OBSERVABILITY_MAP)
 export const HOST_REGISTRY = immutable(Object.values(HOST_MAP));
 export const PROVIDER_REGISTRY = immutable(Object.values(PROVIDER_MAP));
 
+// Cross-axis invariants — duplicate ids, unknown projection/observability
+// references, the canDriveSession → canBePrimary/canRouteActivities
+// relationship, billing/credential consistency — are enforced AT CONSTRUCTION,
+// not only in tests. Previously validateRegistries ran nowhere in production
+// (qe-court charge A3): a host flipped to canRouteActivities without
+// canDriveSession would have loaded silently and been accepted by `ak run`.
+const registryErrors = validateRegistries({
+  hosts: Object.values(HOST_MAP),
+  providers: Object.values(PROVIDER_MAP),
+  projections: Object.values(PROJECTION_MAP),
+  observability: Object.values(OBSERVABILITY_MAP),
+});
+if (registryErrors.length) {
+  throw new Error(`adapter registries invalid: ${registryErrors.map((e) => `${e.path} (${e.code})`).join('; ')}`);
+}
+
 /** @param {(entry: any) => boolean} [predicate] */
 export const hostIds = (predicate = () => true) => HOST_REGISTRY.filter(predicate).map(({ id }) => id);
 /** @param {(entry: any) => boolean} [predicate] */

--- a/src/lib/execution/runner.mjs
+++ b/src/lib/execution/runner.mjs
@@ -48,7 +48,10 @@ export async function executeWorker(worker, adapter, {
     const watched = await observeBeforeDeadline(adapter, state, timeoutMs);
     if (watched.timedOut) {
       const cancelled = await adapter.cancel(state);
-      return adapter.interpret(state, { type: cancelled?.orphaned ? 'orphaned' : 'timeout' });
+      // Schema validation applies to EVERY terminal interpret(), not only the
+      // success path — the timeout branch is exactly where a malformed result
+      // would otherwise ship unbounded into `ak run --json` (qe-court A2).
+      return validateWorkerResult(adapter.interpret(state, { type: cancelled?.orphaned ? 'orphaned' : 'timeout' }));
     }
     return validateWorkerResult(adapter.interpret(state, watched.observation));
   } catch (error) {

--- a/src/lib/execution/subprocess.mjs
+++ b/src/lib/execution/subprocess.mjs
@@ -58,7 +58,11 @@ function resultFor(state, observation, host, clock) {
   return validateWorkerResult({
     workerId: state.worker.id, activity: state.worker.activity, role: state.worker.role, host,
     status, exitCategory, startedAt: state.startedAt, endedAt, durationMs,
-    provider: host, providerProvenance: 'configured', configuredModel: state.worker.configuredModel ?? null,
+    // ADR-0018's invariant: a host or its provider/model selector NEVER proves
+    // the inference provider. The subprocess adapters observe exit codes, not
+    // billing identity (a claude session may be Anthropic, OpenRouter, or
+    // Ollama-served) — record unknown, not `provider: host` (qe-court B6).
+    provider: null, providerProvenance: 'unknown', configuredModel: state.worker.configuredModel ?? null,
     observedModel: null, sessionId: null, transcriptRefs: [], failure, usage: null,
   });
 }

--- a/src/lib/routing.mjs
+++ b/src/lib/routing.mjs
@@ -200,7 +200,12 @@ export function resolveRoutes(policy = {}) {
     if (!p) { out[act] = { ...def, source: 'default', akOriginated: AK_ORIGINATED.has(act) }; continue; }
     out[act] = {
       host: p.host ?? def.host,
-      model: p.model ?? def.model,
+      // A host-only override must NOT inherit the previous host's default
+      // model: `--route implementation:claude` handing codex's default model
+      // to the claude CLI is a live model/protocol error (qe-court B1). The
+      // default only falls forward for the SAME host; a cross-host override
+      // leaves the model to the adapter's own default (null).
+      model: p.model ?? (p.host && p.host !== def.host ? null : def.model),
       ...((p.escalate ?? def.escalate) ? { escalate: p.escalate ?? def.escalate } : {}),
       source: p.source ?? 'user',
       akOriginated: AK_ORIGINATED.has(act),

--- a/tests/kit/adapter-registries.test.mjs
+++ b/tests/kit/adapter-registries.test.mjs
@@ -10,6 +10,11 @@ import {
 import {
   validHost, validProvider, validRegistries,
 } from './helpers/integration-builders.mjs';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
 
 test('the built-in registries satisfy their own contract', () => {
   assert.deepEqual(validateRegistries({
@@ -18,6 +23,18 @@ test('the built-in registries satisfy their own contract', () => {
     projections: PROJECTION_REGISTRY,
     observability: OBSERVABILITY_REGISTRY,
   }), []);
+});
+
+// qe-court A3: the cross-axis invariants now run AT module construction — a
+// host edit that violates canDriveSession → canBePrimary/canRouteActivities
+// (or any other cross-axis rule) makes the import itself throw instead of
+// loading silently. Pin it with a real import in a fresh process.
+test('the shipped registries cannot fail construction-time validation (import cannot throw)', () => {
+  const r = spawnSync(process.execPath, ['-e',
+    "import('./src/lib/adapters/registries.mjs').then(() => console.log('construction-valid'))",
+  ], { encoding: 'utf8', cwd: REPO });
+  assert.equal(r.status, 0, `registries module must import cleanly:\n${r.stderr}`);
+  assert.match(r.stdout, /construction-valid/);
 });
 
 test('built-in ids are unique within each registry and host/provider axes stay distinct', () => {

--- a/tests/kit/execution-runner.test.mjs
+++ b/tests/kit/execution-runner.test.mjs
@@ -33,6 +33,31 @@ function adapter({ observation = { type: 'idle' }, events = [] } = {}) {
   };
 }
 
+// qe-court A2: the timeout branch must schema-validate interpret() too — a
+// malformed timeout result becomes a bounded protocol_error, never garbage
+// shipped raw into `ak run --json`.
+test('a malformed interpret() on the timeout path is bounded, not shipped raw (qe-court A2)', async () => {
+  const malformed = {
+    id: 'mal',
+    async readiness() { return { ready: true }; },
+    async prepare({ worker: w }) { return { worker: w }; },
+    async launch(state) { return state; },
+    async observe() { return new Promise(() => {}); }, // never settles → the deadline hits
+    interpret() { return { bogus: true }; },            // garbage a strict validator must reject
+    async cancel() {},
+    async cleanup() {},
+  };
+  const results = await executeRunPlan({ workers: [worker('a', 'opencode')] }, {
+    adapters: { opencode: malformed }, timeoutMs: 5, clock,
+  });
+  assert.equal(results.length, 1);
+  assert.equal(results[0].workerId, 'a');
+  assert.equal(results[0].status, 'failed');
+  assert.equal(results[0].exitCategory, 'protocol_error',
+    'a malformed timeout interpret() is converted to a bounded protocol error, not shipped as-is');
+  assert.ok(results[0].failure && typeof results[0].failure.reason === 'string');
+});
+
 test('runner schedules a dependency DAG and blocks only descendants of a failure', async () => {
   const events = [];
   const ok = adapter({ events });

--- a/tests/kit/routing.test.mjs
+++ b/tests/kit/routing.test.mjs
@@ -69,9 +69,22 @@ test('a persisted user route overlays defaults and keeps source=user', () => {
 });
 
 test('a persisted entry with no explicit source is treated as a user edit', () => {
-  const routes = resolveRoutes({ testing: { host: 'claude' } });
+  const routes = resolveRoutes({ testing: { host: DEFAULT_ROUTES.testing.host } });
   assert.equal(routes.testing.source, 'user');
-  assert.equal(routes.testing.model, DEFAULT_ROUTES.testing.model, 'unset field falls back to default');
+  assert.equal(routes.testing.model, DEFAULT_ROUTES.testing.model, 'same-host: unset field falls back to default');
+});
+
+test('a host-only override never inherits the previous host default model (qe-court B1)', () => {
+  const foreign = Object.entries(DEFAULT_ROUTES).find(([, d]) => d.host !== 'claude');
+  assert.ok(foreign, 'fixture needs a non-claude default route');
+  const [activity] = foreign;
+  const routes = resolveRoutes({ [activity]: { host: 'claude' } });
+  assert.equal(routes[activity].host, 'claude');
+  assert.equal(routes[activity].model, null,
+    'cross-host override leaves the model to the adapter default, not the other host\'s default');
+  // an explicit model on a cross-host override is still honored verbatim
+  const pinned = resolveRoutes({ [activity]: { host: 'claude', model: 'claude-sonnet-5' } });
+  assert.equal(pinned[activity].model, 'claude-sonnet-5');
 });
 
 // ── seedDualRouting (cost-safety gate) ──────────────────────────────────────

--- a/tests/kit/run-command.test.mjs
+++ b/tests/kit/run-command.test.mjs
@@ -1,7 +1,23 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { buildRunPlan } from '../../src/commands/run.mjs';
+import { buildRunPlan, run } from '../../src/commands/run.mjs';
 import { seedDualRouting } from '../../src/lib/routing.mjs';
+
+/** Run `fn` with console.log captured; returns { result, out }. */
+async function captureLog(fn) {
+  const lines = [];
+  const real = console.log;
+  console.log = (...a) => lines.push(a.map(String).join(' '));
+  try { return { result: await fn(), out: lines.join('\n') }; }
+  finally { console.log = real; }
+}
+
+const succeededResult = (worker) => ({
+  workerId: worker.id, activity: worker.activity, role: worker.role, host: worker.host,
+  status: 'succeeded', exitCategory: 'success', startedAt: 'x', endedAt: 'y', durationMs: 1,
+  provider: null, providerProvenance: 'unknown', configuredModel: worker.configuredModel ?? null,
+  observedModel: null, sessionId: null, transcriptRefs: [], failure: null, usage: null,
+});
 
 test('ak run materializes the host-neutral plan and keeps run-local route overrides ephemeral', () => {
   const cfg = { providers: { dualRouting: seedDualRouting() } };
@@ -19,4 +35,27 @@ test('ak run materializes an explicit OpenCode route', () => {
   const scanner = plan.workers.find((entry) => entry.activity === 'security-scan');
   assert.equal(scanner.host, 'opencode');
   assert.equal(scanner.configuredModel, 'openrouter/example');
+});
+
+// qe-court B8: `--json` must emit exactly one parseable document — the human
+// status line ("✓ run complete" / the failure text) is gated on !json.
+test('ak run --json emits exactly one parseable JSON document (qe-court B8)', async () => {
+  const executePlan = async (plan) => plan.workers.map(succeededResult);
+  const { result, out } = await captureLog(() => run({
+    flags: { json: true }, positionals: ['feature', 'probe'], executePlan,
+  }));
+  assert.equal(result, 0);
+  const parsed = JSON.parse(out); // throws if the status line contaminates the document
+  assert.equal(parsed.plan.template, 'feature');
+  assert.equal(parsed.results.length, parsed.plan.workers.length);
+  assert.ok(!/run complete|non-successful/.test(out), 'no human status line in json mode');
+});
+
+test('ak run without --json still prints the human status line', async () => {
+  const executePlan = async (plan) => plan.workers.map(succeededResult);
+  const { result, out } = await captureLog(() => run({
+    flags: {}, positionals: ['feature', 'probe'], executePlan,
+  }));
+  assert.equal(result, 0);
+  assert.match(out, /run complete/);
 });

--- a/tests/kit/run-command.test.mjs
+++ b/tests/kit/run-command.test.mjs
@@ -39,10 +39,13 @@ test('ak run materializes an explicit OpenCode route', () => {
 
 // qe-court B8: `--json` must emit exactly one parseable document — the human
 // status line ("✓ run complete" / the failure text) is gated on !json.
+// The cfg seam keeps these fully deterministic (no real kit.json is read).
+const testCfg = () => ({ providers: { dualRouting: seedDualRouting() } });
+
 test('ak run --json emits exactly one parseable JSON document (qe-court B8)', async () => {
   const executePlan = async (plan) => plan.workers.map(succeededResult);
   const { result, out } = await captureLog(() => run({
-    flags: { json: true }, positionals: ['feature', 'probe'], executePlan,
+    flags: { json: true }, positionals: ['feature', 'probe'], executePlan, cfg: testCfg(),
   }));
   assert.equal(result, 0);
   const parsed = JSON.parse(out); // throws if the status line contaminates the document
@@ -54,7 +57,7 @@ test('ak run --json emits exactly one parseable JSON document (qe-court B8)', as
 test('ak run without --json still prints the human status line', async () => {
   const executePlan = async (plan) => plan.workers.map(succeededResult);
   const { result, out } = await captureLog(() => run({
-    flags: {}, positionals: ['feature', 'probe'], executePlan,
+    flags: {}, positionals: ['feature', 'probe'], executePlan, cfg: testCfg(),
   }));
   assert.equal(result, 0);
   assert.match(out, /run complete/);

--- a/tests/kit/subprocess-execution.test.mjs
+++ b/tests/kit/subprocess-execution.test.mjs
@@ -34,6 +34,22 @@ test('Claude adapter uses print/json mode without a permission bypass', async ()
   assert.ok(!calls[0].args.some((arg) => arg.includes('dangerously') || arg.includes('bypass')));
 });
 
+// qe-court B6: the subprocess adapters observe exit codes, not billing
+// identity — provider must be recorded as unknown, never fabricated from the
+// host id (ADR-0018's invariant).
+test('subprocess results never fabricate provider identity from the host (qe-court B6)', async () => {
+  for (const host of ['claude', 'codex']) {
+    const adapter = (host === 'claude' ? createClaudeExecutionAdapter : createCodexExecutionAdapter)({
+      haveFn: async () => true, clock,
+      spawnFn: () => child(),
+    });
+    const result = await executeWorker(worker(host), adapter, { cwd: process.cwd(), clock });
+    assert.equal(result.status, 'succeeded');
+    assert.equal(result.provider, null, `${host}: provider must not be the host id`);
+    assert.equal(result.providerProvenance, 'unknown', `${host}: provenance must be unknown without observation`);
+  }
+});
+
 test('Codex adapter pins its supplied workspace and normalizes host failures', async () => {
   const calls = [];
   const adapter = createCodexExecutionAdapter({


### PR DESCRIPTION
## Summary

The cross-vendor qe-court on the #76 final head (`6347d1a`) returned **REMAND** with eight bounded conditions ([record + rationale](https://github.com/pacphi/agentic-kit/issues/76#issuecomment-5118689297)). This PR is the bounded subset:

- **B1** `routing.mjs` — a host-only `--route` override no longer inherits the *previous* host's default model (`implementation:claude` stopped handing codex's model to the claude CLI — reproduced live in the smoke). Cross-host leaves the model to the adapter's own default. The codified "unset falls back to default" behavior it replaces is re-pinned as same-host-only.
- **B8** `run.mjs` — the human status line is gated behind `!flags.json`: `ak run --json` emits exactly one parseable document again.
- **B6** `subprocess.mjs` — `provider`/`providerProvenance` recorded as `unknown` on the claude/codex subprocess path (exit codes don't prove billing identity — ADR-0018's own invariant), never fabricated from the host id.
- **A2** `runner.mjs` — `validateWorkerResult` now covers the timeout `interpret()` branch: a malformed adapter result becomes a bounded `protocol_error` instead of shipping raw.
- **A3** `registries.mjs` — `validateRegistries` (duplicate ids, dangling projection/observability refs, `canDriveSession`→routing capabilities, billing/credential consistency) now runs **at module construction** — a violating host edit throws at import instead of loading silently.

## Deliberately not in this PR

The three remaining conditions are architectural and belong to the maintainer's in-flight work: **B3** (threading dependency outputs into dependent prompts vs. documenting the shared-cwd contract), **B4/B5** (runner lifecycle bounds: timeout coverage of readiness/prepare/launch + `terminate()` close-wait/SIGKILL), and **B7** (generalized `--escalate` in `ak run` — punch-list item 1 on #76).

## Verification

- Regression test per fix: B1 same-host fallback re-pinned + cross-host null; B8 document-purity via a new `run()` `executePlan` test seam; B6 unknown-provenance on both subprocess adapters; A2 malformed-timeout-interpret bounded; A3 fresh-process import pin.
- `pnpm run check` **exit 0** (1055 kit + cjs), `pnpm run test:surface` **exit 0** (25).

Refs #76. Stacks independently of #85 (adapter protocol fix).
