### PR TITLE
docs(swarm-review): three coherence nits from the #76 swarm documentation review

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ ak dashboard    open the local web dashboard (auto-opens your browser)
 ak host         manage execution hosts, routing, and provider bindings
                 status | pick | refresh | off
 ak run          execute a host-neutral activity pipeline (including explicit OpenCode routes)
-                <template> "<task>"  [--dry-run] [--route ...] [--max-concurrent N] [--timeout ms]
+                <template> "<task>"  [--dry-run] [--route ...] [--max-concurrent N] [--timeout ms] [--json]
 ak dual         deprecated Claude+Codex compatibility wrapper; use ak run for new work
 ak x statusline manage Codex's native user-wide status line          status | codex native|extended|off
 ak uninstall    leave cleanly                [--dry-run] [--this-project] [--remove-ruflo] [--remove-aqe] [--purge] [--yes]

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -26,9 +26,9 @@ provider can therefore have independent `ollama-via-claude` and `ollama-via-code
 OpenRouter is a provider behind a host, never automatically a third host. OpenCode is an opt-in
 activity-routing host through `ak run`, while remaining ineligible as a primary host or AQE
 provider. Its configured selector does not establish provider, billing, or vendor-diversity facts.
-This Proposed capability model is
-[ADR-0016](adr/0016-capability-driven-integration-adapters.md); current controls below remain
-backward compatible while its implementation proceeds.
+This capability model is
+[ADR-0016](adr/0016-capability-driven-integration-adapters.md) (Accepted); the controls below
+implement it and remain backward compatible.
 
 > [!IMPORTANT]
 > During the alpha, `ak host` is the canonical namespace for execution-host lifecycle and

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -26,6 +26,10 @@ family on your behalf.
 | `ak x statusline codex native\|extended` | opt into a user-wide Codex status-line preset | **yes** — records the preset |
 | `ak setup`           | first-time bootstrap of absent tooling          | only via explicit flags (`--codex`, `--opencode`, `--primary-host`) |
 
+| Migration surface   | What to know                                    |
+| ------------------- | ----------------------------------------------- |
+| `ak dual` → `ak run` | `ak dual` is a deprecated compatibility wrapper — existing scripts keep working (it warns on stderr and will be removed before the stable release); use `ak run` for new execution work. OpenCode routes require the current release — remove them before downgrading. |
+
 A **host** runs the work; a **provider** serves inference. A binding can connect one provider to
 several hosts through separate native configuration **projections**, while **observability**
 sources establish facts with observed, configured, inferred, or unknown provenance. Upgrading does


### PR DESCRIPTION
## Summary

Three coherence nits from the documentation leg of the #76 swarm review (report on #76):

- `docs/PROVIDERS.md` — ADR-0016 is **Accepted** (the registries it defines are implemented); the page said Proposed.
- `README.md` — `--json` added to the `ak run` flag list (`run.mjs` options + help already document it).
- `docs/UPGRADING.md` — the `ak dual` → `ak run` migration row an upgrader hits via stderr was missing (deprecation state + a note that opencode routes require the current release before downgrading).

markdownlint clean. Refs #76.
