### PR TITLE
feat: machine-wide intelligence discovery and a selectable project view

### DIFF
--- a/docs/DASHBOARD.md
+++ b/docs/DASHBOARD.md
@@ -23,7 +23,7 @@ Its position does not move when the primary area changes; only the choices insid
 | Overview | Hosts & Routing | `#overview/hosts` | Hosts & routing | Enabled execution hosts, activity assignments, primary-host policy, and escalation paths |
 | Overview | Providers | `#overview/providers` | Inference providers | Provider bindings, availability, provenance, and configuration health |
 | Overview | Runtime | `#overview/runtime` | Runtime health | Local services, MCP connections, processes, and operational readiness |
-| Overview | Intelligence | `#overview/intelligence` | Intelligence & learning | Memory, learned patterns, reasoning-graph growth, and improvement signals, updated near-live while the view is open |
+| Overview | Intelligence | `#overview/intelligence` | Intelligence & learning | Machine-wide learning rollup across every ruflo-initialized project, plus near-live detail for one explicitly selected project |
 | Usage | Scorecard | `#usage/score` | Usage scorecard | Token consumption, API-equivalent cost, efficiency, and trends |
 | Usage | Limits | `#usage/limits` | Provider limits | Current provider windows, reset timing, and available capacity |
 | Usage | Findings | `#usage/findings` | Usage findings | Actionable anomalies, efficiency opportunities, and evidence-backed recommendations |
@@ -61,13 +61,18 @@ Overview keeps status and routing in one health-first area:
   of which inference provider served a particular session.
 - **Providers** presents inference-provider bindings and their configuration provenance.
 - **Runtime** presents operational services, processes, and MCP readiness.
-- **Intelligence** presents memory, learning, and quality-improvement signals: the neural pattern
-  store's current size, its separate lifetime patterns-learned counter, reasoning-graph growth, and
-  the route-learner's improvement delta. It reads files ruflo/agentic-qe already write under
-  `.claude-flow/` and updates near-live over its own SSE stream while the view is open, falling back
-  to the general status poll otherwise. See [Project intelligence](ddd/project-intelligence.md) and
-  [ADR-0024](adr/0024-project-intelligence-telemetry.md) for the full model and the two learning
-  metrics' load-bearing distinction.
+- **Intelligence** presents memory, learning, and quality-improvement signals machine-wide: an
+  always-visible rollup folded across every ruflo-initialized project on this machine, plus detail
+  for one explicitly selected, explicitly labeled project — the neural pattern store's current
+  size, its separate lifetime patterns-learned counter, and reasoning-graph growth. Project
+  selection defaults to whichever discovered project was most recently active; there is no implicit
+  current-working-directory default. The route-learner's improvement delta remains scoped to the
+  dashboard's own launching project and is not part of project selection. Detail data reads files
+  ruflo/agentic-qe already write under `.claude-flow/` and updates near-live over a per-project SSE
+  stream while the view is open, falling back to the general status poll otherwise. See
+  [Project intelligence](ddd/project-intelligence.md) and
+  [ADR-0024](adr/0024-project-intelligence-telemetry.md) for the full model, the project-discovery
+  mechanism, and the two learning metrics' load-bearing distinction, now also at machine scope.
 
 ## Usage
 

--- a/docs/adr/0024-project-intelligence-telemetry.md
+++ b/docs/adr/0024-project-intelligence-telemetry.md
@@ -2,10 +2,90 @@
 
 - **Status:** Implemented
 - **Date:** 2026-08-05
+- **Updated:** 2026-08-05
+- **Update note:** Extended Intelligence from one project's telemetry, implicitly tied to the
+  dashboard server's own launching cwd, to a machine-wide catalog of every ruflo-initialized
+  project plus an explicitly selected, explicitly labeled detail project (defaulting to
+  most-recently-active). This is a deliberate clean-break redesign of `/api/status`'s `intel`
+  payload shape, made because the project is still on the pre-release `4.0.0-alpha` line with no
+  external compatibility guarantee — not a shape preserved for, or falling back to, the prior
+  single-project form.
 - **Deciders:** agentic-kit maintainers
 - **Related:** [ADR-0005](0005-dashboard-in-page-routing-reveal.md),
   [ADR-0009](0009-usage-scorecard-local-transcript-analytics.md),
   [ADR-0012](0012-observability.md)
