### PR TITLE
chore: remove the HNSW badge; widen nightly's #2885 scope note

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -62,9 +62,12 @@ jobs:
           APPDATA: ${{ runner.temp }}/kit-home/AppData/Roaming
         run: node bin/agentic-kit.mjs x verify security
 
-      # Non-blocking: ruflo neural train crashes on macos-latest with a native
-      # libc++abi mutex abort, tracked upstream at ruvnet/ruflo#2885 (open as of
-      # 2026-08-06). Remove continue-on-error once that issue closes.
+      # Non-blocking: a native libc++abi mutex abort on macos-latest poisons ruflo
+      # exit codes, tracked upstream at ruvnet/ruflo#2885 (open as of 2026-08-13).
+      # Scope is NOT neural-train-specific: upstream evidence (2026-08-12) shows the
+      # same teardown abort on store-touching commands (`memory search` → correct
+      # output, rc 134), so an `x verify memory` step added here would need the same
+      # guard. Remove continue-on-error once that issue closes.
       - name: Deep proof against the live packages (learning)
         continue-on-error: true
         env:

--- a/src/templates/statusline-footer.cjs
+++ b/src/templates/statusline-footer.cjs
@@ -69,7 +69,12 @@ function rufloActivationSegments(cwd){
         if (pn > 0 || tj > 0) {
           if (pn > 0) parts.push(pn + " patterns");
           if (tj > 0) parts.push(tj + " traj");
-          if (fs.existsSync(path.join(cwd, ".swarm", "hnsw.index"))) parts.push(G + "⚡ HNSW" + R);
+          // "HNSW idx" claims the ARTIFACT (an index was built), never the algorithm:
+          // upstream's default search path is brute-force cosine even when this file
+          // exists (ruflo#2922 renamed its own APIs over that exact overclaim). Revisit
+          // if upstream wires HNSW into the default path or persists an algorithm
+          // signal the footer can read (#140).
+          if (fs.existsSync(path.join(cwd, ".swarm", "hnsw.index"))) parts.push(G + "HNSW idx" + R);
           var dots = Math.max(0, Math.min(5, Math.round(pn / 10)));   // volume gauge: ~10 patterns per dot
           learn = C + "🧠 SONA" + R + "  " + DIM + bar(dots, 5) + R + "  " + parts.join(DIM + " · " + R);
         }

--- a/src/templates/statusline-footer.cjs
+++ b/src/templates/statusline-footer.cjs
@@ -56,7 +56,7 @@ function rufloActivationSegments(cwd){
       }
     } catch(e){ rufloStatuslineDebug("quota-tee", e); }
     function bar(n, max){ n = Math.max(0, Math.min(max, n)); return "[" + "●".repeat(n) + "○".repeat(max - n) + "]"; }
-    // ── self-learning (SONA): own line with a volume bar (patterns/traj/HNSW) plus a
+    // ── self-learning (SONA): own line with a volume bar (patterns/traj) plus a
     // LIVE micro-LoRA adaptation field (Δ‖W‖, appended further below). The Δ‖W‖ tracker
     // is maintained inline in this same function — see the "micro-LoRA LIVE adaptation"
     // block after the route-Q segment.
