### PR TITLE
fix: provider-cli pick spawns anchor at the sandbox project (real-repo config corruption)

### DIFF
--- a/tests/kit/provider-cli.test.mjs
+++ b/tests/kit/provider-cli.test.mjs
@@ -5,7 +5,7 @@
 // real machine's kit.json or ~/.claude — src/lib/paths.mjs's configBase()
 // reads APPDATA (not XDG_CONFIG_HOME) on win32, so both must be set or the
 // sandbox is silently bypassed there.
-import { test } from 'node:test';
+import { test, after } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
@@ -13,6 +13,22 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { DUAL_ROLE_TIP, JUDGE_BIAS_TIP } from '../../src/lib/providers.mjs';
+
+// Tripwire (#137): a spawned `ak x host pick` whose cwd falls back to the test
+// process's cwd writes PROJECT-scoped config (.claude/settings.local.json,
+// .agentic-qe/llm-config.json) into the REAL repository the suite runs from —
+// HOME sandboxing cannot catch that class of leak. Record the real cwd's state
+// at module load and prove it byte-identical when the suite ends.
+const REAL_PROJECT_FILES = ['.claude/settings.local.json', '.agentic-qe/llm-config.json']
+  .map((rel) => path.resolve(process.cwd(), rel));
+const readOrNull = (f) => { try { return fs.readFileSync(f, 'utf8'); } catch { return null; } };
+const realProjectBefore = REAL_PROJECT_FILES.map(readOrNull);
+after(() => {
+  REAL_PROJECT_FILES.forEach((f, i) => {
+    assert.equal(readOrNull(f), realProjectBefore[i],
+      `${f} was modified by this suite — a spawned ak command leaked out of the sandbox (cwd not anchored to the sandbox project?)`);
+  });
+});
 
 const BIN = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../bin/agentic-kit.mjs');
 
@@ -163,10 +179,13 @@ function pickSandbox({
   return { home, project, binDir, catalog };
 }
 
-function akPick(args, { cwd, home, binDir, catalog }, { input, env = {} } = {}) {
+function akPick(args, { cwd, project, home, binDir, catalog }, { input, env = {} } = {}) {
   return spawnSync(process.execPath, [BIN, ...args], {
     encoding: 'utf8',
-    cwd,
+    // Anchor at the sandbox project (#137): an undefined cwd inherits the test
+    // process's cwd — the real repository — and pick's PROJECT-scoped writes
+    // (settings.local.json, llm-config.json) would land there.
+    cwd: cwd ?? project,
     input,
     env: {
       ...process.env,


### PR DESCRIPTION
Fixes #137.

## The leak

`akPick()` destructures `{ cwd, home, binDir, catalog }` but `pickSandbox()` returns `{ home, project, binDir, catalog }` — all 20 call sites pass the sandbox object wholesale, so `cwd` was always `undefined` and `spawnSync` inherited the test process's cwd: **the real repository root**. HOME/XDG/APPDATA were correctly sandboxed (kit.json and ~/.claude were safe), but `ak x host pick --yes` also performs PROJECT-scoped writes anchored at `repoRoot(cwd)`:

- `.claude/settings.local.json` → `ENABLE_CODEX: "false"` from claude-only fixtures
- `.agentic-qe/llm-config.json` → fixture `claude-code→openai` chain, empty `agentOverrides`

Every `pnpm test` / `pnpm run check` on a developer machine silently regressed that machine's real provider/routing state. Two properties kept it invisible: rewrites are idempotent (an already-corrupted repo shows no mtime-content change on reruns), and CI runs in a throwaway checkout. This retroactively explains recurring "mysterious" post-test-run drift on a dev machine that `ak sync` kept re-healing.

## The fix

1. `akPick` anchors the spawn at the sandbox project: `cwd: cwd ?? project` (heals all 20 call sites).
2. A tripwire `after()` hook records the real cwd's two project files at module load and asserts them **byte-identical** when the suite ends — any future harness regression of this class fails the suite loudly instead of corrupting machines silently.

## Verification

- TDD: tripwire added first; from a healthy repo state it **fired** on `settings.local.json` before the anchor fix (the corrupted state had masked it — idempotent rewrites — so the repo was healed first to expose true RED).
- After the fix: suite green (18 tests incl. tripwire), and a full `pnpm run check` (1469 tests, 0 fail) leaves both real files **hash-identical** (md5 before/after).

🤖 Generated with [Claude Code](https://claude.com/claude-code)