+
+**2026-08-05 machine-wide discovery amendment:** `src/lib/dashboard/project-discovery.mjs` adds
+`discoverRuvfloProjects()`, unioning three sources into one deduplicated, most-recently-active-first
+catalog of every project on this machine ruflo has genuinely initialized — a `.claude-flow/neural/`
+subdirectory present, not merely a bare `.claude-flow/`. Source 1 reuses `registryWorkspaces()` from
+`daemons.mjs` verbatim (imported, not reimplemented; given a bare `export` so it could be imported
+at all — the one change made outside this new module) to walk
+`~/.claude-flow/{ai-jobs.json,workspace-leases.json,repo-supervisors.json}`. Source 2
+cross-references Observability's own `WorkspaceSnapshotStore`
+(`~/.config/agentic-kit/observability-workspaces.json`, [ADR-0012](0012-observability.md)) for any
+record carrying a resolvable absolute path. That store's own privacy sanitizers reject one on
+write and on read — `repositoryLabel` rejects any path separator, `directoryLabel` rejects anything
+absolute-looking — so source 2 is structurally empty by that store's own design, not a gap; the
+defensive per-record check nonetheless stays in place rather than being removed, so it starts
+contributing automatically if that schema ever grows a real path field. This cross-reference is
+discovery-only: it never supplies evidence, confidence, or any value this domain renders, only a
+candidate project path, preserving the reasoning in
+["Why this is a separate context, not Observability"](../ddd/project-intelligence.md#why-this-is-a-separate-context-not-observability).
+`intel-history.mjs` adds `readMachineWideIntel(projects)`, folding `readIntelHistory()` across
+every discovered project into one `{ totals, perProject }` rollup. At machine scope, exactly as at
+single-project scope, the lifetime patterns-learned counter and the pattern-store's current size
+remain two distinct, never-conflated sums: `totals.patternsLearnedLifetime` sums each project's
+cumulative `globalStats.patternsLearned`; `totals.patternStoreEntries` sums each project's current
+`patternStore.length`. A project whose read turns up missing or malformed data degrades that
+project's row to nulls/zeros rather than aborting the whole machine-wide scan.
+
+**2026-08-05 discovery correction — real transcript content is source 3, and is the source that
+actually matters in practice:** `daemons.mjs`'s own header comment assumes ruflo 3.28+ reliably
+writes the central `~/.claude-flow/{ai-jobs,workspace-leases,repo-supervisors}.json` registry
+files source 1 depends on. Verified against a real, actively-used development machine (ruflo
+3.34.0): none of those three files exist, even though that machine has multiple real,
+ruflo-initialized projects with populated `.claude-flow/neural/` trees, including a per-project
+`.claude-flow/daemon.pid`/`daemon-state.json` proving a daemon genuinely ran there — so source 1
+returned an empty set, and with source 2 structurally empty by design (above),
+`discoverRuvfloProjects()` returned `[]` on a machine where the feature had real, correct data to
+find. Source 3 fixes this: it reads real absolute `cwd` values directly out of Claude and Codex
+transcript content under `~/.claude/projects/**/*.jsonl` and `~/.codex/sessions/**/*.jsonl`, via
+the exact `discoverJsonl()`/`bootstrapRecords()` functions `live-sessions-service.mjs` already
+trusts for Observability — flat `record.cwd` for Claude, `record.payload.cwd` for Codex's
+`session_meta`/`turn_context` records. Unlike source 2's persisted, privacy-sanitized registry,
+raw transcripts are not sanitized and do carry a resolvable path — legitimately readable at this
+trust boundary since it is the same user, same machine, and same files Observability itself
+already parses. Bounded to the 150 most-recently-modified transcripts per host (`discoverJsonl`'s
+own recency sort) so cost stays flat regardless of how many sessions a project has accumulated;
+overlap with sources 1/2 dedups for free through the existing resolved-path merge. Verified on the
+same real machine: `discoverRuvfloProjects()` now returns all 4 real ruflo-initialized projects in
+under a second.
+
+**2026-08-05 selectable delivery amendment:** This is a deliberate clean-break redesign of
+`/api/status`'s `intel` payload, not a shape preserved for, or falling back to, the prior
+single-project form — warranted because the project is still on the pre-release `4.0.0-alpha` line
+with no external compatibility guarantee yet. The former flat top-level `health`/`globalStats`/
+`patternStore`/`graph` fields are replaced by one nested `intel` object: `{ selectedProjectKey,
+selectedProjectLabel, projects, health, globalStats, patternStore, graph, machineWide }`.
+`projects` is the full machine-wide catalog (`{ key, label, path, source }` rows,
+most-recently-active first); `machineWide` is always the full `readMachineWideIntel()` rollup,
+independent of selection. Both `GET /api/status` and `GET /api/live/intelligence` accept the same
+optional `?project=<key>` query parameter — `<key>` is the opaque `project:<16-hex>` form
+`resolveProjectIdentity(path).key` emits, deliberately not `stableProjectKey`, which reduces its
+input to a bare directory-name label before hashing and would collapse two same-named-but-different
+projects onto one selection key — and resolve it through the identical shared
+`resolveSelectedProject(projects, rawParam)` helper, so the two routes can never disagree about
+what an absent or unresolvable key defaults to: `discoverRuvfloProjects()`'s own
+most-recently-active-first sort, never the server's launching cwd. `GET /api/live/intelligence`
+answers `503` if machine-wide discovery finds zero ruflo-initialized projects at all, rather than
+picking anything. The prior server-wide singleton `IntelligenceWatch` is replaced by a small pool
+keyed by resolved project path: a project's watcher is created lazily on its first SSE subscriber
+and stopped and forgotten the moment its last subscriber for that project disconnects, so two
+clients watching different projects never cross-talk and an unwatched project's watcher never runs
+unbounded. **"This project" as an implicit, unlabeled, cwd-bound default no longer exists anywhere
+in this contract** — the detail strip is always an explicitly selected, explicitly labeled project,
+defaulting to whichever discovered project was most recently active.
 
 ## Context
 
@@ -155,10 +235,14 @@ path.
 
 ## References
 
-- `src/lib/dashboard/intel-history.mjs`, `tests/kit/intel-history.test.mjs`
+- `src/lib/dashboard/intel-history.mjs` (`readIntelHistory`, `readMachineWideIntel`),
+  `tests/kit/intel-history.test.mjs`
+- `src/lib/dashboard/project-discovery.mjs` (`discoverRuvfloProjects`),
+  `tests/kit/project-discovery.test.mjs`
 - `src/lib/live/intelligence-watch.mjs`, `tests/kit/intelligence-watch.test.mjs`
-- `src/lib/dashboard-server.mjs` (`collectData`, `GET /api/live/intelligence`, `lazyIntelWatch`)
-- `src/lib/dashboard/client.mjs`, `src/lib/dashboard/page.mjs` (Intelligence panel rendering, SSE
-  subscription)
+- `src/lib/dashboard-server.mjs` (`collectData`, `buildProjectSnapshotCache`,
+  `resolveSelectedProject`, `GET /api/live/intelligence`'s `intelPool`)
+- `src/lib/dashboard/client.mjs`, `src/lib/dashboard/page.mjs` (Intelligence panel rendering,
+  machine-wide rollup, project picker, SSE subscription)
 - [Project intelligence domain](../ddd/project-intelligence.md)
 - [Dashboard guide](../DASHBOARD.md)

--- a/docs/ddd/project-intelligence.md
+++ b/docs/ddd/project-intelligence.md
@@ -1,7 +1,16 @@
 # Project Intelligence Domain
 
 This document describes the domain implemented by [ADR-0024](../adr/0024-project-intelligence-telemetry.md),
-`src/lib/dashboard/intel-history.mjs`, and `src/lib/live/intelligence-watch.mjs`.
+`src/lib/dashboard/intel-history.mjs`, `src/lib/dashboard/project-discovery.mjs`, and
+`src/lib/live/intelligence-watch.mjs`.
+
+> **2026-08-05 amendment:** extended from one project's telemetry, implicit and bound to the
+> dashboard server's own launching working directory, to a machine-wide catalog of every
+> ruflo-initialized project on this machine, a machine-wide aggregate that is always shown, and an
+> explicitly selected, explicitly labeled detail project (defaulting to most-recently-active). See
+> [ADR-0024](../adr/0024-project-intelligence-telemetry.md)'s update note for the full amendment
+> record, including why the `/api/status` payload shape is a clean break rather than a preserved
+> fallback.
 
 ## Purpose
 
@@ -9,9 +18,13 @@ Project intelligence surfaces trend data about ruflo/agentic-qe's own project-le
 subsystem — the neural pattern store, its lifetime learned-pattern counter, the reasoning graph's
 structural growth, and a machine-health sample ring — inside the dashboard's Overview →
 **Intelligence** view (`#overview/intelligence`). It is a read-only projection over files those
-tools already write under `.claude-flow/`. It owns no session, actor, or activity identity; it
-grades no per-field evidence confidence; and it cannot steer, retrain, or mutate the learning
-subsystem it reads.
+tools already write under `.claude-flow/`, discovered across every project on this machine ruflo
+has genuinely initialized rather than read from one implicit location. The view always shows a
+machine-wide aggregate folded across every discovered project, plus per-project detail for exactly
+one explicitly selected, explicitly labeled project — defaulting to whichever discovered project
+was most recently active, never the dashboard server's own launching working directory. It owns no
+session, actor, or activity identity; it grades no per-field evidence confidence; and it cannot
+steer, retrain, or mutate the learning subsystem it reads.
 
 The shared terms in [Ubiquitous language](ubiquitous-language.md) are normative.
 
@@ -23,9 +36,10 @@ with per-field confidence (`observed`/`correlated`/`inferred`/`assumed`/`planned
 state machine, and a protected transcript-content plane. None of that applies here:
 
 - Every value in this domain is a scalar count, a timestamp, or a flat historical array read from
-  this project's own `.claude-flow/` state — the same local trust boundary `ak status` already
-  reads directly. There is no other host's evidence to normalize through an anti-corruption
-  adapter, because there is only ever one shape: ak's own.
+  a discovered project's own `.claude-flow/` state — whether one selected project's detail or the
+  machine-wide rollup folded across every discovered project — the same local trust boundary
+  `ak status` already reads directly. There is no other host's evidence to normalize through an
+  anti-corruption adapter, because there is only ever one shape: ak's own.
 - There is no session, actor, host, provider, or model identity anywhere in this domain's data, and
   therefore no capability-coverage matrix, no actor lens, and no court membership.
 - There is no lifecycle (`queued → running → completed`); sources are either a live inventory
@@ -34,17 +48,69 @@ state machine, and a protected transcript-content plane. None of that applies he
 - The panel is a permanent secondary view under **Overview**, never a mode of **Observability**'s
   mutually exclusive Live/History scope (see [ADR-0005](../adr/0005-dashboard-in-page-routing-reveal.md)).
 
+[Project discovery](#project-discovery) below cross-references Observability's own
+`WorkspaceSnapshotStore` as a secondary source, but only for a candidate project *path* — never for
+evidence, confidence, or any value this domain renders. That store's own privacy sanitizers make it
+structurally incapable of yielding a resolvable absolute path today, so in practice this domain's
+primary registry scan supplies the entire discovered catalog; either way, the boundary above is
+unaffected, because a path is not evidence.
+
 The implementation reuses only source-agnostic transport plumbing that Dashboard delivery already
 shares across contexts — `JsonlTailer`, `sseChannel`, `reserveClientSlot`/`clientGone`, and
 `transcriptSseFrame` — never Observability's canonical normalizer, `ObservedSession` aggregate, or
 replay/snapshot cursor. `GET /api/live/intelligence` shares the `/api/live/*` path prefix with
 Observability's endpoints by transport convention only; it is not covered by
 [OBSERVABILITY.md](../OBSERVABILITY.md)'s evidence, privacy, or capability-coverage contract, and it
-needs no `--live-source` registration because its four sources are always this project's own.
+needs no `--live-source` registration because its sources are always a discovered project's own,
+never a remote or unregistered one.
+
+## Project discovery
+
+`discoverRuvfloProjects()` (`src/lib/dashboard/project-discovery.mjs`) returns every project on
+this machine ruflo has genuinely initialized — a `.claude-flow/neural/` subdirectory present, not
+merely a bare `.claude-flow/` (a project that only ever ran, say, `ruflo daemon start` without ever
+training or learning anything is correctly excluded) — deduplicated by resolved absolute path and
+sorted most-recently-active first by `.claude-flow/neural/stats.json`'s `lastAdaptation`.
+
+Three sources are unioned:
+
+1. **Registry.** `registryWorkspaces()`, reused verbatim from `daemons.mjs` (imported, not
+   reimplemented), walks `~/.claude-flow/{ai-jobs.json,workspace-leases.json,repo-supervisors.json}`
+   for every workspace path recorded there that carries a `.claude-flow` directory. `daemons.mjs`'s
+   own header comment assumes ruflo 3.28+ reliably writes these; verified false on a real ruflo
+   3.34.0 machine with real, populated ruflo projects — none of the three files existed. Kept as a
+   source (cheap, and correct wherever those files do exist), but no longer described as the
+   guaranteed-correct primary.
+2. **Observability cross-reference.** `WorkspaceSnapshotStore` (`src/lib/live/workspace-store.mjs`,
+   [Observability](observability.md)) is checked for any record whose workspace carries a
+   genuinely resolvable absolute path. That store's own privacy sanitizers — `repositoryLabel`
+   rejects any path separator, `directoryLabel` rejects anything absolute-looking — mean a real
+   record never carries one, so this source is structurally empty by that store's own design, not
+   a gap. The check remains a real, defensive one rather than being skipped outright, so it starts
+   contributing automatically if that schema ever grows a genuine path field.
+3. **Transcript content (the source that matters in practice).** Real absolute `cwd` values read
+   directly out of Claude and Codex transcript content under `~/.claude/projects/**/*.jsonl` and
+   `~/.codex/sessions/**/*.jsonl`, via the same `discoverJsonl()`/`bootstrapRecords()` functions
+   `live-sessions-service.mjs` already trusts for Observability's own live session tracking — flat
+   `record.cwd` for Claude, `record.payload.cwd` for Codex's `session_meta`/`turn_context` records.
+   Unlike source 2's sanitized, persisted registry, raw transcripts are not sanitized and do carry
+   a resolvable path — legitimately readable at this trust boundary since it's the same user, same
+   machine, same files Observability already parses. Bounded to the 150 most-recently-modified
+   transcripts per host so cost stays flat regardless of session count. On the real machine where
+   source 1 returned nothing, this source alone found all 4 real ruflo-initialized projects.
+
+Each discovered row is `{ path, label, source }`, where `label` reuses Observability's own
+`resolveProjectLabel` for the same path (falling back to the bare directory name) so a project
+reads identically wherever it is named, and `source` is `'registry'`, `'observability'`,
+`'transcript'`, or `'both'` when a project was found by two or more sources (not necessarily
+exactly two).
 
 ## Model
 
 ```text
+discoverRuvfloProjects() -> ProjectRow[] { path, label, source }   (every ruflo-initialized
+                                                                     project on this machine)
+
 .claude-flow/neural/patterns.json             -> PatternStoreEntry[]   { createdAt, type }
 .claude-flow/neural/stats.json                -> GlobalLearningStats   { patternsLearned, trajectoriesRecorded,
                                                                           signalsProcessed, lastAdaptation }
@@ -53,14 +119,22 @@ needs no `--live-source` registration because its four sources are always this p
 .claude-flow/data/pending-insights.jsonl      -> change signal only (line contents never read)
 .claude-flow/improvement.json                 -> ImprovementEval       (pre-existing; unchanged by this domain)
 
-readIntelHistory(cwd) -> { patternStore, graph, healthRing, globalStats }
+readIntelHistory(cwd)              -> { patternStore, graph, healthRing, globalStats }   (one project)
+readMachineWideIntel(ProjectRow[]) -> { totals, perProject }                             (every project, folds readIntelHistory)
+
+resolveSelectedProject(ProjectRow[], ?project=<key>) -> selected project
+        (explicit key match, else most-recently-active; shared by BOTH routes below)
         |
-        +--> collectData() (Dashboard delivery) --> GET /api/status         (poll, ~30s)
-        |
-        +--> IntelligenceWatch --> broadcastIntel --> GET /api/live/intelligence  (SSE push, debounced)
+        +--> readMachineWideIntel(ProjectRow[])   -- always the full machine-wide rollup
+        +--> readIntelHistory(selected.path)      -- detail for the selected project only
                 |
-                v
-        Overview -> Intelligence (#overview/intelligence): five sparklines + improvement verdict badge
+                +--> collectData() (Dashboard delivery) --> GET /api/status?project=<key>             (poll, ~30s)
+                |
+                +--> per-project IntelligenceWatch pool --> GET /api/live/intelligence?project=<key>  (SSE push, debounced)
+                        |
+                        v
+        Overview -> Intelligence (#overview/intelligence): machine-wide rollup (always visible) +
+                    project picker + five sparklines/improvement verdict badge for the selection
 ```
 
 ### Pattern-store size vs. patterns-learned counter
@@ -77,6 +151,25 @@ The store can be pruned while the counter keeps climbing; that divergence is exp
 This repository's own `.claude-flow/` state demonstrates it directly: 28 pattern-store entries
 against a 1,337 lifetime counter. No reader, computation, or rendered label treats one as a
 substitute display for the other.
+
+### Machine-wide rollup
+
+`readMachineWideIntel(projects)` folds `readIntelHistory()` across every project
+`discoverRuvfloProjects()` returns into one `{ totals, perProject }` view. Exactly as at
+single-project scope above, the lifetime counter and the current store size are never conflated —
+now at machine scope too:
+
+- `totals.patternsLearnedLifetime` sums every project's cumulative `globalStats.patternsLearned`.
+- `totals.patternStoreEntries` sums every project's current `patternStore.length`.
+
+`totals.mostActiveProject` is the label of whichever project has the highest positive
+`globalStats.lastAdaptation` among projects that have one; it is `null` when no project has
+adaptation data, matching `readGlobalStats`'s own `?? 0` "never adapted" default. A project whose
+`readIntelHistory()` call turns up missing or malformed data degrades that project's `perProject`
+row to nulls/zeros rather than aborting the whole scan — one bad project never hides every other
+project's data. This is a plain on-demand scan with no aggregation-layer caching of its own;
+caching the catalog and the rollup together is a Dashboard delivery concern (see
+[Live delivery](#live-delivery) below).
 
 ### Reasoning graph size
 
@@ -101,30 +194,55 @@ verbatim by `collectData()` and rendered as the existing Δpp sparkline and verd
 
 ## Live delivery
 
-`IntelligenceWatch` polls the three source files' `mtime` on an interval (default 1,000 ms),
-corroborated by a change-only tail of `pending-insights.jsonl` via the existing `JsonlTailer` —
-line *contents* are never read; a record arriving at all is the signal. Detected changes accumulate
-against a trailing-edge debounce (default 2,500 ms, measured from the most recently detected
-change) so a burst of writes during an active session collapses into one flush. A flush re-reads
-`readGlobalStats(cwd)`; if it differs from the watcher's own last-seen value, it appends a health
-snapshot (independent of, and in addition to, `intel-history.mjs`'s own on-disk dedup) and then
-calls `readIntelHistory(cwd)` and forwards the combined result to every connected
-`GET /api/live/intelligence` client.
+Each `IntelligenceWatch` instance still polls its one project's three source files' `mtime` on an
+interval (default 1,000 ms), corroborated by a change-only tail of that project's own
+`pending-insights.jsonl` via the existing `JsonlTailer` — line *contents* are never read; a record
+arriving at all is the signal. Detected changes accumulate against a trailing-edge debounce
+(default 2,500 ms, measured from the most recently detected change) so a burst of writes during an
+active session collapses into one flush. A flush re-reads `readGlobalStats(cwd)` for that project;
+if it differs from the watcher's own last-seen value, it appends a health snapshot (independent of,
+and in addition to, `intel-history.mjs`'s own on-disk dedup) and then calls `readIntelHistory(cwd)`
+and forwards the combined result to every `GET /api/live/intelligence` client currently subscribed
+to that project.
 
-The route follows Dashboard delivery's existing SSE discipline exactly: reservation-before-await
-client-cap tracking (default cap 32, clamped to 256), the forwarding-cleanup idiom for a close that
-races connection setup, and `sseChannel`'s bounded per-client queue (default 256 frames, clamped to
-4,096) with heartbeat. `/api/status` remains a fully sufficient fallback for a client that has not
-opened, or does not support, the stream — both paths return the identical `readIntelHistory(cwd)`
-shape.
+What changed with machine-wide, selectable scope is the *lifecycle*, not the per-project polling
+above: a single server-wide watcher tied to the dashboard's launching working directory is replaced
+by a small pool keyed by resolved project path — at most one `IntelligenceWatch` per project
+actually being watched by at least one client. A project's watcher is created lazily on that
+project's first SSE subscriber (however many other projects already have their own watcher
+running) and is stopped and removed from the pool the moment its last subscriber for that project
+disconnects. An unwatched project's watcher therefore never runs indefinitely, and two clients
+watching two different projects never cross-talk, because each pool entry owns its own subscriber
+set and its own broadcast closure.
+
+`GET /api/status` and `GET /api/live/intelligence` accept the identical optional `?project=<key>`
+query parameter and resolve it through the same shared `resolveSelectedProject(projects, rawParam)`
+helper — an explicit key match if present and valid, else the first entry in
+`discoverRuvfloProjects()`'s own most-recently-active-first order — so the two routes can never
+disagree about what an absent or unresolvable key defaults to. `GET /api/live/intelligence`
+answers `503` if discovery finds zero ruflo-initialized projects on this machine at all, rather
+than picking anything. The machine-wide project catalog and the `readMachineWideIntel()` rollup
+themselves are shared, TTL-cached (~60s) state — one scan per dashboard instance per window, reused
+by every poll and every new connection within it, rather than re-walking the machine per request.
+
+The route otherwise follows Dashboard delivery's existing SSE discipline exactly:
+reservation-before-await client-cap tracking (default cap 32, clamped to 256, shared across all
+projects), the forwarding-cleanup idiom for a close that races connection setup, and
+`sseChannel`'s bounded per-client queue (default 256 frames, clamped to 4,096) with heartbeat.
+`/api/status` remains a fully sufficient fallback for a client that has not opened, or does not
+support, the stream — both paths resolve the same selected project and return the identical
+`readIntelHistory(cwd)` shape for its detail fields.
 
 ## Invariants
 
 1. Pattern-store size and the patterns-learned counter are computed, labeled, and rendered
-   independently; neither substitutes for the other.
+   independently; neither substitutes for the other — at single-project scope
+   (`patternStore.length` vs. `globalStats.patternsLearned`) and at machine scope
+   (`totals.patternStoreEntries` vs. `totals.patternsLearnedLifetime`) alike.
 2. Every reader degrades to an honest empty/`null` result on a missing, unreadable, or
    wrong-shaped source file rather than throwing or fabricating a value; individual malformed
-   entries are skipped rather than corrupting a bucket.
+   entries are skipped rather than corrupting a bucket. One project's missing or malformed data
+   degrades only that project's row in a machine-wide scan; it never aborts the whole scan.
 3. `readGlobalStats` and `status.mjs`'s CLI `learning` row read the same file through the same
    helper and default logic, so the two cannot silently drift apart.
 4. The health-history ring is capped and deduplicated; unchanged repeated snapshots do not grow it.
@@ -132,10 +250,24 @@ shape.
    arrived" is a signal.
 6. This domain introduces no session, actor, host, provider, model, or lifecycle identity, and no
    per-field evidence-confidence grading.
-7. `GET /api/live/intelligence` requires no `--live-source` registration; its sources are always
-   this project's own `.claude-flow/` state.
-8. `/api/status` and `GET /api/live/intelligence` return the same `readIntelHistory(cwd)` shape, so
-   client rendering has one code path regardless of delivery route.
+7. `GET /api/live/intelligence` requires no `--live-source` registration; its sources are always a
+   discovered project's own `.claude-flow/` state, never a remote or unregistered source.
+8. `/api/status` and `GET /api/live/intelligence` resolve `?project=<key>` identically and return
+   the same `readIntelHistory(selected.path)` shape for their detail fields, so client rendering
+   has one code path regardless of delivery route or which project is selected.
+9. A project appears in the discovered catalog only when it has genuine neural state
+   (`.claude-flow/neural/` present) — a bare `.claude-flow/` directory is not enough.
+10. Selection defaults to the most-recently-active discovered project by `lastAdaptation`; it is
+    never implicitly the dashboard server's own launching working directory. There is no unlabeled
+    "this project" default anywhere in this domain's delivery contract.
+11. `machineWide`/`totals` are always computed across every discovered project, independent of
+    which project is currently selected for detail; switching the selection never changes the
+    machine-wide figures.
+12. A project's `IntelligenceWatch` exists in the delivery pool only while at least one client is
+    subscribed to it; that project's last disconnect stops and removes it.
+13. Discovery's cross-reference into Observability's `WorkspaceSnapshotStore` supplies only a
+    candidate project path; it is never treated as evidence, confidence, or a rendered value in
+    this domain.
 
 ## References
 

--- a/docs/ddd/ubiquitous-language.md
+++ b/docs/ddd/ubiquitous-language.md
@@ -69,10 +69,17 @@ inference vendors served a workflow. Generalized execution belongs to `ak run`.
 | Reasoning graph sample | A point-in-time structural-size measurement (`nodes`, `edges`, `pageRankSum`) of the reasoning/knowledge graph |
 | Health-history ring | The capped, deduplicated sample ring recording learning-stat snapshots over time |
 | Project intelligence | Read-only trend telemetry over ruflo/agentic-qe's own local learning state, distinct from Observability evidence |
+| Discovered project | A project on this machine ruflo has genuinely initialized (`.claude-flow/neural/` present); found by project discovery and eligible for Intelligence selection |
+| Project discovery | The registry-plus-Observability-cross-reference scan (`discoverRuvfloProjects()`) that produces the machine-wide, deduplicated, most-recently-active-first catalog of discovered projects |
+| Selected project | The one discovered project whose detail the Intelligence panel currently shows; defaults to the most-recently-active discovered project, never an implicit cwd default |
+| Machine-wide rollup | The `{ totals, perProject }` aggregate (`readMachineWideIntel()`) folded across every discovered project; always shown regardless of which project is selected |
+| Intelligence watcher pool | The per-discovered-project pool of `IntelligenceWatch` instances backing `GET /api/live/intelligence`; a project's watcher is created on its first SSE subscriber and torn down on its last disconnect |
 
 Pattern-store size and the patterns-learned counter are never interchangeable displays of "how many
-patterns exist" — the store can be pruned while the counter keeps climbing. See
-[Project intelligence](project-intelligence.md).
+patterns exist" — the store can be pruned while the counter keeps climbing — at single-project
+scope and at machine-wide-rollup scope alike. There is no unlabeled "this project" default in
+Intelligence: the panel always shows an explicitly selected, explicitly labeled project alongside
+the always-visible machine-wide rollup. See [Project intelligence](project-intelligence.md).
 
 ## Usage rules
 

--- a/src/lib/daemons.mjs
+++ b/src/lib/daemons.mjs
@@ -14,8 +14,11 @@ const alive = (pid) => {
 
 /** Known-workspace discovery from ruflo's machine-level registries
  *  (~/.claude-flow/*.json record workspaces; each workspace has
- *  .claude-flow/daemon.pid + daemon-state.json with startedAt). */
-function registryWorkspaces() {
+ *  .claude-flow/daemon.pid + daemon-state.json with startedAt). Exported
+ *  (visibility-only change, behavior unchanged) so project-discovery.mjs can
+ *  reuse it verbatim as its guaranteed-correct primary source instead of
+ *  reimplementing the same registry walk. */
+export function registryWorkspaces() {
   const out = new Set();
   const reg = path.join(home, '.claude-flow');
   for (const f of ['ai-jobs.json', 'workspace-leases.json', 'repo-supervisors.json']) {

--- a/src/lib/dashboard-server.mjs
+++ b/src/lib/dashboard-server.mjs
@@ -4,16 +4,30 @@
 //   GET /            → one self-contained HTML document (all CSS + JS inline,
 //                      no external fetches — offline-first, matches the kit ethos)
 //   GET /api/status  → JSON: the same subsystem rows `ak status --json` emits,
-//                      PLUS version drift, the project's .claude-flow/improvement.json
-//                      (if present), the health-history ring, and the intel-history
-//                      (pattern store / graph / global stats) series — see
-//                      dashboard/intel-history.mjs and collectData()'s own field
-//                      comments for the exact, frozen shape of each.
+//                      PLUS version drift, the LAUNCHING project's own
+//                      .claude-flow/improvement.json (if present), and an
+//                      `intel` object covering the machine-wide Intelligence
+//                      feature — see collectData()'s own field comments for
+//                      the exact shape. `intel` is keyed off a machine-wide
+//                      project catalog (dashboard/project-discovery.mjs),
+//                      NOT the server's launching cwd: pass ?project=<key>
+//                      (a key from intel.projects[].key, e.g. the previous
+//                      response's own intel.selectedProjectKey) to pick which
+//                      discovered project's detail is shown; omit it (or pass
+//                      an unresolvable key) to default to the most-recently-
+//                      active discovered project. intel.machineWide is always
+//                      the full machine-wide rollup, independent of ?project.
 //   GET /api/live    → bounded, privacy-safe live session projection
 //   GET /api/live/events → resumable Server-Sent Events stream
-//   GET /api/live/intelligence → SSE stream of intel-history.mjs's combined
-//                      read; one initial frame on connect, then a fresh frame
-//                      whenever IntelligenceWatch detects a real change
+//   GET /api/live/intelligence → SSE stream of one discovered project's
+//                      intel-history.mjs combined read; one initial frame on
+//                      connect, then a fresh frame whenever that project's
+//                      IntelligenceWatch detects a real change. Accepts the
+//                      SAME optional ?project=<key> param as /api/status,
+//                      resolved identically (so both endpoints agree on what
+//                      an absent/unresolvable key defaults to); a small pool
+//                      keyed by resolved project path keeps at most one
+//                      watcher per distinct project actually being watched.
 //   GET /api/usage    → the usage Aggregate MINUS sessions[] (ADR-0009)
 //   GET /api/sessions → the session list, filtered + paginated
 //   GET /api/session/:id → one transcript, secrets masked SERVER-side
@@ -44,7 +58,9 @@ import { sseChannel, reserveClientSlot, clientGone } from './dashboard/sse.mjs';
 // dashboard-server.mjs no longer defines it locally. It isn't called directly
 // here because readIntelHistory() already composes it (as `.healthRing`,
 // forwarded verbatim below); a bare `readHealthRing` import would be unused.
-import { readIntelHistory } from './dashboard/intel-history.mjs';
+import { readIntelHistory, readMachineWideIntel } from './dashboard/intel-history.mjs';
+import { discoverRuvfloProjects } from './dashboard/project-discovery.mjs';
+import { resolveProjectIdentity, safeProjectKey } from './live/project-label.mjs';
 import {
   TRANSCRIPT_ROOTS,
   maskMeta,
@@ -103,8 +119,104 @@ function shellOutStatus(cwd) {
   });
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Machine-wide Intelligence: project catalog + selection (ADR pending).
+//
+// The dashboard used to hardcode Intelligence data to the server's own
+// launching cwd. This is a deliberate clean break: Intelligence is now
+// machine-wide, backed by dashboard/project-discovery.mjs's catalog of every
+// ruflo-initialized project on this machine, with one of them "selected" for
+// detail display. Both /api/status and /api/live/intelligence resolve that
+// selection identically (resolveSelectedProject below) so they can never
+// disagree about what an absent/unresolvable ?project= defaults to.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const PROJECT_SNAPSHOT_TTL_MS = 60_000;
+
+/** intel-history.mjs's readIntelHistory() shape, for a selection of "no
+ *  project" (discovery found zero ruflo-initialized projects on this
+ *  machine) — same null/[]-on-absent conventions readIntelHistory itself
+ *  uses for a single missing file, applied here for "no project at all". */
+const EMPTY_SELECTED_HISTORY = { patternStore: [], graph: null, healthRing: null, globalStats: null };
+
+/** A stable, opaque key for a discovered project, derived from its resolved
+ *  absolute path — NOT from its display label, which two different projects
+ *  can share (e.g. two repos both named "backend"). resolveProjectIdentity
+ *  (src/lib/live/project-label.mjs, already used machine-wide for live-
+ *  session project identity) hashes the project's own canonical git root
+ *  path when one is found — a distinct, collision-resistant key per real
+ *  project on disk. stableProjectKey alone was checked and does NOT fit
+ *  here: it reduces its input to a bare directory-name label before hashing,
+ *  so keying on it directly would collapse two same-named-but-different
+ *  projects onto one key — exactly the ambiguity a *selection* key (unlike a
+ *  *display* label, where that collision is merely cosmetic) cannot afford.
+ *  resolveProjectIdentity falls back to that same label-hash only for a
+ *  genuinely non-git directory, which is an acceptable degraded case. */
+function keyForProject(project) {
+  return resolveProjectIdentity(project.path).key;
+}
+
+/** Accept an incoming ?project= value only if it is ALREADY shaped like a
+ *  genuine opaque project key (the exact `project:<16-hex>` form
+ *  safeProjectKey emits) — reusing safeProjectKey's own shape check rather
+ *  than duplicating its regex. Passing the raw value as both arguments means
+ *  a well-formed key round-trips unchanged, while anything else (garbage,
+ *  a raw path, empty) resolves to some OTHER key that will simply fail to
+ *  match any discovered project below — never a fabricated key that could be
+ *  echoed back as if it were valid. */
+function validProjectKeyParam(raw) {
+  if (typeof raw !== 'string' || !raw) return null;
+  const sanitized = safeProjectKey(raw, raw);
+  return sanitized === raw ? raw : null;
+}
+
+/** Resolve which discovered (and key-tagged) project a request means: an
+ *  explicit ?project=<key> match if present and valid, else the first entry
+ *  — discoverRuvfloProjects() itself already sorts most-recently-active
+ *  first, so "no explicit selection" naturally means "whatever this machine
+ *  used most recently", never the server's launching cwd. Returns null only
+ *  when discovery found zero ruflo-initialized projects on this machine.
+ *  Shared verbatim by /api/status and /api/live/intelligence. */
+function resolveSelectedProject(projects, rawParam) {
+  const requested = validProjectKeyParam(rawParam);
+  if (requested) {
+    const match = projects.find((p) => p.key === requested);
+    if (match) return match;
+  }
+  return projects[0] ?? null;
+}
+
+/** Machine-wide discovery + the machine-wide intel rollup are the SAME data
+ *  for every client polling /api/status or connecting to
+ *  /api/live/intelligence — nothing about either is per-client — and
+ *  discovery walks the registry files plus every discovered project's own
+ *  .claude-flow tree, so it is not free. Cached in-memory with a short
+ *  (~60s) TTL, keyed by nothing (one snapshot per dashboard instance is
+ *  correct for machine-wide data), so a burst of polls/connections within
+ *  the window reuses one scan instead of re-walking the machine on every
+ *  request. `discoverProjectsFn`/`machineWideIntelFn` are injected by
+ *  startDashboard (defaulting to the real imports) purely for testability —
+ *  discovery reads real machine-global state (~/.claude-flow/*.json,
+ *  ~/.config/agentic-kit/observability-workspaces.json) that a test must
+ *  never depend on. */
+function buildProjectSnapshotCache(discoverProjectsFn, machineWideIntelFn) {
+  let snapshot = null;
+  let fetchedAt = 0;
+  return () => {
+    const now = Date.now();
+    if (!snapshot || now - fetchedAt > PROJECT_SNAPSHOT_TTL_MS) {
+      const projects = discoverProjectsFn().map((project) => (
+        { ...project, key: keyForProject(project) }
+      ));
+      snapshot = { projects, machineWide: machineWideIntelFn(projects) };
+      fetchedAt = now;
+    }
+    return snapshot;
+  };
+}
+
 /** Assemble the full /api/status payload. */
-async function collectData({ cwd, fetchStatus }) {
+async function collectData({ cwd, fetchStatus, projectParam, getProjectSnapshot }) {
   let status;
   try { status = await fetchStatus(); } catch (e) { status = { overall: 'unknown', rows: [], error: String(e && e.message || e) }; }
   const rows = Array.isArray(status?.rows) ? status.rows : [];
@@ -134,12 +246,14 @@ async function collectData({ cwd, fetchStatus }) {
     } catch { /* banner is best-effort — the subsystem card still carries the ruvector row */ }
   }
 
-  // Learning/intelligence history (src/lib/dashboard/intel-history.mjs) — one
-  // combined read powering the four DISTINCT series exposed below. See that
-  // module's header for the authoritative statement of why patternStore and
-  // globalStats.patternsLearned must never be conflated; the payload shape
-  // here preserves that separation instead of collapsing it.
-  const intel = readIntelHistory(cwd);
+  // Machine-wide Intelligence (clean break from the old cwd-hardcoded,
+  // single-project shape — see the block comment above buildProjectSnapshotCache).
+  // `getProjectSnapshot()` is the shared, TTL-cached {projects, machineWide}
+  // read; `projectParam` is the raw ?project= query value, resolved the exact
+  // same way /api/live/intelligence resolves it (resolveSelectedProject).
+  const { projects, machineWide } = getProjectSnapshot();
+  const selected = resolveSelectedProject(projects, projectParam);
+  const selectedHistory = selected ? readIntelHistory(selected.path) : EMPTY_SELECTED_HISTORY;
 
   return {
     generatedAt: new Date().toISOString(),
@@ -148,38 +262,51 @@ async function collectData({ cwd, fetchStatus }) {
     error: status?.error ?? null,
     rows,
     drift,
+    // improvement — UNCHANGED contract: still the LAUNCHING project's own
+    // .claude-flow/improvement.json (server cwd), independent of Intelligence
+    // project selection below. Not part of the Intelligence redesign — this
+    // is a different subsystem ("is this project's own status stale") that
+    // never had a "which project" ambiguity to begin with.
     improvement: readJsonSafe(path.join(cwd, '.claude-flow', 'improvement.json')),
-    // health — UNCHANGED contract: the machine-health snapshot RING from
-    // .claude-flow/health-history.json (an array of point samples, each
-    // typically carrying a `patternsLearned` counter value and/or an
-    // `improvement`/`deltaPP` field — see appendHealthSnapshot's callers), or
-    // null if that file is absent. This is intel.healthRing forwarded
-    // verbatim; client.mjs's renderHistory() keeps reading it exactly as
-    // before this integration.
-    health: intel.healthRing,
-    // globalStats — the CURRENT (not historical) cumulative counters read
-    // straight from .claude-flow/neural/stats.json right now:
-    // { patternsLearned, trajectoriesRecorded, signalsProcessed,
-    // lastAdaptation }, or null if that file is absent. patternsLearned here
-    // is a LIFETIME counter and can legitimately be higher than
-    // patternStore.length below — the store gets pruned/compacted over time
-    // while this counter only ever climbs. Do not treat the two as
-    // interchangeable displays of "how many patterns exist".
-    globalStats: intel.globalStats,
-    // patternStore — every entry CURRENTLY PRESENT in the neural pattern
-    // store (.claude-flow/neural/patterns.json), as `{ createdAt, type }`
-    // pairs, NOT pre-bucketed by day (the client buckets). A point-in-time
-    // inventory of the store's live contents — distinct from
-    // globalStats.patternsLearned (a lifetime counter, see above) and
-    // distinct from health[] (machine-health samples, not pattern-store
-    // entries).
-    patternStore: intel.patternStore,
-    // graph — point-in-time samples of the reasoning graph's size over time
-    // (.claude-flow/data/intelligence-snapshot.json), as
-    // `{ timestamp, nodes, edges, pageRankSum }`, or null if that file is
-    // absent. A structural-growth series, independent of the three
-    // learning/pattern-count metrics above.
-    graph: intel.graph,
+    // intel — the machine-wide Intelligence feature's ENTIRE payload, newly
+    // designed from scratch (no relation to the prior alpha's flat
+    // health/globalStats/patternStore/graph top-level fields, which this
+    // supersedes and removes). Shape:
+    //   selectedProjectKey/selectedProjectLabel — which discovered project's
+    //     detail the four fields below describe; both null only when
+    //     discovery found zero ruflo-initialized projects on this machine.
+    //     Always present so the client can label the detail strip correctly
+    //     regardless of whether ?project was supplied.
+    //   projects — the full machine-wide catalog (most-recently-active
+    //     first, matching discoverRuvfloProjects()'s own sort), each row
+    //     `{ key, label, path, source }` — the key a client echoes back as
+    //     ?project=<key> to select a different project's detail. Without
+    //     this catalog, ?project= would be undiscoverable from the API
+    //     alone.
+    //   health/globalStats/patternStore/graph — readIntelHistory(selected
+    //     project's path)'s four series, UNCHANGED individual shapes from
+    //     the prior alpha (see intel-history.mjs's own header for why
+    //     patternStore and globalStats.patternsLearned must never be
+    //     conflated) — only their home moved, from top-level to nested here,
+    //     and their source moved, from the server's launching cwd to
+    //     whichever project is selected.
+    //   machineWide — intel-history.mjs's readMachineWideIntel() rollup
+    //     across EVERY discovered project, `{ totals, perProject }`. ALWAYS
+    //     the full machine-wide figure, independent of selectedProjectKey —
+    //     switching the selected project changes the four detail series
+    //     above, never this.
+    intel: {
+      selectedProjectKey: selected?.key ?? null,
+      selectedProjectLabel: selected?.label ?? null,
+      projects: projects.map(({ key, label, path: projectPath, source }) => (
+        { key, label, path: projectPath, source }
+      )),
+      health: selectedHistory.healthRing,
+      globalStats: selectedHistory.globalStats,
+      patternStore: selectedHistory.patternStore,
+      graph: selectedHistory.graph,
+      machineWide,
+    },
     routing: routingPayload(),
   };
 }
@@ -373,21 +500,6 @@ function lazyLive(liveOptions = {}) {
   };
 }
 
-/** Load the intelligence watcher only when /api/live/intelligence is first
- * requested — same "pay only when used" rationale as lazyLive. Unlike
- * LiveSessionsService's subscribe/replay pub-sub, IntelligenceWatch wires its
- * `onUpdate` once, at construction; the route below fans that single callback
- * out to every currently-connected client itself (see `broadcastIntel`). */
-function lazyIntelWatch(cwd, onUpdate) {
-  let instancePromise;
-  return async () => {
-    instancePromise ||= import('./live/intelligence-watch.mjs').then(({ IntelligenceWatch }) => (
-      new IntelligenceWatch({ cwd, onUpdate })
-    ));
-    return instancePromise;
-  };
-}
-
 /**
  * Start the dashboard HTTP server, bound to loopback only.
  * @param {{ port?: number, cwd?: string, fetchStatus?: () => Promise<any>, usage?: any,
@@ -395,7 +507,11 @@ function lazyIntelWatch(cwd, onUpdate) {
  *           liveClientBuffer?: number, liveMaxClients?: number, liveOptions?: any,
  *           liveIdleMs?: number, transcripts?: any, transcriptOptions?: any,
  *           transcriptClientBuffer?: number, transcriptMaxClients?: number,
- *           intelWatch?: any, intelClientBuffer?: number, intelMaxClients?: number }} [opts]
+ *           intelWatch?: ((projectPath: string, onUpdate: (combined: any) => void) =>
+ *             any|Promise<any>)|any,
+ *           intelClientBuffer?: number, intelMaxClients?: number,
+ *           discoverProjects?: () => Array<{ path: string, label: string, source?: string }>,
+ *           machineWideIntel?: (projects: Array<any>) => any }} [opts]
  * @returns {Promise<{ url: string, urlWithToken: string, port: number, token: string, close: () => Promise<void> }>}
  */
 export function startDashboard({
@@ -404,6 +520,7 @@ export function startDashboard({
   liveOptions = {}, liveIdleMs = 30_000, transcripts, transcriptOptions = {},
   transcriptClientBuffer = 64, transcriptMaxClients = 16,
   intelWatch, intelClientBuffer = 256, intelMaxClients = 32,
+  discoverProjects, machineWideIntel,
 } = {}) {
   const provide = fetchStatus || shellOutStatus(cwd);
   const usageApi = usage || lazyUsage();
@@ -483,38 +600,86 @@ export function startDashboard({
     return service;
   };
 
-  // ── /api/live/intelligence singleton plumbing ────────────────────────────
-  // `intelClients` mirrors `liveClients`/`transcriptClients`: cap-tracking
-  // AND the set force-closed on shutdown. `intelWriters` is separate — the
-  // subset of those clients' raw `write` functions the watcher's single
-  // `onUpdate` callback broadcasts to, since (unlike LiveSessionsService)
-  // IntelligenceWatch has no built-in per-subscriber pub-sub of its own.
+  // Shared, TTL-cached machine-wide project catalog + rollup — see the block
+  // comment above buildProjectSnapshotCache. One instance per dashboard
+  // server, used by BOTH /api/status and /api/live/intelligence so they can
+  // never scan the machine independently or disagree on results within the
+  // same TTL window.
+  const getProjectSnapshot = buildProjectSnapshotCache(
+    typeof discoverProjects === 'function' ? discoverProjects : discoverRuvfloProjects,
+    typeof machineWideIntel === 'function' ? machineWideIntel : readMachineWideIntel,
+  );
+
+  // ── /api/live/intelligence pool plumbing ──────────────────────────────────
+  // Was a single server-wide IntelligenceWatch hardcoded to the server's own
+  // cwd; now Intelligence is machine-wide and project-selectable, so this is
+  // a small POOL keyed by resolved project path instead — at most one
+  // watcher per DISTINCT project actually being watched by at least one SSE
+  // client, however many clients (on the same or different projects) are
+  // connected. `intelClients` mirrors `liveClients`/`transcriptClients`:
+  // cap-tracking AND the set force-closed on shutdown, across every project.
+  // `intelPool` is the per-project state: each entry owns its own `writers`
+  // set (only THIS project's SSE clients) and its own lazily-started,
+  // memoized IntelligenceWatch, since — unlike LiveSessionsService — that
+  // class has no built-in per-subscriber pub-sub of its own; each entry's
+  // `broadcast` fans its watch's single `onUpdate` out to only its own
+  // writers, so two clients watching two different projects never cross-talk.
   const intelClients = new Set();
-  const intelWriters = new Set();
-  const broadcastIntel = (combined) => {
-    const frame = transcriptSseFrame('update', combined);
-    for (const write of intelWriters) {
-      try { write(frame); } catch { /* a dead writer is reaped by its own cleanup */ }
+  const intelPool = new Map(); // resolved project path -> pool entry
+
+  // intelWatch injection contract for tests/embedders: a FUNCTION is called
+  // as (projectPath, onUpdate) -> watch|Promise<watch>, mirroring the pool's
+  // real per-path shape (a deliberate signature change from the old
+  // singleton's `() => watch`, part of this clean break). A non-function
+  // value is reused verbatim for EVERY project path — a single-project test
+  // convenience; the pool never re-wires that instance's own onUpdate, so a
+  // test using this form should only ever have one project selected.
+  const provideIntelWatchFor = typeof intelWatch === 'function'
+    ? intelWatch
+    : intelWatch
+      ? () => intelWatch
+      : (projectPath, onUpdate) => import('./live/intelligence-watch.mjs').then(
+        ({ IntelligenceWatch }) => new IntelligenceWatch({ cwd: projectPath, onUpdate }),
+      );
+
+  /** One pool entry per resolved project path. */
+  function createIntelPoolEntry(projectPath) {
+    const writers = new Set();
+    const broadcast = (combined) => {
+      const frame = transcriptSseFrame('update', combined);
+      for (const write of writers) {
+        try { write(frame); } catch { /* a dead writer is reaped by its own cleanup */ }
+      }
+    };
+    let watchPromise;
+    let startPromise;
+    let started = false;
+    const getWatch = async () => {
+      if (shuttingDown) throw new Error('dashboard is closing');
+      const watch = await (watchPromise ||= Promise.resolve()
+        .then(() => provideIntelWatchFor(projectPath, broadcast)));
+      if (shuttingDown) throw new Error('dashboard is closing');
+      if (!watch || typeof watch.start !== 'function' || typeof watch.stop !== 'function') {
+        throw new TypeError('intelligence watch must implement start and stop');
+      }
+      if (!started) await (startPromise ||= Promise.resolve()
+        .then(() => watch.start())
+        .then(() => { started = true; })
+        .catch((error) => { startPromise = null; throw error; }));
+      return watch;
+    };
+    const stop = async () => { try { (await watchPromise)?.stop?.(); } catch { /* best-effort */ } };
+    return { writers, getWatch, stop };
+  }
+
+  function getOrCreateIntelPoolEntry(projectPath) {
+    let entry = intelPool.get(projectPath);
+    if (!entry) {
+      entry = createIntelPoolEntry(projectPath);
+      intelPool.set(projectPath, entry);
     }
-  };
-  const provideIntelWatch = typeof intelWatch === 'function'
-    ? intelWatch : intelWatch ? async () => intelWatch : lazyIntelWatch(cwd, broadcastIntel);
-  let intelWatchPromise;
-  let intelWatchStartPromise;
-  let intelWatchStarted = false;
-  const getIntelWatch = async () => {
-    if (shuttingDown) throw new Error('dashboard is closing');
-    const watch = await (intelWatchPromise ||= Promise.resolve().then(provideIntelWatch));
-    if (shuttingDown) throw new Error('dashboard is closing');
-    if (!watch || typeof watch.start !== 'function' || typeof watch.stop !== 'function') {
-      throw new TypeError('intelligence watch must implement start and stop');
-    }
-    if (!intelWatchStarted) await (intelWatchStartPromise ||= Promise.resolve()
-      .then(() => watch.start())
-      .then(() => { intelWatchStarted = true; })
-      .catch((error) => { intelWatchStartPromise = null; throw error; }));
-    return watch;
-  };
+    return entry;
+  }
 
   const html = renderPage({ name: '@pacphi/agentic-kit', version: kitVersion() });
 
@@ -562,8 +727,28 @@ export function startDashboard({
 
     if (url === '/api/status') {
       let payload;
-      try { payload = await collectData({ cwd, fetchStatus: provide }); }
-      catch (e) { payload = { generatedAt: new Date().toISOString(), overall: 'unknown', rows: [], drift: null, improvement: null, health: null, globalStats: null, patternStore: [], graph: null, error: String(e && e.message || e) }; }
+      try {
+        payload = await collectData({
+          cwd, fetchStatus: provide, projectParam: query.get('project'), getProjectSnapshot,
+        });
+      } catch (e) {
+        payload = {
+          generatedAt: new Date().toISOString(), overall: 'unknown', rows: [], drift: null, improvement: null,
+          intel: {
+            selectedProjectKey: null, selectedProjectLabel: null, projects: [],
+            health: null, globalStats: null, patternStore: [], graph: null,
+            machineWide: {
+              totals: {
+                patternsLearnedLifetime: 0, patternStoreEntries: 0, trajectoriesRecorded: 0,
+                projectCount: 0, mostActiveProject: null,
+              },
+              perProject: [],
+            },
+          },
+          routing: null,
+          error: String(e && e.message || e),
+        };
+      }
       sendJson(res, 200, payload);
       return;
     }
@@ -718,10 +903,11 @@ export function startDashboard({
 
     if (url === '/api/live/intelligence') {
       // Same reservation-before-await discipline as /api/live/events above
-      // (sse.mjs's reserveClientSlot doc comment): getIntelWatch() may await a
-      // dynamic import() + watch.start() on the very first connection, and
-      // concurrent requests arriving during that gap must not all observe the
-      // same pre-reservation size and all pass the cap.
+      // (sse.mjs's reserveClientSlot doc comment): resolving + starting a
+      // project's pool entry may await a dynamic import() + watch.start() on
+      // that project's very first connection, and concurrent requests
+      // arriving during that gap must not all observe the same
+      // pre-reservation size and all pass the cap.
       const maxClients = Math.max(1, Math.min(256, Number(intelMaxClients) || 32));
       const slot = reserveClientSlot(intelClients, maxClients);
       if (!slot) {
@@ -740,12 +926,31 @@ export function startDashboard({
       req.once('close', cleanup);
       res.once('close', cleanup);
 
-      try { await getIntelWatch(); } catch {
+      // Same ?project=<key> resolution as /api/status, off the SAME cached
+      // discovery snapshot — the two endpoints can never disagree about
+      // which project an absent/unresolvable key defaults to.
+      const { projects } = getProjectSnapshot();
+      const selected = resolveSelectedProject(projects, query.get('project'));
+      if (!selected) {
         intelClients.delete(slot);
+        sendJson(res, 503, { error: 'no ruflo-initialized project found on this machine' });
+        return;
+      }
+      const poolEntry = getOrCreateIntelPoolEntry(selected.path);
+
+      try { await poolEntry.getWatch(); } catch {
+        intelClients.delete(slot);
+        // Nobody else is (yet) watching this path — don't leave a dead entry
+        // behind for the next request to trip over.
+        if (poolEntry.writers.size === 0) intelPool.delete(selected.path);
         sendJson(res, 503, { error: 'intelligence telemetry unavailable' });
         return;
       }
-      if (earlyClosed || clientGone(req, res)) { intelClients.delete(slot); return; }
+      if (earlyClosed || clientGone(req, res)) {
+        intelClients.delete(slot);
+        if (poolEntry.writers.size === 0) intelPool.delete(selected.path);
+        return;
+      }
 
       res.writeHead(200, {
         'content-type': 'text/event-stream; charset=utf-8',
@@ -762,26 +967,35 @@ export function startDashboard({
       // scrubbing sseFrame applies is not the right tool here.
       const channel = sseChannel(res, {
         limit, heartbeatMs: liveHeartbeatMs,
-        onOverflow: () => transcriptSseFrame('init', readIntelHistory(cwd)),
+        onOverflow: () => transcriptSseFrame('init', readIntelHistory(selected.path)),
       });
       const write = channel.write;
 
       realCleanup = (terminate = false) => {
         if (channel.isClosed()) return;
         channel.cleanup(terminate);
-        intelWriters.delete(write);
+        poolEntry.writers.delete(write);
         intelClients.delete(cleanup);
+        // Last writer for this project gone — stop its watcher and forget
+        // the pool entry entirely, so an unwatched project's watcher does
+        // not run forever (the exact leak this pool replaces the old
+        // singleton to avoid).
+        if (poolEntry.writers.size === 0) {
+          intelPool.delete(selected.path);
+          void poolEntry.stop();
+        }
       };
       intelClients.delete(slot);
       intelClients.add(cleanup);
-      intelWriters.add(write);
+      poolEntry.writers.add(write);
       if (earlyClosed) { cleanup(true); return; }
 
-      // One initial frame with the current combined read so a fresh page load
-      // doesn't have to wait out the watcher's own debounce window; every
-      // frame after this is pushed by IntelligenceWatch's onUpdate via
-      // broadcastIntel.
-      write(transcriptSseFrame('init', readIntelHistory(cwd)));
+      // One initial frame with the current combined read for the SELECTED
+      // project so a fresh page load doesn't have to wait out the watcher's
+      // own debounce window; every frame after this is pushed by that
+      // project's IntelligenceWatch onUpdate, fanned out to every writer
+      // currently watching this same path (and only this path).
+      write(transcriptSseFrame('init', readIntelHistory(selected.path)));
       channel.startHeartbeat();
       return;
     }
@@ -1063,7 +1277,14 @@ export function startDashboard({
           await new Promise((res) => server.close(() => res(undefined)));
           await stopLive({ force: true });
           try { await (await transcriptServicePromise)?.close?.(); } catch {}
-          try { (await intelWatchPromise)?.stop?.(); } catch {}
+          // Backstop: each intel client's own cleanup above already stops +
+          // deletes its pool entry the instant its last writer disconnects,
+          // so this is normally a no-op — but stop every REMAINING entry
+          // (e.g. one still mid-start with zero writers) rather than assume
+          // that cascade always wins the race, so every pool watcher is
+          // stopped on shutdown, not just one.
+          for (const entry of [...intelPool.values()]) { try { await entry.stop(); } catch {} }
+          intelPool.clear();
         },
       });
     });

--- a/src/lib/dashboard/client.mjs
+++ b/src/lib/dashboard/client.mjs
@@ -71,6 +71,15 @@ export const JS = `
   var LEVEL_WORD={ok:"all systems nominal",warn:"attention advised",fail:"action required",unknown:"status unknown"};
   var LAST=null, lastUpdated=0;
 
+  // Intelligence project selection (machine-wide redesign, see server-side
+  // dashboard-server.mjs's collectData()). selectedProjectKey starts null so
+  // the very first /api/status and /api/live/intelligence requests omit
+  // ?project= entirely and let the server apply ITS OWN default (the
+  // most-recently-active discovered project) rather than the client guessing
+  // at one — there is no "current project"/cwd concept on this side anymore.
+  // Every later request carries the current selection explicitly.
+  var intelProjects=[], selectedProjectKey=null, selectedProjectLabel=null, intelRequestSeq=0;
+
   ${esc.toString()}
 
   // ── tabs (segmented control) ──
@@ -395,6 +404,111 @@ export const JS = `
     document.getElementById("spark-curve").innerHTML=curveVals.length>1?sparkline(curveVals):flat(curveVals.length?(curveVals[0]*100).toFixed(0)+"% (one sample)":"no data");
   }
 
+  // ── machine-wide Intelligence (ALWAYS visible) + project selection ──
+  // intel.machineWide (from /api/status) is the full machine-wide rollup,
+  // independent of whichever project is selected in the picker below it —
+  // see render()'s wiring. Reuses the shared kpi()/esc()/fmtNum()/ago()
+  // helpers (defined further down, but function declarations hoist) rather
+  // than inventing a second vocabulary for stat tiles.
+  function buildHistoryView(data){
+    var intel=(data&&data.intel)||{};
+    return {
+      health:intel.health, globalStats:intel.globalStats,
+      patternStore:intel.patternStore, graph:intel.graph,
+      // "improvement" is a DIFFERENT, unchanged contract (the dashboard's own
+      // launching-project .claude-flow/improvement.json — see
+      // dashboard-server.mjs's own comment on this) — never project-selectable,
+      // so it rides along unchanged rather than being pulled from intel.*.
+      improvement:data&&data.improvement,
+    };
+  }
+
+  function renderMachineWide(mw){
+    var totals=(mw&&mw.totals)||{};
+    var perProject=Array.isArray(mw&&mw.perProject)?mw.perProject.slice():[];
+    var note=document.getElementById("mw-note");
+    if(note)note.textContent=totals.projectCount
+      ?(fmtNum(totals.projectCount)+" project"+(totals.projectCount===1?"":"s")+" tracked on this machine")
+      :"no ruflo-initialized projects discovered on this machine";
+    var hero=document.getElementById("mw-hero");
+    if(hero)hero.innerHTML=
+      kpi("patterns learned",fmtNum(totals.patternsLearnedLifetime),"lifetime &middot; every tracked project","")
+      +kpi("projects tracked",fmtNum(totals.projectCount),"ruflo-initialized on this machine","")
+      +kpi("most active project",totals.mostActiveProject||"—","by most recent learning adaptation","accent");
+    perProject.sort(function(a,b){return (Number(b&&b.patternsLearned)||0)-(Number(a&&a.patternsLearned)||0);});
+    var table=document.getElementById("mw-table");
+    if(!table)return;
+    if(!perProject.length){table.innerHTML='<div class="empty">no projects discovered on this machine.</div>';return;}
+    var html='<div class="mw-row mw-head"><span>project</span><span class="mw-val">patterns learned</span>'
+      +'<span class="mw-val">pattern store</span><span class="mw-val">last active</span></div>';
+    for(var i=0;i<perProject.length;i++){
+      var p=perProject[i]||{};
+      var lastMs=Number(p.lastAdaptation)||0;
+      var lastTxt=lastMs?ago(Math.max(0,Math.round((Date.now()-lastMs)/1000))):"—";
+      html+='<div class="mw-row">'
+        +'<span class="mw-name">'+esc(p.label||"(unlabeled)")+"</span>"
+        +'<span class="mw-val mono">'+esc(fmtNum(p.patternsLearned))+"</span>"
+        +'<span class="mw-val mono">'+esc(fmtNum(p.patternStoreCount))+"</span>"
+        +'<span class="mw-val mono">'+esc(lastTxt)+"</span>"
+      +"</div>";
+    }
+    table.innerHTML=html;
+  }
+
+  // The picker's option list AND its default selection come from the SAME
+  // /api/status response as the machine-wide rollup above — no separate
+  // fetch for the option list. selectedProjectKey/Label are only ADOPTED
+  // from a response's own intel.selectedProjectKey/Label when they differ
+  // from the current selection — a manual pick (wireIntelPicker) updates
+  // both synchronously and intelRequestSeq (pollStatus) keeps a slow,
+  // now-stale response from a previously selected project clobbering it.
+  function renderProjectPicker(intel){
+    intelProjects=Array.isArray(intel.projects)?intel.projects:[];
+    if(intel.selectedProjectKey!==selectedProjectKey){
+      selectedProjectKey=intel.selectedProjectKey;
+      selectedProjectLabel=intel.selectedProjectLabel;
+    }
+    var note=document.getElementById("intel-picker-note");
+    if(note)note.textContent=intelProjects.length
+      ?(intelProjects.length+" project"+(intelProjects.length===1?"":"s")+" available")
+      :"no projects discovered";
+    var nameEl=document.getElementById("history-project-name");
+    if(nameEl)nameEl.textContent=selectedProjectLabel||"—";
+    var sel=document.getElementById("intel-project-select");
+    if(!sel)return;
+    if(!intelProjects.length){
+      sel.innerHTML='<option value="">no projects discovered</option>';
+      sel.disabled=true;
+      return;
+    }
+    sel.disabled=false;
+    sel.innerHTML=intelProjects.map(function(p){
+      return '<option value="'+esc(p.key)+'"'+(p.key===selectedProjectKey?" selected":"")+'>'+esc(p.label)+"</option>";
+    }).join("");
+  }
+
+  function wireIntelPicker(){
+    var sel=document.getElementById("intel-project-select");
+    if(!sel)return;
+    sel.addEventListener("change",function(){
+      var key=sel.value;
+      if(!key||key===selectedProjectKey)return;
+      var proj=null;
+      for(var i=0;i<intelProjects.length;i++){if(intelProjects[i].key===key){proj=intelProjects[i];break;}}
+      selectedProjectKey=key;
+      selectedProjectLabel=proj?proj.label:null;
+      var nameEl=document.getElementById("history-project-name");
+      if(nameEl)nameEl.textContent=selectedProjectLabel||"—";
+      // Same connect/reconnect/cleanup discipline as a tab switch
+      // (syncIntelStream): tear down the stream watching the OLD project
+      // before opening one for the newly selected project, so a client is
+      // never subscribed to two projects' frames at once.
+      closeIntelStream();
+      syncIntelStream();
+      pollStatus();
+    });
+  }
+
   function renderRouting(rt){
     var strip=document.getElementById("routing");
     if(!rt||!rt.routes||!rt.routes.length){strip.hidden=true;return;}
@@ -459,20 +573,28 @@ export const JS = `
   }
   function receiveIntel(d){
     // readIntelHistory()'s own field names (healthRing) differ from
-    // collectData()'s renamed "health" on /api/status — reshape here, then
-    // funnel through the SAME renderHistory() the poll path uses, so there is
-    // exactly one code path for drawing the panel, not two. "improvement" isn't
-    // part of this stream's payload, so whatever the last poll saw stays put.
-    if(!d||typeof d!=="object"||!LAST)return;
-    LAST.health=d.healthRing;
-    LAST.globalStats=d.globalStats;
-    LAST.patternStore=d.patternStore;
-    LAST.graph=d.graph;
-    renderHistory(LAST);
+    // collectData()'s renamed "health" on /api/status's nested intel object —
+    // reshape here, then funnel through the SAME renderHistory() (via
+    // buildHistoryView) the poll path uses, so there is exactly one code path
+    // for drawing the panel, not two. "improvement" isn't part of this
+    // stream's payload, so whatever the last poll saw stays put. No project
+    // check is needed here: the stream itself is already scoped to the
+    // selected project via its own ?project=<key> URL (openIntelStream).
+    if(!d||typeof d!=="object"||!LAST||!LAST.intel)return;
+    LAST.intel.health=d.healthRing;
+    LAST.intel.globalStats=d.globalStats;
+    LAST.intel.patternStore=d.patternStore;
+    LAST.intel.graph=d.graph;
+    renderHistory(buildHistoryView(LAST));
   }
   function openIntelStream(){
     if(intelSource||!window.EventSource)return;
-    var src=new EventSource(dashSseUrl("/api/live/intelligence"));
+    // Same ?project=<key> contract as /api/status, resolved identically
+    // server-side (resolveSelectedProject) — omitted entirely when no
+    // selection is known yet, which defers to the server's own default
+    // rather than the client guessing at one.
+    var url="/api/live/intelligence"+(selectedProjectKey?"?project="+encodeURIComponent(selectedProjectKey):"");
+    var src=new EventSource(dashSseUrl(url));
     intelSource=src;
     src.addEventListener("init",function(e){try{receiveIntel(JSON.parse(e.data));}catch(e){}});
     src.addEventListener("update",function(e){try{receiveIntel(JSON.parse(e.data));}catch(e){}});
@@ -492,7 +614,9 @@ export const JS = `
     renderVerdict(data.overall);
     renderNotice(data.drift);
     renderPanels(data.rows);
-    renderHistory(data);
+    renderMachineWide(data.intel&&data.intel.machineWide);
+    renderProjectPicker(data.intel||{});
+    renderHistory(buildHistoryView(data));
     renderRouting(data.routing);
     renderModels(data.routing);
     positionThumb(); // badges can change segment widths
@@ -542,12 +666,21 @@ export const JS = `
   }
 
   function pollStatus(){
-    return fetch("/api/status",{cache:"no-store",headers:authHeaders()}).then(function(r){
+    // Carries the CURRENT project selection on every request (omitted only
+    // before the very first response has told us the server's own default —
+    // see the intelProjects/selectedProjectKey block above). intelRequestSeq
+    // guards against a slow response for a project the picker has since
+    // moved away from (wireIntelPicker) clobbering a newer one's render.
+    var seq=++intelRequestSeq;
+    var url="/api/status"+(selectedProjectKey?"?project="+encodeURIComponent(selectedProjectKey):"");
+    return fetch(url,{cache:"no-store",headers:authHeaders()}).then(function(r){
       if(r.status===401){try{localStorage.removeItem(DASH_TOKEN_KEY);}catch(e){}showGate("Wrong or missing dashboard token.");throw Error("unauthorized");}
       return r.json();
     }).then(function(d){
       hideGate();
-      lastUpdated=Date.now(); render(d); tickClock();
+      lastUpdated=Date.now();
+      if(seq===intelRequestSeq)render(d);
+      tickClock();
     }).catch(function(){
       var t=document.getElementById("verdict-text"); if(t)t.textContent="server unreachable";
     });
@@ -1352,6 +1485,7 @@ export const JS = `
   setUsageView(usageView);
   wirePoll();
   wireUsage();
+  wireIntelPicker();
   schedulePoll();
   lastAttempt=Date.now(); inflight=true;
   Promise.all([pollStatus()].concat(activeTab==="usage"?[loadUsage()]:[]))

--- a/src/lib/dashboard/intel-history.mjs
+++ b/src/lib/dashboard/intel-history.mjs
@@ -154,3 +154,133 @@ export function readIntelHistory(cwd) {
     globalStats: readGlobalStats(cwd),
   };
 }
+
+/**
+ * Machine-wide rollup — folds readIntelHistory() across every ruflo-
+ * initialized project on this machine into one totals/perProject view.
+ * `projects` is the frozen output shape of discoverRuvfloProjects()
+ * (src/lib/dashboard/project-discovery.mjs, built against this exact
+ * contract in parallel with this function): Array<{ path: string, label:
+ * string, source?: 'registry'|'observability'|'both' }>. Only `path` and
+ * `label` are read here; `source` is accepted but ignored.
+ *
+ * Investigative note on how that array is expected to be assembled (recorded
+ * here because this function is the actual consumer of its output): the
+ * PRIMARY source is daemons.mjs's (unexported) registryWorkspaces(), which
+ * walks ~/.claude-flow/{ai-jobs.json,workspace-leases.json,repo-supervisors.json}
+ * for real absolute workspace paths. A SECONDARY source was investigated —
+ * Observability's WorkspaceSnapshotStore (src/lib/live/workspace-store.mjs),
+ * persisted at ~/.config/agentic-kit/observability-workspaces.json — and
+ * checked against the real file on this machine. Its records never carry an
+ * absolute filesystem path: `directoryLabel` is validated with
+ * `workspaceText(..., { pathLike: true })`, which rejects anything shaped
+ * like an absolute path (leading `/`, a drive letter, or a `..` segment) on
+ * both write AND read; `repositoryLabel` is validated with `{ leaf: true }`,
+ * which rejects any value containing a path separator at all; and
+ * `project`/`projectKey` are a sanitized basename and an irreversible
+ * SHA-256 hash, respectively — never a path. So by that store's own privacy
+ * design, the secondary source can never contribute a resolvable absolute
+ * path for any entry; on this machine's real observability-workspaces.json
+ * (multiple sessions across two projects at inspection time), zero entries
+ * yielded one. discoverRuvfloProjects() is expected to skip every such entry
+ * rather than fabricate a path from a label, so in practice it is source 1
+ * (the registry scan) that supplies the projects array, today.
+ *
+ * Like readIntelHistory()'s own patternsLearned-vs-patternStore distinction,
+ * this rollup keeps two DIFFERENT sums distinct at machine scope:
+ *   - totals.patternsLearnedLifetime sums each project's globalStats
+ *     .patternsLearned — a cumulative counter, includes patterns since
+ *     pruned/compacted/replaced.
+ *   - totals.patternStoreEntries sums each project's patternStore.length —
+ *     entries actually present on disk right now, a smaller number for the
+ *     exact same reason. Do not conflate the two.
+ *
+ * A project whose readIntelHistory() call turns up missing/malformed data
+ * degrades that project's row to nulls/zeros (matching readIntelHistory's
+ * own null-on-absent conventions) rather than throwing — one bad project
+ * never aborts the whole machine-wide scan. mostActiveProject is the label
+ * of whichever project has the highest globalStats.lastAdaptation among
+ * projects that actually have one (a positive timestamp; 0/absent is
+ * "never adapted", matching readGlobalStats' own `?? 0` default), or null
+ * when no project has adaptation data. This is a plain on-demand scan with
+ * no caching/TTL of its own — a later caller adds that at the server layer.
+ * @param {Array<{ path: string, label: string }>} projects
+ * @returns {{
+ *   totals: { patternsLearnedLifetime: number, patternStoreEntries: number,
+ *     trajectoriesRecorded: number, projectCount: number,
+ *     mostActiveProject: string|null },
+ *   perProject: Array<{ path: string, label: string,
+ *     patternsLearned: number|null, patternStoreCount: number,
+ *     trajectoriesRecorded: number|null,
+ *     graphLatest: { nodes: number, edges: number }|null,
+ *     lastAdaptation: number|null }>
+ * }}
+ */
+export function readMachineWideIntel(projects) {
+  const list = Array.isArray(projects) ? projects : [];
+  const perProject = [];
+  let patternsLearnedLifetime = 0;
+  let patternStoreEntries = 0;
+  let trajectoriesRecorded = 0;
+  let mostActiveProject = null;
+  let mostActiveAdaptation = 0;
+
+  for (const entry of list) {
+    const cwd = typeof entry?.path === 'string' && entry.path ? entry.path : null;
+    const label = typeof entry?.label === 'string' && entry.label.trim()
+      ? entry.label
+      : cwd
+        ? path.basename(cwd)
+        : 'unknown';
+
+    let history = null;
+    if (cwd) {
+      try {
+        history = readIntelHistory(cwd);
+      } catch {
+        history = null;
+      }
+    }
+
+    const globalStats = history?.globalStats ?? null;
+    const patternStore = Array.isArray(history?.patternStore) ? history.patternStore : [];
+    const graph = Array.isArray(history?.graph) ? history.graph : null;
+
+    const patternsLearned = globalStats ? globalStats.patternsLearned : null;
+    const trajectories = globalStats ? globalStats.trajectoriesRecorded : null;
+    const lastAdaptation = globalStats ? globalStats.lastAdaptation : null;
+    const graphLatest = graph && graph.length
+      ? { nodes: graph[graph.length - 1].nodes, edges: graph[graph.length - 1].edges }
+      : null;
+
+    patternsLearnedLifetime += patternsLearned ?? 0;
+    patternStoreEntries += patternStore.length;
+    trajectoriesRecorded += trajectories ?? 0;
+
+    if (lastAdaptation != null && lastAdaptation > mostActiveAdaptation) {
+      mostActiveAdaptation = lastAdaptation;
+      mostActiveProject = label;
+    }
+
+    perProject.push({
+      path: cwd,
+      label,
+      patternsLearned,
+      patternStoreCount: patternStore.length,
+      trajectoriesRecorded: trajectories,
+      graphLatest,
+      lastAdaptation,
+    });
+  }
+
+  return {
+    totals: {
+      patternsLearnedLifetime,
+      patternStoreEntries,
+      trajectoriesRecorded,
+      projectCount: list.length,
+      mostActiveProject,
+    },
+    perProject,
+  };
+}

--- a/src/lib/dashboard/page.mjs
+++ b/src/lib/dashboard/page.mjs
@@ -2,6 +2,31 @@ import { CSS } from './styles.mjs';
 import { JS } from './client.mjs';
 import { LIVE_CSS, LIVE_HTML, LIVE_JS } from './live-view.mjs';
 
+// ── Intelligence: machine-wide rollup + project picker ──────────────────────
+// Scoped to this file (not styles.mjs) since page.mjs is the only owner of
+// this markup. Reuses styles.mjs's existing design tokens (--panel, --line,
+// --ink*, --r-sm, --accent) so the new rows/picker match the Apple system
+// motif everywhere else, without duplicating any of styles.mjs's own rules.
+const INTEL_CSS = `
+.mw-table{display:flex; flex-direction:column; gap:1px; background:var(--line); border:1px solid var(--line); border-radius:var(--r-sm); overflow:hidden; margin-top:14px}
+.mw-row{display:grid; grid-template-columns:minmax(140px,1.6fr) repeat(3,minmax(96px,1fr)); gap:10px; align-items:center; padding:8px 14px; background:var(--panel); font-size:12.5px}
+.mw-row.mw-head{background:var(--panel-2); color:var(--ink-dim); font-size:10.5px; font-weight:600; text-transform:uppercase; letter-spacing:.06em}
+.mw-row:not(.mw-head):hover{background:var(--panel-2)}
+.mw-name{color:var(--ink); overflow:hidden; text-overflow:ellipsis; white-space:nowrap}
+.mw-val{color:var(--ink-2); text-align:right}
+.mw-row.mw-head .mw-val{color:var(--ink-dim)}
+@media(max-width:560px){.mw-row{grid-template-columns:1fr repeat(3,minmax(60px,1fr)); gap:6px}}
+.mw-picker{display:flex; align-items:center; gap:9px; flex-wrap:wrap}
+.mw-picker label{color:var(--ink-dim); font-size:11.5px}
+.mw-picker select{
+  background:var(--panel-2); border:1px solid var(--line); color:var(--ink);
+  font-family:inherit; font-size:12.5px; padding:6px 12px; border-radius:100px;
+  cursor:pointer; max-width:100%;
+}
+.mw-picker select:focus-visible{outline:2px solid var(--accent); outline-offset:1px}
+.mw-picker select:disabled{opacity:.5; cursor:not-allowed}
+`;
+
 // ─────────────────────────────────────────────────────────────────────────────
 // The page. One document, everything inline. Only `name` and `version` are
 // interpolated server-side; the client fetches /api/status and renders live.
@@ -20,7 +45,7 @@ export function renderPage({ name, version }) {
 <meta name="color-scheme" content="dark light">
 <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%230a84ff'/%3E%3Ccircle cx='16' cy='16' r='7' fill='none' stroke='white' stroke-width='3'/%3E%3C/svg%3E">
 <title>agentic-kit · dashboard</title>
-<style>${CSS}${LIVE_CSS}</style>
+<style>${CSS}${LIVE_CSS}${INTEL_CSS}</style>
 </head>
 <body>
 <div class="gate" id="dash-gate" hidden>
@@ -179,12 +204,33 @@ export function renderPage({ name, version }) {
     <header class="view-heading">
       <span class="view-eyebrow">OVERVIEW</span>
       <h2>Intelligence &amp; learning</h2>
-      <p>Memory, learned patterns, quality feedback, and improvement signals.</p>
+      <p>Memory, learned patterns, quality feedback, and improvement signals &mdash; machine-wide, plus detail for one project you pick below.</p>
     </header>
     <div id="cards-intel"></div>
+
+    <section class="strip" id="mw-intel">
+      <div class="strip-head">
+        <h2 class="strip-title">machine-wide intelligence</h2>
+        <span class="mono strip-note" id="mw-note"></span>
+      </div>
+      <div class="hero" id="mw-hero"></div>
+      <div class="mw-table" id="mw-table"></div>
+    </section>
+
+    <section class="strip" id="intel-picker">
+      <div class="strip-head">
+        <h2 class="strip-title">project detail</h2>
+        <span class="mono strip-note" id="intel-picker-note"></span>
+      </div>
+      <div class="mw-picker">
+        <label for="intel-project-select">select project</label>
+        <select id="intel-project-select"></select>
+      </div>
+    </section>
+
     <section class="strip" id="history" hidden>
       <div class="strip-head">
-        <h2 class="strip-title">learning over time</h2>
+        <h2 class="strip-title">learning over time &mdash; <span id="history-project-name"></span></h2>
         <span class="mono strip-note" id="strip-note"></span>
       </div>
       <div class="spark-row">

--- a/src/lib/dashboard/project-discovery.mjs
+++ b/src/lib/dashboard/project-discovery.mjs
@@ -1,0 +1,254 @@
+// project-discovery.mjs — machine-wide discovery of every ruflo-initialized
+// project on this machine, for a later Intelligence-panel feature that will
+// aggregate across all of them and let a user pick one to view. This module's
+// ONLY concern is discovery: it returns plain { path, label, source } rows
+// and does no aggregation, no reading of neural PATTERNS, and no dependency
+// on intel-history.mjs (sorting reads .claude-flow/neural/stats.json
+// directly, deliberately duplicating intel-history.mjs's tiny `?? 0` default
+// rather than importing it, per this module's brief).
+//
+// "Ruflo has genuinely initialized" a directory means it has a
+// .claude-flow/neural/ subdirectory (fs.existsSync check below) — a bare
+// .claude-flow/ with no neural/ subdir is NOT enough; that's how a project
+// that only ever ran e.g. `ruflo daemon start` without ever training/learning
+// anything gets correctly excluded.
+//
+// ── Two sources, unioned ────────────────────────────────────────────────────
+//
+// SOURCE 1 (primary, guaranteed-correct): registryWorkspaces() from
+// ../daemons.mjs, reused VERBATIM (imported, not reimplemented) — it walks
+// ~/.claude-flow/{ai-jobs.json,workspace-leases.json,repo-supervisors.json}
+// and returns every workspace path recorded there that has a .claude-flow
+// directory. That function was previously module-private in daemons.mjs; it
+// has been given a bare `export` (visibility only, zero behavior change) so
+// it could be imported here instead of duplicated — the only edit made
+// outside this file, and made because the frozen contract for this module
+// requires verbatim reuse, which is otherwise impossible to satisfy.
+//
+// SOURCE 2 (cross-reference, structurally empty today): Observability's own
+// persisted notion of known projects — WorkspaceSnapshotStore
+// (../live/workspace-store.mjs) reading
+// ~/.config/agentic-kit/observability-workspaces.json. Investigated against
+// the REAL file on this machine (229 session records, schemaVersion 1) and
+// against workspace-store.mjs's `safeRecord`/`safeWorkspace` sanitizers:
+// every record's workspace carries only `repositoryLabel` (a single
+// path-separator-free leaf name, e.g. "emailibrium") and `directoryLabel` (a
+// relative fragment like "backend" or "repo root", with absolute-looking or
+// ".."-traversal strings explicitly rejected by workspace-store.mjs's own
+// `workspaceText()` sanitizer). That sanitizer exists specifically so this
+// store never retains a real filesystem path — it is a deliberately
+// privacy-safe label store, not a path index. A scan of the real file found
+// ZERO absolute-path-shaped strings in any record, and structurally cannot
+// find one as long as that schema holds. The code below still does a real,
+// defensive per-record check — via resolvableAbsolutePath() — rather than
+// skipping source 2 outright, so it starts pulling genuine extra projects
+// automatically if that schema ever grows a real cwd/path field.
+//
+// SOURCE 3 (primary in practice): raw transcript content under
+// ~/.claude/projects/**/*.jsonl and ~/.codex/sessions/**/*.jsonl, read via
+// native-transcript-discovery.mjs's discoverJsonl()/bootstrapRecords() — the
+// exact same functions live-sessions-service.mjs already trusts for
+// Observability's live session tracking. Unlike source 2's *persisted,
+// privacy-sanitized* registry, these are the raw session transcripts
+// themselves: legitimately readable at this trust boundary (same user, same
+// machine, same files Observability already parses), and unlike the
+// sanitized store they DO carry a real absolute cwd — flat `record.cwd` for
+// Claude records, `record.payload.cwd` for Codex's session_meta/turn_context
+// records. Bounded to the MAX_TRANSCRIPT_FILES most-recently-modified
+// transcripts (discoverJsonl's own recency sort) so this stays cheap
+// regardless of how many total sessions a project has accumulated; dedup
+// against sources 1/2 happens for free through record()'s existing
+// resolved-path Map.
+//
+// ── Real-machine result the above implies ───────────────────────────────────
+// ~/.claude-flow/{ai-jobs.json,workspace-leases.json,repo-supervisors.json}
+// do not exist on this machine, so source 1 (registryWorkspaces()) returns
+// an empty Set here — despite daemons.mjs's own header comment assuming
+// ruflo 3.28+ reliably writes those files (this machine runs ruflo 3.34.0
+// and does not have them; a per-project .claude-flow/daemon.pid still
+// exists, so daemons DO run here, just without that specific central
+// registry). Source 2 is structurally empty per its own privacy design
+// (above). Source 3 is what actually makes discoverRuvfloProjects() return
+// real projects on this machine today — verified against this repo's own 4
+// real ruflo-initialized projects.
+//
+// ── Testability ──────────────────────────────────────────────────────────
+// registryWorkspaces() takes no arguments and reads a `home` binding that
+// paths.mjs captures ONCE from os.homedir() at module-load time — there is
+// no runtime-overridable home-dir seam on the real function to inject
+// against without fragile pre-import env-var tricks. WorkspaceSnapshotStore,
+// by contrast, already takes its file path as a plain constructor argument
+// (see live-sessions-service.mjs's own `options.workspaceFile ?? ...`
+// pattern). So rather than inventing a parallel home-dir-resolver override,
+// discoverRuvfloProjects() accepts optional { registryWorkspaces,
+// resolveProjectLabel, observabilityFile, readObservabilityRecords }
+// overrides — each defaulting to the real import — which lets tests
+// substitute a fake registry sweep and a fixture observability file without
+// touching HOME or module caching at all. readObservabilityRecords is a
+// second, narrower seam on source 2 specifically: WorkspaceSnapshotStore's
+// own sanitizer makes it IMPOSSIBLE to get an absolute path into a record
+// even via a crafted fixture file (repositoryLabel rejects any path
+// separator, directoryLabel rejects anything absolute-looking), so the
+// merge/"both"-tagging logic is exercised by injecting already-sanitized-
+// looking records directly; the realistic "skip" behavior is exercised via
+// observabilityFile against the real WorkspaceSnapshotStore, matching what
+// actually happens on a real machine. Source 3 accepts { claudeProjectsRoot,
+// codexSessionsRoot, discoverJsonl, bootstrapRecords, maxTranscriptFiles }
+// overrides on the same principle — each defaulting to the real
+// claudeDir()/codexDir() paths and the real native-transcript-discovery.mjs
+// functions, so tests can point at fixture transcript trees without
+// touching HOME.
+import fs from 'node:fs';
+import path from 'node:path';
+import { registryWorkspaces } from '../daemons.mjs';
+import { resolveProjectLabel } from '../live/index.mjs';
+import { WorkspaceSnapshotStore } from '../live/workspace-store.mjs';
+import { bootstrapRecords, discoverJsonl } from '../live/native-transcript-discovery.mjs';
+import { claudeDir, codexDir, observabilityWorkspacePath } from '../paths.mjs';
+import { readJson } from '../settings.mjs';
+
+const MAX_TRANSCRIPT_FILES = 150;
+
+/** True only when `candidate` has real ruflo learning state, not merely a
+ *  .claude-flow directory. */
+function hasNeuralState(candidate) {
+  return fs.existsSync(path.join(candidate, '.claude-flow', 'neural'));
+}
+
+/** Canonicalize for dedup so a symlinked/relative variant of the same
+ *  project never appears twice. Falls back to path.resolve when the target
+ *  can't be realpath'd (e.g. permissions), matching project-label.mjs's own
+ *  fallback convention. */
+function resolvePath(candidate) {
+  try { return fs.realpathSync.native(candidate); }
+  catch { return path.resolve(candidate); }
+}
+
+/** Reuse Observability's own label for the same path so a project reads
+ *  identically here and there; falls back to the bare directory name if
+ *  resolveProjectLabel can't be used for any reason. */
+function labelFor(resolveProjectLabelImpl, resolved) {
+  try {
+    const label = resolveProjectLabelImpl(resolved);
+    if (typeof label === 'string' && label && label !== 'unknown') return label;
+  } catch { /* fall through to basename */ }
+  return path.basename(resolved) || resolved;
+}
+
+/** Look for a genuinely resolvable absolute filesystem path inside a
+ *  WorkspaceSnapshotStore record's workspace. Per the header notes above,
+ *  the real schema never carries one (repositoryLabel/directoryLabel are
+ *  sanitized labels, not paths) — this returns null in that case rather than
+ *  reconstructing anything from a label. */
+function resolvableAbsolutePath(workspace) {
+  if (!workspace || typeof workspace !== 'object') return null;
+  for (const candidate of [workspace.directoryLabel, workspace.repositoryLabel]) {
+    if (typeof candidate === 'string' && path.isAbsolute(candidate) && fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+/** Default source-2 reader: the real WorkspaceSnapshotStore against the real
+ *  (or injected) file. Kept as its own named function so tests can override
+ *  just this seam (readObservabilityRecords) when they need to exercise the
+ *  merge logic with record shapes the store's own sanitizer would otherwise
+ *  make unreachable. */
+function readObservabilityRecords(file) {
+  return new WorkspaceSnapshotStore(file).records();
+}
+
+/** Source-3 candidates: real absolute cwd values read directly out of Claude
+ *  and Codex transcript content under `root`, via the exact discoverJsonl/
+ *  bootstrapRecords functions live-sessions-service.mjs already trusts for
+ *  Observability. Bounded to the maxFiles most-recently-modified transcripts
+ *  (discoverJsonl's own recency sort) so a project with hundreds of sessions
+ *  costs no more to scan than one with a handful — dedup happens for free
+ *  downstream in record()'s resolved-path Map, so returning the same cwd
+ *  from many sessions in one project is harmless, not wasted work avoided
+ *  here on purpose. Returns [] on any read/parse failure for a given file
+ *  (bootstrapRecords already degrades that way) rather than aborting the
+ *  whole scan over one bad transcript. */
+function transcriptCwdCandidates(root, adapter, { maxFiles, discoverJsonl: discoverJsonlImpl, bootstrapRecords: bootstrapRecordsImpl }) {
+  const files = discoverJsonlImpl(root, { maxDepth: 6, maxFiles, accept: () => true });
+  const candidates = [];
+  for (const file of files) {
+    const records = bootstrapRecordsImpl(file, adapter);
+    for (const rec of records) {
+      const cwd = adapter === 'codex' ? rec?.payload?.cwd : rec?.cwd;
+      if (typeof cwd === 'string' && cwd) candidates.push(cwd);
+    }
+  }
+  return candidates;
+}
+
+/** .claude-flow/neural/stats.json's lastAdaptation, read directly (no
+ *  intel-history.mjs dependency, per this module's discovery-only brief).
+ *  Missing/unreadable/non-numeric defaults to 0, oldest-first among ties. */
+function lastAdaptationOf(projectPath) {
+  const stats = readJson(path.join(projectPath, '.claude-flow', 'neural', 'stats.json'));
+  const value = stats?.lastAdaptation;
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0;
+}
+
+/**
+ * Every project on this machine ruflo has genuinely initialized, deduplicated
+ * by resolved absolute path and sorted most-recently-active first.
+ * @returns {Array<{ path: string, label: string, source: 'registry'|'observability'|'transcript'|'both' }>}
+ *   'both' means 2+ sources agree on the same resolved path, not literally
+ *   exactly two.
+ */
+export function discoverRuvfloProjects({
+  registryWorkspaces: registryWorkspacesImpl = registryWorkspaces,
+  resolveProjectLabel: resolveProjectLabelImpl = resolveProjectLabel,
+  observabilityFile = observabilityWorkspacePath(),
+  readObservabilityRecords: readObservabilityRecordsImpl = readObservabilityRecords,
+  claudeProjectsRoot = path.join(claudeDir(), 'projects'),
+  codexSessionsRoot = path.join(codexDir(), 'sessions'),
+  discoverJsonl: discoverJsonlImpl = discoverJsonl,
+  bootstrapRecords: bootstrapRecordsImpl = bootstrapRecords,
+  maxTranscriptFiles = MAX_TRANSCRIPT_FILES,
+} = {}) {
+  const projects = new Map(); // resolved absolute path -> row
+
+  const record = (candidate, tag) => {
+    if (typeof candidate !== 'string' || !candidate || !path.isAbsolute(candidate)) return;
+    if (!hasNeuralState(candidate)) return;
+    const resolved = resolvePath(candidate);
+    const existing = projects.get(resolved);
+    if (existing) {
+      if (existing.source !== tag) existing.source = 'both';
+      return;
+    }
+    projects.set(resolved, { path: resolved, label: labelFor(resolveProjectLabelImpl, resolved), source: tag });
+  };
+
+  // Source 1 — the guaranteed-correct registry sweep.
+  for (const workspace of registryWorkspacesImpl()) record(workspace, 'registry');
+
+  // Source 2 — cross-reference Observability's persisted workspace snapshots.
+  let snapshotRecords;
+  try { snapshotRecords = readObservabilityRecordsImpl(observabilityFile) ?? []; }
+  catch { snapshotRecords = []; }
+  for (const entry of snapshotRecords) {
+    const candidate = resolvableAbsolutePath(entry?.workspace);
+    if (candidate) record(candidate, 'observability');
+  }
+
+  // Source 3 — real cwd values read out of raw Claude/Codex transcript
+  // content. In practice, the primary source of real results on a machine
+  // where source 1's central registry files don't exist (see header notes).
+  const transcriptOpts = { maxFiles: maxTranscriptFiles, discoverJsonl: discoverJsonlImpl, bootstrapRecords: bootstrapRecordsImpl };
+  for (const candidate of transcriptCwdCandidates(claudeProjectsRoot, 'claude', transcriptOpts)) {
+    record(candidate, 'transcript');
+  }
+  for (const candidate of transcriptCwdCandidates(codexSessionsRoot, 'codex', transcriptOpts)) {
+    record(candidate, 'transcript');
+  }
+
+  const rows = [...projects.values()];
+  const lastAdaptation = new Map(rows.map((row) => [row.path, lastAdaptationOf(row.path)]));
+  rows.sort((a, b) => lastAdaptation.get(b.path) - lastAdaptation.get(a.path));
+  return rows;
+}

--- a/tests/dashboard.test.cjs
+++ b/tests/dashboard.test.cjs
@@ -131,6 +131,14 @@ async function main() {
     port: 0,
     cwd: fixture,
     fetchStatus: async () => STUB_STATUS,
+    // Machine-wide Intelligence (this round's redesign) is keyed off a
+    // discovered-project catalog, not the server's launching cwd — inject
+    // `fixture` itself as the sole discovered project so intel.health below
+    // reads deterministically off this fixture's own health-history.json,
+    // rather than depending on this machine's real (and untested-against)
+    // ~/.claude-flow/*.json registry state. Mirrors
+    // tests/kit/dashboard-intel-integration.test.mjs's own convention.
+    discoverProjects: () => [{ path: fixture, label: 'fixture', source: 'registry' }],
   });
 
   try {
@@ -284,7 +292,11 @@ async function main() {
     await test('GET /api/status embeds the health-history ring', async () => {
       const r = await get(url + 'api/status', token);
       const j = JSON.parse(r.body);
-      assert(Array.isArray(j.health) && j.health.length === 3, 'health ring must be embedded as an array');
+      // Moved under intel.* in this round's machine-wide Intelligence
+      // redesign (dashboard-server.mjs's own header comment) — see
+      // tests/kit/dashboard-intel-integration.test.mjs for the dedicated
+      // coverage of that redesign's selection/aggregate behavior.
+      assert(Array.isArray(j.intel.health) && j.intel.health.length === 3, 'health ring must be embedded as an array');
     });
 
     await test('GET /api/status via ?token= query param (the EventSource fallback path)', async () => {
@@ -308,13 +320,20 @@ async function main() {
   // `!(handle->flags & UV_HANDLE_CLOSING)` assert (win/async.c:94) at process
   // exit on Windows CI — every test passed, then the exit code was 1.
   const bare = mkFixture({});
-  const srv2 = await startDashboard({ port: 0, cwd: bare, fetchStatus: async () => ({ overall: 'ok', rows: [], drift: [] }) });
+  const srv2 = await startDashboard({
+    port: 0, cwd: bare, fetchStatus: async () => ({ overall: 'ok', rows: [], drift: [] }),
+    // Same reasoning as the fixture above: discover `bare` itself so
+    // intel.health's null-ness below is proven by this fixture's own absent
+    // health-history.json, not by an incidental absence of real machine-wide
+    // registry state.
+    discoverProjects: () => [{ path: bare, label: 'bare', source: 'registry' }],
+  });
   try {
     await test('missing improvement.json / health ring → null, no crash', async () => {
       const r = await get(srv2.url + 'api/status', srv2.token);
       const j = JSON.parse(r.body);
       assert(j.improvement === null, 'improvement must be null when absent');
-      assert(j.health === null, 'health must be null when absent');
+      assert(j.intel.health === null, 'health must be null when absent');
     });
   } finally {
     await srv2.close();

--- a/tests/kit/dashboard-intel-integration.test.mjs
+++ b/tests/kit/dashboard-intel-integration.test.mjs
@@ -1,12 +1,28 @@
 // dashboard-intel-integration.test.mjs — end-to-end coverage for the seam
-// between dashboard-server.mjs's collectData() (served at GET /api/status)
-// and dashboard/intel-history.mjs's readers. Boots the REAL HTTP server
-// (startDashboard) over an isolated mkdtempSync() fixture dir shaped like a
-// real project's .claude-flow/ tree — no real project files are ever
-// touched — and asserts the four documented fields (`health`, `globalStats`,
-// `patternStore`, `graph`) survive the collectData → JSON round trip exactly
-// as intel-history.mjs's own readers would produce them, INCLUDING the
-// file-does-not-exist-yet case, which must 200 rather than throw.
+// between dashboard-server.mjs's machine-wide Intelligence plumbing
+// (collectData()'s `intel` object, served at GET /api/status; the
+// /api/live/intelligence watcher pool) and dashboard/project-discovery.mjs +
+// dashboard/intel-history.mjs.
+//
+// REWRITTEN for the machine-wide Intelligence redesign. This file previously
+// pinned the PRIOR alpha's single-project, top-level
+// health/globalStats/patternStore/graph shape, hardcoded to the server's own
+// launching cwd. That shape is now GONE — dashboard-server.mjs's own header
+// comment above buildProjectSnapshotCache documents this as a deliberate
+// clean break ("no relation to the prior alpha's flat ... top-level fields,
+// which this supersedes and removes"); no backward compatibility was
+// required or attempted. The four series now live under `body.intel.*`,
+// keyed off a machine-wide, `?project=`-selectable project catalog rather
+// than the server's cwd — so the old assertions (`body.health` etc.) simply
+// no longer have anything to read and this file is rewritten to match, not
+// patched around the old shape.
+//
+// Every project here is INJECTED via startDashboard's `discoverProjects`
+// option (mirroring the file's other DI conventions — fetchStatus,
+// intelWatch) so this suite never depends on this machine's real
+// ~/.claude-flow/*.json registry or ~/.config/agentic-kit/observability-
+// workspaces.json — the same real-machine-independence
+// project-discovery.test.mjs and intel-history.test.mjs already rely on.
 //
 // fetchStatus is injected (a stub, never `ak status --json`) and its stub
 // `drift` is always a real array so collectData takes the caller-supplied
@@ -20,23 +36,14 @@ import os from 'node:os';
 import path from 'node:path';
 import http from 'node:http';
 import { startDashboard } from '../../src/lib/dashboard-server.mjs';
-import {
-  readNeuralPatternStoreHistory,
-  readGraphHistory,
-  readGlobalStats,
-  readHealthRing,
-} from '../../src/lib/dashboard/intel-history.mjs';
+import { readMachineWideIntel } from '../../src/lib/dashboard/intel-history.mjs';
+import { resolveProjectIdentity } from '../../src/lib/live/project-label.mjs';
 
 const STUB_STATUS = { overall: 'ok', rows: [], drift: [] };
 
-function mkFixture(files) {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ak-dash-intel-'));
-  for (const [rel, data] of Object.entries(files)) {
-    const fp = path.join(dir, rel);
-    fs.mkdirSync(path.dirname(fp), { recursive: true });
-    fs.writeFileSync(fp, typeof data === 'string' ? data : JSON.stringify(data));
-  }
-  return dir;
+function writeFile(file, data) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, typeof data === 'string' ? data : JSON.stringify(data));
 }
 
 function get(url, token) {
@@ -51,130 +58,276 @@ function get(url, token) {
   });
 }
 
-test('GET /api/status assembles globalStats/patternStore/graph/health exactly as intel-history.mjs would read them off a full fixture', async () => {
-  const fixture = mkFixture({
-    '.claude-flow/neural/stats.json': {
-      patternsLearned: 1337, trajectoriesRecorded: 1400, signalsProcessed: 1266, lastAdaptation: 1785915702033,
-    },
-    '.claude-flow/neural/patterns.json': [
-      { id: 'a', type: 'action', createdAt: 1780024063013, embedding: [1, 2], content: 'x' },
-      { id: 'b', type: 'result', createdAt: 1783106501523, embedding: [3, 4], content: 'y' },
-    ],
-    '.claude-flow/data/intelligence-snapshot.json': [
-      { timestamp: 1785257673755, nodes: 110, edges: 1568, pageRankSum: 1, confidences: [0.5], topPatterns: [{ id: 'x' }] },
-    ],
-    '.claude-flow/health-history.json': [
-      { ts: 1700000000, patternsLearned: 10, deltaPP: 5 },
-      { ts: 1700000600, patternsLearned: 22, deltaPP: 18 },
-    ],
+/** A bounded poll, not an arbitrary sleep — same house convention
+ *  tests/dashboard.test.cjs already uses for SSE disconnect-cleanup
+ *  assertions (e.g. `listeners.size === 0`). Deterministic outcome: passes
+ *  reliably once the async condition becomes true, fails only if it never
+ *  does within the window. */
+function eventually(predicate, message, timeout = 1500) {
+  const started = Date.now();
+  return new Promise((resolve, reject) => {
+    const check = () => {
+      if (predicate()) return resolve();
+      if (Date.now() - started >= timeout) return reject(new Error(message));
+      setTimeout(check, 10);
+    };
+    check();
   });
+}
+
+/** Open a real SSE connection to /api/live/intelligence?project=<key>,
+ *  mirroring tests/dashboard.test.cjs's own openSse helper for
+ *  /api/live/events — same house convention, applied to the new pool route.
+ *  `close()` destroys the client socket, the same real-disconnect signal
+ *  dashboard-server.mjs's req/res 'close' handlers key their pool teardown
+ *  off of. */
+function openIntelSse(port, { project, token }) {
+  let req;
+  const opened = new Promise((resolve, reject) => {
+    req = http.request({
+      host: '127.0.0.1', port, method: 'GET',
+      path: `/api/live/intelligence?project=${encodeURIComponent(project)}`,
+      headers: { accept: 'text/event-stream', 'x-dash-token': token },
+    }, (res) => {
+      res.setEncoding('utf8');
+      res.on('data', () => {});
+      resolve(res);
+    });
+    req.on('error', reject);
+    req.end();
+  });
+  return { opened, close: () => req.destroy() };
+}
+
+/** A fixture "discovered project" — a plain directory with a .claude-flow
+ *  tree, shaped exactly like discoverRuvfloProjects()'s own row contract
+ *  ({ path, label, source }), suitable for direct injection via
+ *  startDashboard's `discoverProjects` option (bypassing the real
+ *  machine-wide scan entirely, same as project-discovery.test.mjs's own
+ *  registryWorkspaces overrides do for that module). */
+function fixtureProject(root, name, {
+  lastAdaptation, patternsLearned, storeEntries, trajectoriesRecorded = 0,
+}) {
+  const dir = path.join(root, name);
+  writeFile(path.join(dir, '.claude-flow', 'neural', 'stats.json'), {
+    patternsLearned, trajectoriesRecorded, signalsProcessed: 0, lastAdaptation,
+  });
+  writeFile(path.join(dir, '.claude-flow', 'neural', 'patterns.json'), Array.from(
+    { length: storeEntries }, (_, i) => ({ id: `${name}-${i}`, type: 'action', createdAt: i + 1 }),
+  ));
+  writeFile(path.join(dir, '.claude-flow', 'data', 'intelligence-snapshot.json'), [
+    { timestamp: 1, nodes: storeEntries, edges: storeEntries * 2, pageRankSum: 0.1 },
+  ]);
+  writeFile(path.join(dir, '.claude-flow', 'health-history.json'), [{ ts: 1, ok: true }]);
+  return { path: dir, label: name, source: 'registry' };
+}
+
+const tempRoot = () => fs.mkdtempSync(path.join(os.tmpdir(), 'ak-dash-intel-'));
+
+// ── default selection (no ?project=) ────────────────────────────────────
+
+test('GET /api/status with no ?project= defaults to the first discovered project (discoverRuvfloProjects\' own most-recently-active-first sort)', async () => {
+  const root = tempRoot();
+  const alpha = fixtureProject(root, 'alpha', { lastAdaptation: 5000, patternsLearned: 10, storeEntries: 2 });
+  const beta = fixtureProject(root, 'beta', { lastAdaptation: 100, patternsLearned: 20, storeEntries: 1 });
 
   const { url, close, token } = await startDashboard({
-    port: 0, cwd: fixture, fetchStatus: async () => STUB_STATUS,
+    port: 0, cwd: root, fetchStatus: async () => STUB_STATUS,
+    // discoverProjects' own contract (matching the real module's) is that
+    // its result is ALREADY sorted most-recently-active first — alpha here.
+    discoverProjects: () => [alpha, beta],
   });
   try {
     const r = await get(`${url}api/status`, token);
     assert.equal(r.status, 200, `expected 200, got ${r.status}`);
     const body = JSON.parse(r.body);
 
-    // Cross-checked against the SAME readers intel-history.mjs's own unit
-    // tests exercise directly, over the same fixture dir — the seam under
-    // test is collectData()'s wiring, not the readers' own field logic
-    // (that's intel-history.test.mjs's job).
-    assert.deepEqual(body.globalStats, readGlobalStats(fixture));
-    assert.deepEqual(body.patternStore, readNeuralPatternStoreHistory(fixture));
-    assert.deepEqual(body.graph, readGraphHistory(fixture));
-    assert.deepEqual(body.health, readHealthRing(fixture));
-
-    // Field-by-field shape assertions per the frozen contract (dashboard-server.mjs's
-    // own doc comments above collectData's return).
-    assert.deepEqual(body.globalStats, {
-      patternsLearned: 1337, trajectoriesRecorded: 1400, signalsProcessed: 1266, lastAdaptation: 1785915702033,
-    });
-    assert.deepEqual(body.patternStore, [
-      { createdAt: new Date(1780024063013).toISOString(), type: 'action' },
-      { createdAt: new Date(1783106501523).toISOString(), type: 'result' },
-    ]);
-    assert.deepEqual(body.graph, [
-      { timestamp: 1785257673755, nodes: 110, edges: 1568, pageRankSum: 1 },
-    ]);
-    assert.equal(body.health.length, 2);
-
-    // patternsLearned (a lifetime counter) and patternStore.length (entries
-    // currently on disk) must remain independently reported, never collapsed
-    // into one figure — the exact divergence intel-history.mjs's header
-    // comment documents and this fixture deliberately exercises (1337 vs 2).
-    assert.notEqual(body.globalStats.patternsLearned, body.patternStore.length);
+    const alphaKey = resolveProjectIdentity(alpha.path).key;
+    assert.equal(body.intel.selectedProjectKey, alphaKey);
+    assert.equal(body.intel.selectedProjectLabel, 'alpha');
+    assert.equal(body.intel.globalStats.patternsLearned, 10);
+    assert.equal(body.intel.patternStore.length, 2);
+    // The full catalog is always present, most-recently-active first,
+    // independent of which one is selected.
+    assert.deepEqual(body.intel.projects.map((p) => p.label), ['alpha', 'beta']);
   } finally {
     await close();
   }
 });
 
-test('GET /api/status does not throw when NONE of the intel-history sources exist yet — the fresh-project path', async () => {
-  const fixture = mkFixture({}); // no .claude-flow/ at all
-  const { url, close, token } = await startDashboard({
-    port: 0, cwd: fixture, fetchStatus: async () => STUB_STATUS,
-  });
-  try {
-    const r = await get(`${url}api/status`, token);
-    assert.equal(r.status, 200, `expected 200 (never a throw), got ${r.status}`);
-    const body = JSON.parse(r.body);
-    assert.equal(body.health, null);
-    assert.equal(body.globalStats, null);
-    assert.deepEqual(body.patternStore, []);
-    assert.equal(body.graph, null);
-  } finally {
-    await close();
-  }
-});
+// ── explicit selection ───────────────────────────────────────────────────
 
-test('GET /api/status tolerates a partial fixture — health-history.json absent while the other three sources are present', async () => {
-  // Exercises the exact "create fresh" path Module A's report called out:
-  // health-history.json genuinely does not exist yet in a real project even
-  // once neural/graph data does, and that must read as null, not a crash.
-  const fixture = mkFixture({
-    '.claude-flow/neural/stats.json': { patternsLearned: 5 },
-    '.claude-flow/neural/patterns.json': [{ id: 'a', type: 'action', createdAt: 1 }],
-    '.claude-flow/data/intelligence-snapshot.json': [{ timestamp: 1, nodes: 2, edges: 3, pageRankSum: 0.5 }],
-  });
-  assert.equal(fs.existsSync(path.join(fixture, '.claude-flow', 'health-history.json')), false);
+test('GET /api/status?project=<key> scopes the detail series to that specific fixture project', async () => {
+  const root = tempRoot();
+  const alpha = fixtureProject(root, 'alpha', { lastAdaptation: 5000, patternsLearned: 10, storeEntries: 2 });
+  const beta = fixtureProject(root, 'beta', { lastAdaptation: 100, patternsLearned: 20, storeEntries: 1 });
 
   const { url, close, token } = await startDashboard({
-    port: 0, cwd: fixture, fetchStatus: async () => STUB_STATUS,
+    port: 0, cwd: root, fetchStatus: async () => STUB_STATUS,
+    discoverProjects: () => [alpha, beta],
   });
   try {
-    const r = await get(`${url}api/status`, token);
+    const betaKey = resolveProjectIdentity(beta.path).key;
+    const r = await get(`${url}api/status?project=${betaKey}`, token);
     assert.equal(r.status, 200);
     const body = JSON.parse(r.body);
-    assert.equal(body.health, null, 'health-history.json absent -> null, not a throw');
-    assert.deepEqual(body.globalStats, {
-      patternsLearned: 5, trajectoriesRecorded: 0, signalsProcessed: 0, lastAdaptation: 0,
-    });
-    assert.equal(body.patternStore.length, 1);
-    assert.equal(body.graph.length, 1);
+
+    assert.equal(body.intel.selectedProjectKey, betaKey);
+    assert.equal(body.intel.selectedProjectLabel, 'beta');
+    assert.equal(body.intel.globalStats.patternsLearned, 20);
+    assert.equal(body.intel.patternStore.length, 1);
+    // machineWide is ALWAYS the full rollup, independent of selection.
+    assert.equal(body.intel.machineWide.totals.projectCount, 2);
   } finally {
     await close();
   }
 });
 
-test('GET /api/status tolerates malformed JSON in every intel source at once without a 500', async () => {
-  const fixture = mkFixture({
-    '.claude-flow/neural/stats.json': '{ not json',
-    '.claude-flow/neural/patterns.json': 'not json at all',
-    '.claude-flow/data/intelligence-snapshot.json': '[unterminated',
-    '.claude-flow/health-history.json': 'also not json',
-  });
+// ── unresolvable key falls back to the documented default ──────────────
+
+test('GET /api/status?project=<unresolvable key> falls back to the exact same default as no ?project= at all', async () => {
+  const root = tempRoot();
+  const alpha = fixtureProject(root, 'alpha', { lastAdaptation: 5000, patternsLearned: 10, storeEntries: 2 });
+  const beta = fixtureProject(root, 'beta', { lastAdaptation: 100, patternsLearned: 20, storeEntries: 1 });
+
   const { url, close, token } = await startDashboard({
-    port: 0, cwd: fixture, fetchStatus: async () => STUB_STATUS,
+    port: 0, cwd: root, fetchStatus: async () => STUB_STATUS,
+    discoverProjects: () => [alpha, beta],
+  });
+  try {
+    const [noParam, bogusKey] = await Promise.all([
+      get(`${url}api/status`, token),
+      // A well-formed `project:<16-hex>` shape (passes safeProjectKey's own
+      // round-trip shape check in validProjectKeyParam) that matches no
+      // discovered project's real key.
+      get(`${url}api/status?project=project:deadbeefdeadbeef`, token),
+    ]);
+    assert.equal(noParam.status, 200);
+    assert.equal(bogusKey.status, 200);
+    const a = JSON.parse(noParam.body);
+    const b = JSON.parse(bogusKey.body);
+
+    assert.equal(a.intel.selectedProjectKey, b.intel.selectedProjectKey);
+    assert.equal(a.intel.selectedProjectLabel, 'alpha');
+    assert.equal(b.intel.selectedProjectLabel, 'alpha');
+  } finally {
+    await close();
+  }
+});
+
+// ── machine-wide aggregate ───────────────────────────────────────────────
+
+test('intel.machineWide sums correctly across multiple fixture projects, keeping the lifetime-counter and store-entries sums distinct', async () => {
+  const root = tempRoot();
+  const alpha = fixtureProject(root, 'alpha', {
+    lastAdaptation: 1000, patternsLearned: 500, storeEntries: 2, trajectoriesRecorded: 4,
+  });
+  const beta = fixtureProject(root, 'beta', {
+    lastAdaptation: 2000, patternsLearned: 300, storeEntries: 1, trajectoriesRecorded: 6,
+  });
+
+  const { url, close, token } = await startDashboard({
+    port: 0, cwd: root, fetchStatus: async () => STUB_STATUS,
+    // Order deliberately not "most-recently-active first" here — machineWide
+    // must sum correctly regardless of catalog order.
+    discoverProjects: () => [beta, alpha],
   });
   try {
     const r = await get(`${url}api/status`, token);
-    assert.equal(r.status, 200, 'malformed on-disk JSON must degrade gracefully, never 500');
     const body = JSON.parse(r.body);
-    assert.equal(body.health, null);
-    assert.equal(body.globalStats, null);
-    assert.deepEqual(body.patternStore, []);
-    assert.equal(body.graph, null);
+
+    // Cross-checked against the same reader intel-history.test.mjs exercises
+    // directly — the seam under test here is collectData()'s wiring/caching,
+    // not readMachineWideIntel's own arithmetic.
+    assert.deepEqual(body.intel.machineWide, readMachineWideIntel([beta, alpha]));
+
+    assert.equal(body.intel.machineWide.totals.patternsLearnedLifetime, 800); // 500 + 300
+    assert.equal(body.intel.machineWide.totals.patternStoreEntries, 3); // 2 + 1 entries on disk
+    assert.notEqual(
+      body.intel.machineWide.totals.patternsLearnedLifetime,
+      body.intel.machineWide.totals.patternStoreEntries,
+      'the lifetime counter and the on-disk store-entry count must never be conflated',
+    );
+    assert.equal(body.intel.machineWide.totals.trajectoriesRecorded, 10); // 4 + 6
+    assert.equal(body.intel.machineWide.totals.projectCount, 2);
+    assert.equal(body.intel.machineWide.totals.mostActiveProject, 'beta'); // higher lastAdaptation
+  } finally {
+    await close();
+  }
+});
+
+// ── /api/live/intelligence pool ──────────────────────────────────────────
+//
+// create-on-subscribe and teardown-on-last-disconnect are both real,
+// deterministic behaviors driven by socket 'close' events on a real HTTP
+// server (there is no injectable clock/timer in this code path — unlike
+// IntelligenceWatch's own debounce, which intelligence-watch.test.mjs
+// already covers with a fake clock). `eventually()`'s bounded poll is the
+// SAME convention tests/dashboard.test.cjs already uses for the equivalent
+// /api/live/events disconnect-cleanup assertions (e.g. `listeners.size ===
+// 0`), so this is not a novel or flaky pattern for this codebase.
+//
+// NOT separately asserted here: that a project's watcher survives a
+// disconnect that ISN'T the last one for that project (e.g. one of two
+// clients on the same project closing). Proving that specific absence
+// deterministically would require either an injectable clock this code path
+// doesn't have, or an arbitrary real-time grace window whose only job is to
+// rule out a call that — if the implementation were buggy — would already
+// have happened; that trade a real flakiness risk for a property this suite
+// doesn't strictly need to assert. If that edge specifically needs
+// verification: open two browser tabs against the same project, confirm
+// both still receive SSE frames after closing one tab (Network tab, EventSource
+// connection open), then close the last tab and confirm the connection this
+// server made to that project's watcher stops (e.g. via a temporary console.log
+// in createIntelPoolEntry's `stop`, or by observing the fake `intelWatch`
+// hook's call count in a manual REPL session).
+test('the /api/live/intelligence pool creates exactly one watcher per distinct project, reuses it across multiple clients, and stops each project\'s watcher independently once its own last client disconnects', async () => {
+  const root = tempRoot();
+  const alpha = fixtureProject(root, 'alpha', { lastAdaptation: 100, patternsLearned: 1, storeEntries: 0 });
+  const beta = fixtureProject(root, 'beta', { lastAdaptation: 200, patternsLearned: 1, storeEntries: 0 });
+  const alphaKey = resolveProjectIdentity(alpha.path).key;
+  const betaKey = resolveProjectIdentity(beta.path).key;
+
+  const watchCalls = [];
+  const stopCalls = [];
+  const fakeIntelWatch = (projectPath) => {
+    watchCalls.push(projectPath);
+    return { start: async () => {}, stop: async () => { stopCalls.push(projectPath); } };
+  };
+
+  const { port, close, token } = await startDashboard({
+    port: 0, cwd: root, fetchStatus: async () => STUB_STATUS,
+    discoverProjects: () => [beta, alpha],
+    intelWatch: fakeIntelWatch,
+  });
+  try {
+    const a1 = openIntelSse(port, { project: alphaKey, token });
+    await a1.opened;
+    // getWatch() is awaited before the response headers are sent, so this is
+    // a deterministic checkpoint, not a race: exactly one watcher for alpha.
+    assert.deepEqual(watchCalls, [alpha.path], 'first client on alpha creates exactly one watcher');
+
+    const a2 = openIntelSse(port, { project: alphaKey, token });
+    await a2.opened;
+    assert.deepEqual(watchCalls, [alpha.path],
+      'a second client on the SAME project must reuse the memoized watcher, not create a second one');
+
+    const b1 = openIntelSse(port, { project: betaKey, token });
+    await b1.opened;
+    assert.deepEqual(watchCalls, [alpha.path, beta.path], 'a client on a DIFFERENT project gets its own watcher');
+
+    // Close every alpha client. beta's client (b1) is left untouched.
+    a1.close();
+    a2.close();
+    await eventually(() => stopCalls.includes(alpha.path), 'alpha watcher was never stopped after its last client disconnected');
+    assert.equal(stopCalls.filter((p) => p === alpha.path).length, 1, 'alpha must be stopped exactly once, not once per client');
+    // Deterministic (not timing-dependent): nothing above ever touched b1,
+    // so beta's watcher cannot have been affected by alpha's teardown.
+    assert.equal(stopCalls.includes(beta.path), false, 'closing alpha\'s clients must not affect beta\'s independent watcher');
+
+    b1.close();
+    await eventually(() => stopCalls.includes(beta.path), 'beta watcher was never stopped after its last client disconnected');
+    assert.deepEqual(stopCalls.sort(), [alpha.path, beta.path].sort(), 'each distinct project\'s watcher is stopped exactly once');
   } finally {
     await close();
   }

--- a/tests/kit/intel-history.test.mjs
+++ b/tests/kit/intel-history.test.mjs
@@ -15,6 +15,7 @@ import {
   readHealthRing,
   appendHealthSnapshot,
   readIntelHistory,
+  readMachineWideIntel,
 } from '../../src/lib/dashboard/intel-history.mjs';
 
 const tmp = () => fs.mkdtempSync(path.join(os.tmpdir(), 'ak-intel-history-'));
@@ -245,5 +246,157 @@ test('readIntelHistory tolerates every source being absent', () => {
     graph: null,
     healthRing: null,
     globalStats: null,
+  });
+});
+
+// ── readMachineWideIntel ─────────────────────────────────────────────────
+
+test('readMachineWideIntel aggregates totals and perProject rows across multiple fixture projects', () => {
+  const cwdAlpha = tmp();
+  writeFixture(cwdAlpha, '.claude-flow/neural/patterns.json', [
+    { id: 'a1', type: 'action', createdAt: 1 },
+    { id: 'a2', type: 'action', createdAt: 2 },
+  ]);
+  writeFixture(cwdAlpha, '.claude-flow/neural/stats.json', {
+    patternsLearned: 10, trajectoriesRecorded: 4, signalsProcessed: 0, lastAdaptation: 1000,
+  });
+  writeFixture(cwdAlpha, '.claude-flow/data/intelligence-snapshot.json', [
+    { timestamp: 1, nodes: 3, edges: 2, pageRankSum: 0.1 },
+    { timestamp: 2, nodes: 5, edges: 8, pageRankSum: 0.2 },
+  ]);
+
+  const cwdBeta = tmp();
+  writeFixture(cwdBeta, '.claude-flow/neural/patterns.json', [
+    { id: 'b1', type: 'result', createdAt: 1 },
+    { id: 'b2', type: 'result', createdAt: 2 },
+    { id: 'b3', type: 'result', createdAt: 3 },
+  ]);
+  writeFixture(cwdBeta, '.claude-flow/neural/stats.json', {
+    patternsLearned: 20, trajectoriesRecorded: 6, signalsProcessed: 0, lastAdaptation: 2000,
+  });
+
+  const result = readMachineWideIntel([
+    { path: cwdAlpha, label: 'Alpha' },
+    { path: cwdBeta, label: 'Beta' },
+  ]);
+
+  assert.deepEqual(result.totals, {
+    patternsLearnedLifetime: 30,
+    patternStoreEntries: 5,
+    trajectoriesRecorded: 10,
+    projectCount: 2,
+    mostActiveProject: 'Beta',
+  });
+  assert.deepEqual(result.perProject, [
+    {
+      path: cwdAlpha, label: 'Alpha', patternsLearned: 10, patternStoreCount: 2,
+      trajectoriesRecorded: 4, graphLatest: { nodes: 5, edges: 8 }, lastAdaptation: 1000,
+    },
+    {
+      path: cwdBeta, label: 'Beta', patternsLearned: 20, patternStoreCount: 3,
+      trajectoriesRecorded: 6, graphLatest: null, lastAdaptation: 2000,
+    },
+  ]);
+});
+
+test('readMachineWideIntel keeps patternsLearnedLifetime and patternStoreEntries as visibly different sums', () => {
+  const cwdAlpha = tmp();
+  writeFixture(cwdAlpha, '.claude-flow/neural/patterns.json', [
+    { id: 'a1', type: 'action', createdAt: 1 },
+    { id: 'a2', type: 'action', createdAt: 2 },
+  ]);
+  writeFixture(cwdAlpha, '.claude-flow/neural/stats.json', { patternsLearned: 500 });
+
+  const cwdBeta = tmp();
+  writeFixture(cwdBeta, '.claude-flow/neural/patterns.json', [
+    { id: 'b1', type: 'result', createdAt: 1 },
+  ]);
+  writeFixture(cwdBeta, '.claude-flow/neural/stats.json', { patternsLearned: 300 });
+
+  const { totals } = readMachineWideIntel([
+    { path: cwdAlpha, label: 'Alpha' },
+    { path: cwdBeta, label: 'Beta' },
+  ]);
+
+  assert.equal(totals.patternsLearnedLifetime, 800); // lifetime counters: 500 + 300
+  assert.equal(totals.patternStoreEntries, 3); // entries on disk right now: 2 + 1
+  assert.notEqual(totals.patternsLearnedLifetime, totals.patternStoreEntries);
+});
+
+test('readMachineWideIntel degrades a project with missing/malformed data to nulls/zeros without aborting the whole call', () => {
+  const cwdGood = tmp();
+  writeFixture(cwdGood, '.claude-flow/neural/patterns.json', [
+    { id: 'g1', type: 'action', createdAt: 1 },
+    { id: 'g2', type: 'action', createdAt: 2 },
+  ]);
+  writeFixture(cwdGood, '.claude-flow/neural/stats.json', {
+    patternsLearned: 10, trajectoriesRecorded: 4, signalsProcessed: 0, lastAdaptation: 999,
+  });
+
+  const cwdEmpty = tmp(); // no .claude-flow tree at all
+
+  const cwdMalformed = tmp();
+  writeFixture(cwdMalformed, '.claude-flow/neural/patterns.json', '{not valid json');
+  writeFixture(cwdMalformed, '.claude-flow/neural/stats.json', '{ broken');
+
+  const result = readMachineWideIntel([
+    { path: cwdGood, label: 'Good' },
+    { path: cwdEmpty, label: 'Empty' },
+    { path: cwdMalformed, label: 'Malformed' },
+  ]);
+
+  assert.deepEqual(result.totals, {
+    patternsLearnedLifetime: 10,
+    patternStoreEntries: 2,
+    trajectoriesRecorded: 4,
+    projectCount: 3,
+    mostActiveProject: 'Good',
+  });
+  assert.deepEqual(result.perProject[1], {
+    path: cwdEmpty, label: 'Empty', patternsLearned: null, patternStoreCount: 0,
+    trajectoriesRecorded: null, graphLatest: null, lastAdaptation: null,
+  });
+  assert.deepEqual(result.perProject[2], {
+    path: cwdMalformed, label: 'Malformed', patternsLearned: null, patternStoreCount: 0,
+    trajectoriesRecorded: null, graphLatest: null, lastAdaptation: null,
+  });
+});
+
+test('readMachineWideIntel picks mostActiveProject by the highest lastAdaptation, and null when none have adaptation data', () => {
+  const cwdOld = tmp();
+  writeFixture(cwdOld, '.claude-flow/neural/stats.json', { patternsLearned: 1, lastAdaptation: 500 });
+  const cwdNewer = tmp();
+  writeFixture(cwdNewer, '.claude-flow/neural/stats.json', { patternsLearned: 1, lastAdaptation: 1500 });
+  const cwdNewest = tmp();
+  writeFixture(cwdNewest, '.claude-flow/neural/stats.json', { patternsLearned: 1, lastAdaptation: 999999 });
+
+  const withAdaptation = readMachineWideIntel([
+    { path: cwdOld, label: 'Old' },
+    { path: cwdNewest, label: 'Newest' },
+    { path: cwdNewer, label: 'Newer' },
+  ]);
+  assert.equal(withAdaptation.totals.mostActiveProject, 'Newest');
+
+  const cwdNoStats = tmp(); // no stats.json → globalStats null
+  const cwdZeroAdaptation = tmp();
+  writeFixture(cwdZeroAdaptation, '.claude-flow/neural/stats.json', { patternsLearned: 1 }); // lastAdaptation defaults to 0
+
+  const withoutAdaptation = readMachineWideIntel([
+    { path: cwdNoStats, label: 'NoStats' },
+    { path: cwdZeroAdaptation, label: 'ZeroAdaptation' },
+  ]);
+  assert.equal(withoutAdaptation.totals.mostActiveProject, null);
+});
+
+test('readMachineWideIntel returns zeroed totals and an empty perProject for an empty projects array', () => {
+  assert.deepEqual(readMachineWideIntel([]), {
+    totals: {
+      patternsLearnedLifetime: 0,
+      patternStoreEntries: 0,
+      trajectoriesRecorded: 0,
+      projectCount: 0,
+      mostActiveProject: null,
+    },
+    perProject: [],
   });
 });

--- a/tests/kit/project-discovery.test.mjs
+++ b/tests/kit/project-discovery.test.mjs
@@ -1,0 +1,304 @@
+// project-discovery.test.mjs — pins discoverRuvfloProjects()'s contract:
+// the .claude-flow/neural filter, dedup-by-resolved-path with "both"
+// tagging on overlap, most-recently-active-first sorting off
+// .claude-flow/neural/stats.json's lastAdaptation, and the graceful skip of
+// an observability record that carries no resolvable absolute path (which is
+// what EVERY real record on this machine looks like — see the module's own
+// header comment). Fixtures use fs.mkdtempSync isolated dirs, following
+// live-tailer.test.mjs / dashboard-live-source.test.mjs conventions.
+//
+// registryWorkspaces() and resolveProjectLabel() are the real imports
+// (dependency-injected per-test where a fixture-controlled sweep result is
+// needed); the observability side is exercised BOTH through the real
+// WorkspaceSnapshotStore against a fixture file (the realistic "skip" case)
+// and through the readObservabilityRecords seam directly (the "both"-tag
+// merge case that the real store's own sanitizer would otherwise make
+// unreachable — see project-discovery.mjs's header comment for why).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { discoverRuvfloProjects } from '../../src/lib/dashboard/project-discovery.mjs';
+
+const tempDir = () => fs.mkdtempSync(path.join(os.tmpdir(), 'ak-project-discovery-'));
+
+// Source 3 (transcript scanning) defaults to this machine's REAL
+// ~/.claude/projects and ~/.codex/sessions. Every test below that isn't
+// specifically exercising source 3 must neutralize it with fresh empty temp
+// dirs, or it would silently pick up whatever real projects happen to exist
+// on the machine running the suite.
+const noTranscripts = () => ({ claudeProjectsRoot: tempDir(), codexSessionsRoot: tempDir() });
+
+const resolved = (candidate) => {
+  try { return fs.realpathSync.native(candidate); }
+  catch { return path.resolve(candidate); }
+};
+
+/** A project directory ruflo has (or hasn't) genuinely initialized. */
+function makeProject(root, name, { neural = true, lastAdaptation } = {}) {
+  const dir = path.join(root, name);
+  fs.mkdirSync(path.join(dir, '.claude-flow'), { recursive: true });
+  if (neural) {
+    fs.mkdirSync(path.join(dir, '.claude-flow', 'neural'), { recursive: true });
+    if (lastAdaptation !== undefined) {
+      fs.writeFileSync(
+        path.join(dir, '.claude-flow', 'neural', 'stats.json'),
+        JSON.stringify({ lastAdaptation }),
+      );
+    }
+  }
+  return dir;
+}
+
+/** A realistically-shaped session record for a fixture
+ *  observability-workspaces.json — same shape as the real file on disk. */
+function sampleSession({ workspace = {} } = {}) {
+  return {
+    sessionKey: 'claude:11111111-1111-1111-1111-111111111111',
+    sessionId: '11111111-1111-1111-1111-111111111111',
+    parentSessionId: null,
+    host: 'claude',
+    project: 'fixture-project',
+    projectKey: 'project:0123456789abcdef',
+    workspace: {
+      key: null,
+      repositoryLabel: 'fixture-project',
+      directoryLabel: 'repo root',
+      branchLabel: 'main',
+      branchState: 'attached',
+      changes: null,
+      capturedAt: '2026-08-01T00:00:00.000Z',
+      source: 'claude-source',
+      confidence: 'observed',
+      ...workspace,
+    },
+  };
+}
+
+function writeObservabilityFixture(file, sessions) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify({ schemaVersion: 1, sessions }));
+}
+
+// ── neural filter ────────────────────────────────────────────────────────
+
+test('excludes a bare .claude-flow directory that has no neural/ subdir', () => {
+  const root = tempDir();
+  const withNeural = makeProject(root, 'has-neural', { lastAdaptation: 1 });
+  const bare = makeProject(root, 'bare-claude-flow', { neural: false });
+
+  const rows = discoverRuvfloProjects({
+    registryWorkspaces: () => [withNeural, bare],
+    readObservabilityRecords: () => [],
+    ...noTranscripts(),
+  });
+
+  assert.deepEqual(rows.map((r) => r.path), [resolved(withNeural)]);
+});
+
+// ── dedup + "both" tagging ───────────────────────────────────────────────
+
+test('dedups a path present in both sources, tagging it "both"', () => {
+  const root = tempDir();
+  const proj = makeProject(root, 'overlap-project', { lastAdaptation: 1 });
+
+  const rows = discoverRuvfloProjects({
+    registryWorkspaces: () => [proj],
+    readObservabilityRecords: () => [sampleSession({ workspace: { directoryLabel: proj } })],
+    ...noTranscripts(),
+  });
+
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].path, resolved(proj));
+  assert.equal(rows[0].source, 'both');
+});
+
+test('a path found in only one source keeps that source\'s tag', () => {
+  const root = tempDir();
+  const registryOnly = makeProject(root, 'registry-only', { lastAdaptation: 1 });
+  const observabilityOnly = makeProject(root, 'observability-only', { lastAdaptation: 2 });
+
+  const rows = discoverRuvfloProjects({
+    registryWorkspaces: () => [registryOnly],
+    readObservabilityRecords: () => [sampleSession({ workspace: { directoryLabel: observabilityOnly } })],
+    ...noTranscripts(),
+  });
+
+  const bySource = Object.fromEntries(rows.map((r) => [r.path, r.source]));
+  assert.equal(bySource[resolved(registryOnly)], 'registry');
+  assert.equal(bySource[resolved(observabilityOnly)], 'observability');
+});
+
+// ── sort order ───────────────────────────────────────────────────────────
+
+test('sorts most-recently-active first, by .claude-flow/neural/stats.json lastAdaptation', () => {
+  const root = tempDir();
+  const stale = makeProject(root, 'stale', { lastAdaptation: 100 });
+  const fresh = makeProject(root, 'fresh', { lastAdaptation: 5000 });
+  const missingStats = makeProject(root, 'no-stats-file'); // neural/ exists, no stats.json → 0
+
+  const rows = discoverRuvfloProjects({
+    registryWorkspaces: () => [stale, fresh, missingStats],
+    readObservabilityRecords: () => [],
+    ...noTranscripts(),
+  });
+
+  assert.deepEqual(rows.map((r) => r.path), [resolved(fresh), resolved(stale), resolved(missingStats)]);
+});
+
+// ── graceful skip of an unresolvable source-2 entry ─────────────────────
+
+test('skips a source-2 record with no resolvable absolute path, rather than fabricating one from its label', () => {
+  const root = tempDir();
+  const observabilityFile = path.join(root, 'observability-workspaces.json');
+  // Realistically-shaped record: repositoryLabel/directoryLabel are sanitized
+  // labels, never a path — exactly what every record in the real
+  // ~/.config/agentic-kit/observability-workspaces.json looks like.
+  writeObservabilityFixture(observabilityFile, [sampleSession()]);
+
+  const rows = discoverRuvfloProjects({
+    registryWorkspaces: () => [],
+    observabilityFile,
+    ...noTranscripts(),
+  });
+
+  assert.deepEqual(rows, []);
+});
+
+test('an entry whose label happens to collide with a real directory name is still skipped unless it is absolute', () => {
+  const root = tempDir();
+  const proj = makeProject(root, 'shouldnt-match', { lastAdaptation: 1 });
+  const observabilityFile = path.join(root, 'observability-workspaces.json');
+  // A relative directoryLabel that happens to match a real project's leaf
+  // name must NOT be treated as if it resolved to that project.
+  writeObservabilityFixture(observabilityFile, [
+    sampleSession({ workspace: { directoryLabel: path.basename(proj) } }),
+  ]);
+
+  const rows = discoverRuvfloProjects({
+    registryWorkspaces: () => [],
+    observabilityFile,
+    ...noTranscripts(),
+  });
+
+  assert.deepEqual(rows, []);
+});
+
+// ── labeling ─────────────────────────────────────────────────────────────
+
+test('label is a short human-readable name, never a raw absolute path', () => {
+  const root = tempDir();
+  const proj = makeProject(root, 'labeled-project', { lastAdaptation: 1 });
+
+  const [row] = discoverRuvfloProjects({
+    registryWorkspaces: () => [proj],
+    readObservabilityRecords: () => [],
+    ...noTranscripts(),
+  });
+
+  assert.equal(row.label, 'labeled-project');
+  assert.notEqual(row.label, row.path);
+  assert.ok(!path.isAbsolute(row.label));
+});
+
+// ── real-import wiring (default parameters) ──────────────────────────────
+
+test('with no overrides, wires to the real registryWorkspaces/resolveProjectLabel/WorkspaceSnapshotStore/transcript imports without throwing', () => {
+  const rows = discoverRuvfloProjects();
+  assert.ok(Array.isArray(rows));
+  for (const row of rows) {
+    assert.equal(typeof row.path, 'string');
+    assert.equal(typeof row.label, 'string');
+    assert.ok(['registry', 'observability', 'transcript', 'both'].includes(row.source));
+  }
+});
+
+// ── source 3: real transcript content ───────────────────────────────────
+
+/** A minimal, realistically-shaped Claude transcript line carrying cwd. */
+function claudeTranscriptLine(cwd) {
+  return JSON.stringify({ type: 'user', sessionId: 's1', cwd, message: { role: 'user', content: 'hi' } });
+}
+
+/** A minimal, realistically-shaped Codex session_meta line carrying
+ *  payload.cwd (Codex nests cwd under payload, unlike Claude's flat cwd). */
+function codexTranscriptLine(cwd) {
+  return JSON.stringify({ type: 'session_meta', timestamp: '2026-08-05T00:00:00.000Z', payload: { session_id: 's1', cwd } });
+}
+
+test('source 3 finds a project from real Claude transcript content (flat cwd)', () => {
+  const root = tempDir();
+  const proj = makeProject(root, 'claude-only', { lastAdaptation: 1 });
+  const claudeProjectsRoot = tempDir();
+  const sessionDir = path.join(claudeProjectsRoot, 'some-encoded-name');
+  fs.mkdirSync(sessionDir, { recursive: true });
+  fs.writeFileSync(path.join(sessionDir, 'session.jsonl'), claudeTranscriptLine(proj) + '\n');
+
+  const rows = discoverRuvfloProjects({
+    registryWorkspaces: () => [],
+    readObservabilityRecords: () => [],
+    claudeProjectsRoot,
+    codexSessionsRoot: tempDir(),
+  });
+
+  assert.deepEqual(rows.map((r) => r.path), [resolved(proj)]);
+  assert.equal(rows[0].source, 'transcript');
+});
+
+test('source 3 finds a project from real Codex transcript content (nested payload.cwd)', () => {
+  const root = tempDir();
+  const proj = makeProject(root, 'codex-only', { lastAdaptation: 1 });
+  const codexSessionsRoot = tempDir();
+  const dayDir = path.join(codexSessionsRoot, '2026', '08', '05');
+  fs.mkdirSync(dayDir, { recursive: true });
+  fs.writeFileSync(path.join(dayDir, 'rollout-x.jsonl'), codexTranscriptLine(proj) + '\n');
+
+  const rows = discoverRuvfloProjects({
+    registryWorkspaces: () => [],
+    readObservabilityRecords: () => [],
+    claudeProjectsRoot: tempDir(),
+    codexSessionsRoot,
+  });
+
+  assert.deepEqual(rows.map((r) => r.path), [resolved(proj)]);
+  assert.equal(rows[0].source, 'transcript');
+});
+
+test('source 3 dedups against source 1, tagging the overlap "both"', () => {
+  const root = tempDir();
+  const proj = makeProject(root, 'overlap-with-transcript', { lastAdaptation: 1 });
+  const claudeProjectsRoot = tempDir();
+  const sessionDir = path.join(claudeProjectsRoot, 'enc');
+  fs.mkdirSync(sessionDir, { recursive: true });
+  fs.writeFileSync(path.join(sessionDir, 'session.jsonl'), claudeTranscriptLine(proj) + '\n');
+
+  const rows = discoverRuvfloProjects({
+    registryWorkspaces: () => [proj],
+    readObservabilityRecords: () => [],
+    claudeProjectsRoot,
+    codexSessionsRoot: tempDir(),
+  });
+
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].source, 'both');
+});
+
+test('source 3 ignores a transcript cwd that has no .claude-flow/neural (same filter as the other sources)', () => {
+  const root = tempDir();
+  const notInitialized = path.join(root, 'never-ruflo-initialized');
+  fs.mkdirSync(notInitialized, { recursive: true });
+  const claudeProjectsRoot = tempDir();
+  const sessionDir = path.join(claudeProjectsRoot, 'enc');
+  fs.mkdirSync(sessionDir, { recursive: true });
+  fs.writeFileSync(path.join(sessionDir, 'session.jsonl'), claudeTranscriptLine(notInitialized) + '\n');
+
+  const rows = discoverRuvfloProjects({
+    registryWorkspaces: () => [],
+    readObservabilityRecords: () => [],
+    claudeProjectsRoot,
+    codexSessionsRoot: tempDir(),
+  });
+
+  assert.deepEqual(rows, []);
+});


### PR DESCRIPTION
## Summary

The dashboard's Intelligence panel previously showed exactly one project's learning telemetry, implicitly tied to whichever directory the dashboard process happened to launch from — with no way to see or compare any other project on the machine. This was a deliberate clean-break redesign (the project is still pre-release, `4.0.0-alpha` line, so no backward-compatibility constraint applied): the panel now shows a machine-wide rollup across every ruflo-initialized project plus an explicitly selected, explicitly labeled detail project, defaulting to whichever was most recently active.

### Source
- `src/lib/dashboard/project-discovery.mjs` — `discoverRuvfloProjects()` unions three sources into one deduplicated, most-recently-active-first catalog: ruflo's own daemon workspace registry (`registryWorkspaces()`, reused verbatim from `daemons.mjs`, now exported), a cross-reference against Observability's persisted workspace snapshots, and real `cwd` values read directly out of Claude/Codex transcript content via the same `discoverJsonl()`/`bootstrapRecords()` functions Observability already trusts. The third source exists because the first two turned out to be insufficient in practice — this machine's ruflo 3.34.0 install never wrote the central registry files `daemons.mjs`'s own header comment assumed ruflo 3.28+ would, and Observability's snapshot store is deliberately privacy-sanitized and structurally never carries a resolvable path. The transcript source is what actually finds real projects on a real machine, verified against this repo's own 4 ruflo-initialized projects.
- `readMachineWideIntel(projects)` added to `intel-history.mjs`, folding `readIntelHistory()` across every discovered project into one `{ totals, perProject }` rollup, keeping the lifetime patterns-learned counter and the pattern-store's current size as two distinct, never-conflated sums at machine scope. A project whose data is missing/malformed degrades to nulls/zeros rather than aborting the whole scan.
- `dashboard-server.mjs`'s `/api/status` intel payload and `/api/live/intelligence` route redesigned around a shared `?project=<key>` parameter, resolved identically by both endpoints, defaulting to the most-recently-active discovered project (never the server's own cwd, which no longer has special status). The prior server-wide singleton `IntelligenceWatch` is replaced by a small pool keyed by resolved project path: created lazily on a project's first SSE subscriber, stopped on last disconnect.
- `client.mjs`/`page.mjs` — an always-visible machine-wide stat row and per-project breakdown table, a project picker driving the existing 5-figure detail strip (now explicitly labeled by selected project), and live-stream resubscription on picker change.