@@ -69,12 +69,6 @@ function rufloActivationSegments(cwd){
         if (pn > 0 || tj > 0) {
           if (pn > 0) parts.push(pn + " patterns");
           if (tj > 0) parts.push(tj + " traj");
-          // "HNSW idx" claims the ARTIFACT (an index was built), never the algorithm:
-          // upstream's default search path is brute-force cosine even when this file
-          // exists (ruflo#2922 renamed its own APIs over that exact overclaim). Revisit
-          // if upstream wires HNSW into the default path or persists an algorithm
-          // signal the footer can read (#140).
-          if (fs.existsSync(path.join(cwd, ".swarm", "hnsw.index"))) parts.push(G + "HNSW idx" + R);
           var dots = Math.max(0, Math.min(5, Math.round(pn / 10)));   // volume gauge: ~10 patterns per dot
           learn = C + "🧠 SONA" + R + "  " + DIM + bar(dots, 5) + R + "  " + parts.join(DIM + " · " + R);
         }

--- a/tests/statusline-segments.test.cjs
+++ b/tests/statusline-segments.test.cjs
@@ -107,6 +107,26 @@ test('SONA segment absent when counts are zero', () => {
   absent(out, '🧠 SONA');
 });
 
+// #140 / upstream ruflo#2922: the index FILE existing proves an HNSW index was
+// BUILT — not that the search path uses it (upstream's default is brute-force
+// cosine; they renamed their own APIs over exactly this overclaim). The badge
+// may claim the artifact, never the algorithm.
+test('a built hnsw.index shows the artifact badge, not an algorithm claim (#140)', () => {
+  const out = strip(rufloActivationSegments(mkFixture({
+    '.claude-flow/neural/stats.json': { patternsLearned: 50, trajectoriesRecorded: 110 },
+    '.swarm/hnsw.index': 'binary-ish',
+  })));
+  contains(out, 'HNSW idx');
+  absent(out, '⚡ HNSW');
+});
+
+test('no hnsw.index → no HNSW mention at all', () => {
+  const out = strip(rufloActivationSegments(mkFixture({
+    '.claude-flow/neural/stats.json': { patternsLearned: 50, trajectoriesRecorded: 110 },
+  })));
+  absent(out, 'HNSW');
+});
+
 // ── route Q-learner segment ───────────────────────────────────────────────
 test('route 📈 RL renders ε/δ̄/|Q|/upd when updateCount > 0', () => {
   const out = strip(rufloActivationSegments(mkFixture({
@@ -521,7 +541,7 @@ test('unresolvable ruflo → silent (a probe miss must never fail loud and wrong
 
 // Test-quality Finding 5: bump deliberately when adding/removing a test —
 // see admin-model.test.cjs's identical guard for the full rationale.
-const EXPECTED = 45;
+const EXPECTED = 47;
 if (passed + failed !== EXPECTED) {
   console.error(`\nPLAN MISMATCH: expected ${EXPECTED} tests, ran ${passed + failed}`);
   process.exit(1);

--- a/tests/statusline-segments.test.cjs
+++ b/tests/statusline-segments.test.cjs
@@ -107,22 +107,13 @@ test('SONA segment absent when counts are zero', () => {
   absent(out, '🧠 SONA');
 });
 
-// #140 / upstream ruflo#2922: the index FILE existing proves an HNSW index was
-// BUILT — not that the search path uses it (upstream's default is brute-force
-// cosine; they renamed their own APIs over exactly this overclaim). The badge
-// may claim the artifact, never the algorithm.
-test('a built hnsw.index shows the artifact badge, not an algorithm claim (#140)', () => {
+// #140: index-file existence proves nothing about the active search path
+// (upstream default is brute-force cosine, ruflo#2922) — the footer shows only
+// genuinely active features, so no HNSW claim at all.
+test('hnsw.index on disk produces no HNSW claim (#140)', () => {
   const out = strip(rufloActivationSegments(mkFixture({
     '.claude-flow/neural/stats.json': { patternsLearned: 50, trajectoriesRecorded: 110 },
     '.swarm/hnsw.index': 'binary-ish',
-  })));
-  contains(out, 'HNSW idx');
-  absent(out, '⚡ HNSW');
-});
-
-test('no hnsw.index → no HNSW mention at all', () => {
-  const out = strip(rufloActivationSegments(mkFixture({
-    '.claude-flow/neural/stats.json': { patternsLearned: 50, trajectoriesRecorded: 110 },
   })));
   absent(out, 'HNSW');
 });
@@ -541,7 +532,7 @@ test('unresolvable ruflo → silent (a probe miss must never fail loud and wrong
 
 // Test-quality Finding 5: bump deliberately when adding/removing a test —
 // see admin-model.test.cjs's identical guard for the full rationale.
-const EXPECTED = 47;
+const EXPECTED = 46;
 if (passed + failed !== EXPECTED) {
   console.error(`\nPLAN MISMATCH: expected ${EXPECTED} tests, ran ${passed + failed}`);
   process.exit(1);


### PR DESCRIPTION
Fixes #139, fixes #140. Two follow-ups from the ruflo 3.38.5–3.38.8 impact assessment.

## Remove the HNSW badge (#140)

The activation footer's founding contract (10fc4e7) is to show *only features genuinely active in the project*. The `⚡ HNSW` badge keyed off `.swarm/hnsw.index` existing — but upstream ruflo#2922 (3.38.7) established the default memory search path is brute-force cosine even when that index exists (upstream renamed `bridgeSearchHNSW` → `bridgeSearchBruteForceCosine` over exactly this overclaim). The file therefore proves no active feature, so the badge is removed rather than relabeled. Reintroduction condition: upstream wires HNSW into the default search path, or persists an algorithm signal the footer can read.

TDD: regression test asserts no HNSW claim renders even with the index file present (watched fail against the old badge); segment suite plan 45 → 46.

## nightly.yml #2885 scope note (#139)

The non-blocking guard's comment described ruflo#2885 as a `neural train` crash ("open as of 2026-08-06"). Upstream evidence (2026-08-12) shows the same macOS arm64 libc++abi teardown abort poisoning exit codes of store-touching commands (`memory search` → correct output, rc 134). Comment rewritten to the widened scope, with the note that a future `x verify memory` step would need the same guard. Guard behavior unchanged; comment-only.

Full `pnpm run check` green (1469 node tests + 46/46 segment tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)