### PR TITLE
fix(opencode): adopt legacy artifact receipts safely

### DIFF
--- a/src/commands/status.mjs
+++ b/src/commands/status.mjs
@@ -9,7 +9,10 @@ import * as paths from '../lib/paths.mjs';
 import { nativesStatus, rufloRuntimeNatives, dbPathPinStatus, aidefencePresent, securityPresent } from '../lib/natives.mjs';
 import { scanNpxStale } from '../lib/npx.mjs';
 import { registrationStatus, codexMcpStatus, rufloCodexMcpStatus, ruvectorRegistered } from '../lib/mcp.mjs';
-import { opencodeMcpStatus, opencodeConverged, catalogSource, agentsStatus, pluginStatus, skillStatus } from '../lib/opencode.mjs';
+import {
+  opencodeMcpStatus, opencodeConverged, catalogSource, agentsStatus,
+  pluginStatus, skillStatus, opencodeArtifactReceiptState,
+} from '../lib/opencode.mjs';
 import { listDaemons, staleDaemons } from '../lib/daemons.mjs';
 import { scanRvf } from '../lib/rvf.mjs';
 import { registry, syncBlocks, blocksForTarget, retiredForTarget, guidanceTargets } from '../lib/blocks.mjs';
@@ -396,36 +399,64 @@ export async function collect({ pkgRoot, cwd = process.cwd() }) {
           rows.push(row('opencode', 'ok',
             `opencode.json converged (claude-flow${st.brain ? ' + ruvnet-brain' : ''} MCP, ${st.paths?.length ?? 0} skills path(s))${st.owned ? '' : ' — pre-existing (not ak-managed)'}`));
         }
