### PR TITLE
chore(release): v4.0.0-alpha.36

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pacphi/agentic-kit",
-  "version": "4.0.0-alpha.35",
+  "version": "4.0.0-alpha.36",
   "description": "Setup, healing, verification, and multi-host execution routing (Claude, Codex, OpenCode) for your AI agent stack (ruflo/claude-flow, agentic-qe, RuvNet Brain) — cross-platform, zero-dependency",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Release intent

Publish `@pacphi/agentic-kit@4.0.0-alpha.36` from the exact merged commit through the repository-owned tag workflow. This release carries the Observability and provider-consistency work merged in #106; the release commit itself changes only `package.json`.

## Dashboard information architecture

- Reduce primary navigation to three durable product areas: Overview, Usage, and Observability.
- Move Summary, Hosts & Routing, Providers, Runtime, and Intelligence into a fixed, left-aligned Overview subtab rail.
- Keep secondary tabs in one stable position across Overview, Usage, and Observability.
- Add a heading and concise explanation to every dashboard view.
- Establish canonical hierarchical routes for all primary areas and subtabs.

## Observability Live and History modes

- Rename the former Live product area to Observability across UI, routing, architecture, and user documentation.
- Make Live show only projects and sessions with current process evidence.
- Make History show retained projects and sessions without live-state semantics.
- Suppress green live dots, pulsation, moving dashes, and follow affordances on historical maps.
- Reserve playback controls for historical/review use and dock them below the map to prevent overlap.
- Add 5x and 10x historical playback speeds.

## Agent Activity experience

- Unify Claude Code, Codex, and OpenCode around one evidence-aware visual grammar where each host supports it.
- Distinguish process presence, meaningful work, in-flight operations, and static relationships.
- Add long-running presence breathing and current-operation movement without manufacturing activity.
- Improve automatic actor/operation layout and retain drag, pin, zoom, pan, Fit, Focus, and Reset interactions.
- Add evidence-aware rollover help, persistent selection details, and a consultable Legend / Help dialog.
- Fix Legend Close, Escape behavior, and keyboard focus restoration.
- Replace synthetic/internal labels with user-facing activity language.

## Session Stream and workspace context

- Add a chevron-controlled Session Stream collapse/restore rail.
- Let Agent Activity reclaim the released panel width while preserving stream connections, selection, camera, pins, and unread state.
- Capture safe repository, directory, branch, tracked line-count, changed-file, timestamp, and confidence evidence.
- Persist safe workspace snapshots for History.
- Remove redundant repository labels and unhelpful `Directory: repo root` text; render branches with a compact branch mark.
- Clarify that working-tree counts describe the captured tree and are not automatically attributable to one session.

## Provider identity and session hierarchy

- Keep execution host, inference provider, and model as independent axes.
- Fix `claudeunknown` / `codexunknown` usage pills and use explicit missing-evidence language.
- Ingest Codex `session_meta.model_provider` as observed provenance without inferring providers from host/model names.
- Preserve native Codex worker-thread relationships and render Claude sidechains as nested workers without fabricating sessions.
- Keep OpenCode in the common shell while remaining honest about unavailable hierarchy, transcript, and provider evidence.
- Use official OpenAI/Codex and OpenCode O marks with accessible adjacent identity text.

## Documentation and architecture

- Add the user-facing `docs/DASHBOARD.md` interaction guide.
- Replace `docs/LIVE-SESSIONS.md` with `docs/OBSERVABILITY.md`.
- Rename and update the Observability DDD model, context map, and ADR-0012.
- Refresh affected ADRs as living plans and document routes, mode semantics, animation rules, host capabilities, evidence confidence, and Git-count limitations.
- Refresh transcript and Usage scorecard citations after the Usage schema update.

## Quality and release evidence

- `pnpm run check` — passed.
- `pnpm run test:ui` — 193 passed, 0 failed; no console errors or failed browser requests.
- `git diff --check` — passed.
- `npm pack` — 132 files; package version `4.0.0-alpha.36`.
- Candidate SHA-256 — `9528fc8fea0630e3906331659445f988c74371579a4b7f32d1bc41986407658c`.
- Clean tarball install — both `ak --version` and `agentic-kit --version` returned `4.0.0-alpha.36`.

After merge, the exact merged SHA must pass main CI before tag `v4.0.0-alpha.36` is created. The tag workflow will publish the prerelease to npm dist-tag `next` and create the GitHub prerelease.
