### PR TITLE
docs: propose MetaHarness assurance companion

### DIFF
--- a/docs/METAHARNESS-COMPANION-PROPOSAL.md
+++ b/docs/METAHARNESS-COMPANION-PROPOSAL.md
@@ -1,0 +1,366 @@
+# MetaHarness as an Optional Assurance Companion
+
+- **Status:** Proposed
+- **Date:** 2026-08-04
+- **Decision record:**
+  [ADR-0022](adr/0022-metaharness-as-optional-assurance-companion.md)
+- **Replaces:** branch-only MetaHarness retrieval proposal in commit
+  [`8dcad80`](https://github.com/pacphi/agentic-kit/commit/8dcad806c015e3de42f46b8fa4858edf9dd439c1)
+
+## Executive decision
+
+Use MetaHarness primarily **around** agentic-kit, as an optional assurance and optimization
+companion. Keep agentic-kit responsible for installing, configuring, routing, and supervising the
+user's agent stack. Let MetaHarness observe bounded `ak run` outcomes, evaluate quality/cost/safety,
+compare policies, and produce evidence or recommendations without becoming another execution or
+configuration authority.
+
+A small integration **inside** agentic-kit can still be valuable, but only as a capability-aware,
+read-only projection over upstream evidence: availability, health, recent evaluations, and a safe
+next command. It must not embed a second harness, reproduce gates, promote policies, or add another
+routing surface.
+
+This gives a reason for both forms:
+
+| Form | Value | Authority |
+| --- | --- | --- |
+| MetaHarness around agentic-kit | Independent measurement, experiments, red/blue exercises, and cost-quality learning | Advises; does not operate agentic-kit |
+| Thin MetaHarness projection in agentic-kit | Discoverability, status, repair guidance, and consistent evidence display | Reads upstream state; does not recreate it |
+
+The external companion is the higher-value starting point. The internal projection is justified
+only after the companion proves that users repeatedly need those results in the normal `ak`
+experience.
+
+## The three systems that must not be conflated
+
+The name “MetaHarness” currently appears at three different boundaries:
+
+1. **Standalone MetaHarness** is a factory and deterministic control plane for generated agent
+   harnesses. Its worker contract is a function, and its packages cover repo scoring, policy,
+   auditing, receipts, red/blue testing, and Darwin evolution.
+2. **Ruflo's MetaHarness surface** is an upstream CLI bridge and, in particular releases, a
+   retrieval-flywheel integration. Ruflo remains authoritative for its own receipt, ledger,
+   champion, and promotion semantics.
+3. **Agentic-kit** is the lifecycle and execution product. It owns supported-host setup, sync,
+   status, configuration projections, activity routing, and the supervised `ak run` contract.
+
+“Incorporating MetaHarness” is ambiguous unless it identifies which boundary it means. This
+proposal uses **companion** for standalone MetaHarness around agentic-kit and **projection** for any
+read-only agentic-kit UX over Ruflo or MetaHarness evidence.
+
+## Product thesis
+
+Agentic-kit makes an agent stack operable. MetaHarness can make that operation measurable.
+
+The combined value proposition is:
+
+> Run a bounded multi-host workflow through agentic-kit; independently measure whether it was good,
+> safe, and cost-effective; learn from labeled outcomes; and require a separate explicit decision
+> before any learned policy influences future execution.
+
+The separation matters. A harness that both selects the route, executes it, defines success, and
+promotes itself cannot provide strong independent evidence. A companion can compare agentic-kit
+versions or routing policies while agentic-kit remains usable when the companion is absent.
+
+## Explicit use cases
+
+### 1. Pre-adoption repository fit analysis
+
+**User:** an agentic-kit maintainer or adopter considering a MetaHarness workflow.
+
+**MetaHarness does:** statically score harness fit, compile confidence, inferred task coverage,
+recommended mode, and scaffold constraints without executing repository code.
+
+**Helpful because:** it quickly identifies whether generating a harness is plausible and which
+shape MetaHarness would recommend.
+
+**Boundary:** this score describes the **recommended generated harness**, not the current
+repository's security, correctness, or production readiness. For example, “tool safety” is computed
+from the proposed policy posture; it is not proof that existing MCP configuration is safe.
+
+### 2. Read-only tool and MCP posture review
+
+**User:** a maintainer reviewing the trust boundary before allowing agent execution.
+
+**MetaHarness does:** inventory exposed MCP/tool surfaces, produce a threat model, and run an OIA
+audit in dry-run/read-only mode.
+
+**Helpful because:** `ak run` intentionally inherits the user's CLI trust posture in the target
+repository. A separate review can expose unexpected tools, broad permissions, or missing policy
+before execution.
+
+**Boundary:** a finding such as “no `.harness/mcp-policy.json`” means the repository is not governed
+as a generated MetaHarness harness. It is not automatically an agentic-kit vulnerability. Findings
+must be interpreted against the product that owns the configuration.
+
+### 3. Shadow evaluation of `ak run`
+
+**User:** a maintainer comparing execution templates, routes, versions, or escalation policies.
+
+**MetaHarness does:** invoke a dedicated adapter that treats one complete `ak run` pipeline as a
+candidate worker, records bounded outcome evidence, and scores the result against an external task
+and verifier suite.
+
+**Helpful because:** it can compare “did this workflow solve the task?” across policies without
+changing the policy used by normal users.
+
+**Boundary:** start at the whole-pipeline level. MetaHarness must not reschedule individual
+agentic-kit workers or replace the runner's readiness, timeout, cancellation, escalation, and
+cleanup lifecycle.
+
+**Required correction before implementation:** today's `ak run --json` emits `{plan, results}` but
+has no explicit top-level schema version or companion-safe export profile. The adapter needs a
+versioned, sanitized result contract that states provenance, redaction, terminal status, and which
+fields are stable. Raw prompts, task text, repository content, secrets, handoffs, and host protocol
+streams must not become training data by accident.
+
+### 4. Cost-quality routing advice
+
+**User:** a team with repeated, labeled executions and multiple eligible host/model routes.
+
+**MetaHarness does:** compare quality, latency, and cost evidence and recommend the cheapest route
+that meets a declared quality floor.
+
+**Helpful because:** agentic-kit's current routing is explicit intent and subscription-aware;
+MetaHarness can add empirical outcome evidence once a representative labeled dataset exists.
+
+**Boundary:** recommendations run in shadow/advisory mode first. They do not rewrite `kit.json`,
+change `routing.routes`, enable a host/provider, spend against a new metered provider, or claim
+vendor diversity. Agentic-kit applies only a user-approved route through its existing canonical
+surface.
+
+### 5. Harness-policy evolution with Darwin
+
+**User:** an advanced maintainer optimizing the companion itself.
+
+**MetaHarness does:** evolve its approved harness policy surfaces—planner, context builder,
+reviewer, retry policy, tool policy, memory policy, and score policy—inside a bounded sandbox and
+score variants against fixed tasks.
+
+**Helpful because:** it can improve how the companion evaluates and conducts work without turning
+agentic-kit into self-modifying product code.
+
+**Boundary:** Darwin does not mutate agentic-kit core, `kit.json`, host projections, credentials,
+permissions, provider access, or the `ak run` supervisor. A winning variant remains an evaluation
+artifact until a maintainer separately reviews and promotes it.
+
+### 6. Red/blue evaluation of LLM and tool surfaces
+
+**User:** a maintainer of an LLM-facing workflow built on agentic-kit.
+
+**MetaHarness does:** use `@metaharness/redblue` to test prompt-injection, data-exfiltration, tool
+misuse, and related scenarios against a bounded test target.
+
+**Helpful because:** conventional code tests do not fully exercise adversarial model/tool behavior.
+
+**Boundary:** red/blue runs target only systems the user owns or is authorized to test. They use
+fixtures or isolated environments, no production credentials or live third-party targets, fixed
+budgets, and explicit network/tool allowlists. This complements rather than replaces agentic-qe's
+code, integration, security, and regression testing.
+
+### 7. Release and regression evidence
+
+**User:** agentic-kit maintainers preparing a release.
+
+**MetaHarness does:** run the same held-out task suite against two agentic-kit commits or two routing
+policies and emit comparable receipts or scorecards.
+
+**Helpful because:** ordinary tests prove deterministic contracts; outcome evaluation can detect a
+quality or cost regression in otherwise passing agent workflows.
+
+**Boundary:** the evidence informs a release decision. It does not publish, tag, deploy, or bypass
+the repository's existing release and QE gates.
+
+### 8. Read-only improvement status in agentic-kit
+
+**User:** an operator who wants to know whether an upstream Ruflo evaluation exists or needs
+attention.
+
+**Agentic-kit does:** capability-probe the installed upstream CLI, render its provenance and state,
+and provide a copyable next command. A future dashboard projection may display the same evidence.
+
+**Helpful because:** it makes an upstream capability discoverable in the normal operational
+experience.
+
+**Boundary:** status and dashboard stay read-only. Ruflo owns its receipt, ledger, active champion,
+and promotion transaction. This use case does not by itself justify a new top-level `ak improve`
+command.
+
+## What MetaHarness should not do
+
+MetaHarness is not helpful when it becomes a second owner of agentic-kit. It must not:
+
+- install, update, enable, sync, or uninstall supported hosts and providers;
+- own or rewrite agentic-kit's routing envelope, projections, or ownership receipts;
+- schedule agentic-kit's internal worker DAG or weaken its deadlines and cleanup proof;
+- infer inference-provider identity or vendor diversity from a host/model label;
+- copy project memory into a second canonical store;
+- replace agentic-qe for deterministic code, integration, and security verification;
+- promote retrieval, routing, tool, permission, model, or spending policy unattended;
+- generate over checked-in `AGENTS.md`, `CLAUDE.md`, `.mcp.json`, `.codex`, or `.claude` state;
+- become a runtime dependency required for `ak setup`, `ak sync`, `ak status`, or `ak run`;
+- treat its self-score as proof that agentic-kit is secure or production-ready.
+
+## Corrective disposition of the earlier proposal
+
+The 2026-07-28 branch proposal contains useful safety instincts—especially separate evaluation and
+promotion, explicit confirmation, capability probing, and Ruflo authority—but its product boundary
+needs correction.
+
+| Earlier direction | Correction |
+| --- | --- |
+| Call the workflow “MetaHarness retrieval improvement” | Name Ruflo's retrieval flywheel as a Ruflo capability; use MetaHarness for the separate factory/harness project |
+| Add a full top-level `ak improve` lifecycle | Start with an external companion and read-only capability/status projection; require evidence and a follow-up decision before expanding the GA command surface |
+| Make agentic-kit generate and own signing keys | Keep signing semantics and key-provider ownership with the system that verifies receipts; expose references only if a later key-lifecycle design proves install, rotation, redaction, and uninstall safety |
+| Persist MetaHarness preferences and key paths in `kit.json` | Do not add state until a stable upstream contract and an agentic-kit ownership model exist |
+| Treat Ruflo version facts as the capability contract | Probe supported verbs and structured schemas; command availability has changed across branches/releases |
+| Present MetaHarness score dimensions as repository facts | Label them as static pre-scaffold estimates derived from repository signals and the recommended policy |
+| Use current `ak run --json` as the adapter boundary | First version and sanitize a companion result envelope; the current payload is machine-readable, not yet a public interop contract |
+| Let Darwin improve “agentic-kit” | Limit mutation to MetaHarness's seven harness-policy surfaces; agentic-kit product changes remain normal reviewed code changes |
+| Treat MetaHarness routing as a replacement | Use learned routing only as evidence/advice; agentic-kit retains explicit route and provider authority |
+| Treat generated harness policy as repository policy | Generate in a sibling, temporary, or dedicated companion workspace and never overwrite user/project configuration |
+
+The branch-only ADR used number 0016, which now belongs to the accepted capability-adapter ADR on
+`main`. It must not be merged under that number. ADR-0022 records the revised decision.
+
+### Branch asset disposition
+
+The old branch must not be merged or rebased as a unit. Its unique MetaHarness commit
+(`8dcad80`) has the following disposition:
+
+| Branch asset | Disposition on `main` | Reason |
+| --- | --- | --- |
+| `docs/METAHARNESS-INTEGRATION-PROPOSAL.md` | Replace with this proposal | The old document makes a full internal retrieval workflow the product center; this proposal makes the external assurance companion primary |
+| `docs/adr/0016-curated-retrieval-improvement-workflow.md` | Replace with ADR-0022; do not copy or renumber mechanically | Number 0016 is already assigned on `main`, and the decision boundary changed materially |
+| `docs/ddd/retrieval-improvement.md` | Retire; do not port | Its aggregates and commands assume agentic-kit owns `ak improve`, signing identity, preferences, review, and promotion UX—responsibilities ADR-0022 does not authorize |
+| Branch `docs/adr/README.md` edit | Discard; use the current `main` index entry for ADR-0022 | The branch index predates ADRs 0017–0021 and would regress living-plan history |
+
+The branch also contains an earlier Codex-statusline commit, but `git cherry` identifies it as
+patch-equivalent to work already on `main`. It is not part of the MetaHarness migration.
+
+### Documentation-only path to `main`
+
+1. Create a fresh documentation branch from current `main`; do not build on or merge the old
+   proposal branch.
+2. Commit only this proposal, ADR-0022, and the current ADR index update.
+3. Open a pull request that links commit `8dcad80` as replaced history and includes the asset
+   disposition table above.
+4. Review the PR as a **Proposed architecture decision**, not as implemented functionality. The PR
+   must not claim that a companion adapter, result schema, status projection, or `ak improve`
+   command exists.
+5. Run Markdown lint and internal/external link checks. No runtime, package, configuration, or test
+   implementation change is expected from this documentation PR.
+6. Merge the documentation PR into `main` after maintainers accept the boundary.
+7. After merge, and after confirming no pull request or worktree depends on it, delete the
+   unprotected remote and local `docs/metaharness-integration-proposal` branch. The merged proposal
+   preserves the old decision's material rationale and exact commit identifier.
+
+Until step 6, keep the old branch as reviewable source history. Deleting it earlier creates no
+technical advantage and makes the replacement harder to audit. Branch deletion makes the old
+commit unreachable from normal Git refs; if exact long-term patch recovery matters, retain an
+explicit archival tag instead of assuming a hosting provider will preserve an unreachable object.
+
+## Integration contract
+
+The first companion adapter should have one narrow shape:
+
+```text
+external task + verifier suite
+          │
+          ▼
+MetaHarness candidate worker
+          │ spawn with explicit cwd, limits, and sanitized environment
+          ▼
+      ak run <template> <task> --json
+          │
+          ▼
+versioned companion result → external scorer/receipt
+```
+
+The contract must define:
+
+- a schema version independent of internal plan/result object shapes;
+- one correlation ID and honest host/model/provider provenance per observed fact;
+- terminal categories, escalation evidence, timing, and cleanup/orphan status;
+- redaction and maximum-size rules for task text, paths, failures, and outputs;
+- no raw protocol streams, dependency handoffs, credentials, environment, or repository files;
+- explicit cost evidence (`observed`, `estimated`, `unpriced`, or `unknown`);
+- an opt-in retention location with a deletion policy;
+- no network or model spend unless the command declares a budget and the user opts in.
+
+MetaHarness's current worker API accepts a function; it does not supply an agentic-kit subprocess
+adapter. That adapter is new integration work and must be tested as an anti-corruption layer, not
+described as already available.
+
+## Delivery sequence
+
+### Phase 0 — freeze the boundary
+
+- Accept or revise ADR-0022.
+- Define representative tasks, external verifiers, data classification, budgets, and retention.
+- Specify the versioned companion result envelope; do not change routing behavior.
+
+### Phase 1 — read-only companion
+
+- Run MetaHarness score/genome and dry-run tool/MCP audits from a separate workspace.
+- Publish interpretation guidance that distinguishes generated-policy estimates from live findings.
+- Record baseline evidence for at least two agentic-kit versions or policies.
+
+### Phase 2 — shadow `ak run` adapter
+
+- Implement the subprocess adapter and sanitized result envelope.
+- Evaluate whole pipelines only; leave agentic-kit's internal DAG under its supervisor.
+- Collect labeled quality, safety, latency, and cost evidence without writing configuration.
+
+### Phase 3 — advisory optimization
+
+- Produce cost-quality recommendations only after the dataset is representative.
+- Show provenance, sample size, confidence, unknowns, and expected budget impact.
+- Require explicit application through agentic-kit's existing routing surface.
+
+### Phase 4 — gated companion evolution
+
+- Evolve only approved MetaHarness policy surfaces in an isolated workspace.
+- Use held-out tasks and independent QE/review before adopting a variant.
+- Keep promotion and rollback deliberate and auditable.
+
+### Optional later phase — internal projection
+
+Add read-only status/dashboard integration only if companion usage demonstrates a recurring user
+need and the upstream schema is stable. Any new mutating command, key ownership, route application,
+or promotion flow requires a separate ADR or an explicit amendment to ADR-0022.
+
+## Success criteria
+
+- Removing MetaHarness leaves every core agentic-kit lifecycle and execution command functional.
+- MetaHarness can compare bounded `ak run` outcomes without controlling its worker lifecycle.
+- No companion run mutates `kit.json`, host projections, routing, permissions, or upstream ledgers.
+- Every retained artifact has a schema, provenance, redaction policy, budget, and deletion path.
+- Score output is labeled as fit/recommendation evidence, not a live security verdict.
+- Learned route advice remains shadow-only until a user applies it through the canonical surface.
+- Darwin variants cannot write outside the dedicated companion policy workspace.
+- Agentic-qe and repository tests remain the release authority for deterministic product behavior.
+- No new runtime dependency is added to the zero-dependency agentic-kit package.
+
+## Open questions that require evidence
+
+1. Which result fields can be exported without leaking task or repository content?
+2. What verifier suite predicts useful agentic-kit outcomes rather than merely test pass/fail?
+3. How many labeled runs are needed before a routing recommendation is statistically useful?
+4. Where should companion artifacts live, and what is their retention/deletion contract?
+5. Which upstream MetaHarness/Ruflo schemas are stable enough to capability-probe and consume?
+6. Does repeated usage justify an internal status projection, or are standalone reports sufficient?
+
+## Sources
+
+- [MetaHarness repository](https://github.com/ruvnet/metaharness)
+- [MetaHarness harness worker contract](https://github.com/ruvnet/metaharness/blob/main/packages/harness/src/types.ts)
+- [MetaHarness repo scorecard](https://github.com/ruvnet/metaharness/blob/main/packages/create-agent-harness/src/repo-scorecard.ts)
+- [MetaHarness Darwin mutation surfaces](https://github.com/ruvnet/metaharness/blob/main/packages/darwin-mode/src/types.ts)
+- [Ruflo MetaHarness CLI bridge](https://github.com/ruvnet/ruflo/blob/main/v3/%40claude-flow/cli/src/commands/metaharness.ts)
+- [Ruflo ADR-322 at v3.32.26](https://github.com/ruvnet/ruflo/blob/v3.32.26/v3/docs/adr/ADR-322-metaharness-flywheel-integration.md)
+- [ADR-0016 — capability-driven adapters](adr/0016-capability-driven-integration-adapters.md)
+- [ADR-0018 — generalized host-worker execution](adr/0018-generalized-host-worker-execution.md)
+- [ADR-0020 — one stable GA surface](adr/0020-ga-stable-surfaces.md)
+- RuvNet Brain source:
+  `ruflo/v3/@claude-flow/cli/src/commands/metaharness.ts`

--- a/docs/adr/0022-metaharness-as-optional-assurance-companion.md
+++ b/docs/adr/0022-metaharness-as-optional-assurance-companion.md
@@ -1,0 +1,250 @@
+# ADR-0022 — MetaHarness as an optional assurance companion
+
+- **Status:** Proposed
+- **Date:** 2026-08-04
+- **Updated:** 2026-08-04
+- **Update note:** Clarified the branch-asset disposition and the documentation-only path to
+  `main`; no implementation is authorized or claimed.
+- **Deciders:** agentic-kit maintainers
+- **Related:** [ADR-0016](0016-capability-driven-integration-adapters.md),
+  [ADR-0018](0018-generalized-host-worker-execution.md),
+  [ADR-0020](0020-ga-stable-surfaces.md)
+- **Product proposal:**
+  [MetaHarness as an Optional Assurance Companion](../METAHARNESS-COMPANION-PROPOSAL.md)
+- **Replaces:** the direction, but not the ADR number, in the unpublished branch-only
+  `ADR-0016 — Curate retrieval improvement while Ruflo retains promotion authority`; its
+  retrieval-improvement DDD is retired rather than ported
+
+## Context
+
+Agentic-kit installs, configures, heals, observes, and executes a multi-host agent stack. Its
+canonical `ak run` command materializes explicit per-activity routing and supervises worker
+readiness, deadlines, escalation, cancellation, and cleanup. ADR-0020 deliberately reduced the GA
+surface to one execution command and one host-management namespace.
+
+MetaHarness offers a different value: a deterministic control plane and factory for agent
+harnesses, with static repository scoring, policy and MCP auditing, receipts, red/blue testing,
+cost-quality learning, and Darwin evolution. Its worker interface is a function; it does not
+currently provide an adapter that invokes `ak run` as a subprocess and maps its evidence.
+
+Ruflo also exposes commands under the MetaHarness name and has shipped a retrieval-flywheel
+integration in specific releases. Ruflo's CLI surface and flywheel state are not the standalone
+MetaHarness harness. In a flywheel workflow, Ruflo—not agentic-kit—owns receipt validation, ledger
+state, active champion, and promotion.
+
+The earlier branch-only proposal recommended a full `ak improve` lifecycle around Ruflo's retrieval
+flywheel. It preserved several correct safety properties, but it conflated the standalone
+MetaHarness product, Ruflo's integration, and agentic-kit's lifecycle. It also proposed new command,
+configuration, and signing-key ownership before proving a stable interop contract or repeated user
+need. Its ADR number now collides with the accepted ADR-0016 on `main`.
+
+An alternative is to place MetaHarness around agentic-kit: treat a complete `ak run` pipeline as a
+candidate worker, evaluate it using an external task/verifier suite, and feed the evidence back as
+advice. This preserves separation of concerns, but needs a safe machine contract. The current
+`ak run --json` payload is machine-readable `{plan, results}` without an explicit top-level schema
+version or a companion-specific redaction and stability contract.
+
+## Decision
+
+### 1. Make the external companion the primary integration model
+
+MetaHarness is optional development and assurance tooling around agentic-kit. It may:
+
+- statically assess whether a generated harness fits the repository;
+- audit bounded MCP/tool policy in read-only or dry-run mode;
+- invoke a complete `ak run` through a dedicated adapter;
+- score held-out outcome quality, safety, latency, and cost;
+- compare agentic-kit versions, templates, or routing policies;
+- produce receipts and advisory cost-quality recommendations;
+- red/blue an authorized, isolated LLM/tool surface;
+- evolve only its own approved harness-policy surfaces.
+
+Agentic-kit remains fully functional when MetaHarness is absent.
+
+### 2. Keep execution and lifecycle authority in agentic-kit
+
+The companion treats one complete `ak run` as the initial worker boundary. It does not reschedule
+the internal DAG or replace readiness, preparation, launch, observation, timeout, escalation,
+cancellation, or cleanup.
+
+MetaHarness does not install or manage hosts/providers, write configuration projections, edit
+`kit.json`, change routes, infer provider identity, manage user subscriptions, or own project
+memory. Any route recommendation is evidence only. The user applies an accepted change through
+agentic-kit's existing canonical host/routing surface.
+
+### 3. Require a versioned, sanitized companion result contract
+
+Before an adapter depends on `ak run --json`, agentic-kit must define an explicit companion export
+envelope. It includes:
+
+- a schema version and correlation identifier;
+- stable terminal categories and bounded failure evidence;
+- observed versus configured host/model/provider provenance;
+- attempt/escalation, timing, and cleanup/orphan evidence;
+- cost marked as observed, estimated, unpriced, or unknown;
+- field-level redaction and size limits.
+
+It excludes raw host protocol streams, dependency handoffs, credentials, environment variables,
+repository files, and unbounded prompt/task/output text. Retention is opt-in and has an explicit
+location and deletion policy. Network access or metered model use requires a declared budget and
+user opt-in.
+
+Defining or implementing that envelope is not authorized by this proposed ADR; it is the first
+implementation prerequisite after acceptance.
+
+### 4. Keep MetaHarness findings honest about what they measure
+
+Static `metaharness score` output is pre-scaffold fit and recommendation evidence. Dimensions such
+as tool safety are derived from the recommended generated policy, not a live audit or proof of the
+current repository's security.
+
+Audit findings are interpreted against the owning product. Absence of a generated
+`.harness/mcp-policy.json` in agentic-kit can be a MetaHarness integration gap without being an
+agentic-kit vulnerability. Live safety claims require the relevant audit and product-specific
+evidence.
+
+### 5. Bound Darwin and red/blue authority
+
+Darwin may mutate only MetaHarness's approved planner, context-builder, reviewer, retry, tool,
+memory, and score policy surfaces in a dedicated workspace. It does not modify agentic-kit source,
+configuration, permissions, providers, credentials, or spending authority. Variants are evaluated
+against fixed and held-out tasks and require separate maintainer review before adoption.
+
+Red/blue testing uses `@metaharness/redblue` against systems the user owns or is authorized to
+test. Runs use isolated fixtures, explicit tool/network allowlists, no production credentials, and
+fixed budgets. MetaHarness complements rather than replaces agentic-qe and repository tests.
+
+### 6. Permit only a thin internal projection without a new authority
+
+A future agentic-kit integration may capability-probe and render read-only MetaHarness/Ruflo
+availability, provenance, health, evaluation state, and repair or next-command guidance. Dashboard
+integration remains read-only.
+
+This ADR does not authorize:
+
+- a new top-level `ak improve` command;
+- signing-key generation or ownership;
+- copied receipt, ledger, champion, or promotion state in `kit.json`;
+- evaluation during `setup` or `sync`;
+- mutation from status, dashboard, hooks, daemons, or generated guidance;
+- automatic route, retrieval, tool, permission, model, provider, or spending-policy promotion.
+
+Any of those requires an explicit amendment or separate ADR after the companion proves user value
+and the upstream contract is stable.
+
+### 7. Preserve Ruflo authority for Ruflo's flywheel
+
+Where a compatible Ruflo release exposes a retrieval flywheel, agentic-kit may show its state but
+does not reproduce its gate. Ruflo remains the sole authority for candidate evaluation semantics,
+signed receipts, lineage, ledger head, active champion, serving epoch, and promotion transaction.
+
+Support is capability-probed from actual commands and structured schema, not inferred from a
+package name or version alone. Agentic-kit does not generate or take custody of flywheel signing
+keys until a later design proves creation, provider integration, rotation, permission, redaction,
+recovery, and uninstall ownership.
+
+## Consequences
+
+### Positive
+
+- Agentic-kit gains independent outcome and regression evidence without embedding a second
+  orchestrator.
+- Optional tooling cannot make core setup, status, sync, routing, or execution unavailable.
+- MetaHarness can evolve quickly without expanding agentic-kit's zero-runtime-dependency package.
+- The component operating the workflow is distinct from the component measuring it.
+- Existing agentic-kit authority, trust, provider-provenance, and cleanup boundaries remain intact.
+- A small internal status projection remains possible if real usage justifies it.
+
+### Costs and limitations
+
+- A new subprocess adapter and companion result envelope must be designed and tested.
+- Useful quality/cost advice requires representative tasks, independent verifiers, and enough
+  labeled outcomes; sparse data must remain inconclusive.
+- Whole-pipeline evaluation provides less internal detail than letting MetaHarness orchestrate each
+  worker, by design.
+- Maintainers must distinguish static fit scores, live audits, deterministic QE, and empirical
+  outcome evaluation in documentation and release decisions.
+- Ruflo/MetaHarness command and schema drift requires capability probing and versioned adapters.
+
+## Rejected alternatives
+
+- **Embed MetaHarness as agentic-kit's execution engine.** Rejected because it duplicates the
+  canonical runner, routing, deadlines, escalation, and lifecycle boundaries.
+- **Implement the branch proposal unchanged.** Rejected because it adds a second user workflow,
+  configuration, and key ownership before proving demand or a stable upstream contract.
+- **Let MetaHarness rewrite routes automatically.** Rejected because evaluation evidence is not
+  authorization, may be sparse, and may silently change provider cost or trust posture.
+- **Let MetaHarness orchestrate each `ak run` worker.** Rejected initially because two schedulers
+  would disagree over dependencies, retries, cancellation, and cleanup.
+- **Generate a MetaHarness scaffold over the agentic-kit repository.** Rejected because generated
+  policy/configuration could collide with checked-in host guidance and MCP settings. A companion
+  uses a sibling, temporary, or dedicated workspace.
+- **Treat the scorecard as a security certification.** Rejected because its safety dimension scores
+  the recommended policy, while a live security conclusion requires a relevant audit.
+- **Use only an internal projection.** Rejected because display without independent tasks,
+  verifiers, and comparison evidence does not deliver the main assurance value.
+- **Use only an external companion forever.** Not decided. A read-only internal projection remains
+  available if measured usage shows it removes repeated operational friction.
+
+## Adoption gates
+
+1. **Boundary gate:** accept this ADR and define data classification, budgets, retention, and
+   representative tasks.
+2. **Contract gate:** version and test a redacted companion result envelope without changing
+   routing behavior.
+3. **Shadow gate:** compare whole `ak run` pipelines and collect labeled evidence with no writes to
+   agentic-kit configuration or upstream ledgers.
+4. **Advisory gate:** require adequate samples and surface confidence, provenance, unknowns, and
+   expected cost before recommending a route.
+5. **Evolution gate:** isolate Darwin mutation surfaces and require held-out evaluation plus normal
+   QE/review before adoption.
+6. **Projection gate:** add read-only agentic-kit UX only when repeated companion use proves the
+   need and the consumed upstream schema is stable.
+
+No gate implies the next. Mutating integration requires a later explicit decision.
+
+## Documentation disposition
+
+This Proposed ADR and its product proposal are the documentation replacement for the unique
+MetaHarness commit `8dcad80` on `docs/metaharness-integration-proposal`. That branch is not a merge
+base for implementation and must not be merged or rebased into `main`:
+
+- the branch proposal is replaced by the companion proposal;
+- the branch ADR is replaced by ADR-0022 rather than copied into the occupied 0016 slot;
+- the branch retrieval-improvement DDD is retired because it models responsibilities this ADR does
+  not authorize;
+- the branch ADR-index edit is discarded in favor of the current `main` index.
+
+After the documentation replacement is accepted and merged, maintainers may delete the old remote
+and local branch after confirming no open pull request or worktree depends on it. Branch deletion
+does not change this ADR's status: it remains Proposed until separately accepted.
+
+## Verification requirements
+
+- Removing MetaHarness leaves all core agentic-kit commands and tests operational.
+- Companion integration adds no agentic-kit runtime dependency.
+- Contract tests reject unknown schema versions, oversized fields, secrets, raw handoffs, and
+  ungrounded provider/cost claims.
+- Adapter tests prove one absolute bounded invocation, cancellation propagation, and no second
+  scheduler over the worker DAG.
+- Filesystem tests prove the companion cannot write agentic-kit configuration or generated host
+  guidance.
+- Budget tests prove no network/model spend without explicit opt-in and ceilings.
+- Darwin tests prove mutation is limited to its seven approved policy surfaces.
+- Documentation and UI distinguish score estimates, audit findings, QE results, and outcome
+  evaluations.
+
+## References
+
+- [Product proposal](../METAHARNESS-COMPANION-PROPOSAL.md)
+- [MetaHarness repository](https://github.com/ruvnet/metaharness)
+- [MetaHarness harness worker contract](https://github.com/ruvnet/metaharness/blob/main/packages/harness/src/types.ts)
+- [MetaHarness repo scorecard](https://github.com/ruvnet/metaharness/blob/main/packages/create-agent-harness/src/repo-scorecard.ts)
+- [MetaHarness Darwin mutation surfaces](https://github.com/ruvnet/metaharness/blob/main/packages/darwin-mode/src/types.ts)
+- [Ruflo MetaHarness CLI bridge](https://github.com/ruvnet/ruflo/blob/main/v3/%40claude-flow/cli/src/commands/metaharness.ts)
+- [Ruflo ADR-322 at v3.32.26](https://github.com/ruvnet/ruflo/blob/v3.32.26/v3/docs/adr/ADR-322-metaharness-flywheel-integration.md)
+- [ADR-0016 — capability-driven adapters](0016-capability-driven-integration-adapters.md)
+- [ADR-0018 — generalized host-worker execution](0018-generalized-host-worker-execution.md)
+- [ADR-0020 — one stable GA surface](0020-ga-stable-surfaces.md)
+- RuvNet Brain source:
+  `ruflo/v3/@claude-flow/cli/src/commands/metaharness.ts`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -30,6 +30,7 @@ Consequences**, and cites the grounded source it rests on where relevant.
 | [0019](0019-escalation-in-ak-run.md) | Bounded per-worker escalation in `ak run` | Accepted; historical context closed |
 | [0020](0020-ga-stable-surfaces.md) | One stable GA surface per capability | Implemented |
 | [0021](0021-inference-provider-provenance.md) | Inference-provider provenance for live sessions | Accepted |
+| [0022](0022-metaharness-as-optional-assurance-companion.md) | MetaHarness as an optional assurance companion | Proposed |
 
 Theme: ADRs **0001–0006** define **dual-host LLM routing and leadership** — how `ak` lets ruflo route
 each development activity (architecture, implementation, testing, review, …) to the right host (Claude
@@ -106,3 +107,10 @@ in-artifact `model_provider` (rollouts + state ledger) is read as observed evide
 provider is resolved from its documented configuration surface (Bedrock/Vertex/Foundry flags,
 `ANTHROPIC_BASE_URL` gateways) with configured/inferred provenance, since its transcripts never
 record the serving endpoint.
+
+**0022** places MetaHarness primarily around agentic-kit as optional assurance tooling. It may
+score, audit, red/blue, compare, and evolve its own harness policies while `ak` retains lifecycle,
+routing, and supervised-execution authority. A future internal integration is limited to a
+capability-probed, read-only projection unless another decision authorizes mutation. The ADR also
+requires a versioned, sanitized companion result contract before treating `ak run --json` as an
+interop API.


### PR DESCRIPTION
## Summary

- replace the branch-only MetaHarness retrieval direction with an optional assurance-companion proposal
- add Proposed ADR-0022 with explicit external companion and thin read-only projection boundaries
- document the file-by-file disposition of commit 8dcad80 and the retirement of its retrieval-improvement DDD
- keep all runtime integration, result-schema, command, routing, key, and promotion work unimplemented

## Status

Documentation only. ADR-0022 remains Proposed; merging this PR does not mark it Accepted or Implemented.

## Superseded branch

This PR replaces the unique MetaHarness documentation commit 8dcad806c015e3de42f46b8fa4858edf9dd439c1 on docs/metaharness-integration-proposal. That branch should be deleted only after this PR merges and a final dependency check passes.

## Validation

- pnpm run check
- pnpm run lint:links:internal
- pnpm run lint:links
- git diff --check