### PR TITLE
test(ci): keep isolated CLI checks offline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,14 @@ jobs:
           # Isolate every home-relative write (kit.json, CLAUDE.md, settings).
           HOME: ${{ runner.temp }}/kit-home
           USERPROFILE: ${{ runner.temp }}\kit-home
+          XDG_CONFIG_HOME: ${{ runner.temp }}/kit-home/.config
           APPDATA: ${{ runner.temp }}\kit-home\AppData\Roaming
         run: |
           mkdir -p "$HOME"
+          # The smoke test proves local CLI behavior, not npm reachability.
+          # Seed a fresh empty drift cache so an offline Windows runner does
+          # not pay four sequential 20s `npm view` timeouts inside status.
+          node -e 'const fs=require("node:fs"),p=require("node:path"),base=process.platform==="win32"?process.env.APPDATA:process.env.XDG_CONFIG_HOME,dir=p.join(base,"agentic-kit"),last=Date.now();fs.mkdirSync(dir,{recursive:true});fs.writeFileSync(p.join(dir,"kit.json"),JSON.stringify({versionCheck:{last,seen:{},self:{last,best:null}}}))'
           node bin/agentic-kit.mjs --version
           node bin/agentic-kit.mjs --help --all > /dev/null
           # status must emit valid JSON and exit deterministically even on a

--- a/tests/kit/dual-cli.test.mjs
+++ b/tests/kit/dual-cli.test.mjs
@@ -15,8 +15,13 @@ function sandbox({ dualRouting }) {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), 'kit-dual-home-'));
   const cfgDir = path.join(home, '.config', 'agentic-kit');
   fs.mkdirSync(cfgDir, { recursive: true });
+  const last = Date.now();
   fs.writeFileSync(path.join(cfgDir, 'kit.json'),
-    JSON.stringify({ providers: { hosts: { claude: true, codex: true }, dualRouting } }));
+    JSON.stringify({
+      providers: { hosts: { claude: true, codex: true }, dualRouting },
+      // Real CLI spawns must not turn an isolated unit test into an npm network probe.
+      versionCheck: { last, seen: {}, self: { last, best: null } },
+    }));
   const project = fs.mkdtempSync(path.join(os.tmpdir(), 'kit-dual-proj-'));
   fs.mkdirSync(path.join(project, '.git'));
   return { home, project };

--- a/tests/kit/provider-cli.test.mjs
+++ b/tests/kit/provider-cli.test.mjs
@@ -20,7 +20,12 @@ function sandbox({ hosts }) {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), 'kit-prov-cli-home-'));
   const cfgDir = path.join(home, '.config', 'agentic-kit');
   fs.mkdirSync(cfgDir, { recursive: true });
-  fs.writeFileSync(path.join(cfgDir, 'kit.json'), JSON.stringify({ providers: { hosts } }));
+  const last = Date.now();
+  fs.writeFileSync(path.join(cfgDir, 'kit.json'), JSON.stringify({
+    providers: { hosts },
+    // Real CLI spawns must not turn an isolated unit test into an npm network probe.
+    versionCheck: { last, seen: {}, self: { last, best: null } },
+  }));
   const project = fs.mkdtempSync(path.join(os.tmpdir(), 'kit-prov-cli-proj-'));
   fs.mkdirSync(path.join(project, '.git'));
   return { home, project };

--- a/tests/kit/provider-refresh-cli.test.mjs
+++ b/tests/kit/provider-refresh-cli.test.mjs
@@ -27,7 +27,16 @@ function sandbox(providers) {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), 'kit-refresh-home-'));
   const cfgDir = path.join(home, '.config', 'agentic-kit');
   fs.mkdirSync(cfgDir, { recursive: true });
-  fs.writeFileSync(path.join(cfgDir, 'kit.json'), JSON.stringify({ providers }));
+  // These tests exercise provider output and persistence, not version egress.
+  // A fresh sandbox otherwise makes every real CLI spawn run two sequential
+  // `npm view` probes; an unreachable Windows runner pays both 20s timeouts
+  // for every test in this file. Seed the same honest "checked, no answer"
+  // cache shape a completed drift probe would persist.
+  const last = Date.now();
+  fs.writeFileSync(path.join(cfgDir, 'kit.json'), JSON.stringify({
+    providers,
+    versionCheck: { last, seen: {}, self: { last, best: null } },
+  }));
   const project = fs.mkdtempSync(path.join(os.tmpdir(), 'kit-refresh-proj-'));
   fs.mkdirSync(path.join(project, '.git'));
   return { home, project };


### PR DESCRIPTION
## Outcome

Eliminates accidental npm egress from the provider CLI integration sandbox and the cross-platform CLI smoke job while preserving production version-drift behavior unchanged.

## Root cause

The CLI drift nudge predates these tests. Fresh test homes had no `versionCheck` cache, so each spawned provider command ran two sequential `npm view` probes. On Windows runners both reached their 20-second timeout, making each test take about 40.5 seconds. The smoke status path additionally paid four probes. Node buffered the next test file, making all Windows lanes appear hung at the same prior output line.

## Change

- seed the provider integration sandbox with a fresh, empty, truthful drift result
- seed the CLI smoke HOME with both package and self-drift cache entries
- set `XDG_CONFIG_HOME` explicitly for POSIX smoke parity
- leave all production drift/nudge code and upgrade semantics untouched

## Evidence

- affected provider file: 14/14 pass in 4.8s locally
- previous Windows log: affected tests ~40.5s each; unit step 590.8s
- `pnpm run check`
- `pnpm audit --audit-level high`
- `pnpm run lint:links:internal`
- workflow YAML parse
- `ak x verify memory` passes; project AgentDB checkpoint confirmed in the ADR-0016 native sibling store