### PR TITLE
fix(natives): resolve @claude-flow/security & aidefence when npm nests instead of hoisting

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ codebase.
 
 - [rUv](https://github.com/ruvnet) — [ruflo/claude-flow](https://github.com/ruvnet/ruflo); upstream issues filed from this kit's verification work: [#2219](https://github.com/ruvnet/ruflo/issues/2219), [#2222](https://github.com/ruvnet/ruflo/issues/2222), [#2239](https://github.com/ruvnet/ruflo/issues/2239), [#2360](https://github.com/ruvnet/ruflo/issues/2360), [#2549](https://github.com/ruvnet/ruflo/issues/2549), [#2670](https://github.com/ruvnet/ruflo/issues/2670)
 - [Dragan Spiridonov](https://github.com/proffesor-for-testing) — [agentic-qe](https://github.com/proffesor-for-testing/agentic-qe)
+- [Stuart Kerr](https://github.com/stuinfla) — [RuvNet Brain](https://github.com/stuinfla/ruvnet-brain), the source-grounded knowledge base over the rUv stack that `ak setup` installs and `ak sync` keeps current
 - [Ciprian Melian](https://github.com/ciprianmelian) — prior art: [repair gist](https://gist.github.com/ciprianmelian/eb7e8ff7d24018141ca34bb8a7e216a6)
 
 ### Contributors

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pacphi/agentic-kit",
   "version": "4.0.0-alpha.30",
-  "description": "Setup, healing, verification, and multi-host execution routing (Claude, Codex, OpenCode) for your AI agent stack (ruflo/claude-flow, agentic-qe) — cross-platform, zero-dependency",
+  "description": "Setup, healing, verification, and multi-host execution routing (Claude, Codex, OpenCode) for your AI agent stack (ruflo/claude-flow, agentic-qe, RuvNet Brain) — cross-platform, zero-dependency",
   "type": "module",
   "bin": {
     "agentic-kit": "bin/agentic-kit.mjs",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pacphi/agentic-kit",
   "version": "4.0.0-alpha.30",
-  "description": "Machine-level setup, healing, and verification kit for your AI agent stack (ruflo/claude-flow, agentic-qe, Claude Code glue) — cross-platform, zero-dependency",
+  "description": "Setup, healing, verification, and multi-host execution routing (Claude, Codex, OpenCode) for your AI agent stack (ruflo/claude-flow, agentic-qe) — cross-platform, zero-dependency",
   "type": "module",
   "bin": {
     "agentic-kit": "bin/agentic-kit.mjs",

--- a/src/lib/natives.mjs
+++ b/src/lib/natives.mjs
@@ -177,8 +177,19 @@ export function dbPathPinStatus({ settingsLocalFile, projectRoot }) {
   return { warn: false, pinned };
 }
 
-export const aidefencePresent = () =>
-  fs.existsSync(path.join(rufloNodeModules(), '@claude-flow', 'aidefence', 'package.json'));
+// npm only hoists a @claude-flow/* package to the top of ruflo's node_modules when
+// every dependent can share one version; a conflicting sibling (e.g. @claude-flow/cli
+// pinning a different range) leaves it nested under that dependent instead. A
+// top-level-only check then false-negatives on a package that IS installed — seen
+// with @claude-flow/security landing under cli/node_modules instead of hoisting.
+// Check the top level plus the known @claude-flow/* dependents (mirrors
+// rufloMemoryContexts' consumer list) rather than a full recursive search.
+function claudeFlowPackagePresent(name) {
+  const nm = rufloNodeModules();
+  const roots = [nm, path.join(nm, '@claude-flow', 'cli', 'node_modules')];
+  return roots.some((root) => fs.existsSync(path.join(root, '@claude-flow', name, 'package.json')));
+}
 
-export const securityPresent = () =>
-  fs.existsSync(path.join(rufloNodeModules(), '@claude-flow', 'security', 'package.json'));
+export const aidefencePresent = () => claudeFlowPackagePresent('aidefence');
+
+export const securityPresent = () => claudeFlowPackagePresent('security');

--- a/tests/kit/natives.test.mjs
+++ b/tests/kit/natives.test.mjs
@@ -6,7 +6,8 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { bsq3Root, bsq3IsNative, selfSpecConflicts } from '../../src/lib/natives.mjs';
+import { bsq3Root, bsq3IsNative, selfSpecConflicts, aidefencePresent, securityPresent } from '../../src/lib/natives.mjs';
+import { _setGlobalRootForTest } from '../../src/lib/paths.mjs';
 
 function makeFixture({ withBinding }) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ak-natives-'));
@@ -110,4 +111,63 @@ test('selfSpecConflicts ignores non-plain-semver declarations (workspace:/link:/
   writePkgJson(dir, { name: 'x', dependencies: { 'better-sqlite3': 'link:../better-sqlite3' } });
   assert.deepEqual(selfSpecConflicts(dir, '^12.10.0'), []);
   fs.rmSync(dir, { recursive: true, force: true });
+});
+
+function makeGlobalRootFixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ak-natives-cfpkg-'));
+  fs.mkdirSync(path.join(root, 'ruflo', 'node_modules'), { recursive: true });
+  return root;
+}
+
+test('securityPresent is true when the package is hoisted to the top of ruflo/node_modules', () => {
+  const root = makeGlobalRootFixture();
+  writePkgJson(path.join(root, 'ruflo', 'node_modules', '@claude-flow', 'security'), { name: '@claude-flow/security' });
+  _setGlobalRootForTest(root);
+  try {
+    assert.equal(securityPresent(), true);
+  } finally {
+    _setGlobalRootForTest(null);
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('securityPresent is true when npm nests the package under @claude-flow/cli instead of hoisting it (regression: false WARN when a version conflict prevents hoisting)', () => {
+  const root = makeGlobalRootFixture();
+  writePkgJson(
+    path.join(root, 'ruflo', 'node_modules', '@claude-flow', 'cli', 'node_modules', '@claude-flow', 'security'),
+    { name: '@claude-flow/security' },
+  );
+  _setGlobalRootForTest(root);
+  try {
+    assert.equal(securityPresent(), true);
+  } finally {
+    _setGlobalRootForTest(null);
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('securityPresent is false when the package is genuinely absent from both locations', () => {
+  const root = makeGlobalRootFixture();
+  _setGlobalRootForTest(root);
+  try {
+    assert.equal(securityPresent(), false);
+  } finally {
+    _setGlobalRootForTest(null);
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('aidefencePresent follows the same top-level-or-nested-under-cli resolution', () => {
+  const root = makeGlobalRootFixture();
+  writePkgJson(
+    path.join(root, 'ruflo', 'node_modules', '@claude-flow', 'cli', 'node_modules', '@claude-flow', 'aidefence'),
+    { name: '@claude-flow/aidefence' },
+  );
+  _setGlobalRootForTest(root);
+  try {
+    assert.equal(aidefencePresent(), true);
+  } finally {
+    _setGlobalRootForTest(null);
+    fs.rmSync(root, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## Summary
- `securityPresent()`/`aidefencePresent()` only checked the top level of `ruflo/node_modules`, producing a false WARN on the diagnostic panel when npm nests `@claude-flow/security` (or `aidefence`) under `@claude-flow/cli/node_modules` instead of hoisting it.
- Adds `claudeFlowPackagePresent()` which checks both the top-level and known nested location, mirroring the existing `rufloMemoryContexts()` consumer-list pattern.
- Refreshes `package.json`'s description to reflect the multi-host (Claude/Codex/OpenCode) execution routing shipped through alpha.30.

## Test plan
- [x] `node --test tests/kit/natives.test.mjs` — new hermetic regression tests (hoisted / nested-under-cli / absent) pass
- [x] `pnpm test` — full suite (1159 tests) passes
- [x] `pnpm run check` — typecheck + lint + markdown lint + build + test all pass