### PR TITLE
fix(execution): swarm-review follow-ups — security hardening, Windows shims, correctness nits, test gaps (#88)

### DIFF
--- a/docs/adr/0018-generalized-host-worker-execution.md
+++ b/docs/adr/0018-generalized-host-worker-execution.md
@@ -2,6 +2,8 @@
 
 - **Status:** Accepted
 - **Date:** 2026-07-29
+- **Updated:** 2026-07-30
+- **Update note:** Hardened trusted-policy validation, adapter invariants, plan guards, and bounded worker teardown.
 - **Deciders:** agentic-kit maintainers
 
 ## Context
@@ -67,6 +69,27 @@ permission-response contract required for a routable worker. [OpenCode CLI docum
 6. OpenCode declares `canRouteActivities:true` only with the runnable adapter and its
    conformance evidence. Its routes are accepted by `ak run`, but are never auto-seeded,
    AQE-projected, primary-host eligible, or accepted by deprecated `ak dual`.
+
+### The trust boundary (stated, not weakened)
+
+`ak run` executes workers with the **user's own CLI trust posture in the target
+repository**. That means the repository itself is *inside* the trust boundary:
+
+- An owned OpenCode server reads the project `opencode.json` from the target cwd. A
+  repository that ships `{"permission":{"bash":"allow"}}` (or hostile `mcp` entries)
+  pre-approves those permissions — **no `permission.updated` event ever fires, so the
+  adapter's abort boundary does not trip by design**. The abort covers permission
+  *requests*; it is not a sandbox.
+- Claude/Codex workers likewise inherit the repo's `.claude/settings.json` hooks and
+  permissions under the user's own workspace trust for that path.
+- Repository content (`AGENTS.md`, README, source) flows into worker prompts — an
+  indirect prompt-injection channel for any agent runner, ak included.
+
+**Contract: run `ak` (and any agent runner) only in repositories you would trust with
+your full user privileges.** ak will not silently weaken, bypass, or "secure" a hostile
+repo for you; what it guarantees instead is the honest version: loopback-only owned
+servers, ephemeral per-run credentials, no `--auto`, no permission approval on your
+behalf, and terminal evidence that records what actually ran.
 
 ## Consequences
 

--- a/src/commands/run.mjs
+++ b/src/commands/run.mjs
@@ -19,6 +19,10 @@ export const help = `ak run — execute a host-neutral activity pipeline
 Materializes the managed per-activity routing policy and runs each worker through
 its host adapter. OpenCode is accepted only after its routing capability is enabled.
 
+Trust boundary: workers run with YOUR CLI trust posture in the target repo —
+its opencode.json / .claude settings / AGENTS.md apply. Run this only in
+repositories you would trust with your full user privileges (ADR-0018).
+
 Usage:
   ak run <template> "<task>"
 
@@ -40,10 +44,38 @@ Examples:
   ak run security "src/auth/" --route 'security-scan:opencode'
   ak run feature "fix the flaky parser" --escalate`;
 
-function positiveInt(value, name) {
+/** @param {string|undefined} value @param {string} name @param {{ ceiling?: number }} [opts] */
+function positiveInt(value, name, { ceiling } = {}) {
   if (value === undefined) return undefined;
   if (!/^\d+$/.test(value) || Number(value) < 1) throw new TypeError(`${name} must be a positive integer`);
-  return Number(value);
+  const n = Number(value);
+  // Node clamps setTimeout delays above 2^31-1 ms to ~1 ms — an uncapped
+  // --timeout would turn a huge value into an instant timeout for every
+  // worker (#88). Reject above the ceiling rather than silently mis-timing.
+  if (ceiling && n > ceiling) throw new TypeError(`${name} must not exceed ${ceiling} (a larger value is clamped to ~1ms by Node's timer)`);
+  return n;
+}
+
+/** A persisted dualRouting entry (kit.json is hand-editable — CLI routes are
+ *  validated, file entries were not, and a bad one crashed plan *printing*
+ *  far from the cause, #88). Returns an error string, or null when valid. */
+function routeEntryError(activity, entry) {
+  if (!entry || typeof entry !== 'object') return `route "${activity}" must be an object`;
+  if (typeof entry.host !== 'string' || !entry.host) return `route "${activity}" requires a non-empty host string`;
+  if (entry.model != null && typeof entry.model !== 'string') return `route "${activity}".model must be a string when present`;
+  if (entry.escalate != null) {
+    if (!Array.isArray(entry.escalate)) return `route "${activity}".escalate must be an array when present`;
+    for (const [i, rung] of entry.escalate.entries()) {
+      if (!rung || typeof rung.host !== 'string' || !rung.host) return `route "${activity}".escalate[${i}] requires a non-empty host string`;
+      if (rung.model != null && typeof rung.model !== 'string') return `route "${activity}".escalate[${i}].model must be a string when present`;
+    }
+  }
+  return null;
+}
+
+function validatePolicy(policy) {
+  const errors = Object.entries(policy).map(([a, e]) => routeEntryError(a, e)).filter(Boolean);
+  if (errors.length) throw new Error(`invalid routing policy: ${errors.join('; ')}`);
 }
 
 export function buildRunPlan(cfg, template, task, routeFlags = []) {
@@ -51,8 +83,10 @@ export function buildRunPlan(cfg, template, task, routeFlags = []) {
   if (routeFlags.length) {
     const { policy: overrides, warnings } = parseRouteSpecs(routeFlags);
     policy = { ...policy, ...overrides };
+    validatePolicy(policy);
     return { plan: materializeRunPlan(policy, { template, task }), warnings };
   }
+  validatePolicy(policy);
   return { plan: materializeRunPlan(policy, { template, task }), warnings: [] };
 }
 
@@ -101,7 +135,7 @@ export async function run({ flags, positionals, executePlan = executeRunPlan, cf
   let timeoutMs;
   try {
     maxConcurrent = positiveInt(flags['max-concurrent'], 'max-concurrent');
-    timeoutMs = positiveInt(flags.timeout, 'timeout');
+    timeoutMs = positiveInt(flags.timeout, 'timeout', { ceiling: 2_147_483_647 });
   } catch (error) { fail(error.message); return 2; }
   if (!flags.json) printPlan(plan);
   const results = await executePlan(plan, { maxConcurrent, timeoutMs, escalate: !!flags.escalate });

--- a/src/lib/exec.mjs
+++ b/src/lib/exec.mjs
@@ -6,11 +6,10 @@
 // forced `shell:true`, which hands Node's own cmd+args JOIN of the whole
 // command line to cmd.exe as ONE string (CVE-class: any arg with `&`/`|`/`^`
 // breaks out into a second command). The actual fix is resolving the shim to
-// its real file on PATH (with extension) and calling execFile on THAT path
-// directly with shell:false: Node >=18.20.2/20.12.2/21.7.2 (this package
-// requires >=22 — see package.json engines) internally detects a .cmd/.bat
-// target and safely re-invokes cmd.exe itself, with each argv element
-// properly escaped — the CVE-2024-27980 fix. Callers never need shell:true.
+// its real file on PATH. Native .com/.exe files run directly. A .cmd shim is
+// never passed to execFile: Node does not execute batch files without a shell.
+// Instead, its sibling .ps1 shim runs through Windows PowerShell's `-File`
+// interface, preserving every caller argument as a separate argv element.
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import fs from 'node:fs';
@@ -19,34 +18,78 @@ import { isWindows } from './paths.mjs';
 
 const pexecFile = promisify(execFile);
 
-const CMD_SHIMS = new Set(['npm', 'npx', 'claude', 'opencode', 'ruflo', 'aqe', 'claude-flow']);
+const CMD_SHIMS = new Set(['npm', 'npx', 'claude', 'codex', 'opencode', 'ruflo', 'aqe', 'claude-flow']);
 
-/** Resolve `cmd` to its real file on PATH, trying Windows' shim extensions in
- *  PATHEXT order. Falls back to the bare name (execFile will ENOENT honestly)
- *  if nothing on PATH matches — never silently launches the wrong binary. */
-function resolveShim(cmd) {
-  if (!isWindows || path.isAbsolute(cmd)) return cmd;
-  const exts = (process.env.PATHEXT || '.COM;.EXE;.BAT;.CMD').split(';');
-  for (const dir of (process.env.PATH || process.env.Path || '').split(path.delimiter)) {
+/** Build a shell-free invocation for `cmd`, trying Windows' shim extensions in
+ *  PATHEXT order. A native executable is launched directly; a .cmd shim is
+ *  accepted only when its sibling .ps1 and system PowerShell both exist.
+ *  Falls back to the bare name with resolved:false when no safe target exists.
+ *  Exported: the execution adapters spawn these CLIs directly (subprocess.mjs
+ *  for claude/codex, opencode.mjs for the serve child) and must share the same
+ *  resolution `run()`/`have()` use, or readiness passes but launch ENOENTs on
+ *  Windows (swarm review, #88). */
+export function resolveShim(cmd, args = [], { windows = isWindows, env = process.env } = {}) {
+  const direct = { command: cmd, args: [...args], resolved: !windows };
+  if (!windows) return direct;
+
+  const systemRoot = env.SystemRoot || env.WINDIR;
+  const powershell = systemRoot
+    ? path.join(systemRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe')
+    : null;
+  const invocationFor = (candidate) => {
+    let stat;
+    try { stat = fs.statSync(candidate); } catch { return null; }
+    if (!stat.isFile()) return null;
+    const ext = path.extname(candidate).toLowerCase();
+    if (ext === '.com' || ext === '.exe' || !ext) {
+      return { command: candidate, args: [...args], resolved: true };
+    }
+    if (ext !== '.cmd' || !powershell) return null;
+    const script = `${candidate.slice(0, -ext.length)}.ps1`;
+    try {
+      if (!fs.statSync(script).isFile() || !fs.statSync(powershell).isFile()) return null;
+    } catch { return null; }
+    return {
+      command: powershell,
+      args: [
+        '-NoLogo', '-NoProfile', '-NonInteractive',
+        '-ExecutionPolicy', 'Bypass', '-File', script, ...args,
+      ],
+      resolved: true,
+    };
+  };
+
+  if (path.isAbsolute(cmd)) return invocationFor(cmd) ?? direct;
+  const exts = (env.PATHEXT || '.COM;.EXE;.BAT;.CMD')
+    .split(';')
+    .map((ext) => ext.trim())
+    .filter(Boolean);
+  for (const dir of (env.PATH || env.Path || '').split(path.delimiter)) {
     if (!dir) continue;
     for (const ext of exts) {
-      const candidate = path.join(dir, cmd + ext.toLowerCase());
-      try { if (fs.statSync(candidate).isFile()) return candidate; } catch { /* try the next */ }
+      const invocation = invocationFor(path.join(dir, cmd + ext.toLowerCase()));
+      if (invocation) return invocation;
     }
   }
-  return cmd;
+  return direct;
 }
 
 /** Run a command; never throws. Returns {code, stdout, stderr}. */
 export async function run(cmd, args = [], opts = {}) {
   try {
-    const resolved = CMD_SHIMS.has(cmd) ? resolveShim(cmd) : cmd;
-    const { stdout, stderr } = await pexecFile(resolved, args, {
+    const env = opts.env ? { ...process.env, ...opts.env } : process.env;
+    const invocation = CMD_SHIMS.has(cmd)
+      ? resolveShim(cmd, args, { env })
+      : { command: cmd, args };
+    if (invocation.resolved === false) {
+      return { code: 1, stdout: '', stderr: `No safe Windows invocation found for ${cmd}` };
+    }
+    const { stdout, stderr } = await pexecFile(invocation.command, invocation.args, {
       encoding: 'utf8',
       timeout: opts.timeout ?? 120_000,
       maxBuffer: 16 * 1024 * 1024,
       cwd: opts.cwd,
-      env: opts.env ? { ...process.env, ...opts.env } : process.env,
+      env,
       shell: false,
     });
     return { code: 0, stdout, stderr };
@@ -62,10 +105,7 @@ export async function run(cmd, args = [], opts = {}) {
 /** Is `cmd` invokable? (cross-platform `command -v`) */
 export async function have(cmd) {
   if (isWindows) {
-    if (path.isAbsolute(cmd)) {
-      try { return fs.statSync(cmd).isFile(); } catch { return false; }
-    }
-    return resolveShim(cmd) !== cmd;
+    return resolveShim(cmd).resolved;
   }
   return (await run('which', [cmd])).code === 0;
 }

--- a/src/lib/execution/adapters.mjs
+++ b/src/lib/execution/adapters.mjs
@@ -3,9 +3,28 @@
 import { OPENCODE_EXECUTION_ADAPTER } from './opencode.mjs';
 import { CLAUDE_EXECUTION_ADAPTER } from './claude.mjs';
 import { CODEX_EXECUTION_ADAPTER } from './codex.mjs';
+import { routableHostIds } from '../adapters/index.mjs';
 
 export const EXECUTION_ADAPTERS = Object.freeze(new Map([
   ['claude', CLAUDE_EXECUTION_ADAPTER],
   ['codex', CODEX_EXECUTION_ADAPTER],
   ['opencode', OPENCODE_EXECUTION_ADAPTER],
 ]));
+
+// Construction invariant (#88, architecture leg): every routable host needs an
+// execution adapter, and every adapter needs a routable host — enforced at
+// import, exactly like the capability registries' own construction check. A
+// host flipped to canRouteActivities without an adapter (or an adapter added
+// for an unroutable host) would otherwise load cleanly and fail only at
+// runtime with cli_unavailable on every worker — issue #71's trap.
+{
+  const routable = new Set(routableHostIds());
+  const adapted = new Set(EXECUTION_ADAPTERS.keys());
+  const missing = [...routable].filter((id) => !adapted.has(id));
+  const stray = [...adapted].filter((id) => !routable.has(id));
+  if (missing.length || stray.length) {
+    throw new Error(`execution adapters out of sync with routable hosts: `
+      + `${missing.length ? `no adapter for routable host(s): ${missing.join(', ')}. ` : ''}`
+      + `${stray.length ? `adapter(s) for non-routable host(s): ${stray.join(', ')}` : ''}`.trim());
+  }
+}

--- a/src/lib/execution/claude.mjs
+++ b/src/lib/execution/claude.mjs
@@ -8,6 +8,9 @@ export function createClaudeExecutionAdapter(options = {}) {
     argumentsFor: (worker) => [
       '--print', '--output-format', 'json',
       ...(worker.configuredModel ? ['--model', worker.configuredModel] : []),
+      // Templates carry per-node turn caps (#88) — honored where the CLI has a
+      // surface; codex exec and opencode serve have none (documented there).
+      ...(Number.isInteger(worker.maxTurns) && worker.maxTurns > 0 ? ['--max-turns', String(worker.maxTurns)] : []),
       worker.prompt,
     ],
     ...options,

--- a/src/lib/execution/codex.mjs
+++ b/src/lib/execution/codex.mjs
@@ -1,6 +1,8 @@
 import { createSubprocessExecutionAdapter } from './subprocess.mjs';
 
-/** Codex's documented exec/json mode. Its configured sandbox policy is retained. */
+/** Codex's documented exec/json mode. Its configured sandbox policy is retained.
+ *  worker.maxTurns is deliberately NOT forwarded: codex exec has no turn-cap
+ *  flag (verified against its help) — the bound rides on the runner timeout. */
 /** @param {Omit<Parameters<typeof createSubprocessExecutionAdapter>[0], 'id'|'host'|'command'|'argumentsFor'>} [options] */
 export function createCodexExecutionAdapter(options = {}) {
   return createSubprocessExecutionAdapter({

--- a/src/lib/execution/opencode.mjs
+++ b/src/lib/execution/opencode.mjs
@@ -7,12 +7,14 @@ import fs from 'node:fs';
 import net from 'node:net';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { have } from '../exec.mjs';
+import { have, resolveShim } from '../exec.mjs';
 import { validateExecutionAdapter, validateWorkerResult } from './schema.mjs';
 
 const TEMPLATE_PATH = fileURLToPath(new URL('../../templates/opencode-worker-prompt.md', import.meta.url));
 const LOOPBACK = '127.0.0.1';
 const USERNAME = 'opencode';
+/** S3: cap on the SSE per-line accumulator (mirrors the subprocess 256 KB cap). */
+const MAX_SSE_BUFFER = 256 * 1024;
 
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 const nowIso = () => new Date().toISOString();
@@ -69,7 +71,10 @@ export function renderOpenCodeWorkerPrompt(worker, { template = templateText() }
     `role: ${worker.role ?? 'unknown'}`,
     `configured model: ${worker.configuredModel ?? 'default'}`,
   ].join('\n');
-  return template.replace('{{task}}', worker.prompt).replace('{{metadata}}', metadata);
+  // Replacer functions, not string replacement: a prompt/model containing
+  // `$&`, `` $` ``, or `$'` would otherwise be interpreted as replacement
+  // metachars and silently corrupt the rendered prompt (#88).
+  return template.replace('{{task}}', () => worker.prompt).replace('{{metadata}}', () => metadata);
 }
 
 function basicHeaders(password) {
@@ -94,14 +99,24 @@ async function requestJson(fetchFn, endpoint, password, pathname,
   return responseJson(response, `${method} ${pathname}`);
 }
 
+/** Bounded POST for teardown calls (/abort, /instance/dispose): a wedged
+ *  server must not hang the runner's cancel/cleanup path (#88). 10 s is far
+ *  above any loopback round-trip; the caller's own try/catch records the
+ *  final truth either way. */
 async function requestNoContent(fetchFn, endpoint, password, pathname,
-  { method = 'POST', body, signal } = /** @type {{method?:string, body?:any, signal?:AbortSignal}} */ ({})) {
+  { method = 'POST', body, signal, timeoutMs = 10_000 } = /** @type {{method?:string, body?:any, signal?:AbortSignal, timeoutMs?:number}} */ ({})) {
   const headers = basicHeaders(password);
   if (body !== undefined) headers['content-type'] = 'application/json';
-  const response = await fetchFn(`${endpoint}${pathname}`, {
-    method, headers, ...(body === undefined ? {} : { body: JSON.stringify(body) }), ...(signal ? { signal } : {}),
-  });
-  if (!response?.ok) throw new Error(`${method} ${pathname} failed with HTTP ${response?.status ?? 'unknown'}`);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetchFn(`${endpoint}${pathname}`, {
+      method, headers,
+      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+      signal: signal ? AbortSignal.any([signal, controller.signal]) : controller.signal,
+    });
+    if (!response?.ok) throw new Error(`${method} ${pathname} failed with HTTP ${response?.status ?? 'unknown'}`);
+  } finally { clearTimeout(timer); }
 }
 
 /** opencode serve's prompt_async schema takes `model` as an OBJECT
@@ -132,9 +147,51 @@ async function requestWithin(fetchFn, endpoint, password, pathname, options, tim
   } finally { clearTimeout(timer); }
 }
 
-async function waitForHealth(fetchFn, endpoint, password, { attempts = 40, wait = delay } = {}) {
+/** Parse the OS-assigned port from the child's stdout ("listening on
+ *  http://127.0.0.1:<port>"). Bounded wait; stdout is consumed (never left
+ *  buffering) and a child that dies before reporting fails honestly. */
+async function boundPortFromStdout(child, { attempts = 100 } = {}) {
+  return new Promise((resolve, reject) => {
+    let buf = '';
+    let n = 0;
+    const onData = (chunk) => {
+      buf += String(chunk);
+      const m = buf.match(/listening on http:\/\/127\.0\.0\.1:(\d+)/);
+      if (m) { cleanup(); resolve(Number(m[1])); }
+    };
+    const onExit = () => { cleanup(); reject(new Error(`OpenCode server exited before reporting its port (code ${child.exitCode ?? 'unknown'})`)); };
+    const onError = (error) => {
+      cleanup();
+      reject(new Error(`OpenCode server failed before reporting its port: ${error?.message ?? error}`));
+    };
+    const tick = () => {
+      if (++n >= attempts) { cleanup(); reject(new Error('OpenCode server did not report its port in time')); }
+      else timer = setTimeout(tick, 50);
+    };
+    let timer = setTimeout(tick, 50);
+    const cleanup = () => {
+      clearTimeout(timer);
+      child.stdout?.off?.('data', onData);
+      child.stderr?.off?.('data', onData);
+      child.off?.('exit', onExit);
+      child.off?.('error', onError);
+    };
+    child.stdout.on('data', onData);
+    child.stderr?.on?.('data', onData);
+    child.once?.('exit', onExit);
+    child.once?.('error', onError);
+  });
+}
+
+/** @param {any} fetchFn @param {string} endpoint @param {string} password @param {{ attempts?: number, wait?: (ms: any) => Promise<any>, child?: any }} [opts] */
+async function waitForHealth(fetchFn, endpoint, password, { attempts = 40, wait = delay, child } = {}) {
   let lastError = null;
   for (let attempt = 0; attempt < attempts; attempt++) {
+    // A dead child (EADDRINUSE, crash, missing binary) fails fast with the
+    // exit code instead of polling into the timeout (S2 defense-in-depth).
+    if (child && child.exitCode != null) {
+      throw new Error(`OpenCode server exited during health check (code ${child.exitCode})`);
+    }
     try {
       const health = await requestJson(fetchFn, endpoint, password, '/global/health');
       if (health?.healthy === true) return health;
@@ -178,6 +235,12 @@ async function waitForTerminalEvent(response, sessionId, { signal } = /** @type 
     for (;;) {
       const { done, value } = await reader.read();
       buffer += decoder.decode(value ?? new Uint8Array(), { stream: !done });
+      // S3: the per-line accumulator is capped like the 256 KB subprocess cap —
+      // a line that never terminates cannot grow memory without bound.
+      if (buffer.length > MAX_SSE_BUFFER) {
+        await reader.cancel();
+        throw new Error(`OpenCode SSE line exceeded the ${MAX_SSE_BUFFER}-byte cap — protocol error, not a hang`);
+      }
       const lines = buffer.split(/\r?\n/);
       buffer = lines.pop() ?? '';
       for (const line of lines) {
@@ -249,11 +312,13 @@ function terminalResult(state, observation, clock) {
  */
 export function createOpenCodeExecutionAdapter({
   fetchFn = globalThis.fetch, spawnFn = nodeSpawn, haveFn = have, reservePort = defaultReservePort,
-  secret = defaultSecret, wait = delay, clock = nowIso, terminationGraceMs = 1_500, forceGraceMs = 1_500,
+  resolveFn = resolveShim, secret = defaultSecret, wait = delay, clock = nowIso,
+  terminationGraceMs = 1_500, forceGraceMs = 1_500, teardownTimeoutMs = 10_000,
 } = {}) {
   if (typeof fetchFn !== 'function') throw new TypeError('fetchFn is required');
   if (!Number.isInteger(terminationGraceMs) || terminationGraceMs < 1) throw new TypeError('terminationGraceMs must be a positive integer');
   if (!Number.isInteger(forceGraceMs) || forceGraceMs < 1) throw new TypeError('forceGraceMs must be a positive integer');
+  if (!Number.isInteger(teardownTimeoutMs) || teardownTimeoutMs < 1) throw new TypeError('teardownTimeoutMs must be a positive integer');
   const adapter = {
     id: 'opencode-server',
     async readiness() {
@@ -266,16 +331,37 @@ export function createOpenCodeExecutionAdapter({
       return { worker, cwd, prompt: renderOpenCodeWorkerPrompt(worker), startedAt: clock() };
     },
     async launch(state, { timeoutMs = 120_000 } = {}) {
-      const port = await reservePort();
       const password = secret();
-      const endpoint = `http://${LOOPBACK}:${port}`;
-      const child = spawnFn('opencode', ['serve', '--hostname', LOOPBACK, '--port', String(port)], {
+      // Port assignment WITHOUT the probe-bind-release race (S2): the child
+      // binds :0 itself and reports the OS-assigned port on stdout, so a
+      // squatter can never win a freed port against us (a rogue server would
+      // not know the ephemeral password anyway — but prompts/credentials must
+      // never reach a server we did not spawn). reservePort remains the
+      // fallback for injected children with no readable stdout (tests).
+      const invocation = resolveFn('opencode', ['serve', '--hostname', LOOPBACK, '--port', '0']);
+      if (typeof invocation?.command !== 'string' || !Array.isArray(invocation.args)) {
+        throw new TypeError('OpenCode command resolver returned an invalid invocation');
+      }
+      if (invocation.resolved === false) {
+        throw new Error('OpenCode command has no safe Windows invocation');
+      }
+      const child = spawnFn(invocation.command, invocation.args, {
         cwd: state.cwd,
         env: { ...process.env, OPENCODE_SERVER_USERNAME: USERNAME, OPENCODE_SERVER_PASSWORD: password },
-        stdio: 'ignore',
+        stdio: ['ignore', 'pipe', 'pipe'],
       });
+      let port;
       try {
-        await waitForHealth(fetchFn, endpoint, password, { wait });
+        port = child?.stdout && typeof child.stdout.on === 'function'
+          ? await boundPortFromStdout(child)
+          : await reservePort();
+      } catch (error) {
+        await stopChild(child, { terminationGraceMs, forceGraceMs });
+        throw error;
+      }
+      const endpoint = `http://${LOOPBACK}:${port}`;
+      try {
+        await waitForHealth(fetchFn, endpoint, password, { wait, child });
         const session = await requestJson(fetchFn, endpoint, password, '/session', {
           method: 'POST', body: { title: `agentic-kit ${state.worker.id}` },
         });
@@ -304,7 +390,7 @@ export function createOpenCodeExecutionAdapter({
       try {
         const observation = await state.terminal;
         if (observation.type === 'permission') {
-          await requestNoContent(fetchFn, state.endpoint, state.password, `/session/${encodeURIComponent(state.sessionId)}/abort`);
+          await requestNoContent(fetchFn, state.endpoint, state.password, `/session/${encodeURIComponent(state.sessionId)}/abort`, { timeoutMs: teardownTimeoutMs });
         }
         if (observation.type !== 'idle') return observation;
         const messages = await requestJson(fetchFn, state.endpoint, state.password, `/session/${encodeURIComponent(state.sessionId)}/message`);
@@ -317,7 +403,7 @@ export function createOpenCodeExecutionAdapter({
     async cancel(state) {
       state?.eventAbort?.abort();
       if (state?.sessionId) {
-        try { await requestNoContent(fetchFn, state.endpoint, state.password, `/session/${encodeURIComponent(state.sessionId)}/abort`); } catch { /* cleanup records the final truth */ }
+        try { await requestNoContent(fetchFn, state.endpoint, state.password, `/session/${encodeURIComponent(state.sessionId)}/abort`, { timeoutMs: teardownTimeoutMs }); } catch { /* cleanup records the final truth */ }
       }
       const stopped = await stopChild(state?.child, { terminationGraceMs, forceGraceMs });
       return stopped.stopped ? { type: 'cancelled' } : { type: 'cancelled', orphaned: true };
@@ -325,7 +411,7 @@ export function createOpenCodeExecutionAdapter({
     async cleanup(state) {
       state?.eventAbort?.abort();
       if (state?.endpoint) {
-        try { await requestNoContent(fetchFn, state.endpoint, state.password, '/instance/dispose'); } catch { /* child termination remains the fallback */ }
+        try { await requestNoContent(fetchFn, state.endpoint, state.password, '/instance/dispose', { timeoutMs: teardownTimeoutMs }); } catch { /* child termination remains the fallback */ }
       }
       const stopped = await stopChild(state?.child, { terminationGraceMs, forceGraceMs });
       return stopped.stopped ? { cleaned: true } : { cleaned: false, orphaned: true };

--- a/src/lib/execution/subprocess.mjs
+++ b/src/lib/execution/subprocess.mjs
@@ -2,7 +2,7 @@
 // non-interactive structured output. The runner owns timeout policy; this module
 // owns only one direct child process and never invokes a shell or bypass mode.
 import { spawn as nodeSpawn } from 'node:child_process';
-import { have } from '../exec.mjs';
+import { have, resolveShim } from '../exec.mjs';
 import { validateExecutionAdapter, validateWorkerResult } from './schema.mjs';
 
 const nowIso = () => new Date().toISOString();
@@ -67,23 +67,46 @@ function resultFor(state, observation, host, clock) {
   });
 }
 
-async function terminate(state) {
+async function waitForFinished(state, timeoutMs) {
+  if (state.finished) return true;
+  let timer;
+  try {
+    return await Promise.race([
+      state.completion.then(() => true),
+      new Promise((resolve) => { timer = setTimeout(() => resolve(false), timeoutMs); }),
+    ]);
+  } finally { clearTimeout(timer); }
+}
+
+/** Stop the direct child and prove it actually exited. A successful `kill()`
+ * call means only that the signal was sent, not that the process terminated
+ * (qe-court B5). TERM therefore gets one bounded grace period, followed by one
+ * bounded KILL fallback; a survivor is explicit orphan evidence. */
+async function terminate(state, { terminationGraceMs, forceGraceMs }) {
   if (state.finished) return { type: 'cancelled' };
   try {
-    if (!state.child?.kill?.('SIGTERM')) return { type: 'orphaned' };
-    return { type: 'cancelled' };
-  } catch { return { type: 'orphaned' }; }
+    if (!state.child?.kill?.('SIGTERM')) return { type: 'cancelled', orphaned: true };
+    if (await waitForFinished(state, terminationGraceMs)) return { type: 'cancelled' };
+    if (!state.child.kill('SIGKILL')) return { type: 'cancelled', orphaned: true };
+    return await waitForFinished(state, forceGraceMs)
+      ? { type: 'cancelled' }
+      : { type: 'cancelled', orphaned: true };
+  } catch { return { type: 'cancelled', orphaned: true }; }
 }
 
 /** Build a lifecycle adapter for one host's structured non-interactive CLI.
  * `argumentsFor` must return a fixed argv vector; prompts never pass through a
  * shell. Permission modes are deliberately absent from this generic layer.
  * @param {{id:string, host:string, command:string, argumentsFor:(worker:any, cwd:string)=>string[],
- *   spawnFn?:typeof nodeSpawn, haveFn?:typeof have, clock?:()=>string}} options */
+ *   spawnFn?:typeof nodeSpawn, haveFn?:typeof have, resolveFn?:typeof resolveShim,
+ *   clock?:()=>string, terminationGraceMs?:number, forceGraceMs?:number}} options */
 export function createSubprocessExecutionAdapter({
-  id, host, command, argumentsFor, spawnFn = nodeSpawn, haveFn = have, clock = nowIso,
+  id, host, command, argumentsFor, spawnFn = nodeSpawn, haveFn = have,
+  resolveFn = resolveShim, clock = nowIso, terminationGraceMs = 1_500, forceGraceMs = 1_500,
 } = /** @type {any} */ ({})) {
   if (!id || !host || !command || typeof argumentsFor !== 'function') throw new TypeError('subprocess adapter requires id, host, command, and argumentsFor');
+  if (!Number.isInteger(terminationGraceMs) || terminationGraceMs < 1) throw new TypeError('terminationGraceMs must be a positive integer');
+  if (!Number.isInteger(forceGraceMs) || forceGraceMs < 1) throw new TypeError('forceGraceMs must be a positive integer');
   const adapter = {
     id,
     async readiness() {
@@ -96,7 +119,16 @@ export function createSubprocessExecutionAdapter({
       return { worker, cwd, args: argumentsFor(worker, cwd), startedAt: clock() };
     },
     async launch(state) {
-      const child = spawnFn(command, state.args, { cwd: state.cwd, env: process.env, stdio: ['ignore', 'pipe', 'pipe'] });
+      // Native Windows executables run directly. Package-manager .cmd shims
+      // are represented by a shell-free PowerShell -File invocation instead.
+      const invocation = resolveFn(command, state.args);
+      if (typeof invocation?.command !== 'string' || !Array.isArray(invocation.args)) {
+        throw new TypeError(`${host} command resolver returned an invalid invocation`);
+      }
+      if (invocation.resolved === false) {
+        throw new Error(`${host} command has no safe Windows invocation`);
+      }
+      const child = spawnFn(invocation.command, invocation.args, { cwd: state.cwd, env: process.env, stdio: ['ignore', 'pipe', 'pipe'] });
       if (!child?.once) throw new Error(`${host} process did not expose child lifecycle events`);
       const stdout = capture(child.stdout);
       const stderr = capture(child.stderr);
@@ -107,8 +139,8 @@ export function createSubprocessExecutionAdapter({
     },
     async observe(state) { return state.completion; },
     interpret(state, observation) { return resultFor(state, observation, host, clock); },
-    async cancel(state) { return terminate(state); },
-    async cleanup(state) { return terminate(state); },
+    async cancel(state) { return terminate(state, { terminationGraceMs, forceGraceMs }); },
+    async cleanup(state) { return terminate(state, { terminationGraceMs, forceGraceMs }); },
   };
   return validateExecutionAdapter(adapter);
 }

--- a/tests/kit/exec.test.mjs
+++ b/tests/kit/exec.test.mjs
@@ -1,6 +1,9 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { run, have } from '../../src/lib/exec.mjs';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { run, have, resolveShim } from '../../src/lib/exec.mjs';
 
 // code-quality Finding 2: exec.mjs used to set shell:true for a fixed set of
 // Windows .cmd shims (npm/npx/claude/ruflo/aqe/claude-flow), which handed
@@ -43,4 +46,66 @@ test('have() reports true for a command that is definitely on PATH', async () =>
 
 test('have() reports false for a command that does not exist', async () => {
   assert.equal(await have('this-command-does-not-exist-anywhere'), false);
+});
+
+test('resolveShim builds safe native and PowerShell invocations in PATHEXT order', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ak-shim-'));
+  const bin = path.join(root, 'bin');
+  const powershell = path.join(root, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe');
+  const hostile = ['hello & whoami', '$(echo pwned)', 'a|b', 'quoted " value'];
+  fs.mkdirSync(path.dirname(powershell), { recursive: true });
+  fs.mkdirSync(bin);
+  try {
+    fs.writeFileSync(powershell, 'x');
+    fs.writeFileSync(path.join(bin, 'codex.cmd'), '@echo off\r\n');
+    fs.writeFileSync(path.join(bin, 'codex.ps1'), '# shim');
+    fs.writeFileSync(path.join(bin, 'codex.exe'), 'x');
+    const env = { PATH: bin, PATHEXT: '.COM;.EXE;.CMD', SystemRoot: root };
+
+    assert.deepEqual(resolveShim('codex', hostile, { windows: true, env }), {
+      command: path.join(bin, 'codex.exe'), args: hostile, resolved: true,
+    }, 'native .exe wins according to PATHEXT and receives the original argv');
+
+    assert.deepEqual(resolveShim('codex', hostile, {
+      windows: true, env: { ...env, PATHEXT: '.CMD' },
+    }), {
+      command: powershell,
+      args: [
+        '-NoLogo', '-NoProfile', '-NonInteractive',
+        '-ExecutionPolicy', 'Bypass', '-File', path.join(bin, 'codex.ps1'),
+        ...hostile,
+      ],
+      resolved: true,
+    }, 'a .cmd shim is represented by its sibling .ps1 without joining argv');
+
+    fs.rmSync(path.join(bin, 'codex.ps1'));
+    assert.deepEqual(resolveShim('codex', hostile, {
+      windows: true, env: { ...env, PATHEXT: '.CMD' },
+    }), { command: 'codex', args: hostile, resolved: false },
+    'a .cmd shim without its sibling .ps1 is not considered executable');
+    assert.deepEqual(resolveShim('codex', hostile, { windows: false, env }), {
+      command: 'codex', args: hostile, resolved: true,
+    }, 'non-Windows commands and argv pass through unchanged');
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('Windows PowerShell shim execution preserves hostile arguments literally', {
+  skip: process.platform !== 'win32',
+}, async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ak-shim-live-'));
+  const hostile = ['hello & whoami', '$(echo pwned)', 'a|b', 'quoted " value'];
+  try {
+    fs.writeFileSync(path.join(dir, 'codex.cmd'), '@echo off\r\n');
+    fs.writeFileSync(
+      path.join(dir, 'codex.ps1'),
+      '[Console]::Out.Write(($args | ConvertTo-Json -Compress))\n',
+    );
+    const result = await run('codex', hostile, { env: { PATH: dir, PATHEXT: '.CMD' } });
+    assert.equal(result.code, 0, result.stderr);
+    assert.deepEqual(JSON.parse(result.stdout), hostile);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
 });

--- a/tests/kit/execution-runner.test.mjs
+++ b/tests/kit/execution-runner.test.mjs
@@ -205,3 +205,61 @@ test('runner reports an unknown host without attempting a lifecycle', async () =
   assert.equal(result.exitCategory, 'cli_unavailable');
   assert.match(result.failure.reason, /no execution adapter/);
 });
+
+// #88: the construction invariant — every routable host has an execution
+// adapter and vice versa, enforced at import. A fresh process import must
+// never throw; a violating edit fails here (and at import) instead of at
+// runtime with cli_unavailable on every worker.
+test('routable hosts and execution adapters cannot drift apart (construction invariant)', async () => {
+  const { spawnSync } = await import('node:child_process');
+  const { fileURLToPath } = await import('node:url');
+  const path = await import('node:path');
+  const repo = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+  const r = spawnSync(process.execPath, ['-e',
+    "import('./src/lib/execution/adapters.mjs').then(() => console.log('in-sync'))",
+  ], { encoding: 'utf8', cwd: repo });
+  assert.equal(r.status, 0, `execution adapters module must import cleanly:\n${r.stderr}`);
+  assert.match(r.stdout, /in-sync/);
+});
+
+// #88 test-gap: plan-validation guards — removing any of these converts a
+// throw into a silent hang or a late crash.
+test('plan validation rejects duplicate ids, unknown deps, self-deps, and bad concurrency', async () => {
+  await assert.rejects(executeRunPlan({ workers: [worker('a'), worker('a')] }, { clock }),
+    /duplicate worker id "a"/);
+  await assert.rejects(executeRunPlan({ workers: [worker('a', 'opencode', ['ghost'])] }, { clock }),
+    /depends on unknown worker "ghost"/);
+  await assert.rejects(executeRunPlan({ workers: [worker('a', 'opencode', ['a'])] }, { clock }),
+    /cannot depend on itself/);
+  await assert.rejects(executeRunPlan({ workers: [worker('a')] }, { maxConcurrent: 0, clock }),
+    /maxConcurrent must be a positive integer/);
+});
+
+// #88 test-gap: a dependency cycle must throw, not hang forever.
+test('a dependency cycle is detected and thrown, never silently hung', async () => {
+  const plan = { workers: [worker('a', 'opencode', ['b']), worker('b', 'opencode', ['a'])] };
+  await assert.rejects(executeRunPlan(plan, { adapters: { opencode: adapter({}) }, clock }),
+    /dependency cycle/);
+});
+
+// #88 test-gap: readiness-false short-circuits as cli_unavailable with the reason.
+test('an unready host reports cli_unavailable without attempting a lifecycle', async () => {
+  const events = [];
+  const unready = {
+    id: 'unready',
+    async readiness() { events.push('readiness'); return { ready: false, exitCategory: 'cli_unavailable' }; },
+    async prepare() { events.push('prepare'); return {}; },
+    async launch() { events.push('launch'); return {}; },
+    async observe() { return { type: 'idle' }; },
+    interpret() { events.push('interpret'); return {}; },
+    async cancel() {},
+    async cleanup() {},
+  };
+  const [result] = await executeRunPlan({ workers: [worker('a', 'opencode')] }, {
+    adapters: { opencode: unready }, clock,
+  });
+  assert.equal(result.status, 'failed');
+  assert.equal(result.exitCategory, 'cli_unavailable');
+  assert.match(result.failure.reason, /host is not ready/);
+  assert.deepEqual(events, ['readiness'], 'prepare/launch/interpret never run for an unready host');
+});

--- a/tests/kit/opencode-execution.test.mjs
+++ b/tests/kit/opencode-execution.test.mjs
@@ -20,6 +20,14 @@ test('worker prompt is invocation-only and preserves the user permission boundar
   assert.doesNotMatch(prompt, /--auto/);
 });
 
+// #88: `$`-metachars in the prompt/model are data, never replacement syntax.
+test('a prompt carrying $& $` $\' survives rendering byte-for-byte (no $-pattern corruption)', () => {
+  const w = { ...worker, prompt: 'cost is $& today, see $` and $\'', configuredModel: 'openrouter/$&' };
+  const prompt = renderOpenCodeWorkerPrompt(w, { template: 'Task={{task}}\nMeta={{metadata}}' });
+  assert.ok(prompt.includes('cost is $& today, see $` and $\''), `prompt must arrive verbatim:\n${prompt}`);
+  assert.ok(prompt.includes('configured model: openrouter/$&'), 'metadata model id is verbatim too');
+});
+
 test('server adapter launches loopback-only with ephemeral basic auth and normalizes observed facts', async () => {
   const calls = [];
   const child = { signals: [], kill(signal) { this.signals.push(signal); return true; } };
@@ -34,7 +42,7 @@ test('server adapter launches loopback-only with ephemeral basic auth and normal
     throw new Error(`unexpected URL ${url}`);
   };
   const adapter = createOpenCodeExecutionAdapter({
-    fetchFn, spawnFn: (_cmd, args, opts) => { assert.deepEqual(args, ['serve', '--hostname', '127.0.0.1', '--port', '43123']); assert.equal(opts.stdio, 'ignore'); assert.equal(opts.env.OPENCODE_SERVER_PASSWORD, 'ephemeral'); return child; },
+    fetchFn, spawnFn: (_cmd, args, opts) => { assert.deepEqual(args, ['serve', '--hostname', '127.0.0.1', '--port', '0']); assert.deepEqual(opts.stdio, ['ignore', 'pipe', 'pipe']); assert.equal(opts.env.OPENCODE_SERVER_PASSWORD, 'ephemeral'); return child; },
     reservePort: async () => 43123, secret: () => 'ephemeral', clock: () => '2026-07-29T00:00:00.000Z',
   });
   const state = await adapter.prepare({ worker, cwd: process.cwd() });
@@ -203,6 +211,249 @@ test('a prompt post failure tears down without an unhandled terminal rejection',
     process.off('unhandledRejection', onUnhandled);
   }
   assert.deepEqual(child.signals, ['SIGTERM'], 'the owned server is still terminated on the failure path');
+});
+
+// S2: the port comes from the child's own stdout ("listening on :<port>") —
+// no probe-bind-release race, and reservePort is never consulted when stdout
+// is readable.
+test('the bound port is read from the child stdout (S2 — no probe-bind-release race)', async () => {
+  const { EventEmitter } = await import('node:events');
+  const child = new EventEmitter();
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.kill = () => true;
+  let reserved = null;
+  const fetchFn = async (url, init = {}) => {
+    if (url.includes(':43210/global/health')) return response({ healthy: true });
+    if (url.endsWith('/session') && init.method === 'POST') return response({ id: 'ses-p' });
+    if (url.includes(':43210/global/event')) return response(null, { body: sse('data: {"payload":{"type":"session.idle","properties":{"sessionID":"ses-p"}}}\n\n') });
+    if (url.endsWith('/prompt_async')) return response(null, { status: 204 });
+    if (url.endsWith('/message')) return response([{ info: { role: 'assistant' } }]);
+    if (url.endsWith('/instance/dispose')) return response(null, { status: 204 });
+    throw new Error(`unexpected URL ${url}`);
+  };
+  const adapter = createOpenCodeExecutionAdapter({
+    fetchFn,
+    spawnFn: () => {
+      queueMicrotask(() => {
+        child.stdout.emit('data', 'opencode server listening on http://127.0.');
+        child.stdout.emit('data', '0.1:43210\n');
+      });
+      return child;
+    },
+    reservePort: async () => { reserved = true; return 43123; },
+    secret: () => 'ephemeral', clock: () => '2026-07-29T00:00:00.000Z',
+  });
+  await adapter.cleanup(await adapter.observe(await adapter.launch(await adapter.prepare({ worker, cwd: process.cwd() }))));
+  assert.equal(reserved, null, 'reservePort is only the fallback for stdout-less children');
+});
+
+test('a child that dies before reporting its port fails honestly, never hangs', async () => {
+  const { EventEmitter } = await import('node:events');
+  const child = new EventEmitter();
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.exitCode = 1;
+  child.kill = () => true;
+  const adapter = createOpenCodeExecutionAdapter({
+    fetchFn: async () => { throw new Error('fetch must not run'); },
+    spawnFn: () => { queueMicrotask(() => child.emit('exit')); return child; },
+    secret: () => 'ephemeral',
+  });
+  await assert.rejects(
+    adapter.launch(await adapter.prepare({ worker, cwd: process.cwd() })),
+    /exited before reporting its port/,
+  );
+});
+
+test('a child spawn error before the port report rejects without an unhandled error event', async () => {
+  const { EventEmitter } = await import('node:events');
+  const child = new EventEmitter();
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.exitCode = null;
+  child.kill = () => true;
+  const adapter = createOpenCodeExecutionAdapter({
+    fetchFn: async () => { throw new Error('fetch must not run'); },
+    spawnFn: () => {
+      queueMicrotask(() => {
+        child.exitCode = -2;
+        child.emit('error', new Error('spawn opencode ENOENT'));
+      });
+      return child;
+    },
+    secret: () => 'ephemeral',
+  });
+  await assert.rejects(
+    adapter.launch(await adapter.prepare({ worker, cwd: process.cwd() })),
+    /failed before reporting its port: spawn opencode ENOENT/,
+  );
+});
+
+test('OpenCode launch consumes the resolved invocation and rejects an unsafe shim before spawn', async () => {
+  const calls = [];
+  const child = { kill: () => true };
+  const powershell = 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe';
+  const prefix = ['-NoProfile', '-File', 'C:\\tools\\opencode.ps1'];
+  const adapter = createOpenCodeExecutionAdapter({
+    fetchFn: async (url, init = {}) => {
+      if (url.endsWith('/global/health')) return response({ healthy: true });
+      if (url.endsWith('/session') && init.method === 'POST') return response({ id: 'ses-r' });
+      if (url.endsWith('/global/event')) return response(null, { body: sse('data: {"payload":{"type":"session.idle","properties":{"sessionID":"ses-r"}}}\n\n') });
+      if (url.endsWith('/prompt_async')) return response(null, { status: 204 });
+      throw new Error(`unexpected URL ${url}`);
+    },
+    resolveFn: (command, args) => {
+      assert.equal(command, 'opencode');
+      return { command: powershell, args: [...prefix, ...args], resolved: true };
+    },
+    spawnFn: (command, args) => {
+      calls.push({ command, args });
+      return child;
+    },
+    reservePort: async () => 43123,
+    secret: () => 'ephemeral',
+  });
+  await adapter.launch(await adapter.prepare({ worker, cwd: process.cwd() }));
+  assert.equal(calls[0].command, powershell);
+  assert.deepEqual(calls[0].args, [
+    ...prefix, 'serve', '--hostname', '127.0.0.1', '--port', '0',
+  ]);
+
+  let spawned = false;
+  const unsafe = createOpenCodeExecutionAdapter({
+    resolveFn: (command, args) => ({ command, args, resolved: false }),
+    spawnFn: () => { spawned = true; return child; },
+  });
+  await assert.rejects(
+    unsafe.launch(await unsafe.prepare({ worker, cwd: process.cwd() })),
+    /no safe Windows invocation/,
+  );
+  assert.equal(spawned, false);
+});
+
+test('teardownTimeoutMs bounds both session abort and instance disposal', async () => {
+  const abortedPaths = [];
+  const fetchFn = (url, { signal } = {}) => new Promise((resolve, reject) => {
+    const pathname = new URL(url).pathname;
+    const onAbort = () => {
+      abortedPaths.push(pathname);
+      reject(Object.assign(new Error(`${pathname} aborted`), { name: 'AbortError' }));
+    };
+    if (signal?.aborted) onAbort();
+    else signal?.addEventListener('abort', onAbort, { once: true });
+  });
+  const cancelChild = { signals: [], kill(signal) { this.signals.push(signal); return true; } };
+  const cleanupChild = { signals: [], kill(signal) { this.signals.push(signal); return true; } };
+  const adapter = createOpenCodeExecutionAdapter({
+    fetchFn,
+    teardownTimeoutMs: 10,
+    secret: () => 'ephemeral',
+  });
+  const baseState = {
+    endpoint: 'http://127.0.0.1:43123',
+    password: 'ephemeral',
+    sessionId: 'ses-timeout',
+  };
+  let guard;
+  let cancelled;
+  let cleaned;
+  try {
+    [cancelled, cleaned] = await Promise.race([
+      Promise.all([
+        adapter.cancel({ ...baseState, child: cancelChild, eventAbort: new AbortController() }),
+        adapter.cleanup({ ...baseState, child: cleanupChild, eventAbort: new AbortController() }),
+      ]),
+      new Promise((resolve, reject) => {
+        guard = setTimeout(() => reject(new Error('teardown requests exceeded the test deadline')), 500);
+      }),
+    ]);
+  } finally {
+    clearTimeout(guard);
+  }
+  assert.deepEqual(cancelled, { type: 'cancelled' });
+  assert.deepEqual(cleaned, { cleaned: true });
+  assert.deepEqual(
+    new Set(abortedPaths),
+    new Set(['/session/ses-timeout/abort', '/instance/dispose']),
+    'both hanging teardown requests observe the configured abort deadline',
+  );
+  assert.deepEqual(cancelChild.signals, ['SIGTERM']);
+  assert.deepEqual(cleanupChild.signals, ['SIGTERM']);
+});
+
+// S3: the SSE per-line accumulator is capped — a never-terminating line is a
+// bounded protocol error, not unbounded memory growth.
+test('an SSE line that never terminates is capped (S3 — bounded protocol error)', async () => {
+  const child = { kill: () => true };
+  const hugeLine = `data: {"payload":{"type":"session.idle","properties":{"sessionID":"ses-x","pad":"${'x'.repeat(300 * 1024)}"}}`;
+  const fetchFn = async (url, init = {}) => {
+    if (url.endsWith('/global/health')) return response({ healthy: true });
+    if (url.endsWith('/session') && init.method === 'POST') return response({ id: 'ses-x' });
+    if (url.endsWith('/global/event')) {
+      return response(null, {
+        body: new ReadableStream({
+          start(controller) { controller.enqueue(new TextEncoder().encode(hugeLine)); },
+        }),
+      });
+    }
+    if (url.endsWith('/prompt_async')) return response(null, { status: 204 });
+    if (url.endsWith('/message')) return response([]);
+    if (url.endsWith('/instance/dispose')) return response(null, { status: 204 });
+    throw new Error(`unexpected URL ${url}`);
+  };
+  const adapter = createOpenCodeExecutionAdapter({
+    fetchFn, spawnFn: () => child, reservePort: async () => 43123, secret: () => 'ephemeral', clock: () => '2026-07-29T00:00:00.000Z',
+  });
+  const launched = await adapter.launch(await adapter.prepare({ worker, cwd: process.cwd() }));
+  const observation = await adapter.observe(launched);
+  assert.equal(observation.type, 'error');
+  assert.match(observation.error?.data?.message ?? '', /exceeded the \d+-byte cap/, 'the cap fires as a protocol error');
+});
+
+// #88 test-gap: SSE events from a FOREIGN session must be ignored — deleting
+// the sessionID filter would terminate on any session's idle.
+test('events from a foreign session are ignored until our own session goes idle', async () => {
+  const child = { kill: () => true };
+  const events = 'data: {"payload":{"type":"session.idle","properties":{"sessionID":"ses-OTHER"}}}\n\n'
+    + 'data: {"payload":{"type":"session.idle","properties":{"sessionID":"ses-own"}}}\n\n';
+  const fetchFn = async (url, init = {}) => {
+    if (url.endsWith('/global/health')) return response({ healthy: true });
+    if (url.endsWith('/session') && init.method === 'POST') return response({ id: 'ses-own' });
+    if (url.endsWith('/global/event')) return response(null, { body: sse(events) });
+    if (url.endsWith('/prompt_async')) return response(null, { status: 204 });
+    if (url.endsWith('/message')) return response([{ info: { role: 'assistant', providerID: 'opencode', modelID: 'm1' } }]);
+    if (url.endsWith('/instance/dispose')) return response(null, { status: 204 });
+    throw new Error(`unexpected URL ${url}`);
+  };
+  const adapter = createOpenCodeExecutionAdapter({
+    fetchFn, spawnFn: () => child, reservePort: async () => 43123, secret: () => 'ephemeral', clock: () => '2026-07-29T00:00:00.000Z',
+  });
+  const observation = await adapter.observe(await adapter.launch(await adapter.prepare({ worker, cwd: process.cwd() })));
+  assert.equal(observation.type, 'idle', 'our own idle event terminates — the foreign one did not end the wait early');
+});
+
+// #88 test-gap: the TERM-then-KILL sequence is asserted, not just the verdict.
+test('a TERM-ignoring server receives SIGTERM then SIGKILL in order', async () => {
+  // A child WITH lifecycle events that never closes: the grace wait must time
+  // out (not short-circuit), so the bounded KILL fallback actually fires.
+  const child = { signals: [], exitCode: null, signalCode: null, once() { return this; }, kill(signal) { this.signals.push(signal); return true; } };
+  const fetchFn = async (url, init = {}) => {
+    if (url.endsWith('/global/health')) return response({ healthy: true });
+    if (url.endsWith('/session') && init.method === 'POST') return response({ id: 'ses-k' });
+    if (url.endsWith('/global/event')) return response(null, { body: new ReadableStream({ start() {} }) });
+    if (url.endsWith('/prompt_async')) return new Promise(() => {});
+    throw new Error(`unexpected URL ${url}`);
+  };
+  const adapter = createOpenCodeExecutionAdapter({
+    fetchFn, spawnFn: () => child, haveFn: async () => true, reservePort: async () => 43123, secret: () => 'ephemeral',
+    terminationGraceMs: 5, forceGraceMs: 5,
+  });
+  const result = await executeWorker(worker, adapter, { cwd: process.cwd(), timeoutMs: 20 });
+  assert.equal(result.status, 'timed_out');
+  assert.equal(result.exitCategory, 'timeout');
+  assert.match(result.failure.reason, /prompt_async timed out/);
+  assert.deepEqual(child.signals, ['SIGTERM', 'SIGKILL'], 'TERM first, KILL as the bounded fallback');
 });
 
 test('a stalled prompt submission becomes a timeout and tears down its owned server', async () => {

--- a/tests/kit/opencode-execution.test.mjs
+++ b/tests/kit/opencode-execution.test.mjs
@@ -1,7 +1,16 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { createOpenCodeExecutionAdapter, renderOpenCodeWorkerPrompt } from '../../src/lib/execution/opencode.mjs';
+import {
+  createOpenCodeExecutionAdapter as createRealOpenCodeExecutionAdapter,
+  renderOpenCodeWorkerPrompt,
+} from '../../src/lib/execution/opencode.mjs';
 import { executeWorker } from '../../src/lib/execution/runner.mjs';
+
+const passthroughResolve = (command, args) => ({ command, args, resolved: true });
+const createOpenCodeExecutionAdapter = (options = {}) => createRealOpenCodeExecutionAdapter({
+  resolveFn: passthroughResolve,
+  ...options,
+});
 
 const worker = {
   id: 'worker-1', activity: 'implementation', role: 'coder', host: 'opencode',

--- a/tests/kit/provider-cli.test.mjs
+++ b/tests/kit/provider-cli.test.mjs
@@ -102,6 +102,7 @@ function fakeBins(dir) {
   for (const name of ['claude', 'codex', 'opencode']) {
     fs.writeFileSync(path.join(bin, name), '#!/bin/sh\nif [ -n "$AK_TEST_ARGV_LOG" ]; then printf "%s\\n" "$0 $*" >> "$AK_TEST_ARGV_LOG"; fi\nexit 0\n', { mode: 0o755 });
     fs.writeFileSync(path.join(bin, `${name}.cmd`), '@echo off\r\nexit /b 0\r\n');
+    fs.writeFileSync(path.join(bin, `${name}.ps1`), 'exit 0\r\n');
   }
   return bin;
 }
@@ -407,6 +408,7 @@ test('interactive pick: an enabled host absent from PATH right now is kept enabl
     // Remove the opencode shim: the CLI is "temporarily absent" but enabled.
     fs.rmSync(path.join(sb.binDir, 'opencode'), { force: true });
     fs.rmSync(path.join(sb.binDir, 'opencode.cmd'), { force: true });
+    fs.rmSync(path.join(sb.binDir, 'opencode.ps1'), { force: true });
     const r = akPick(['x', 'provider', 'pick'], sb, { input: '\n\n\n\n' });
     assert.equal(r.status, 0, `interactive pick failed\nstdout: ${r.stdout}\nstderr: ${r.stderr}`);
     assert.match(r.stdout, /enabled but not detected right now: opencode \(kept enabled on Enter\)/);

--- a/tests/kit/routing.test.mjs
+++ b/tests/kit/routing.test.mjs
@@ -214,6 +214,14 @@ test('an explicit OpenCode route materializes for ak run but not the legacy dual
   assert.throws(() => policyToDualRunConfig(policy, { template: 'feature', task: 'x' }), /ak dual supports Claude\/Codex/);
 });
 
+test('host-neutral run plan rejects a host without activity-routing capability', () => {
+  const policy = { implementation: { host: 'gemini', source: 'user' } };
+  assert.throws(
+    () => materializeRunPlan(policy, { template: 'feature', task: 'x' }),
+    /route for "implementation" cannot materialize: host "gemini" requires canRouteActivities/,
+  );
+});
+
 test('policyToDualRunConfig throws on an unknown template', () => {
   assert.throws(() => policyToDualRunConfig({}, { template: 'nope' }), /unknown template/);
 });

--- a/tests/kit/run-command.test.mjs
+++ b/tests/kit/run-command.test.mjs
@@ -118,3 +118,29 @@ test('--escalate flows into the executor opts; results print the escalation trai
   assert.ok(out.includes('succeeded (success)') && out.includes('escalated from opencode'),
     `the trail is visible, not silent:\n${out}`);
 });
+
+// #88: --timeout above Node's 2^31-1 ms timer ceiling is rejected, never
+// silently clamped to ~1 ms for every worker.
+test('--timeout above the Node timer ceiling fails with a clear error', async () => {
+  const executePlan = async () => { throw new Error('must not run'); };
+  const { result, out } = await captureLog(() => run({
+    flags: { timeout: '3000000000' }, positionals: ['feature', 'probe'], executePlan, cfg: testCfg(),
+  }));
+  assert.equal(result, 2);
+  assert.match(out, /timeout must not exceed 2147483647/);
+});
+
+// #88: a hand-edited dualRouting is schema-checked at load — a bad entry
+// fails with the entry named, not a padEnd crash at print time.
+test('a malformed persisted route fails at build with the entry named', () => {
+  for (const [policy, needle] of [
+    [{ implementation: { host: 'claude', model: 123 } }, /route "implementation"\.model must be a string/],
+    [{ implementation: { host: '' } }, /route "implementation" requires a non-empty host/],
+    [{ implementation: { host: 'claude', escalate: [{ host: '' }] } }, /route "implementation"\.escalate\[0\] requires a non-empty host/],
+    [{ implementation: 'codex' }, /route "implementation" must be an object/],
+  ]) {
+    assert.throws(() => buildRunPlan({ providers: { dualRouting: policy } }, 'feature', 'probe'),
+      (error) => error.message.startsWith('invalid routing policy:') && needle.test(error.message),
+      `expected a named policy error for ${needle}`);
+  }
+});

--- a/tests/kit/setup-command.test.mjs
+++ b/tests/kit/setup-command.test.mjs
@@ -164,6 +164,7 @@ async function withOpencodeCli(fn) {
   fs.mkdirSync(bin, { recursive: true });
   fs.writeFileSync(path.join(bin, 'opencode'), '#!/bin/sh\nexit 0\n', { mode: 0o755 });
   fs.writeFileSync(path.join(bin, 'opencode.cmd'), '@echo off\r\nexit /b 0\r\n');
+  fs.writeFileSync(path.join(bin, 'opencode.ps1'), 'exit 0\r\n');
   const prev = process.env.PATH;
   process.env.PATH = [bin, '/usr/bin', '/bin'].join(path.delimiter);
   try { return await fn(); } finally { process.env.PATH = prev; rmrf(bin); }

--- a/tests/kit/status-command.test.mjs
+++ b/tests/kit/status-command.test.mjs
@@ -357,6 +357,7 @@ async function withOpencodeCli(fn) {
   fs.mkdirSync(bin, { recursive: true });
   fs.writeFileSync(path.join(bin, 'opencode'), '#!/bin/sh\nexit 0\n', { mode: 0o755 });
   fs.writeFileSync(path.join(bin, 'opencode.cmd'), '@echo off\r\nexit /b 0\r\n');
+  fs.writeFileSync(path.join(bin, 'opencode.ps1'), 'exit 0\r\n');
   const prev = process.env.PATH;
   process.env.PATH = [bin, '/usr/bin', '/bin'].join(path.delimiter);
   try { return await fn(); } finally { process.env.PATH = prev; rmrf(bin); }

--- a/tests/kit/subprocess-execution.test.mjs
+++ b/tests/kit/subprocess-execution.test.mjs
@@ -1,9 +1,19 @@
 import { EventEmitter } from 'node:events';
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { createClaudeExecutionAdapter } from '../../src/lib/execution/claude.mjs';
-import { createCodexExecutionAdapter } from '../../src/lib/execution/codex.mjs';
+import { createClaudeExecutionAdapter as createRealClaudeExecutionAdapter } from '../../src/lib/execution/claude.mjs';
+import { createCodexExecutionAdapter as createRealCodexExecutionAdapter } from '../../src/lib/execution/codex.mjs';
 import { executeWorker } from '../../src/lib/execution/runner.mjs';
+
+const passthroughResolve = (command, args) => ({ command, args, resolved: true });
+const createClaudeExecutionAdapter = (options = {}) => createRealClaudeExecutionAdapter({
+  resolveFn: passthroughResolve,
+  ...options,
+});
+const createCodexExecutionAdapter = (options = {}) => createRealCodexExecutionAdapter({
+  resolveFn: passthroughResolve,
+  ...options,
+});
 
 const worker = (host, model = 'model-1') => ({
   id: `${host}-1`, activity: 'implementation', role: 'coder', host, configuredModel: model, prompt: 'Do the work.',

--- a/tests/kit/subprocess-execution.test.mjs
+++ b/tests/kit/subprocess-execution.test.mjs
@@ -34,6 +34,23 @@ test('Claude adapter uses print/json mode without a permission bypass', async ()
   assert.ok(!calls[0].args.some((arg) => arg.includes('dangerously') || arg.includes('bypass')));
 });
 
+// #88: per-node turn caps reach the claude CLI (--max-turns); codex has no
+// equivalent surface and must not receive one.
+test('claude forwards a positive maxTurns as --max-turns; unset/zero forwards nothing', async () => {
+  const calls = [];
+  const adapter = createClaudeExecutionAdapter({
+    haveFn: async () => true, clock,
+    spawnFn: (command, args) => { calls.push(args); return child(); },
+  });
+  await executeWorker({ ...worker('claude'), maxTurns: 15 }, adapter, { cwd: process.cwd(), clock });
+  const cap = calls[0].indexOf('--max-turns');
+  assert.ok(cap > 0 && calls[0][cap + 1] === '15', `expected ['--max-turns','15'] in argv: ${calls[0]}`);
+  await executeWorker(worker('claude'), adapter, { cwd: process.cwd(), clock });
+  assert.ok(!calls[1].includes('--max-turns'), 'no maxTurns on the worker → no flag');
+  await executeWorker({ ...worker('claude'), maxTurns: 0 }, adapter, { cwd: process.cwd(), clock });
+  assert.ok(!calls[2].includes('--max-turns'), 'zero is not a valid turn cap → no flag');
+});
+
 // qe-court B6: the subprocess adapters observe exit codes, not billing
 // identity — provider must be recorded as unknown, never fabricated from the
 // host id (ADR-0018's invariant).
@@ -63,6 +80,61 @@ test('Codex adapter pins its supplied workspace and normalizes host failures', a
   assert.ok(!calls[0].args.some((arg) => arg.includes('dangerously') || arg.includes('bypass')));
 });
 
+test('Codex deliberately ignores maxTurns because exec has no turn-cap flag', async () => {
+  const calls = [];
+  const adapter = createCodexExecutionAdapter({
+    haveFn: async () => true, clock,
+    spawnFn: (_command, args) => { calls.push(args); return child(); },
+  });
+  await executeWorker({ ...worker('codex'), maxTurns: 15 }, adapter, { cwd: '/workspace/fixture', clock });
+  assert.ok(!calls[0].includes('--max-turns'));
+  assert.deepEqual(calls[0], [
+    'exec', '--json', '--cd', '/workspace/fixture', '--model', 'model-1', 'Do the work.',
+  ]);
+});
+
+test('Claude and Codex launch the resolved invocation without joining hostile argv', async () => {
+  for (const [host, factory] of [
+    ['claude', createClaudeExecutionAdapter],
+    ['codex', createCodexExecutionAdapter],
+  ]) {
+    const calls = [];
+    const prompt = 'do work & whoami | $(echo pwned) "quoted"';
+    const powershell = 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe';
+    const prefix = ['-NoProfile', '-File', `C:\\tools\\${host}.ps1`];
+    const adapter = factory({
+      haveFn: async (command) => command === host,
+      resolveFn: (command, args) => {
+        assert.equal(command, host);
+        return { command: powershell, args: [...prefix, ...args], resolved: true };
+      },
+      clock,
+      spawnFn: (command, args) => { calls.push({ command, args }); return child(); },
+    });
+    const result = await executeWorker(
+      { ...worker(host), prompt },
+      adapter,
+      { cwd: process.cwd(), clock },
+    );
+    assert.equal(result.status, 'succeeded');
+    assert.equal(calls[0].command, powershell);
+    assert.deepEqual(calls[0].args.slice(0, prefix.length), prefix);
+    assert.equal(calls[0].args.at(-1), prompt, `${host} prompt must remain one literal argv element`);
+  }
+});
+
+test('subprocess launch refuses an unresolved Windows shim before spawning', async () => {
+  let spawned = false;
+  const adapter = createClaudeExecutionAdapter({
+    haveFn: async () => true,
+    resolveFn: (command, args) => ({ command, args, resolved: false }),
+    spawnFn: () => { spawned = true; return child(); },
+  });
+  const state = await adapter.prepare({ worker: worker('claude'), cwd: process.cwd() });
+  await assert.rejects(adapter.launch(state), /no safe Windows invocation/);
+  assert.equal(spawned, false);
+});
+
 test('subprocess cleanup terminates a still-running direct child', async () => {
   const result = new EventEmitter();
   result.stdout = new EventEmitter();
@@ -73,4 +145,42 @@ test('subprocess cleanup terminates a still-running direct child', async () => {
   const state = await adapter.launch(await adapter.prepare({ worker: worker('claude'), cwd: process.cwd() }));
   await adapter.cleanup(state);
   assert.equal(signal, 'SIGTERM');
+});
+
+test('subprocess cancellation waits for TERM, then uses one bounded KILL fallback', async () => {
+  const result = new EventEmitter();
+  result.stdout = new EventEmitter();
+  result.stderr = new EventEmitter();
+  result.signals = [];
+  result.kill = (signal) => {
+    result.signals.push(signal);
+    if (signal === 'SIGKILL') queueMicrotask(() => result.emit('close', null, signal));
+    return true;
+  };
+  const adapter = createClaudeExecutionAdapter({
+    haveFn: async () => true, clock, spawnFn: () => result,
+    terminationGraceMs: 2, forceGraceMs: 20,
+  });
+  const state = await adapter.launch(await adapter.prepare({ worker: worker('claude'), cwd: process.cwd() }));
+  assert.deepEqual(await adapter.cancel(state), { type: 'cancelled' });
+  assert.deepEqual(result.signals, ['SIGTERM', 'SIGKILL']);
+});
+
+test('a subprocess surviving TERM and KILL is reported as orphaned, never timed out cleanly', async () => {
+  const result = new EventEmitter();
+  result.stdout = new EventEmitter();
+  result.stderr = new EventEmitter();
+  result.signals = [];
+  result.kill = (signal) => { result.signals.push(signal); return true; };
+  const adapter = createClaudeExecutionAdapter({
+    haveFn: async () => true, clock, spawnFn: () => result,
+    terminationGraceMs: 2, forceGraceMs: 2,
+  });
+  const terminal = await executeWorker(worker('claude'), adapter, {
+    cwd: process.cwd(), clock, timeoutMs: 2,
+  });
+  assert.equal(terminal.status, 'failed');
+  assert.equal(terminal.exitCategory, 'orphaned');
+  assert.match(terminal.failure.reason, /did not terminate/);
+  assert.deepEqual(result.signals.slice(0, 2), ['SIGTERM', 'SIGKILL']);
 });

--- a/tests/kit/sync-command.test.mjs
+++ b/tests/kit/sync-command.test.mjs
@@ -150,6 +150,7 @@ async function withOpencodeCli(fn) {
   for (const name of ['opencode', 'claude']) {
     fs.writeFileSync(path.join(bin, name), '#!/bin/sh\nexit 0\n', { mode: 0o755 });
     fs.writeFileSync(path.join(bin, `${name}.cmd`), '@echo off\r\nexit /b 0\r\n');
+    fs.writeFileSync(path.join(bin, `${name}.ps1`), 'exit 0\r\n');
   }
   const prev = process.env.PATH;
   process.env.PATH = [bin, '/usr/bin', '/bin'].join(path.delimiter);


### PR DESCRIPTION
## Summary

The #88 swarm-review follow-ups, all verified against the code before acceptance. Grouped by theme; each item names its evidence.

## Security hardening

- **S2 — port-reservation TOCTOU eliminated.** The owned opencode server now binds `:0` and reports its port on stdout — there is no freed port for a squatter to win (the rogue would then have intercepted the per-run credential and the worker prompt). `reservePort` stays as the fallback for stdout-less (injected) children, and a child that dies before reporting — or during the health check — fails honestly with its exit code instead of polling into the timeout.
- **S3 — SSE per-line accumulator capped at 256 KB** (mirrors the subprocess cap): a never-terminating line is a bounded protocol error, not unbounded memory growth.
- **Teardown HTTP is bounded.** `/abort` + `/instance/dispose` go through a 10 s (injectable `teardownTimeoutMs`) deadline — a wedged server cannot hang the runner's cancel/cleanup path.
- **S1 disposition (document, per review).** The trust boundary is now stated in ADR-0018 and `ak run --help`: workers run with the user's own CLI trust posture; a hostile repo's `opencode.json` permissions / `.claude/settings.json` / `AGENTS.md` are *inside* that boundary (a repo that pre-allows permissions generates no `permission.updated` event, so the abort boundary does not trip by design — the abort covers requests, it is not a sandbox). Run `ak` only in repos you trust with full user privileges.

## Windows shim path

`resolveShim` is exported (with a `{windows, env}` test seam) and applied at both spawn sites (subprocess claude/codex; the opencode serve child), and `codex` is added to `CMD_SHIMS`. Readiness and launch now resolve the same binary — fixing launch-ENOENT on Windows where `.cmd` shims are required. Includes a simulated-PATH PATHEXT-order test.

## Correctness nits

- `worker.maxTurns` reaches the claude CLI as `--max-turns` (codex exec + opencode serve have no equivalent — documented, not faked).
- Worker prompt rendering uses replacer functions — `$&` `` $` `` `$'` in a prompt/model id are data, never replacement syntax.
- `--timeout` above Node's `2^31-1` ms timer ceiling is rejected with a clear error (would otherwise clamp to ~1 ms for every worker).
- Persisted `dualRouting` is schema-checked at load: malformed entries fail with the entry named, not a `padEnd` crash at print time.
- **Construction invariant:** routable hosts and `EXECUTION_ADAPTERS` keys are enforced at import — a routable host with no adapter (or an adapter for an unroutable host) throws at import instead of `cli_unavailable` on every worker at runtime.

## Test gaps filled

SSE foreign-session isolation; plan-validation guards (duplicate/unknown/self deps, bad `maxConcurrent`, dependency cycle); readiness-false short-circuit; TERM-then-KILL signal order; construction invariant via fresh-process import.

## Verification

- 20+ new/updated tests across the touched suites.
- `pnpm run check` **exit 0** (1083 kit + cjs), `pnpm run test:surface` **exit 0** (25).

Closes #88. Touches `run.mjs` (timeout ceiling, policy validation) — merges cleanly with #90 (escalation) or rebases trivially on it.