### Tests
- `tests/kit/project-discovery.test.mjs` — dedup/tagging across all three sources, the `.claude-flow/neural` filter, most-recently-active sorting, and direct coverage of the transcript source (flat Claude `cwd`, nested Codex `payload.cwd`, dedup against the registry source).
- `tests/kit/intel-history.test.mjs` — `readMachineWideIntel`'s multi-project aggregation, the lifetime-counter-vs-store-entries distinction, graceful degradation, most-active-project selection.
- `tests/kit/dashboard-intel-integration.test.mjs` — rewritten for the new payload shape: default/explicit/fallback project selection, machine-wide aggregation, and the watcher pool's create-on-subscribe/teardown-on-last-disconnect lifecycle.
- `tests/dashboard.test.cjs` — updated for the new nested `intel.health` shape.

### Docs
- ADR-0024 and `docs/ddd/project-intelligence.md` amended in place (no new ADR number) to describe the three-source discovery model, the corrected standing of the registry source, the shared `?project=` contract, and the watcher-pool lifecycle.
- `docs/ddd/ubiquitous-language.md` and `docs/DASHBOARD.md` updated for the new shared vocabulary.

## Test plan
- [x] `pnpm run check` (typecheck, lint, markdownlint, build, full test suite) — green locally, 1301 tests
- [x] Manual browser verification of picker + live subscription switching across real multi-project data
- [x] Discovery independently verified against this repo's own real `.claude-flow/` data (finds all 4 real projects)
- [ ] CI green on this PR