-        const artifactReceipts = cfg.providers?.opencodeManaged?.artifacts ?? {};
-        const plug = pluginStatus({ pkgRoot, receipt: artifactReceipts.plugin });
-        if (plug.foreign) {
+        const receiptState = opencodeArtifactReceiptState(cfg.providers?.opencodeManaged);
+        const artifactReceipts = receiptState.receipts;
+        if (receiptState.adoptionBlocked) {
+          rows.push(row('opencode', 'warn',
+            'artifact receipt ledger is malformed — ownership adoption blocked; artifacts left untouched',
+            'repair providers.opencodeManaged.artifacts in kit.json or restore it from backup'));
+        }
+        const plug = pluginStatus({
+          pkgRoot, receipt: artifactReceipts.plugin,
+          adoptionBlocked: receiptState.adoptionBlocked,
+        });
+        if (!receiptState.adoptionBlocked && plug.adoptable) {
+          rows.push(row('opencode', 'warn',
+            'lifecycle plugin is exact and marker-bearing but lacks an ownership receipt',
+            'sync adopts it into the receipt ledger without rewriting it'));
+        } else if (!receiptState.adoptionBlocked && plug.foreign) {
           rows.push(row('opencode', 'info', 'lifecycle plugin slot occupied by a user-owned ruflo-hooks.js — ak leaves it alone'));
-        } else if (!plug.present) {
+        } else if (!receiptState.adoptionBlocked && !plug.present) {
           rows.push(row('opencode', 'warn', 'lifecycle plugin (ruflo-hooks.js) not deployed', 'sync deploys it'));
-        } else if (!plug.current) {
+        } else if (!receiptState.adoptionBlocked && !plug.current) {
           rows.push(row('opencode', 'warn', 'lifecycle plugin out of date', 'sync rewrites it'));
         }
-        const ag = agentsStatus({ source, receipts: artifactReceipts.agents });
-        if (ag.count === 0 && !source) {
+        const ag = agentsStatus({
+          source, receipts: artifactReceipts.agents,
+          stampReceipt: artifactReceipts.agentStamp,
+          adoptionBlocked: receiptState.agentsAdoptionBlocked,
+        });
+        if (!receiptState.adoptionBlocked && ag.adoptable) {
+          rows.push(row('opencode', 'warn',
+            `${ag.count} exact marker-bearing agents or stamp lack ownership receipts`,
+            'sync adopts them into the receipt ledger without rewriting them'));
+        } else if (!receiptState.adoptionBlocked && ag.count === 0 && !source) {
           rows.push(row('opencode', 'warn', 'no ruflo catalog source (marketplace clone or @claude-flow/cli)', 'install ruflo (or claude marketplace) for the agent catalog'));
-        } else if (ag.count === 0) {
+        } else if (!receiptState.adoptionBlocked && ag.count === 0) {
           rows.push(row('opencode', 'warn', 'no converted ruflo agents', 'sync converts the ruflo agent set'));
-        } else if (ag.modified) {
+        } else if (!receiptState.adoptionBlocked && ag.modified) {
           rows.push(row('opencode', 'info',
             `${ag.count} converted agents include user edits — ak leaves those files alone`));
-        } else if (ag.stale) {
+        } else if (!receiptState.adoptionBlocked && ag.stale) {
           rows.push(row('opencode', 'warn',
             `${ag.count} agents from ${ag.stampedId ?? 'unknown source'}, current source is ${ag.currentId ?? 'none'}`,
             'sync re-converts the agent set'));
-        } else {
+        } else if (!receiptState.adoptionBlocked) {
           rows.push(row('opencode', 'ok', `${ag.count} converted agents (${ag.currentId})`));
         }
-        const sk = skillStatus({ source, receipt: artifactReceipts.skill });
-        if (sk.foreign) {
+        const sk = skillStatus({
+          source, receipt: artifactReceipts.skill,
+          adoptionBlocked: receiptState.adoptionBlocked,
+        });
+        if (!receiptState.adoptionBlocked && sk.adoptable) {
+          rows.push(row('opencode', 'warn',
+            'platform skill is exact and marker-bearing but lacks an ownership receipt',
+            'sync adopts it into the receipt ledger without rewriting it'));
+        } else if (!receiptState.adoptionBlocked && sk.foreign) {
           rows.push(row('opencode', 'info', 'skills/ruflo/SKILL.md is user-owned — ak leaves it alone'));
-        } else if (source?.hasPlatformSkill && !sk.present) {
+        } else if (!receiptState.adoptionBlocked && source?.hasPlatformSkill && !sk.present) {
           rows.push(row('opencode', 'warn', 'platform skill (skills/ruflo/SKILL.md) not deployed', 'sync deploys it'));
-        } else if (source?.hasPlatformSkill && !sk.current) {
+        } else if (!receiptState.adoptionBlocked && source?.hasPlatformSkill && !sk.current) {
           rows.push(row('opencode', 'warn', 'platform skill out of date', 'sync re-deploys it'));
         }
       }

--- a/src/lib/opencode.mjs
+++ b/src/lib/opencode.mjs
@@ -168,6 +168,9 @@ function deepEqual(a, b) {
 }
 
 const contentHash = (text) => createHash('sha256').update(text).digest('hex');
+const hasReceiptValue = (value) => value !== null && value !== undefined;
+const receiptMatches = (text, receipt) =>
+  typeof receipt === 'string' && contentHash(text) === receipt;
 
 /** Normalize an opencodeManaged record — the current precise shape
  *  { mcp: {name:{prior,written}}, paths: [], permissions: {key:{prior,written}} },
@@ -175,7 +178,14 @@ const contentHash = (text) => createHash('sha256').update(text).digest('hex');
  *  (legacy entries have unknown prior/written → treated conservatively: prior
  *  null, written null → never auto-deleted, only re-recorded on next apply). */
 function normalizeManaged(m) {
-  const out = { mcp: {}, paths: [], permissions: {}, permissionScalar: null, artifacts: {} };
+  const out = {
+    mcp: {}, paths: [], permissions: {}, permissionScalar: null,
+    artifacts: { plugin: null, agents: {}, agentStamp: null, skill: null },
+    artifactState: {
+      containerMalformed: false, agentsMalformed: false,
+      rawContainer: null,
+    },
+  };
   if (!m || typeof m !== 'object') return out;
   const legacyNames = Array.isArray(m.mcp) ? m.mcp : Object.keys(m.mcp ?? {});
   for (const n of legacyNames) {
@@ -189,8 +199,41 @@ function normalizeManaged(m) {
     out.permissions[k] = rec && typeof rec === 'object' && 'written' in rec ? rec : { prior: null, written: null };
   }
   out.permissionScalar = typeof m.permissionScalar === 'string' ? m.permissionScalar : null;
-  if (m.artifacts && typeof m.artifacts === 'object') out.artifacts = structuredClone(m.artifacts);
+  if (hasReceiptValue(m.artifacts)) {
+    out.artifactState.rawContainer = structuredClone(m.artifacts);
+  }
+  if (hasReceiptValue(m.artifacts)
+      && (typeof m.artifacts !== 'object' || Array.isArray(m.artifacts))) {
+    out.artifactState.containerMalformed = true;
+    return out;
+  }
+  const artifacts = m.artifacts ?? {};
+  out.artifacts.plugin = hasReceiptValue(artifacts.plugin) ? artifacts.plugin : null;
+  out.artifacts.agentStamp = hasReceiptValue(artifacts.agentStamp) ? artifacts.agentStamp : null;
+  out.artifacts.skill = hasReceiptValue(artifacts.skill) ? artifacts.skill : null;
+  if (hasReceiptValue(artifacts.agents)
+      && (typeof artifacts.agents !== 'object' || Array.isArray(artifacts.agents))) {
+    out.artifactState.agentsMalformed = true;
+  } else if (artifacts.agents) {
+    out.artifacts.agents = Object.fromEntries(
+      Object.entries(artifacts.agents).filter(([, hash]) => hasReceiptValue(hash)),
+    );
+  }
   return out;
+}
+
+/** Read-only artifact receipt boundary shared by lifecycle and status paths.
+ *  Only null/absent containers represent a pre-receipts migration gap;
+ *  malformed non-null containers fail closed and block adoption. */
+export function opencodeArtifactReceiptState(managed) {
+  const normalized = normalizeManaged(managed);
+  const blocked = normalized.artifactState.containerMalformed
+    || normalized.artifactState.agentsMalformed;
+  return {
+    receipts: normalized.artifacts,
+    adoptionBlocked: blocked,
+    agentsAdoptionBlocked: blocked,
+  };
 }
 
 /** Reconcile opencode.json: ak's MCP servers, skills.paths, and permission
@@ -243,7 +286,10 @@ export async function applyOpencode(cfg, { dryRun = false, configFile = paths.op
   }
   const managed = {
     mcp: {}, paths: [], permissions: {}, permissionScalar: null,
-    artifacts: structuredClone(prevManaged.artifacts),
+    artifacts: (prevManaged.artifactState.containerMalformed
+      || prevManaged.artifactState.agentsMalformed)
+      ? structuredClone(prevManaged.artifactState.rawContainer)
+      : structuredClone(prevManaged.artifacts),
   };
   for (const [name, want] of Object.entries(entries)) {
     const cur = next.mcp[name];
@@ -438,24 +484,44 @@ export async function opencodeStack(cfg, { pkgRoot, configFile, brainShim, plugi
     const skipped = { ok: false, changed: false, detail: 'skipped because opencode.json did not converge' };
     return { oc, plugin: skipped, agents: skipped, skill: skipped, source: null, markersChanged: false };
   }
-  const receipts = normalizeManaged(cfg.providers?.opencodeManaged).artifacts;
-  const plugin = deployPlugin({
-    pkgRoot, receipt: receipts.plugin, ...(pluginsDir ? { pluginsDir } : {}),
-  });
+  const receiptState = opencodeArtifactReceiptState(cfg.providers?.opencodeManaged);
+  const { receipts, adoptionBlocked } = receiptState;
   const source = catalogSource({ override: cfg.providers?.opencodeCatalogDir });
+  if (adoptionBlocked) {
+    const detail = 'skipped because the artifact receipt ledger is malformed';
+    const plugin = { ok: false, changed: false, receipt: receipts.plugin, adoptionBlocked: true, detail };
+    const agents = {
+      ok: false, changed: false, receipts: receipts.agents,
+      stampReceipt: receipts.agentStamp, adopted: 0, adoptionBlocked: true, detail,
+    };
+    const skill = { ok: false, changed: false, receipt: receipts.skill, adoptionBlocked: true, detail };
+    const markersChanged = JSON.stringify([
+      cfg.providers?.opencodeMcp ?? null,
+      cfg.providers?.opencodeManaged ?? null,
+    ]) !== before;
+    return { oc, plugin, agents, skill, source, markersChanged };
+  }
+  const plugin = deployPlugin({
+    pkgRoot, receipt: receipts.plugin, adoptionBlocked,
+    ...(pluginsDir ? { pluginsDir } : {}),
+  });
   const agents = syncAgents({
     source, receipts: receipts.agents, stampReceipt: receipts.agentStamp,
+    adoptionBlocked: receiptState.agentsAdoptionBlocked,
     ...(agentsDir ? { destDir: agentsDir } : {}),
   });
   const skill = deploySkill({
-    source, receipt: receipts.skill, ...(skillsDir ? { skillsDir } : {}),
+    source, receipt: receipts.skill, adoptionBlocked,
+    ...(skillsDir ? { skillsDir } : {}),
   });
-  cfg.providers.opencodeManaged.artifacts = {
-    plugin: plugin.receipt ?? receipts.plugin ?? null,
-    agents: agents.receipts ?? receipts.agents ?? {},
-    agentStamp: agents.stampReceipt ?? receipts.agentStamp ?? null,
-    skill: skill.receipt ?? receipts.skill ?? null,
-  };
+  if (!adoptionBlocked) {
+    cfg.providers.opencodeManaged.artifacts = {
+      plugin: plugin.receipt ?? receipts.plugin ?? null,
+      agents: agents.receipts ?? receipts.agents ?? {},
+      agentStamp: agents.stampReceipt ?? receipts.agentStamp ?? null,
+      skill: skill.receipt ?? receipts.skill ?? null,
+    };
+  }
   const markersChanged = JSON.stringify([cfg.providers?.opencodeMcp ?? null, cfg.providers?.opencodeManaged ?? null]) !== before;
   return { oc, plugin, agents, skill, source, markersChanged };
 }
@@ -503,18 +569,22 @@ export function createOpencodeLifecycleAdapter(defaults = {}) {
       ...(opts.configFile ? { configFile: opts.configFile } : {}),
       ...(opts.brainShim ? { brainShim: opts.brainShim } : {}),
     });
-    const receipts = normalizeManaged(cfg.providers?.opencodeManaged).artifacts;
+    const receiptState = opencodeArtifactReceiptState(cfg.providers?.opencodeManaged);
+    const { receipts, adoptionBlocked } = receiptState;
     const plugin = opts.pkgRoot
       ? pluginStatus({
-          pkgRoot: opts.pkgRoot, receipt: receipts.plugin,
+          pkgRoot: opts.pkgRoot, receipt: receipts.plugin, adoptionBlocked,
           ...(opts.pluginsDir ? { pluginsDir: opts.pluginsDir } : {}),
         })
-      : { present: false, current: false, foreign: false };
+      : { present: false, current: false, foreign: false, adoptable: false };
     const agents = agentsStatus({
-      source, receipts: receipts.agents, ...(opts.agentsDir ? { destDir: opts.agentsDir } : {}),
+      source, receipts: receipts.agents, stampReceipt: receipts.agentStamp,
+      adoptionBlocked: receiptState.agentsAdoptionBlocked,
+      ...(opts.agentsDir ? { destDir: opts.agentsDir } : {}),
     });
     const skill = skillStatus({
-      source, receipt: receipts.skill, ...(opts.skillsDir ? { skillsDir: opts.skillsDir } : {}),
+      source, receipt: receipts.skill, adoptionBlocked,
+      ...(opts.skillsDir ? { skillsDir: opts.skillsDir } : {}),
     });
     return { enabled: !!cfg.providers?.hosts?.opencode, convergence, plugin, agents, skill };
   };
@@ -524,9 +594,9 @@ export function createOpencodeLifecycleAdapter(defaults = {}) {
     async plan(request = {}) {
       const facts = request.facts ?? await detect(request);
       const changed = facts.enabled && (!facts.convergence.converged
-        || (!facts.plugin.current && !facts.plugin.foreign)
-        || facts.agents.stale
-        || (!facts.skill.current && !facts.skill.foreign));
+        || facts.plugin.adoptable || (!facts.plugin.current && !facts.plugin.foreign)
+        || (!facts.agents.adoptionBlocked && (facts.agents.adoptable || facts.agents.stale))
+        || facts.skill.adoptable || (!facts.skill.current && !facts.skill.foreign));
       return { changed, facts, operations: changed ? ['config', 'plugin', 'agents', 'skill'] : [] };
     },
     async apply(request = {}) {
@@ -725,32 +795,45 @@ const isGeneratedContent = (text) => AGENT_MARKERS.some((m) => text.includes(m))
  *  is preserved and reported). The stamp records the source id + the exact
  *  generated file list and is only rewritten when the set actually changed
  *  (no per-run timestamp churn — idempotent-write semantics).
- *  @param {{ source: CatalogSource|null, destDir?: string, dryRun?: boolean, receipts?:Record<string,string>, stampReceipt?:string|null }} opts */
+ *  @param {{ source: CatalogSource|null, destDir?: string, dryRun?: boolean, receipts?:Record<string,string>, stampReceipt?:string|null, adoptionBlocked?:boolean }} opts */
 export function syncAgents({
   source, destDir = paths.opencodeAgentsDir(), dryRun = false, receipts = {}, stampReceipt = null,
+  adoptionBlocked = false,
 }) {
   if (!source) return { ok: false, changed: false, detail: 'no ruflo catalog source (marketplace clone or @claude-flow/cli) found' };
+  const receiptMap = receipts && typeof receipts === 'object' && !Array.isArray(receipts)
+    ? receipts
+    : {};
   const { agents, scanned, skipped, renamed } = convertAgents(source.root);
   if (!dryRun) fs.mkdirSync(destDir, { recursive: true });
-  let removed = 0, userOwned = 0;
+  let removed = 0, userOwned = 0, adopted = 0;
+  const removedFiles = new Set();
   if (fs.existsSync(destDir)) {
     for (const f of fs.readdirSync(destDir).filter((f) => f.endsWith('.md'))) {
       const p = path.join(destDir, f);
       let owned = false;
-      try { owned = receipts[f] && contentHash(fs.readFileSync(p, 'utf8')) === receipts[f]; } catch { /* leave alone */ }
+      try { owned = receiptMatches(fs.readFileSync(p, 'utf8'), receiptMap[f]); } catch { /* leave alone */ }
       const wanted = agents.some((a) => `${a.name}.md` === f);
-      if (owned && !wanted) { if (!dryRun) fs.rmSync(p); removed++; }
+      if (owned && !wanted) {
+        if (!dryRun) fs.rmSync(p);
+        removedFiles.add(f);
+        removed++;
+      }
     }
   }
   let written = 0;
   const deployed = [];
   for (const a of agents) {
-    const p = path.join(destDir, `${a.name}.md`);
+    const file = `${a.name}.md`;
+    const p = path.join(destDir, file);
     const cur = fs.existsSync(p) ? fs.readFileSync(p, 'utf8') : null;
-    const priorOwned = cur !== null && receipts[`${a.name}.md`]
-      && contentHash(cur) === receipts[`${a.name}.md`];
-    if (cur !== null && !priorOwned) { userOwned++; continue; }
-    deployed.push(`${a.name}.md`);
+    const priorReceipt = receiptMap[file];
+    const hasPriorReceipt = adoptionBlocked || hasReceiptValue(priorReceipt);
+    const priorOwned = cur !== null && receiptMatches(cur, priorReceipt);
+    const adoptable = cur === a.content && !hasPriorReceipt && isGeneratedContent(cur);
+    if (cur !== null && !priorOwned && !adoptable) { userOwned++; continue; }
+    if (adoptable) adopted++;
+    deployed.push(file);
     if (cur !== a.content) {
       written++;
       if (!dryRun) fs.writeFileSync(p, a.content);
@@ -759,16 +842,33 @@ export function syncAgents({
   const changed = written > 0 || removed > 0;
   // The stamp records what was ACTUALLY deployed (a user-owned file occupying
   // a slot is never in it) — otherwise status would diverge forever.
-  const nextReceipts = Object.fromEntries(deployed.map((f) => {
+  // Preserve a non-null mismatched receipt while its file still exists. If it
+  // were dropped, a later pass could mistake the resulting absence for a
+  // pre-receipts install and launder an edited file back into ak ownership.
+  const nextReceipts = Object.fromEntries(Object.entries(receiptMap).filter(([f]) => (
+    !removedFiles.has(f) && fs.existsSync(path.join(destDir, f))
+  )));
+  const deployedHashes = Object.fromEntries(deployed.map((f) => {
     const agent = agents.find((a) => `${a.name}.md` === f);
     return [f, contentHash(agent.content)];
   }));
-  const stamp = { source: source.id, count: deployed.length, files: deployed.sort(), hashes: nextReceipts };
+  Object.assign(nextReceipts, deployedHashes);
+  const stamp = { source: source.id, count: deployed.length, files: deployed.sort(), hashes: deployedHashes };
   const stampText = JSON.stringify(stamp, null, 2) + '\n';
   const stampPath = path.join(destDir, STAMP_FILE);
   const priorStampText = fs.existsSync(stampPath) ? fs.readFileSync(stampPath, 'utf8') : null;
-  const stampOwned = priorStampText !== null && stampReceipt && contentHash(priorStampText) === stampReceipt;
-  const mayWriteStamp = priorStampText === null || stampOwned;
+  const hasStampReceipt = adoptionBlocked || hasReceiptValue(stampReceipt);
+  const stampOwned = priorStampText !== null && receiptMatches(priorStampText, stampReceipt);
+  // The stamp has no marker of its own, so exact bytes are adoptable only when
+  // every file it lists was independently receipt-owned, newly written, or
+  // adopted through exact marker-bearing content.
+  const stampAdoptable = priorStampText === stampText && !hasStampReceipt && deployed.length > 0
+    && deployed.every((f) => {
+      try {
+        return contentHash(fs.readFileSync(path.join(destDir, f), 'utf8')) === deployedHashes[f];
+      } catch { return false; }
+    });
+  const mayWriteStamp = priorStampText === null || stampOwned || stampAdoptable;
   if (!dryRun && mayWriteStamp && priorStampText !== stampText) {
     fs.writeFileSync(stampPath, stampText);
   }
@@ -777,7 +877,8 @@ export function syncAgents({
     changed,
     receipts: nextReceipts,
     stampReceipt: mayWriteStamp ? contentHash(stampText) : stampReceipt,
-    detail: `${agents.length} agents from ${source.id} (${written} written, ${removed} removed, ${skipped} skipped, ${renamed} collision-renamed${userOwned ? `, ${userOwned} user-owned preserved` : ''}; scanned ${scanned})`,
+    adopted,
+    detail: `${agents.length} agents from ${source.id} (${written} written, ${removed} removed, ${skipped} skipped, ${renamed} collision-renamed${adopted ? `, ${adopted} adopted` : ''}${userOwned ? `, ${userOwned} user-owned preserved` : ''}; scanned ${scanned})`,
   };
 }
 
@@ -786,11 +887,22 @@ export function syncAgents({
  *  file set differs from the stamp. Count reports marker-bearing agents for
  *  visibility, while receipt/hash divergence is reported as `modified` so
  *  callers classify user edits as preserved rather than repairable drift.
- *  @param {{ source?: CatalogSource|null, destDir?: string, receipts?:Record<string,string>|null }} [opts] */
+ *  @param {{ source?: CatalogSource|null, destDir?: string, receipts?:Record<string,string>|null, stampReceipt?:string|null, adoptionBlocked?:boolean }} [opts] */
 export function agentsStatus({
-  source, destDir = paths.opencodeAgentsDir(), receipts = null,
+  source, destDir = paths.opencodeAgentsDir(), receipts = null, stampReceipt = null,
+  adoptionBlocked = false,
 } = {}) {
-  const stamp = readJson(path.join(destDir, STAMP_FILE), null);
+  const stampPath = path.join(destDir, STAMP_FILE);
+  const stamp = readJson(stampPath, null);
+  const stampText = fs.existsSync(stampPath) ? fs.readFileSync(stampPath, 'utf8') : null;
+  const hasReceiptLedger = receipts !== null;
+  const receiptMap = receipts && typeof receipts === 'object' && !Array.isArray(receipts)
+    ? receipts
+    : {};
+  const desired = source
+    ? new Map(convertAgents(source.root).agents.map((a) => [`${a.name}.md`, a.content]))
+    : new Map();
+  const adoptableFiles = [];
   let generatedCount = 0;
   if (fs.existsSync(destDir)) {
     for (const f of fs.readdirSync(destDir).filter((f) => f.endsWith('.md'))) {
@@ -802,7 +914,13 @@ export function agentsStatus({
         if (!f.endsWith('.md')) return false;
         try {
           const text = fs.readFileSync(path.join(destDir, f), 'utf8');
-          if (receipts) return !!receipts[f] && contentHash(text) === receipts[f];
+          if (hasReceiptLedger) {
+            const hasReceipt = adoptionBlocked || hasReceiptValue(receiptMap[f]);
+            const receiptOwned = receiptMatches(text, receiptMap[f]);
+            const adoptable = !hasReceipt && isGeneratedContent(text) && desired.get(f) === text;
+            if (adoptable) adoptableFiles.push(f);
+            return receiptOwned || adoptable;
+          }
           return isGeneratedContent(text);
         } catch { return false; }
       }).sort()
@@ -812,15 +930,32 @@ export function agentsStatus({
   const contentDiverged = !!stamp?.hashes && onDisk.some((f) => {
     try { return contentHash(fs.readFileSync(path.join(destDir, f), 'utf8')) !== stamp.hashes[f]; } catch { return true; }
   });
+  const expectedStamp = source && onDisk.length > 0 && onDisk.every((f) => desired.has(f))
+    ? `${JSON.stringify({
+        source: source.id,
+        count: onDisk.length,
+        files: onDisk,
+        // syncAgents hashes in converter declaration order, then sorts only
+        // the separate files list. Preserve that byte order for exact
+        // stamp-only adoption detection.
+        hashes: Object.fromEntries([...desired.entries()]
+          .filter(([f]) => onDisk.includes(f))
+          .map(([f, text]) => [f, contentHash(text)])),
+      }, null, 2)}\n`
+    : null;
+  const stampAdoptable = hasReceiptLedger && !adoptionBlocked && !hasReceiptValue(stampReceipt)
+    && expectedStamp !== null && stampText === expectedStamp;
   return {
     count: generatedCount,
     stampedId: stamp?.source ?? null,
     currentId: source?.id ?? null,
-    modified: contentDiverged || (!!receipts && fs.existsSync(destDir)
+    adoptable: !adoptionBlocked && (adoptableFiles.length > 0 || stampAdoptable),
+    adoptionBlocked,
+    modified: contentDiverged || (hasReceiptLedger && fs.existsSync(destDir)
       && fs.readdirSync(destDir).filter((f) => f.endsWith('.md')).some((f) => {
         try {
-          return !!receipts[f]
-            && contentHash(fs.readFileSync(path.join(destDir, f), 'utf8')) !== receipts[f];
+          return hasReceiptValue(receiptMap[f])
+            && !receiptMatches(fs.readFileSync(path.join(destDir, f), 'utf8'), receiptMap[f]);
         } catch { return true; }
       })),
     stale: !stamp || stamp.source !== (source?.id ?? null) || filesDiverged,
@@ -839,19 +974,25 @@ const PLUGIN_MARKER = 'src/templates/opencode-ruflo-hooks.js';
  *  (rewrites only when the template changed — hash-stamped by content itself).
  *  A destination file that exists WITHOUT the ak marker is user-owned:
  *  preserved and reported, never overwritten.
- *  @param {{ pkgRoot: string, pluginsDir?: string, dryRun?: boolean, receipt?:string|null }} opts */
+ *  @param {{ pkgRoot: string, pluginsDir?: string, dryRun?: boolean, receipt?:string|null, adoptionBlocked?:boolean }} opts */
 export function deployPlugin({
   pkgRoot, pluginsDir = paths.opencodePluginsDir(), dryRun = false, receipt = null,
+  adoptionBlocked = false,
 }) {
   const tpl = pluginTemplate(pkgRoot);
   if (!fs.existsSync(tpl)) return { ok: false, changed: false, detail: `template missing: ${tpl}` };
   const want = fs.readFileSync(tpl, 'utf8');
   const dest = path.join(pluginsDir, PLUGIN_NAME);
   const cur = fs.existsSync(dest) ? fs.readFileSync(dest, 'utf8') : null;
-  if (cur === want && receipt && contentHash(cur) === receipt) {
-    return { ok: true, changed: false, receipt, detail: 'lifecycle plugin current' };
+  const hasReceipt = adoptionBlocked || hasReceiptValue(receipt);
+  const adoptable = cur === want && !hasReceipt && cur.includes(PLUGIN_MARKER);
+  if (cur === want && (receiptMatches(cur, receipt) || adoptable)) {
+    return {
+      ok: true, changed: false, receipt: contentHash(cur), adopted: adoptable,
+      detail: adoptable ? 'lifecycle plugin adopted into receipt ledger' : 'lifecycle plugin current',
+    };
   }
-  if (cur !== null && (!receipt || contentHash(cur) !== receipt)) {
+  if (cur !== null && (!hasReceipt || !receiptMatches(cur, receipt))) {
     return { ok: true, changed: false, receipt, detail: `⚠ ${dest} differs from ak's last-written receipt (user-owned/edited) — left untouched` };
   }
   if (!dryRun) {
@@ -864,19 +1005,21 @@ export function deployPlugin({
 /** Plugin presence/currency against the kit template. `foreign` flags a
  *  user-owned file occupying the destination (status must not nag to
  *  overwrite it — deploy will leave it alone). */
-export function pluginStatus({ pkgRoot, pluginsDir = paths.opencodePluginsDir(), receipt = null }) {
+export function pluginStatus({
+  pkgRoot, pluginsDir = paths.opencodePluginsDir(), receipt = null, adoptionBlocked = false,
+}) {
   const dest = path.join(pluginsDir, PLUGIN_NAME);
   const present = fs.existsSync(dest);
   const currentText = present ? fs.readFileSync(dest, 'utf8') : null;
-  const foreign = present && (
-    !receipt || !currentText.includes(PLUGIN_MARKER)
-    || (!!receipt && contentHash(currentText) !== receipt
-      && fs.existsSync(pluginTemplate(pkgRoot))
-      && currentText !== fs.readFileSync(pluginTemplate(pkgRoot), 'utf8'))
-  );
   const tpl = pluginTemplate(pkgRoot);
-  const current = present && !foreign && fs.existsSync(tpl) && fs.readFileSync(dest, 'utf8') === fs.readFileSync(tpl, 'utf8');
-  return { present, current, foreign };
+  const desired = fs.existsSync(tpl) ? fs.readFileSync(tpl, 'utf8') : null;
+  const hasReceipt = adoptionBlocked || hasReceiptValue(receipt);
+  const receiptOwned = present && receiptMatches(currentText, receipt);
+  const adoptable = present && !hasReceipt && desired !== null
+    && currentText === desired && currentText.includes(PLUGIN_MARKER);
+  const foreign = present && !receiptOwned && !adoptable;
+  const current = present && !foreign && desired !== null && currentText === desired;
+  return { present, current, foreign, adoptable, adoptionBlocked };
 }
 
 // ── platform skill ───────────────────────────────────────────────────────────
@@ -886,19 +1029,25 @@ const SKILL_DEPLOYED_MARKER = '<!-- deployed by agentic-kit -->';
 /** Deploy ruflo's platform SKILL.md (from the catalog source) into opencode's
  *  global skills dir, stamped with the source id for drift detection. A
  *  destination SKILL.md without the ak marker is user-owned: preserved.
- *  @param {{ source: CatalogSource|null, skillsDir?: string, dryRun?: boolean, receipt?:string|null }} opts */
+ *  @param {{ source: CatalogSource|null, skillsDir?: string, dryRun?: boolean, receipt?:string|null, adoptionBlocked?:boolean }} opts */
 export function deploySkill({
   source, skillsDir = paths.opencodeSkillsDir(), dryRun = false, receipt = null,
+  adoptionBlocked = false,
 }) {
   if (!source?.hasPlatformSkill) return { ok: true, changed: false, detail: `no platform SKILL.md in catalog source${source ? ` (${source.id})` : ''}` };
   const src = path.join(source.root, 'SKILL.md');
   const dest = path.join(skillsDir, 'ruflo', 'SKILL.md');
   const want = `${fs.readFileSync(src, 'utf8').replace(/\s*$/, '')}\n\n${SKILL_DEPLOYED_MARKER} from ${source.id} — re-synced by \`ak sync\`\n`;
   const cur = fs.existsSync(dest) ? fs.readFileSync(dest, 'utf8') : null;
-  if (cur === want && receipt && contentHash(cur) === receipt) {
-    return { ok: true, changed: false, receipt, detail: 'platform skill current' };
+  const hasReceipt = adoptionBlocked || hasReceiptValue(receipt);
+  const adoptable = cur === want && !hasReceipt && cur.includes(SKILL_DEPLOYED_MARKER);
+  if (cur === want && (receiptMatches(cur, receipt) || adoptable)) {
+    return {
+      ok: true, changed: false, receipt: contentHash(cur), adopted: adoptable,
+      detail: adoptable ? 'platform skill adopted into receipt ledger' : 'platform skill current',
+    };
   }
-  if (cur !== null && (!receipt || contentHash(cur) !== receipt)) {
+  if (cur !== null && (!hasReceipt || !receiptMatches(cur, receipt))) {
     return { ok: true, changed: false, receipt, detail: `⚠ ${dest} differs from ak's last-written receipt (user-owned/edited) — left untouched` };
   }
   if (!dryRun) {
@@ -910,9 +1059,9 @@ export function deploySkill({
 
 /** Platform skill presence/currency against the catalog source id. `foreign`
  *  flags a user-owned SKILL.md at the destination.
- *  @param {{ source?: CatalogSource|null, skillsDir?: string, receipt?:string|null }} [opts] */
+ *  @param {{ source?: CatalogSource|null, skillsDir?: string, receipt?:string|null, adoptionBlocked?:boolean }} [opts] */
 export function skillStatus({
-  source, skillsDir = paths.opencodeSkillsDir(), receipt = null,
+  source, skillsDir = paths.opencodeSkillsDir(), receipt = null, adoptionBlocked = false,
 } = {}) {
   const dest = path.join(skillsDir, 'ruflo', 'SKILL.md');
   const present = fs.existsSync(dest);
@@ -921,13 +1070,16 @@ export function skillStatus({
   const desired = sourceFile && fs.existsSync(sourceFile)
     ? `${fs.readFileSync(sourceFile, 'utf8').replace(/\s*$/, '')}\n\n${SKILL_DEPLOYED_MARKER} from ${source.id} — re-synced by \`ak sync\`\n`
     : null;
-  const foreign = present && (
-    !receipt || !text.includes(SKILL_DEPLOYED_MARKER)
-    || (!!receipt && contentHash(text) !== receipt && text !== desired)
-  );
+  const hasReceipt = adoptionBlocked || hasReceiptValue(receipt);
+  const receiptOwned = present && receiptMatches(text, receipt);
+  const adoptable = present && !hasReceipt && desired !== null
+    && text === desired && text.includes(SKILL_DEPLOYED_MARKER);
+  const foreign = present && !receiptOwned && !adoptable;
   return {
     present,
     foreign,
+    adoptable,
+    adoptionBlocked,
     current: present && !foreign && desired != null && text === desired,
   };
 }

--- a/tests/kit/opencode.test.mjs
+++ b/tests/kit/opencode.test.mjs
@@ -489,12 +489,13 @@ test('edited agent and skill are preserved on receipt-aware redeploy and reporte
   const skillRetry = deploySkill({ source, skillsDir, receipt: skill.receipt });
   assert.equal(fs.readFileSync(agentPath, 'utf8'), editedAgent);
   assert.equal(fs.readFileSync(skillPath, 'utf8'), editedSkill);
-  assert.equal(agentRetry.receipts['coder.md'], undefined, 'edited agent ownership is relinquished');
+  assert.equal(agentRetry.receipts['coder.md'], agents.receipts['coder.md'],
+    'edited agent keeps its mismatched receipt so a later pass cannot launder it as unreceipted');
   assert.equal(skillRetry.changed, false);
   rm(d);
 });
 
-test('exact desired bytes without a prior receipt are never adopted for teardown', () => {
+test('exact marker-bearing desired bytes without prior receipts are adopted once for safe teardown', () => {
   const d = tmp('ak-oc-unreceipted-');
   const source = catalogSource({ override: makeCatalog(path.join(d, 'catalog')) });
   const skillsDir = path.join(d, 'skills');
@@ -509,12 +510,13 @@ test('exact desired bytes without a prior receipt are never adopted for teardown
   const firstAgents = syncAgents({ source, destDir: agentsDir });
   const skillPath = path.join(skillsDir, 'ruflo', 'SKILL.md');
   const pluginPath = path.join(pluginsDir, PLUGIN_NAME);
-  const agentPath = path.join(agentsDir, 'coder.md');
   const stampPath = path.join(agentsDir, '.ak-agents-stamp.json');
   const exact = {
     skill: fs.readFileSync(skillPath, 'utf8'),
     plugin: fs.readFileSync(pluginPath, 'utf8'),
-    agent: fs.readFileSync(agentPath, 'utf8'),
+    agents: Object.fromEntries(Object.keys(firstAgents.receipts).map((file) => [
+      file, fs.readFileSync(path.join(agentsDir, file), 'utf8'),
+    ])),
     stamp: fs.readFileSync(stampPath, 'utf8'),
   };
   fs.rmSync(path.join(skillsDir, 'ruflo'), { recursive: true });
@@ -525,17 +527,30 @@ test('exact desired bytes without a prior receipt are never adopted for teardown
   fs.mkdirSync(agentsDir, { recursive: true });
   fs.writeFileSync(skillPath, exact.skill);
   fs.writeFileSync(pluginPath, exact.plugin);
-  fs.writeFileSync(agentPath, exact.agent);
+  for (const [file, text] of Object.entries(exact.agents)) {
+    fs.writeFileSync(path.join(agentsDir, file), text);
+  }
   fs.writeFileSync(stampPath, exact.stamp);
+  assert.equal(skillStatus({ source, skillsDir, receipt: null }).adoptable, true);
+  assert.equal(pluginStatus({ pkgRoot, pluginsDir, receipt: null }).adoptable, true);
+  assert.equal(agentsStatus({
+    source, destDir: agentsDir, receipts: {}, stampReceipt: null,
+  }).adoptable, true);
   const unownedSkill = deploySkill({ source, skillsDir, receipt: null });
   const unownedPlugin = deployPlugin({ pkgRoot, pluginsDir, receipt: null });
   const unownedAgents = syncAgents({
     source, destDir: agentsDir, receipts: {}, stampReceipt: null,
   });
-  assert.equal(unownedSkill.receipt, null);
-  assert.equal(unownedPlugin.receipt, null);
-  assert.equal(unownedAgents.receipts['coder.md'], undefined);
-  assert.equal(unownedAgents.stampReceipt, null);
+  assert.equal(unownedSkill.changed, false);
+  assert.equal(unownedPlugin.changed, false);
+  assert.equal(unownedAgents.changed, false, unownedAgents.detail);
+  assert.equal(unownedSkill.adopted, true);
+  assert.equal(unownedPlugin.adopted, true);
+  assert.equal(unownedAgents.adopted, Object.keys(exact.agents).length);
+  assert.ok(unownedSkill.receipt);
+  assert.ok(unownedPlugin.receipt);
+  assert.ok(unownedAgents.receipts['coder.md']);
+  assert.ok(unownedAgents.stampReceipt);
   removeArtifacts({
     skillsDir, pluginsDir, agentsDir,
     receipts: {
@@ -543,10 +558,12 @@ test('exact desired bytes without a prior receipt are never adopted for teardown
       agents: unownedAgents.receipts, agentStamp: unownedAgents.stampReceipt,
     },
   });
-  assert.ok(fs.existsSync(skillPath), 'matching bytes are not proof that ak wrote the file');
-  assert.ok(fs.existsSync(pluginPath));
-  assert.ok(fs.existsSync(agentPath));
-  assert.ok(fs.existsSync(stampPath));
+  assert.equal(fs.existsSync(skillPath), false);
+  assert.equal(fs.existsSync(pluginPath), false);
+  for (const file of Object.keys(exact.agents)) {
+    assert.equal(fs.existsSync(path.join(agentsDir, file)), false);
+  }
+  assert.equal(fs.existsSync(stampPath), false);
   assert.ok(first.receipt, 'fixture first deploy produced a real receipt');
   assert.ok(firstPlugin.receipt);
   assert.ok(firstAgents.stampReceipt);
@@ -581,6 +598,37 @@ test('receipt-based teardown preserves marker-bearing artifacts edited by the us
   assert.ok(fs.existsSync(path.join(pluginsDir, PLUGIN_NAME)));
   assert.ok(fs.existsSync(path.join(agentsDir, 'coder.md')));
   assert.ok(fs.existsSync(path.join(skillsDir, 'ruflo', 'SKILL.md')));
+  rm(d);
+});
+
+test('a mismatched agent receipt survives two passes and cannot become an adoption gap', () => {
+  const d = tmp('ak-oc-agent-launder-');
+  const root = makeCatalog(path.join(d, 'catalog'));
+  const source = catalogSource({ override: root });
+  const agentsDir = path.join(d, 'agents');
+  const first = syncAgents({ source, destDir: agentsDir });
+  const agentPath = path.join(agentsDir, 'coder.md');
+  fs.appendFileSync(agentPath, '\nUser edit.\n');
+
+  const sourceAgent = path.join(root, '.claude', 'agents', 'core', 'coder.md');
+  fs.appendFileSync(sourceAgent, '\nCatalog v2.\n');
+  const upgraded = catalogSource({ override: root });
+  const second = syncAgents({
+    source: upgraded, destDir: agentsDir,
+    receipts: first.receipts, stampReceipt: first.stampReceipt,
+  });
+  assert.equal(second.receipts['coder.md'], first.receipts['coder.md'],
+    'the mismatched receipt remains as negative ownership evidence');
+
+  const desiredV2 = convertAgents(root).agents.find((a) => a.name === 'coder').content;
+  fs.writeFileSync(agentPath, desiredV2);
+  const third = syncAgents({
+    source: upgraded, destDir: agentsDir,
+    receipts: second.receipts, stampReceipt: second.stampReceipt,
+  });
+  assert.equal(third.adopted, 0, 'a non-null mismatched receipt blocks absence-based adoption');
+  assert.equal(third.receipts['coder.md'], first.receipts['coder.md']);
+  assert.match(third.detail, /user-owned preserved/);
   rm(d);
 });
 
@@ -770,11 +818,146 @@ test('opencodeStack reports markersChanged when a converged file has stale/missi
   const second = await opencodeStack(cfg, { pkgRoot, ...seams });
   assert.equal(second.oc.changed, false, 'the file itself is already converged');
   assert.equal(second.markersChanged, true, 'but the refreshed markers must be persisted by the caller');
+  assert.equal(second.plugin.adopted, true);
+  assert.ok(second.agents.adopted > 0);
+  assert.equal(second.skill.adopted, true);
   assert.equal(cfg.providers.opencodeMcp, 'ak');
   assert.ok(cfg.providers.opencodeManaged?.mcp?.['claude-flow']?.written);
+  assert.ok(cfg.providers.opencodeManaged?.artifacts?.plugin);
+  assert.ok(cfg.providers.opencodeManaged?.artifacts?.agents?.['coder.md']);
+  assert.ok(cfg.providers.opencodeManaged?.artifacts?.agentStamp);
+  assert.ok(cfg.providers.opencodeManaged?.artifacts?.skill);
   // A third run with truthful markers is then fully quiet.
   const third = await opencodeStack(cfg, { pkgRoot, ...seams });
   assert.equal(third.markersChanged, false, 'no kit.json churn once the markers are truthful');
+  rm(d);
+});
+
+test('opencodeStack normalizes poisoned null artifact maps before adopting exact legacy files', async () => {
+  const { opencodeStack } = await import('../../src/lib/opencode.mjs');
+  const { fileURLToPath } = await import('node:url');
+  const d = tmp('ak-oc-null-receipts-');
+  const seams = {
+    configFile: path.join(d, 'opencode.json'),
+    pluginsDir: path.join(d, 'plugins'),
+    agentsDir: path.join(d, 'agents'),
+    skillsDir: path.join(d, 'skills'),
+  };
+  const cfg = cfgOn();
+  cfg.providers.opencodeCatalogDir = makeCatalog(path.join(d, 'catalog'));
+  const pkgRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+  await opencodeStack(cfg, { pkgRoot, ...seams });
+  cfg.providers.opencodeManaged.artifacts = {
+    plugin: null, agents: null, agentStamp: null, skill: null,
+  };
+  const adopted = await opencodeStack(cfg, { pkgRoot, ...seams });
+  assert.equal(adopted.plugin.adopted, true);
+  assert.ok(adopted.agents.adopted > 0);
+  assert.equal(adopted.skill.adopted, true);
+  assert.ok(cfg.providers.opencodeManaged.artifacts.agents['coder.md']);
+  rm(d);
+});
+
+test('non-null poisoned receipts are preserved and never treated as an adoption gap', async () => {
+  const { opencodeStack } = await import('../../src/lib/opencode.mjs');
+  const { fileURLToPath } = await import('node:url');
+  const d = tmp('ak-oc-poisoned-receipts-');
+  const seams = {
+    configFile: path.join(d, 'opencode.json'),
+    pluginsDir: path.join(d, 'plugins'),
+    agentsDir: path.join(d, 'agents'),
+    skillsDir: path.join(d, 'skills'),
+  };
+  const cfg = cfgOn();
+  cfg.providers.opencodeCatalogDir = makeCatalog(path.join(d, 'catalog'));
+  const pkgRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+  await opencodeStack(cfg, { pkgRoot, ...seams });
+  const agentNames = Object.keys(cfg.providers.opencodeManaged.artifacts.agents);
+  cfg.providers.opencodeManaged.artifacts = {
+    plugin: '',
+    agents: Object.fromEntries(agentNames.map((name) => [name, ''])),
+    agentStamp: '',
+    skill: '',
+  };
+  const refused = await opencodeStack(cfg, { pkgRoot, ...seams });
+  assert.notEqual(refused.plugin.adopted, true);
+  assert.equal(refused.agents.adopted, 0);
+  assert.notEqual(refused.skill.adopted, true);
+  assert.equal(cfg.providers.opencodeManaged.artifacts.plugin, '');
+  assert.deepEqual(cfg.providers.opencodeManaged.artifacts.agents,
+    Object.fromEntries(agentNames.map((name) => [name, ''])));
+  assert.equal(cfg.providers.opencodeManaged.artifacts.agentStamp, '');
+  assert.equal(cfg.providers.opencodeManaged.artifacts.skill, '');
+  rm(d);
+});
+
+test('malformed non-null receipt containers fail closed without adopting or rewriting the ledger', async () => {
+  const { opencodeStack } = await import('../../src/lib/opencode.mjs');
+  const { fileURLToPath } = await import('node:url');
+  const d = tmp('ak-oc-malformed-receipts-');
+  const seams = {
+    configFile: path.join(d, 'opencode.json'),
+    pluginsDir: path.join(d, 'plugins'),
+    agentsDir: path.join(d, 'agents'),
+    skillsDir: path.join(d, 'skills'),
+  };
+  const cfg = cfgOn();
+  cfg.providers.opencodeCatalogDir = makeCatalog(path.join(d, 'catalog'));
+  const pkgRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+  await opencodeStack(cfg, { pkgRoot, ...seams });
+  const artifactFiles = [
+    path.join(seams.pluginsDir, PLUGIN_NAME),
+    ...Object.keys(cfg.providers.opencodeManaged.artifacts.agents)
+      .map((file) => path.join(seams.agentsDir, file)),
+    path.join(seams.agentsDir, '.ak-agents-stamp.json'),
+    path.join(seams.skillsDir, 'ruflo', 'SKILL.md'),
+  ];
+  const exactBytes = artifactFiles.map((file) => fs.readFileSync(file, 'utf8'));
+
+  for (const malformed of ['corrupt', [], { agents: 'corrupt' }]) {
+    cfg.providers.opencodeManaged.artifacts = structuredClone(malformed);
+    const result = await opencodeStack(cfg, { pkgRoot, ...seams });
+    assert.notEqual(result.plugin.adopted, true);
+    assert.equal(result.agents.adopted, 0);
+    assert.notEqual(result.skill.adopted, true);
+    assert.deepEqual(cfg.providers.opencodeManaged.artifacts, malformed,
+      'a non-null malformed container is preserved byte-for-byte as repair evidence');
+    assert.deepEqual(artifactFiles.map((file) => fs.readFileSync(file, 'utf8')), exactBytes,
+      'fail-closed reconciliation never rewrites artifact files');
+  }
+  rm(d);
+});
+
+test('a malformed receipt ledger cannot create absent artifacts across repeated reconciliation', async () => {
+  const { opencodeStack } = await import('../../src/lib/opencode.mjs');
+  const { fileURLToPath } = await import('node:url');
+  const d = tmp('ak-oc-malformed-empty-');
+  const seams = {
+    configFile: path.join(d, 'opencode.json'),
+    pluginsDir: path.join(d, 'plugins'),
+    agentsDir: path.join(d, 'agents'),
+    skillsDir: path.join(d, 'skills'),
+  };
+  const cfg = cfgOn();
+  cfg.providers.opencodeCatalogDir = makeCatalog(path.join(d, 'catalog'));
+  cfg.providers.opencodeManaged = { artifacts: 'corrupt' };
+  const pkgRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+
+  for (let pass = 1; pass <= 2; pass++) {
+    const result = await opencodeStack(cfg, { pkgRoot, ...seams });
+    assert.equal(result.plugin.adoptionBlocked, true);
+    assert.equal(result.agents.adoptionBlocked, true);
+    assert.equal(result.skill.adoptionBlocked, true);
+    assert.equal(result.plugin.changed, false);
+    assert.equal(result.agents.changed, false);
+    assert.equal(result.skill.changed, false);
+    assert.equal(result.markersChanged, pass === 1,
+      'only the independently managed opencode.json receipt may converge');
+    assert.equal(cfg.providers.opencodeManaged.artifacts, 'corrupt');
+    for (const dir of [seams.pluginsDir, seams.agentsDir, seams.skillsDir]) {
+      assert.equal(fs.existsSync(dir), false, `${path.basename(dir)} must remain absent`);
+    }
+  }
   rm(d);
 });
 
@@ -847,8 +1030,24 @@ test('OpenCode lifecycle detect/plan/dry-run are read-only; apply and undo are i
   assert.equal(fs.existsSync(options.configFile), false, 'dry-run creates no OpenCode surface');
 
   const first = await runLifecycle({ adapter, action: 'apply', cfg });
+  cfg.providers.opencodeManaged.artifacts = {
+    plugin: null, agents: {}, agentStamp: null, skill: null,
+  };
+  const adoptionPlan = await runLifecycle({ adapter, action: 'plan', cfg });
+  assert.equal(adoptionPlan.changed, true, 'read-only detection exposes receipt adoption as planned work');
+  assert.equal(adoptionPlan.facts.plugin.adoptable, true);
+  assert.equal(adoptionPlan.facts.agents.adoptable, true);
+  assert.equal(adoptionPlan.facts.skill.adoptable, true);
+  const migrated = await runLifecycle({ adapter, action: 'apply', cfg });
+  cfg.providers.opencodeManaged.artifacts.agentStamp = null;
+  const stampPlan = await runLifecycle({ adapter, action: 'plan', cfg });
+  assert.equal(stampPlan.facts.agents.adoptable, true,
+    'an exact stamp with independently receipted agents is itself adoptable');
+  const stampMigrated = await runLifecycle({ adapter, action: 'apply', cfg });
   const second = await runLifecycle({ adapter, action: 'apply', cfg });
   assert.equal(first.changed, true);
+  assert.equal(migrated.changed, true, 'receipt-only adoption persists markers without rewriting artifacts');
+  assert.equal(stampMigrated.changed, true);
   assert.equal(second.changed, false);
   const undone = await runLifecycle({ adapter, action: 'undo', cfg });
   const repeated = await runLifecycle({ adapter, action: 'undo', cfg });

--- a/tests/kit/status-command.test.mjs
+++ b/tests/kit/status-command.test.mjs
@@ -398,6 +398,46 @@ test('enabled + converged: every opencode row is ok with no fix planned', async 
   assert.ok(oc.some((r) => /converged/.test(r.message)), 'the wiring row reports convergence');
 });
 
+test('exact legacy artifacts without receipts surface as read-only adoption work', async () => {
+  seedHome();
+  const cfg = await seedConvergedOpencode();
+  cfg.providers.opencodeManaged.artifacts = {
+    plugin: null, agents: {}, agentStamp: null, skill: null,
+  };
+  writeKitConfig(HOME, cfg);
+  const before = snapshot(HOME);
+
+  const rows = await withOpencodeCli(() => collect());
+  const adoption = rowsFor(rows, 'opencode')
+    .filter((r) => /lacks? (?:an |ownership )?ownership receipt|lack ownership receipts/.test(r.message));
+  assert.equal(adoption.length, 3,
+    `plugin, agents/stamp, and skill must each expose adoption: ${rowsFor(rows, 'opencode').map((r) => r.message)}`);
+  for (const row of adoption) {
+    assert.equal(row.level, 'warn');
+    assert.match(row.fix, /sync adopts .*receipt ledger without rewriting/i);
+  }
+  assertUnchanged(before, HOME, 'status must report receipt adoption without persisting it');
+});
+
+test('a malformed artifact receipt ledger blocks adoption and remains read-only', async () => {
+  seedHome();
+  const cfg = await seedConvergedOpencode();
+  cfg.providers.opencodeManaged.artifacts = 'corrupt';
+  writeKitConfig(HOME, cfg);
+  const before = snapshot(HOME);
+
+  const rows = await withOpencodeCli(() => collect());
+  const oc = rowsFor(rows, 'opencode');
+  const blocked = oc.filter((r) => /artifact receipt ledger is malformed/.test(r.message));
+  assert.equal(blocked.length, 1, `one actionable malformed-ledger row expected: ${oc.map((r) => r.message)}`);
+  assert.equal(blocked[0].level, 'warn');
+  assert.match(blocked[0].message, /ownership adoption blocked; artifacts left untouched/);
+  assert.match(blocked[0].fix, /repair providers\.opencodeManaged\.artifacts/);
+  assert.equal(oc.some((r) => /ownership receipt|user-owned ruflo-hooks|converted agents/.test(r.message)), false,
+    'blocked ownership evidence must not be reinterpreted as adoption, foreign files, or healthy agents');
+  assertUnchanged(before, HOME, 'status must preserve malformed recovery evidence byte-for-byte');
+});
+
 test('enabled + drifted: a warn row names the sync fix', async () => {
   seedHome();
   await seedConvergedOpencode();


### PR DESCRIPTION
Closes #92.

## What changed

- adopts exact marker-bearing OpenCode plugin, agent, stamp, and skill artifacts when legacy ownership receipts are absent
- preserves edited, stale, foreign, or non-null mismatched receipt state without laundering ownership on a later pass
- fails closed on malformed receipt containers and leaves all artifact slots untouched, including absent directories
- surfaces read-only adoption and malformed-ledger status with actionable remediation
- keeps receipt-only adoption idempotent while reporting marker persistence accurately

## Safety contract

Adoption occurs only when the receipt is absent/null, the artifact carries the agentic-kit marker where applicable, and its bytes exactly equal the current desired bytes. The marker-free agent stamp is adopted only when its canonical bytes and every independently accepted agent file match.

## Verification

- `pnpm run check`
- `pnpm audit --audit-level high`
- `pnpm run test:surface`
- `pnpm run lint:links:internal`
- focused OpenCode/status suite: 75/75 passing
- independent reconciliation review: no blockers