### PR TITLE
docs: ADR-0031 capability graduation + local artifact snapshots

### DIFF
--- a/docs/ADAPTER-CONTRACT-DOSSIER.html
+++ b/docs/ADAPTER-CONTRACT-DOSSIER.html
@@ -1,0 +1,698 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Adapter Contract Dossier</title>
+<style>
+  :root {
+    --bg: #faf7f4;
+    --surface: #f1ebe5;
+    --ink: #2b2420;
+    --muted: #6d6156;
+    --line: #ddd2c7;
+    --accent: #9a4e2e;
+    --accent-ink: #7c3d21;
+    --mono-bg: #ece4db;
+    --adopt: #2e6b46;
+    --adapt: #8a6d1f;
+    --avoid: #a03c34;
+    --chipbg-adopt: #e2efe7;
+    --chipbg-adapt: #f3ecd6;
+    --chipbg-avoid: #f6e3e0;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) {
+      --bg: #201a16;
+      --surface: #2a221d;
+      --ink: #e8e0d8;
+      --muted: #a99c8f;
+      --line: #423731;
+      --accent: #d98a63;
+      --accent-ink: #e5a381;
+      --mono-bg: #322922;
+      --adopt: #7fc39a;
+      --adapt: #d3b45e;
+      --avoid: #e08a80;
+      --chipbg-adopt: #23372c;
+      --chipbg-adapt: #3a3221;
+      --chipbg-avoid: #3f2724;
+    }
+  }
+  :root[data-theme="dark"] {
+    --bg: #201a16;
+    --surface: #2a221d;
+    --ink: #e8e0d8;
+    --muted: #a99c8f;
+    --line: #423731;
+    --accent: #d98a63;
+    --accent-ink: #e5a381;
+    --mono-bg: #322922;
+    --adopt: #7fc39a;
+    --adapt: #d3b45e;
+    --avoid: #e08a80;
+    --chipbg-adopt: #23372c;
+    --chipbg-adapt: #3a3221;
+    --chipbg-avoid: #3f2724;
+  }
+  * { box-sizing: border-box; }
+  body {
+    background: var(--bg);
+    color: var(--ink);
+    font: 16px/1.65 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    margin: 0;
+    padding: 0 1.25rem 5rem;
+  }
+  main { max-width: 76ch; margin: 0 auto; }
+  h1, h2, h3 {
+    font-family: "Iowan Old Style", "Palatino Linotype", Palatino, Georgia, serif;
+    line-height: 1.25;
+    text-wrap: balance;
+  }
+  h1 { font-size: 2.1rem; margin: 2.5rem 0 0.4rem; }
+  h2 {
+    font-size: 1.45rem; margin: 3rem 0 0.8rem;
+    padding-top: 1.2rem; border-top: 1px solid var(--line);
+  }
+  h3 { font-size: 1.12rem; margin: 1.8rem 0 0.5rem; }
+  p { margin: 0.7rem 0; }
+  .lede { font-size: 1.08rem; color: var(--muted); max-width: 66ch; }
+  .meta { color: var(--muted); font-size: 0.85rem; letter-spacing: 0.02em; }
+  .eyebrow {
+    text-transform: uppercase; letter-spacing: 0.14em; font-size: 0.72rem;
+    color: var(--accent); font-weight: 600; margin-top: 3.2rem;
+  }
+  code, .mono {
+    font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    font-size: 0.86em;
+    background: var(--mono-bg);
+    padding: 0.08em 0.35em;
+    border-radius: 3px;
+  }
+  .cite {
+    font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    font-size: 0.76rem; color: var(--muted); background: none; padding: 0;
+  }
+  a { color: var(--accent-ink); }
+  table {
+    border-collapse: collapse; width: 100%; font-size: 0.9rem; margin: 1rem 0;
+  }
+  .tablewrap { overflow-x: auto; }
+  th, td {
+    text-align: left; padding: 0.5rem 0.7rem; vertical-align: top;
+    border-bottom: 1px solid var(--line);
+  }
+  th {
+    font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.08em;
+    color: var(--muted); font-weight: 600;
+  }
+  .chip {
+    display: inline-block; font-size: 0.7rem; font-weight: 700;
+    text-transform: uppercase; letter-spacing: 0.06em;
+    padding: 0.12em 0.55em; border-radius: 999px; white-space: nowrap;
+  }
+  .chip.adopt { color: var(--adopt); background: var(--chipbg-adopt); }
+  .chip.adapt { color: var(--adapt); background: var(--chipbg-adapt); }
+  .chip.avoid { color: var(--avoid); background: var(--chipbg-avoid); }
+  .panel {
+    background: var(--surface); border: 1px solid var(--line);
+    border-left: 3px solid var(--accent);
+    border-radius: 6px; padding: 1rem 1.2rem; margin: 1.4rem 0;
+  }
+  .panel h3 { margin-top: 0.2rem; }
+  ul, ol { padding-left: 1.3rem; }
+  li { margin: 0.35rem 0; }
+  .verdict {
+    display: grid; grid-template-columns: auto 1fr; gap: 0.4rem 1rem;
+    font-size: 0.95rem; margin: 1rem 0;
+  }
+  .verdict dt { font-weight: 700; white-space: nowrap; }
+  .verdict dd { margin: 0; }
+  nav.toc {
+    background: var(--surface); border: 1px solid var(--line); border-radius: 6px;
+    padding: 0.9rem 1.2rem; margin: 1.6rem 0; font-size: 0.92rem;
+  }
+  nav.toc a { text-decoration: none; }
+  nav.toc li { margin: 0.2rem 0; }
+  .qgrid { display: grid; gap: 0.9rem; margin: 1rem 0; }
+  .q {
+    border: 1px solid var(--line); border-radius: 6px; padding: 0.8rem 1rem;
+    background: var(--surface);
+  }
+  .q .qtag {
+    font-size: 0.7rem; font-weight: 700; letter-spacing: 0.08em;
+    text-transform: uppercase; color: var(--muted);
+  }
+  .q .state-open { color: var(--adapt); }
+  .q .state-closed { color: var(--adopt); }
+</style>
+</head>
+<body>
+<main>
+<div style="max-width:76ch;margin:1.4rem auto 0;padding:.55rem .95rem;background:var(--surface);border:1px solid var(--line);border-left:3px solid var(--accent);border-radius:8px;font-size:.82rem;line-height:1.5;color:var(--muted)">📎 <strong style="color:var(--accent)">Origin.</strong> Authored as a Claude artifact; this file is the repository’s local snapshot for review. Live version: <a href="https://claude.ai/code/artifact/d611cd1c-03a4-4c4b-9b9c-94d129b7ee0d" style="color:var(--accent)">https://claude.ai/code/artifact/d611cd1c-03a4-4c4b-9b9c-94d129b7ee0d</a></div>
+
+<p class="eyebrow">agentic-kit · phase 2 design input · grounded 2026-08-14/15</p>
+<h1>Adapter Contract Dossier</h1>
+<p class="lede">What four source-grounded research sweeps — ruflo's plugin history, the three
+hosts' extension models, Hermes at HEAD, and agentic-qe's parity constraints — teach us about
+building agentic-kit's host-adapter extension point without sacrificing quality, symmetry, or
+maintainability. Ends in one finalized mechanism recommendation and the decisions still open.</p>
+<p class="meta">Prepared 2026-08-15 · companion to the Host &amp; Provider Consistency master
+document · every claim below carries a citation from a live sweep of upstream source</p>
+
+<nav class="toc">
+  <strong>Contents</strong>
+  <ol>
+    <li><a href="#correction">The manifesto correction</a></li>
+    <li><a href="#evidence">Evidence base</a></li>
+    <li><a href="#lessons">Five load-bearing lessons</a></li>
+    <li><a href="#constraints">Hard constraints the design inherits</a></li>
+    <li><a href="#anatomy">Interfaces &amp; anatomy — as-is and to-be</a></li>
+    <li><a href="#mechanism">The recommended mechanism (Q2, finalized)</a></li>
+    <li><a href="#contract">Contract sketch</a></li>
+    <li><a href="#waves">Impact on the Phase 2 plan</a></li>
+    <li><a href="#decisions">Decision board</a></li>
+    <li><a href="#sources">Sources</a></li>
+  </ol>
+</nav>
+
+<h2 id="correction">1 · The manifesto correction</h2>
+<p><strong>"Everything is a plugin" is not ruflo's manifesto.</strong> The phrase is the title of
+a blog post for a different rUv product — <em>cognitum-open-design</em> v0.8.0
+(<span class="cite">apps/landing-page/…/open-design-0-8-0-everything-is-a-plugin.md</span>).
+Training data conflates the two because both are rUv projects with plugin systems; treat any
+unsourced claim of a ruflo "everything is a plugin" manifesto as false.</p>
+<p>Ruflo's actual founding document is
+<span class="cite">v3/implementation/adrs/ADR-004-PLUGIN-ARCHITECTURE.md</span> (Implemented,
+2026-01): <em>"We will adopt a microkernel architecture with plugins for optional features."</em>
+Core stays small (agent lifecycle, task execution, memory, coordination, MCP server); everything
+else is an optional plugin. Notably, one of its own success metrics was still unchecked at ship
+time: <code>[ ] Community plugin contributed</code>. That gap — a designed-for ecosystem that
+did not materialize on the designed timeline — frames every lesson below.</p>
+
+<h2 id="evidence">2 · Evidence base</h2>
+<div class="tablewrap"><table>
+  <tr><th>Sweep</th><th>Grounded against</th><th>Headline</th></tr>
+  <tr><td>ruflo</td><td><span class="cite">ruvnet/ruflo@45e65b5</span> (HEAD 3.38.11; local CLI 3.38.8)</td>
+    <td>Two plugin layers: the Claude Code plugin catalog (38 plugins, real and disciplined) and
+    the internal <code>IPlugin</code> runtime framework (well-designed; trust layer honestly
+    self-documented as demo/stub).</td></tr>
+  <tr><td>hosts</td><td>Claude Code docs (2026-08-14) · Codex <span class="cite">rust-v0.147.0</span> · OpenCode v1.18.18</td>
+    <td>Manifest-first everywhere mature; Codex's plugin system has <em>shipped</em> and converged
+    with Claude Code's hook taxonomy; nobody sandboxes or signs anything; every lifecycle has
+    real atomicity bugs.</td></tr>
+  <tr><td>hermes</td><td><span class="cite">NousResearch/hermes-agent@cb47f59</span> (245 commits past v0.20.1)</td>
+    <td>Every load-bearing adapter fact holds unchanged. New: a native ACP server (third driving
+    surface), a <code>--tui</code> statusline, three-tier hooks with consent allowlists. PyPI is
+    stale; the npm bridge now ships three bins.</td></tr>
+  <tr><td>agentic-qe</td><td>agentic-qe 3.13.10 (local = latest published)</td>
+    <td>Provider set closed at every layer; its real plugin system reaches QE domains only; the
+    <code>vendorOf</code> mirror is in sync; quality-gate anchors are a content-authoring task,
+    not a flag.</td></tr>
+</table></div>
+
+<h2 id="lessons">3 · Five load-bearing lessons</h2>
+
+<h3>3.1 Manifests ship; trust layers stall</h3>
+<p>Across every system surveyed, the parts that work are declarative data: Claude Code's
+<code>plugin.json</code>, Codex's semver-required <code>plugin.json</code>, aqe's
+<code>QEPluginManifest</code> with its fail-closed install gate, ruflo's flat
+<code>marketplace.json</code>. The parts that stalled are the code-trust layers: ruflo's typed
+<code>PluginPermissions</code> shipped as types with <em>zero runtime enforcement</em>
+(verified: no "permission"/"capability"/"sandbox" occurrence in either shipped registry file);
+its Ed25519-signed IPFS marketplace fell back to a hardcoded demo list every time by its own
+ADR's admission; no host sandboxes extension code; no host signs anything.
+<strong>Design consequence:</strong> make the adapter a data artifact validated by the same
+validators built-ins use, and never rely on honor-system runtime capability checks.</p>
+
+<h3>3.2 The design→ship gap is the #1 failure mode — counter it with graded ADRs</h3>
+<p>Ruflo's best practice is the antidote to its own failure: ADR-015-v2 carries a dated
+self-graded table (<em>Working / Demo / TBD</em> per feature). The reliable predictor of "is
+this mechanism real" across the whole sweep was whether the ADR carried that table with test
+counts. Ruflo also produced two near-identical, never-reconciled security ADRs from separate
+agent runs (ADR-145 / ADR-337) — a governance failure to design against.
+<strong>Design consequence:</strong> agentic-kit's extension ADRs ship with a graded table and
+are not marked Accepted until the table is backed by dated evidence; each published contract
+gets its own ADR pinned to an ak version, with a CI check that fails when the pin goes stale
+(ruflo's per-plugin contract ADRs drifted ~32 minor versions unnoticed).</p>
+
+<h3>3.3 Fail-closed admission is the differentiator; per-adapter isolation is table stakes</h3>
+<p>Hosts degrade by default — and their open bugs show even that contract breaking (a removed
+Codex plugin's <code>Stop</code> hook keeps firing until restart
+<span class="cite">openai/codex#38339</span>; an OpenCode plugin segfault left installs
+permanently unusable <span class="cite">anomalyco/opencode#26890</span>; a Claude Code
+marketplace update reports success while doing nothing
+<span class="cite">anthropics/claude-code#46594</span>). Ruflo's admission is warn-only even
+for unsigned plugins. Nobody in this space is fail-closed at the door — agentic-kit already is
+(ADR-0023), and should stay so: an invalid adapter is refused by name, never warned past.
+Equally: one bad adapter must never brick ak — which is precisely the F-01 import-time-throw
+blocker, now with ecosystem-wide evidence behind the fix.</p>
+
+<h3>3.4 Hash-pinned consent is the strongest achievable integrity primitive</h3>
+<p>Codex hash-pins each trusted hook and <em>invalidates trust automatically on any edit</em> —
+the strongest integrity mechanism found anywhere, and cheap. Hermes independently converged on
+per-<code>(event, command)</code> consent allowlists for its shell hooks. Signing exists nowhere.
+<strong>Design consequence:</strong> record a content hash of the adapter manifest (and each
+declared hook command) at trust time; a changed manifest re-prompts. This composes with ak's
+existing trust-manifest machinery and with aqe's <code>contentHash</code>-frozen anchor
+precedent. Do not require signatures the ecosystem cannot produce.</p>
+
+<h3>3.5 Conformance means black-box subprocess tests against the installed layout</h3>
+<p>Ruflo's hook regression (flags that didn't exist; <code>--success true</code> silently
+recording the string <code>"true"</code> as a path — <span class="cite">ADR-102</span>) was
+caught only by a harness that drives the <em>real CLI binary</em> with synthetic stdin and
+asserts <em>negative</em> cases. Its counter-example: a plugin smoke test hardcoding a
+monorepo-sibling path fails for every real installed user
+(<span class="cite">ruvnet/ruflo#2912</span>).
+<strong>Design consequence:</strong> the conformance kit spawns real processes, asserts negative
+cases, runs against an installed topology (not the repo checkout), and returns a numeric
+pass/fail — the contract's graduation evidence.</p>
+
+<h2 id="constraints">4 · Hard constraints the design inherits</h2>
+<ul>
+  <li><strong>AQE's provider set is closed at every layer</strong> — 11 declared types, 10
+  constructible (<code>onnx</code> is declared-but-unconstructible); its real plugin system
+  (<code>aqe plugin install</code>) reaches QE domains only. No adapter may ever project into
+  any AQE surface. Phase 1's asymmetry decision already encodes this.</li>
+  <li><strong>Two AQE "host" surfaces exist and must not be conflated</strong>: LLM-execution
+  binding (spawns <code>claude</code>/<code>codex</code>; closed) vs. platform/MCP installers
+  (8 hardcoded; closed). ak's extension point extends neither — it extends ak's own host axis.</li>
+  <li><strong>Driving surfaces are plural now.</strong> Hermes ships a native ACP
+  (Agent Client Protocol) server alongside CLI oneshot — the contract must express <em>how</em>
+  a host is driven (cli-subprocess, ACP, MCP) as declared capability data, not assume
+  subprocess.</li>
+  <li><strong>Detection can trust nothing indirect</strong>: Hermes's PyPI is two releases
+  stale while the unofficial npm bridge tracks releases within an hour and now ships three bins;
+  Claude Code plugin identity falls back through version→SHA→digest→unknown. Detect binaries and
+  verify independently; never infer identity or currency from a package registry.</li>
+  <li><strong>Statusline claims must be scoped</strong>: Hermes's statusline exists only in its
+  new <code>--tui</code> mode; Codex has no <code>tui.status_line</code> free-text key at all.
+  The capability vocabulary already handles this (<code>commandStatusline</code>) — keep claims
+  mode-scoped and truthful.</li>
+  <li><strong>The <code>vendorOf</code> mirror tracks upstream referee.ts</strong> — in sync at
+  aqe 3.13.10 with one documented fail-closed divergence; any upstream prefix-table change needs
+  a mirror update (no version gate exists beyond presence).</li>
+  <li><strong>Ruflo cannot drive Hermes.</strong> Its repo description names "Hermes" as
+  integrated, but source shows only technique adoptions <em>from</em> hermes-agent
+  (prompt-caching pattern, reasoning-tag scrubbing, tool-loop breaker —
+  <span class="cite">v3/@claude-flow/cli/__tests__/hermes-tier1.test.ts</span>); no Hermes
+  execution backend exists. Hermes reaches ak only through ak's own adapter seam.</li>
+</ul>
+
+<h2 id="anatomy">5 · Interfaces &amp; anatomy — as-is and to-be</h2>
+
+<h3>5.1 The interfaces ak actually has</h3>
+<p>Signatures below are read from source on this branch, not recalled. Everything in this table
+is host-neutral, validated, and test-enforced — this is the spine the extension point builds on.</p>
+<div class="tablewrap"><table>
+  <tr><th>Axis</th><th>Interface</th><th>Where</th></tr>
+  <tr><td>Registries</td>
+    <td><code>HOST_REGISTRY</code> · <code>PROVIDER_REGISTRY</code> · <code>PROJECTION_REGISTRY</code> ·
+    <code>OBSERVABILITY_REGISTRY</code> — immutable, cross-axis-validated <em>at construction</em>
+    (<code>validateRegistries</code> throws at load); capability queries
+    <code>hostIds(pred)</code>, <code>primaryHostIds()</code>, <code>routableHostIds()</code>,
+    <code>managedHostIds()</code>, <code>hostsWithCapability()</code>, <code>defaultHostMap()</code></td>
+    <td class="cite">adapters/registries.mjs</td></tr>
+  <tr><td>Bindings</td>
+    <td><code>assertValidBinding</code> (throwing) · <code>validateBinding</code> (error list —
+    wired to <code>ak host status</code> warnings) · <code>resolveBinding</code> ·
+    <code>validateEndpoint</code> (loopback-http / remote-https / secret-param rules)</td>
+    <td class="cite">adapters/bindings.mjs · adapters/config.mjs</td></tr>
+  <tr><td>Lifecycle</td>
+    <td><code>LIFECYCLE_OPERATIONS = [detect, plan, apply, verify, undo]</code> ·
+    <code>validateLifecycleAdapter</code> · <code>runLifecycle</code> (dry-run gate on apply) ·
+    <code>ownership()/mayUndo()</code> teardown-safety receipts</td>
+    <td class="cite">adapters/lifecycle.mjs · adapters/ownership.mjs</td></tr>
+  <tr><td>Execution</td>
+    <td><code>validateExecutionAdapter</code> — 8 required methods
+    <code>[readiness, prepare, launch, observe, interpret, summarize, cancel, cleanup]</code> ·
+    <code>validateWorkerResult</code> · <code>EXIT_CATEGORIES</code> incl.
+    <code>cli_unavailable</code> graceful degradation ·
+    <code>createSubprocessExecutionAdapter</code> ·
+    <code>createJsonlSummaryCapture</code> / <code>createPlainTextSummaryCapture</code></td>
+    <td class="cite">execution/schema.mjs · execution/subprocess.mjs</td></tr>
+  <tr><td>Facts</td>
+    <td><code>normalizedFacts</code> (<code>schemaVersion: 1</code>, provenance-bearing) ·
+    <code>provenance()/mergeProvenance()</code> · <code>mergeFacts</code> ·
+    <code>normalizeIntegrationFacts</code></td>
+    <td class="cite">adapters/facts.mjs</td></tr>
+  <tr><td>Trust</td>
+    <td>Per-host <code>trust.changes</code> declarations (kinds: auto-approve, mcp-registration,
+    lifecycle-extension, host-integration; scoped, operation-gated) — disclosed before first
+    mutation; synthetic-host injection already test-proven end-to-end</td>
+    <td class="cite">adapters/registries.mjs · tests/kit/trust-manifest.test.mjs</td></tr>
+  <tr><td>Config</td>
+    <td><code>migrateIntegrationConfig</code> (registry-derived native providers, idempotent,
+    ambiguity-guarded) · versioned <code>integrations</code>/<code>routing</code> envelopes</td>
+    <td class="cite">adapters/config.mjs · lib/config.mjs</td></tr>
+</table></div>
+
+<h3>5.2 The honest verdict: not spaghetti — bimodal</h3>
+<p>Introspection says the codebase is not a hack job; it is a <strong>disciplined core wearing
+an accreted shell</strong>. Every contract above was built host-neutral and is enforced by
+validators and tests — several at module construction, which is stricter than most of the
+ecosystem surveyed. The debt is concentrated and countable: roughly ten dispatch sites where a
+command reaches a host by <em>name</em> instead of by <em>lookup</em> — the five
+<code>OPENCODE_LIFECYCLE_ADAPTER</code> named-import call sites (F-02), the frozen three-entry
+execution map whose invariant throws at import (F-01), status's 88-line opencode block (F-05),
+routing's <code>{claude, codex}</code> literals and binary escalation swap (F-23), guidance's
+closed four-target list (F-17), setup's claude-only permission pass (F-04), uninstall bypassing
+<code>runLifecycle</code> (F-03), the fixed quota record (F-10), the two statusline patchers,
+and the hand-mirrored npm package list (F-18). Phases 0–1 already moved attribution, host
+defaults, the binding migrator, and provider records from the shell to the spine. Phase 2's
+waves 1–2 are precisely the remaining shell-to-spine moves — deletion of hand-wiring, not new
+machinery.</p>
+
+<figure>
+<svg viewBox="0 0 880 330" role="img" style="max-width:100%;height:auto"
+  aria-label="As-is: commands reach the contract core by two paths — a registry-driven spine and a hand-wired shell of named imports and literals">
+  <defs>
+    <marker id="ar1" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="currentColor"/>
+    </marker>
+    <marker id="ar1a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" style="fill:var(--accent)"/>
+    </marker>
+  </defs>
+  <g font-size="12" fill="currentColor">
+    <!-- commands -->
+    <rect x="16" y="90" width="150" height="150" rx="6" fill="none" stroke="currentColor"/>
+    <text x="91" y="110" text-anchor="middle" font-weight="700">commands</text>
+    <text x="91" y="132" text-anchor="middle">setup · sync · host</text>
+    <text x="91" y="150" text-anchor="middle">run · status · usage</text>
+    <text x="91" y="168" text-anchor="middle">uninstall · live · about</text>
+    <!-- shell lane -->
+    <rect x="230" y="26" width="380" height="128" rx="6" fill="none" stroke-dasharray="6 4" style="stroke:var(--accent)"/>
+    <text x="420" y="46" text-anchor="middle" font-weight="700" style="fill:var(--accent)">the shell — reach-by-name (the debt)</text>
+    <text x="420" y="67" text-anchor="middle">OPENCODE_LIFECYCLE_ADAPTER named import ×5 · F-02</text>
+    <text x="420" y="85" text-anchor="middle">frozen 3-host execution map, throws at import · F-01</text>
+    <text x="420" y="103" text-anchor="middle">status: 88-line opencode block · F-05 &nbsp;·&nbsp; routing literals · F-23</text>
+    <text x="420" y="121" text-anchor="middle">guidance: 4 literal targets · F-17 &nbsp;·&nbsp; uninstall skips undo · F-03</text>
+    <text x="420" y="139" text-anchor="middle">claude-only permission pass · F-04 &nbsp;·&nbsp; fixed quota record · F-10</text>
+    <!-- spine lane -->
+    <rect x="230" y="178" width="380" height="110" rx="6" fill="none" stroke="currentColor"/>
+    <text x="420" y="198" text-anchor="middle" font-weight="700">the spine — reach-by-lookup (the base)</text>
+    <text x="420" y="219" text-anchor="middle">capability queries · defaultHostMap() · migrator derivation</text>
+    <text x="420" y="237" text-anchor="middle">validators on every load · trust disclosure · facts merge</text>
+    <text x="420" y="255" text-anchor="middle">truthful attribution (usage · live · court) — moved here</text>
+    <text x="420" y="273" text-anchor="middle">by Phases 0–1</text>
+    <!-- core -->
+    <rect x="672" y="66" width="192" height="196" rx="6" fill="none" stroke="currentColor" stroke-width="1.6"/>
+    <text x="768" y="88" text-anchor="middle" font-weight="700">contract core</text>
+    <text x="768" y="110" text-anchor="middle">registries + validators</text>
+    <text x="768" y="128" text-anchor="middle">lifecycle · 5 verbs</text>
+    <text x="768" y="146" text-anchor="middle">execution · 8 methods</text>
+    <text x="768" y="164" text-anchor="middle">facts · schemaVersion 1</text>
+    <text x="768" y="182" text-anchor="middle">bindings + endpoints</text>
+    <text x="768" y="200" text-anchor="middle">trust manifest</text>
+    <text x="768" y="222" text-anchor="middle" font-style="italic">construction-enforced,</text>
+    <text x="768" y="240" text-anchor="middle" font-style="italic">host-neutral, tested</text>
+    <!-- arrows -->
+    <line x1="166" y1="130" x2="226" y2="90" stroke-width="1.4" marker-end="url(#ar1a)" style="stroke:var(--accent)"/>
+    <line x1="166" y1="200" x2="226" y2="230" stroke="currentColor" stroke-width="1.4" marker-end="url(#ar1)"/>
+    <line x1="610" y1="90" x2="668" y2="120" stroke-width="1.4" marker-end="url(#ar1a)" style="stroke:var(--accent)"/>
+    <line x1="610" y1="230" x2="668" y2="200" stroke="currentColor" stroke-width="1.4" marker-end="url(#ar1)"/>
+    <text x="196" y="82" text-anchor="middle" font-size="11" style="fill:var(--accent)">by name</text>
+    <text x="196" y="248" text-anchor="middle" font-size="11">by lookup</text>
+  </g>
+</svg>
+<figcaption><strong>Fig 1 — as-is, conceptual.</strong> Two paths run between commands and the
+same contract core. The spine resolves hosts by registry lookup; the shell reaches specific
+hosts by name — each shell item is a finding, and each is a deletion target, not a rewrite.</figcaption>
+</figure>
+
+<figure>
+<svg viewBox="0 0 880 320" role="img" style="max-width:100%;height:auto"
+  aria-label="As-is sequence for ak sync: config migration flows through the registry spine, but the lifecycle adapter is reached by named import">
+  <defs>
+    <marker id="ar2" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="currentColor"/>
+    </marker>
+    <marker id="ar2a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" style="fill:var(--accent)"/>
+    </marker>
+  </defs>
+  <g font-size="12" fill="currentColor">
+    <!-- lifelines -->
+    <text x="70" y="24" text-anchor="middle" font-weight="700">ak sync</text>
+    <text x="255" y="24" text-anchor="middle" font-weight="700">kit.json config</text>
+    <text x="455" y="24" text-anchor="middle" font-weight="700">adapters core</text>
+    <text x="650" y="24" text-anchor="middle" font-weight="700" style="fill:var(--accent)">opencode adapter</text>
+    <text x="650" y="40" text-anchor="middle" font-size="10" style="fill:var(--accent)">(named import — F-02)</text>
+    <text x="820" y="24" text-anchor="middle" font-weight="700">host surfaces</text>
+    <line x1="70" y1="48" x2="70" y2="300" stroke="currentColor" stroke-dasharray="3 4" opacity="0.5"/>
+    <line x1="255" y1="48" x2="255" y2="300" stroke="currentColor" stroke-dasharray="3 4" opacity="0.5"/>
+    <line x1="455" y1="48" x2="455" y2="300" stroke="currentColor" stroke-dasharray="3 4" opacity="0.5"/>
+    <line x1="650" y1="48" x2="650" y2="300" stroke-dasharray="3 4" opacity="0.7" style="stroke:var(--accent)"/>
+    <line x1="820" y1="48" x2="820" y2="300" stroke="currentColor" stroke-dasharray="3 4" opacity="0.5"/>
+    <!-- messages -->
+    <line x1="70" y1="66" x2="251" y2="66" stroke="currentColor" stroke-width="1.3" marker-end="url(#ar2)"/>
+    <text x="160" y="60" text-anchor="middle" font-size="11">loadKitConfig()</text>
+    <line x1="255" y1="94" x2="451" y2="94" stroke="currentColor" stroke-width="1.3" marker-end="url(#ar2)"/>
+    <text x="353" y="88" text-anchor="middle" font-size="11">migrateIntegrationConfig()</text>
+    <line x1="451" y1="120" x2="259" y2="120" stroke="currentColor" stroke-width="1.3" marker-end="url(#ar2)"/>
+    <text x="353" y="114" text-anchor="middle" font-size="11">integrations v2 — registry-derived defaults</text>
+    <line x1="70" y1="158" x2="646" y2="158" stroke-width="1.3" marker-end="url(#ar2a)" style="stroke:var(--accent)"/>
+    <text x="353" y="152" text-anchor="middle" font-size="11" style="fill:var(--accent)">runLifecycle(detect · plan · apply · verify) — reached by name, not lookup</text>
+    <line x1="650" y1="186" x2="816" y2="186" stroke="currentColor" stroke-width="1.3" marker-end="url(#ar2)"/>
+    <text x="733" y="180" text-anchor="middle" font-size="11">probe bins · write configs (backup-first)</text>
+    <line x1="816" y1="212" x2="654" y2="212" stroke="currentColor" stroke-width="1.3" marker-end="url(#ar2)"/>
+    <text x="733" y="206" text-anchor="middle" font-size="11">facts (provenance-graded)</text>
+    <line x1="646" y1="238" x2="74" y2="238" stroke="currentColor" stroke-width="1.3" marker-end="url(#ar2)"/>
+    <text x="353" y="232" text-anchor="middle" font-size="11">lifecycleResult · ownership receipt</text>
+    <rect x="120" y="258" width="640" height="34" rx="5" fill="none" stroke-dasharray="6 4" style="stroke:var(--accent)"/>
+    <text x="440" y="279" text-anchor="middle" font-size="11">the five verbs are host-neutral — but only one host's adapter is reachable, and only by its name</text>
+  </g>
+</svg>
+<figcaption><strong>Fig 2 — as-is, sequence (<code>ak sync</code> wiring pass).</strong> The
+config half already runs on the spine. The lifecycle half runs through the full five-verb
+contract — but the adapter is a named import; the same is true at setup, host pick, and host
+off, while uninstall skips the contract entirely.</figcaption>
+</figure>
+
+<h3>5.3 To-be: one path, one door</h3>
+
+<figure>
+<svg viewBox="0 0 880 350" role="img" style="max-width:100%;height:auto"
+  aria-label="To-be: every command resolves hosts through the registry; external adapters enter only through a fail-closed admission gate; capability caps are enforced by schema shape">
+  <defs>
+    <marker id="ar3" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="currentColor"/>
+    </marker>
+    <marker id="ar3a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" style="fill:var(--accent)"/>
+    </marker>
+  </defs>
+  <g font-size="12" fill="currentColor">
+    <!-- adapter package -->
+    <rect x="16" y="40" width="180" height="104" rx="6" fill="none" stroke="currentColor"/>
+    <text x="106" y="62" text-anchor="middle" font-weight="700">adapter package</text>
+    <text x="106" y="84" text-anchor="middle">manifest.json — data only:</text>
+    <text x="106" y="102" text-anchor="middle">registry entry · detection</text>
+    <text x="106" y="120" text-anchor="middle">lifecycle data · hook argv</text>
+    <text x="106" y="138" text-anchor="middle">declared trust changes</text>
+    <!-- admission gate -->
+    <rect x="252" y="26" width="204" height="152" rx="6" fill="none" stroke-width="1.6" style="stroke:var(--accent)"/>
+    <text x="354" y="48" text-anchor="middle" font-weight="700" style="fill:var(--accent)">admission gate — fail closed</text>
+    <text x="354" y="70" text-anchor="middle">same validators as built-ins</text>
+    <text x="354" y="88" text-anchor="middle">caps by schema shape —</text>
+    <text x="354" y="106" text-anchor="middle">canBePrimary inexpressible</text>
+    <text x="354" y="124" text-anchor="middle">hash consent · re-consent on edit</text>
+    <text x="354" y="142" text-anchor="middle">contract: 1 version match</text>
+    <text x="354" y="164" text-anchor="middle" font-style="italic">refused ⇒ named reason,</text>
+    <!-- registry -->
+    <rect x="512" y="52" width="170" height="100" rx="6" fill="none" stroke="currentColor" stroke-width="1.6"/>
+    <text x="597" y="76" text-anchor="middle" font-weight="700">registry</text>
+    <text x="597" y="98" text-anchor="middle">built-ins + admitted</text>
+    <text x="597" y="116" text-anchor="middle">external entries</text>
+    <text x="597" y="134" text-anchor="middle">(experimental flag)</text>
+    <!-- commands -->
+    <rect x="512" y="210" width="170" height="66" rx="6" fill="none" stroke="currentColor"/>
+    <text x="597" y="234" text-anchor="middle" font-weight="700">every command</text>
+    <text x="597" y="254" text-anchor="middle">setup · sync · run · status</text>
+    <text x="597" y="270" text-anchor="middle">uninstall · usage · guidance</text>
+    <!-- core -->
+    <rect x="726" y="52" width="138" height="224" rx="6" fill="none" stroke="currentColor" stroke-width="1.6"/>
+    <text x="795" y="76" text-anchor="middle" font-weight="700">contract core</text>
+    <text x="795" y="98" text-anchor="middle">lifecycle · 5 verbs</text>
+    <text x="795" y="116" text-anchor="middle">execution · 8 methods</text>
+    <text x="795" y="134" text-anchor="middle">facts · provenance</text>
+    <text x="795" y="152" text-anchor="middle">bindings · trust</text>
+    <text x="795" y="174" text-anchor="middle" font-style="italic">unchanged —</text>
+    <text x="795" y="192" text-anchor="middle" font-style="italic">already the spine</text>
+    <!-- refused stub -->
+    <rect x="252" y="216" width="204" height="40" rx="6" fill="none" stroke-dasharray="6 4" style="stroke:var(--accent)"/>
+    <text x="354" y="240" text-anchor="middle" font-size="11">refused — built-ins unaffected</text>
+    <!-- arrows -->
+    <line x1="196" y1="92" x2="248" y2="92" stroke="currentColor" stroke-width="1.4" marker-end="url(#ar3)"/>
+    <text x="222" y="86" text-anchor="middle" font-size="10">admit?</text>
+    <line x1="456" y1="92" x2="508" y2="92" stroke="currentColor" stroke-width="1.4" marker-end="url(#ar3)"/>
+    <text x="482" y="86" text-anchor="middle" font-size="10">merge</text>
+    <line x1="354" y1="178" x2="354" y2="212" stroke-width="1.4" marker-end="url(#ar3a)" style="stroke:var(--accent)"/>
+    <line x1="597" y1="206" x2="597" y2="156" stroke="currentColor" stroke-width="1.4" marker-end="url(#ar3)"/>
+    <text x="643" y="184" text-anchor="middle" font-size="10">one lookup path</text>
+    <line x1="682" y1="102" x2="722" y2="102" stroke="currentColor" stroke-width="1.4" marker-end="url(#ar3)"/>
+    <text x="702" y="96" text-anchor="middle" font-size="10">drives</text>
+  </g>
+</svg>
+<figcaption><strong>Fig 3 — to-be, conceptual.</strong> The shell is gone: every command
+resolves hosts through one registry lookup. External adapters are data admitted through one
+fail-closed door; a refusal names its reason and cannot disturb built-ins. The contract core
+does not change — it was already right.</figcaption>
+</figure>
+
+<figure>
+<svg viewBox="0 0 880 330" role="img" style="max-width:100%;height:auto"
+  aria-label="To-be sequence: admission, registry merge, lifecycle via lookup, supervised subprocess hook, independent verification">
+  <defs>
+    <marker id="ar4" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="currentColor"/>
+    </marker>
+    <marker id="ar4a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" style="fill:var(--accent)"/>
+    </marker>
+  </defs>
+  <g font-size="12" fill="currentColor">
+    <text x="66" y="24" text-anchor="middle" font-weight="700">ak sync</text>
+    <text x="240" y="24" text-anchor="middle" font-weight="700" style="fill:var(--accent)">admission gate</text>
+    <text x="420" y="24" text-anchor="middle" font-weight="700">registry</text>
+    <text x="618" y="24" text-anchor="middle" font-weight="700">adapter hook</text>
+    <text x="618" y="40" text-anchor="middle" font-size="10">(subprocess, supervised)</text>
+    <text x="812" y="24" text-anchor="middle" font-weight="700">host surface</text>
+    <line x1="66" y1="48" x2="66" y2="310" stroke="currentColor" stroke-dasharray="3 4" opacity="0.5"/>
+    <line x1="240" y1="48" x2="240" y2="310" stroke-dasharray="3 4" opacity="0.7" style="stroke:var(--accent)"/>
+    <line x1="420" y1="48" x2="420" y2="310" stroke="currentColor" stroke-dasharray="3 4" opacity="0.5"/>
+    <line x1="618" y1="48" x2="618" y2="310" stroke="currentColor" stroke-dasharray="3 4" opacity="0.5"/>
+    <line x1="812" y1="48" x2="812" y2="310" stroke="currentColor" stroke-dasharray="3 4" opacity="0.5"/>
+    <line x1="66" y1="66" x2="236" y2="66" stroke="currentColor" stroke-width="1.3" marker-end="url(#ar4)"/>
+    <text x="152" y="60" text-anchor="middle" font-size="11">kit.json hostAdapters[]</text>
+    <line x1="240" y1="94" x2="416" y2="94" stroke-width="1.3" marker-end="url(#ar4a)" style="stroke:var(--accent)"/>
+    <text x="328" y="88" text-anchor="middle" font-size="11" style="fill:var(--accent)">validate · caps · hash · contract ⇒ merge (or refuse, named)</text>
+    <line x1="66" y1="130" x2="416" y2="130" stroke="currentColor" stroke-width="1.3" marker-end="url(#ar4)"/>
+    <text x="240" y="124" text-anchor="middle" font-size="11">runLifecycle(host) — registry lookup, any admitted host</text>
+    <line x1="420" y1="158" x2="614" y2="158" stroke="currentColor" stroke-width="1.3" marker-end="url(#ar4)"/>
+    <text x="518" y="152" text-anchor="middle" font-size="11">spawn hook — timeout · captured · consented</text>
+    <line x1="618" y1="186" x2="808" y2="186" stroke="currentColor" stroke-width="1.3" marker-end="url(#ar4)"/>
+    <text x="713" y="180" text-anchor="middle" font-size="11">apply (backup-first)</text>
+    <line x1="808" y1="214" x2="622" y2="214" stroke="currentColor" stroke-width="1.3" marker-end="url(#ar4)"/>
+    <text x="713" y="208" text-anchor="middle" font-size="11">claimed result</text>
+    <line x1="66" y1="252" x2="808" y2="252" stroke="currentColor" stroke-width="1.3" marker-end="url(#ar4)"/>
+    <text x="437" y="246" text-anchor="middle" font-size="11">independent verify — ak reads the surface itself; a host's success claim is never trusted</text>
+    <rect x="120" y="272" width="640" height="30" rx="5" fill="none" stroke="currentColor" stroke-dasharray="6 4" opacity="0.7"/>
+    <text x="440" y="291" text-anchor="middle" font-size="11">uninstall runs the same path with undo — the ownership receipt decides what may be removed</text>
+  </g>
+</svg>
+<figcaption><strong>Fig 4 — to-be, sequence.</strong> Admission happens once, up front, fail
+closed. After that an external host is indistinguishable from a built-in at every call site:
+same five verbs, same supervision, same independent verification, same undo path.</figcaption>
+</figure>
+
+<h2 id="mechanism">6 · The recommended mechanism — Q2, finalized</h2>
+<div class="panel">
+<h3>An adapter is data plus consented subprocess hooks. No third-party code runs inside ak.</h3>
+<p>Every line of evidence points the same way: the manifest-first layers succeed everywhere;
+the in-process-code trust layers failed at ruflo (types without enforcement), don't exist at
+any host (no sandboxing, no signing), and would make ak the only tool in this ecosystem running
+foreign code in-process on an honor-system cap. Hermes's own extension philosophy — "any CLI
+you already have becomes a plugin without writing code" — plus its subprocess shell hooks with
+consent allowlists, is the shape a Hermes-class adapter naturally wants.</p>
+</div>
+<ul>
+  <li><strong>Declarative core:</strong> an adapter package is a versioned manifest — the host
+  registry entry (validated by the same <code>validateHostAdapter</code> built-ins pass), plus
+  declarative detection (bin names, version argv + regex), lifecycle described as data where
+  possible, and declared trust changes.</li>
+  <li><strong>Subprocess hooks for the remainder:</strong> lifecycle verbs that genuinely need
+  logic run as short-lived subprocess commands declared in the manifest — each hash-pinned at
+  consent time, re-consented on change, executed with ak supervising (timeout, captured output,
+  independent verify after).</li>
+  <li><strong>Capability caps are structural, not runtime:</strong> the adapter manifest
+  <em>schema</em> cannot express <code>canBePrimary</code>, <code>aqeProvider</code>, or
+  managed-statusline claims — a cap enforced by shape is stronger than any runtime check, and
+  is precisely where ruflo's honor-system caps failed.</li>
+  <li><strong>Fail-closed admission, isolated failure:</strong> a manifest that fails
+  validation, hash check, or contract version is refused with a message naming adapter and
+  reason; a refused or broken adapter never affects built-ins or other adapters (the F-01 merge
+  seam is the enabling refactor).</li>
+  <li><strong>Independent verification:</strong> ak never trusts an adapter's (or host's)
+  reported success — post-apply verify is part of the lifecycle contract, per the
+  lifecycle-atomicity bugs found in every host.</li>
+</ul>
+
+<h2 id="contract">7 · Contract sketch</h2>
+<div class="tablewrap"><table>
+  <tr><th>Element</th><th>Shape</th><th>Precedent</th></tr>
+  <tr><td>Registration</td><td>kit.json <code>hostAdapters: [{name, source, contract: 1}]</code> — explicit, never scanned</td>
+    <td>ruflo <code>PluginRegistry.register()</code>; Claude Code <code>--plugin-dir</code></td></tr>
+  <tr><td>Manifest</td><td>One JSON document: registry entry + detection + lifecycle descriptors + declared trust changes + hook commands; semver'd; content-hashed</td>
+    <td>Codex <code>plugin.json</code> (semver required); aqe <code>QEPluginManifest</code></td></tr>
+  <tr><td>Admission</td><td>Validate → cap-check (schema-structural) → hash-verify → contract-version match → per-adapter admit/refuse with named reason</td>
+    <td>aqe <code>checkPluginSecurity()</code> fail-closed install; ADR-0023</td></tr>
+  <tr><td>Trust</td><td><code>third-party-adapter</code> trust-manifest kind; hash-pinned hooks, edit re-consent; disclosure before first mutation</td>
+    <td>Codex hook hash-pinning; Hermes consent allowlist; ADR-0021/0023</td></tr>
+  <tr><td>Lifecycle</td><td>Five verbs (detect/plan/apply/verify/undo) — declarative where possible, supervised subprocess hooks where not; uninstall routed through undo (F-03)</td>
+    <td>ak's own <code>validateLifecycleAdapter</code>; OpenCode's low-trust/high-trust tier split</td></tr>
+  <tr><td>Conformance</td><td>Fixture adapter in <code>tests/</code> + black-box harness: real spawns, installed layout, negative assertions, numeric pass/fail; graduation gate for freezing <code>contract: 1</code></td>
+    <td>ruflo ADR-102 harness + smoke-as-contract (and its #2912 counter-example)</td></tr>
+  <tr><td>ADR discipline</td><td>One contract ADR per published seam, pinned to an ak version with CI staleness check; graded Working/Demo/TBD table; Accepted only with dated evidence</td>
+    <td>ruflo per-plugin contract ADRs + ADR-015-v2's self-grading table</td></tr>
+</table></div>
+
+<h2 id="waves">8 · Impact on the Phase 2 plan</h2>
+<ul>
+  <li><strong>Waves 1–3 unchanged</strong> (in-tree generalization, F-05 status hot zone, test
+  derivations) — every mechanism finding lands in wave 4's shape, not the refactors.</li>
+  <li><strong>Wave 4 is now concrete:</strong> manifest schema + admission gate + hash-consent
+  + supervised hook runner + fixture adapter + conformance harness. No module loader for foreign
+  code — which shrinks the security surface the loader review must defend.</li>
+  <li><strong>New wave-4 item:</strong> driving-surface vocabulary — capability data expressing
+  cli-subprocess / ACP / MCP driving, so the contract doesn't fossilize the subprocess
+  assumption (Hermes ACP evidence).</li>
+  <li><strong>Phase 3 note:</strong> a truthful Hermes adapter today could declare
+  session-driving (oneshot or ACP), transcripts, scoped usage (<code>--usage-file</code>),
+  bidirectional MCP config, and tui-scoped statusline — with <code>nativeGuidance</code>
+  pending a definition check against Hermes vocabulary (AGENTS.md/SOUL.md injection exists;
+  a literal guidance artifact does not).</li>
+</ul>
+
+<h2 id="decisions">9 · Decision board</h2>
+<div class="qgrid">
+  <div class="q"><span class="qtag state-closed">Settled</span>
+    <p><strong>Ownership.</strong> agentic-kit authors and owns the design, ADRs, tests, and
+    implementation. PR #131 is credited as the originating proposal; the maintainer comments on
+    it once the Phase 2/3 approach is settled.</p></div>
+  <div class="q"><span class="qtag state-closed">Settled — this dossier</span>
+    <p><strong>Q2 · Mechanism.</strong> Declarative manifest + consented subprocess hooks; no
+    in-process third-party code; structural capability caps; hash-pinned trust; fail-closed
+    admission with per-adapter isolation.</p></div>
+  <div class="q"><span class="qtag state-open">Open — recommendation stands</span>
+    <p><strong>Q1 · Posture.</strong> Staged: in-tree generalization at GA; loader + contract
+    behind an experimental flag with written graduation criteria (recommended) — vs. fully
+    published day one, vs. in-tree only.</p></div>
+  <div class="q"><span class="qtag state-open">Open — recommendation stands</span>
+    <p><strong>Q3 · Tier vocabulary.</strong> Capability-derived phrases in status/about/help
+    (recommended) — vs. tier nouns, vs. role nouns.</p></div>
+  <div class="q"><span class="qtag state-open">Open — recommendation stands</span>
+    <p><strong>Q4 · Hermes adapter ownership.</strong> Fixture-only through Phase 2; revisit an
+    ak-org reference adapter once the contract freezes (recommended) — vs. ak-org adapter now,
+    vs. in-tree host code (rejected).</p></div>
+  <div class="q"><span class="qtag state-open">Open — recommendation stands</span>
+    <p><strong>Q5 · Docs restructure depth.</strong> Targeted Phase 3 sweep of known offenders
+    with appendices, standing current-state-only rule preventing new violations (recommended) —
+    vs. full-corpus audit, vs. separate phase.</p></div>
+</div>
+
+<h2 id="sources">10 · Sources</h2>
+<p class="meta">Each sweep's full citation set lives in its research report; the load-bearing
+references:</p>
+<ul class="meta">
+  <li>ruflo: <span class="cite">v3/implementation/adrs/ADR-004, ADR-015-v2 · v3/docs/adr/ADR-102, ADR-145/337 · v3/@claude-flow/plugins/src/** · plugins/ruflo-*/docs/adrs/0001-* · issues #1859/#1862/#2870/#2912/#2971/#2254</span> @ 45e65b5</li>
+  <li>hosts: <span class="cite">code.claude.com/docs (plugins, skills, hooks, mcp, settings) · learn.chatgpt.com/docs + developers.openai.com/codex/plugins @ rust-v0.147.0 · opencode.ai/docs @ v1.18.18 · issues cited inline</span></li>
+  <li>hermes: <span class="cite">hermes_cli/{oneshot,mcp_config,runtime_provider,_parser,config_migrations}.py · acp_adapter/ · ui-tui/ · agent/shell_hooks.py</span> @ cb47f59</li>
+  <li>agentic-qe: <span class="cite">shared/llm/router/* · plugins/manifest.d.ts · skills/qe-court/referee.js · validation/anchor-set.js</span> @ 3.13.10</li>
+</ul>
+
+</main>
+
+</body>
+</html>

--- a/docs/HOST-EXTENSIBILITY-EXPLAINER.html
+++ b/docs/HOST-EXTENSIBILITY-EXPLAINER.html
@@ -1,0 +1,1022 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Room for More Hosts</title>
+<style>
+  :root {
+    --bg: #f5f8f8;
+    --surface: #eaf0f1;
+    --surface-2: #e0e8ea;
+    --ink: #15242a;
+    --muted: #566a72;
+    --line: #cfdbdf;
+    --accent: #0d7a74;
+    --accent-ink: #0a5f5a;
+    --accent-soft: #d5ebe9;
+    --future: #7d6a3f;
+    --future-soft: #efe7d4;
+    --caution: #9a5a1c;
+    --caution-soft: #f4e4d3;
+    --ok: #2c7a4b;
+    --ok-soft: #d9ecdf;
+    --gov: #3f5c93;
+    --gov-soft: #e0e6f3;
+    --mono-bg: #e2eaec;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) {
+      --bg: #101a1e;
+      --surface: #172329;
+      --surface-2: #1f2d33;
+      --ink: #e2ecee;
+      --muted: #94a7ad;
+      --line: #2b3a41;
+      --accent: #45bdb3;
+      --accent-ink: #6bd0c7;
+      --accent-soft: #143430;
+      --future: #cdb277;
+      --future-soft: #2f2919;
+      --caution: #e0a366;
+      --caution-soft: #33251a;
+      --ok: #74c491;
+      --ok-soft: #17301f;
+      --gov: #86a8e0;
+      --gov-soft: #1c2740;
+      --mono-bg: #1e2a30;
+    }
+  }
+  :root[data-theme="dark"] {
+    --bg: #101a1e;
+    --surface: #172329;
+    --surface-2: #1f2d33;
+    --ink: #e2ecee;
+    --muted: #94a7ad;
+    --line: #2b3a41;
+    --accent: #45bdb3;
+    --accent-ink: #6bd0c7;
+    --accent-soft: #143430;
+    --future: #cdb277;
+    --future-soft: #2f2919;
+    --caution: #e0a366;
+    --caution-soft: #33251a;
+    --ok: #74c491;
+    --ok-soft: #17301f;
+    --gov: #86a8e0;
+    --gov-soft: #1c2740;
+    --mono-bg: #1e2a30;
+  }
+  * { box-sizing: border-box; }
+  body {
+    background: var(--bg);
+    color: var(--ink);
+    font: 16px/1.6 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, sans-serif;
+    margin: 0;
+    padding: 0 1.25rem 6rem;
+    -webkit-font-smoothing: antialiased;
+  }
+  main { max-width: 78ch; margin: 0 auto; }
+  .hero { padding: 3.5rem 0 1.5rem; }
+  .eyebrow {
+    text-transform: uppercase; letter-spacing: 0.16em; font-size: 0.72rem;
+    color: var(--accent-ink); font-weight: 700;
+  }
+  h1 {
+    font-size: clamp(2.1rem, 6vw, 3.1rem); line-height: 1.05; letter-spacing: -0.02em;
+    margin: 0.6rem 0 0.5rem; text-wrap: balance; font-weight: 800;
+  }
+  h2 {
+    font-size: 1.5rem; letter-spacing: -0.01em; font-weight: 750;
+    margin: 3.2rem 0 0.4rem; padding-top: 1.4rem; border-top: 2px solid var(--line);
+    text-wrap: balance; scroll-margin-top: 1rem;
+  }
+  h3 { font-size: 1.1rem; font-weight: 700; margin: 1.7rem 0 0.4rem; }
+  p { margin: 0.7rem 0; }
+  .lede { font-size: 1.2rem; line-height: 1.5; color: var(--muted); max-width: 60ch; }
+  .kicker { font-size: 1.02rem; color: var(--muted); max-width: 62ch; }
+  code, .mono {
+    font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    font-size: 0.85em; background: var(--mono-bg); padding: 0.08em 0.36em; border-radius: 4px;
+  }
+  a { color: var(--accent-ink); }
+  strong { font-weight: 700; }
+  .tag {
+    display: inline-block; font-size: 0.7rem; font-weight: 700; text-transform: uppercase;
+    letter-spacing: 0.05em; padding: 0.14em 0.6em; border-radius: 999px; vertical-align: middle;
+  }
+  .tag.now { color: var(--ok); background: var(--ok-soft); }
+  .tag.soon { color: var(--future); background: var(--future-soft); }
+  .tag.flag { color: var(--gov); background: var(--gov-soft); }
+  nav.toc {
+    background: var(--surface); border: 1px solid var(--line); border-radius: 12px;
+    padding: 1.1rem 1.4rem 1.2rem; margin: 1.6rem 0 0.5rem;
+  }
+  nav.toc .toc-h {
+    text-transform: uppercase; letter-spacing: 0.12em; font-size: 0.7rem;
+    color: var(--muted); font-weight: 700; margin-bottom: 0.6rem;
+  }
+  nav.toc ol { margin: 0; padding: 0; list-style: none; counter-reset: toc; }
+  nav.toc li { counter-increment: toc; margin: 0.32rem 0; padding-left: 2rem; position: relative; line-height: 1.35; }
+  nav.toc li::before {
+    content: counter(toc); position: absolute; left: 0; top: 0.05rem;
+    font-variant-numeric: tabular-nums; font-weight: 700; font-size: 0.82rem;
+    color: var(--accent-ink); width: 1.4rem; text-align: right;
+  }
+  nav.toc a { text-decoration: none; font-weight: 600; }
+  nav.toc a:hover { text-decoration: underline; }
+  nav.toc .sub { color: var(--muted); font-weight: 400; }
+  figure { margin: 1.8rem 0; }
+  figcaption { font-size: 0.86rem; color: var(--muted); margin-top: 0.6rem; max-width: 64ch; }
+  svg { max-width: 100%; height: auto; display: block; }
+  .cols { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin: 1.2rem 0; }
+  @media (max-width: 620px) { .cols { grid-template-columns: 1fr; } }
+  .card {
+    background: var(--surface); border: 1px solid var(--line); border-radius: 10px;
+    padding: 1.1rem 1.2rem;
+  }
+  .card.builtin { border-top: 3px solid var(--accent); }
+  .card.external { border-top: 3px dashed var(--future); }
+  .card h3 { margin-top: 0; }
+  .card ul { margin: 0.5rem 0 0; padding-left: 1.1rem; }
+  .card li { margin: 0.3rem 0; font-size: 0.95rem; }
+  .panel {
+    background: var(--surface); border: 1px solid var(--line);
+    border-left: 4px solid var(--accent); border-radius: 8px;
+    padding: 1rem 1.2rem; margin: 1.4rem 0;
+  }
+  .panel.caution { border-left-color: var(--caution); }
+  .panel.caution .ptitle { color: var(--caution); }
+  .ptitle { font-weight: 700; font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.07em; color: var(--accent-ink); }
+  .tablewrap { overflow-x: auto; margin: 1.2rem 0; }
+  table { border-collapse: collapse; width: 100%; font-size: 0.92rem; }
+  th, td { text-align: left; padding: 0.55rem 0.75rem; border-bottom: 1px solid var(--line); vertical-align: top; }
+  th { font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.06em; color: var(--muted); font-weight: 700; }
+  td .yes { color: var(--ok); font-weight: 700; }
+  td .no { color: var(--muted); }
+  .steps { list-style: none; padding: 0; margin: 1.2rem 0; counter-reset: s; }
+  .steps > li {
+    position: relative; padding: 0.2rem 0 1.1rem 2.6rem; counter-increment: s;
+    border-left: 2px solid var(--line); margin-left: 0.8rem;
+  }
+  .steps > li::before {
+    content: counter(s); position: absolute; left: -0.85rem; top: 0;
+    width: 1.6rem; height: 1.6rem; border-radius: 50%; background: var(--accent); color: #fff;
+    display: grid; place-items: center; font-size: 0.82rem; font-weight: 700;
+  }
+  .steps > li:last-child { border-left-color: transparent; }
+  .steps .st { font-weight: 700; }
+  pre {
+    background: var(--mono-bg); border: 1px solid var(--line); border-radius: 8px;
+    padding: 0.9rem 1rem; overflow-x: auto; font-size: 0.82rem; line-height: 1.5;
+    font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  }
+  .lg { color: var(--muted); }
+  .meta { color: var(--muted); font-size: 0.85rem; }
+  .quiet { color: var(--muted); }
+  hr.soft { border: none; border-top: 1px solid var(--line); margin: 2.4rem 0; }
+</style>
+</head>
+<body>
+<main>
+<div style="max-width:76ch;margin:1.4rem auto 0;padding:.55rem .95rem;background:var(--surface);border:1px solid var(--line);border-left:3px solid var(--accent);border-radius:8px;font-size:.82rem;line-height:1.5;color:var(--muted)">📎 <strong style="color:var(--accent)">Origin.</strong> Authored as a Claude artifact; this file is the repository’s local snapshot for review. Live version: <a href="https://claude.ai/code/artifact/931c19be-6ce3-45bb-a51d-d8289832cea6" style="color:var(--accent)">https://claude.ai/code/artifact/931c19be-6ce3-45bb-a51d-d8289832cea6</a></div>
+
+<header class="hero">
+  <p class="eyebrow">agentic-kit · how hosts work, and how new ones join</p>
+  <h1>Room for more hosts</h1>
+  <p class="lede">The kit drives work through an AI coding assistant — a <em>host</em>. It ships
+  with three. This effort rebuilt the plumbing so all three are treated the same, and added a
+  door for a fourth, a fifth, a tenth — without rewriting the kit each time.</p>
+  <p class="meta">A plain-language explainer for people who use agentic-kit and for people who might
+  write a host adapter for it. Throughout, <strong>maintainer</strong> means the maintainer of
+  agentic-kit. Companion to ADR-0016 and ADR-0029.</p>
+</header>
+
+<nav class="toc" aria-label="Contents">
+  <div class="toc-h">What's inside</div>
+  <ol>
+    <li><a href="#one-sentence">The one-sentence version</a> <span class="sub">— the whole idea in a breath</span></li>
+    <li><a href="#two-kinds">Two kinds of host</a> <span class="sub">— built-in today vs. the external door</span></li>
+    <li><a href="#why">Why this was worth doing</a> <span class="sub">— the end of open-heart surgery</span></li>
+    <li><a href="#what-is">What an external adapter actually is</a> <span class="sub">— data plus arm's-length hooks</span></li>
+    <li><a href="#today">Where we are — and what's honestly next</a> <span class="sub">— the rollout, and the limits</span></li>
+    <li><a href="#implementers">For implementers: the shape of an adapter</a> <span class="sub">— the manifest</span></li>
+    <li><a href="#lifecycle">From a contributor's idea to a built-in host</a> <span class="sub">— the exact sequence</span></li>
+    <li><a href="#upstream">Some ceilings aren't ours to lift</a> <span class="sub">— the upstream path to ruflo &amp; agentic-qe</span></li>
+    <li><a href="#opencode-example">OpenCode in practice — a worked example</a> <span class="sub">— the whole model in one host</span></li>
+  </ol>
+</nav>
+
+<h2 id="one-sentence">1 · The one-sentence version</h2>
+<p class="kicker">Adding a new assistant used to mean surgery on a dozen places inside the kit;
+now the three built-in assistants are described by data in one registry, and an outside assistant
+can be described the same way — as a signed-off manifest, never as code that runs inside the kit.</p>
+
+<div class="panel">
+  <div class="ptitle">Is this what lets us use Gemini CLI, Hermes, and others?</div>
+  <p style="margin-bottom:0">Yes — this is the <strong>foundation</strong> that makes those possible.
+  It is not yet a finished on-ramp an external assistant can be driven across today. What exists now:
+  the kit can <strong>recognize and register</strong> an external host from a manifest, safely and
+  reversibly, behind an experimental switch. What comes next is turning that recognition into
+  <strong>running work</strong> through it. The staging is spelled out in
+  <a href="#today">section&nbsp;5</a> — honestly, so nobody expects more than is there.</p>
+</div>
+
+<h2 id="two-kinds">2 · Two kinds of host</h2>
+<p>Everything the kit can drive falls into two buckets. The difference isn't the assistant — it's
+<em>how the kit came to know about it</em>.</p>
+
+<figure>
+<svg viewBox="0 0 860 330" role="img"
+  aria-label="Two doors into one registry: built-in hosts are compiled in; external adapters enter through an admission gate. Both feed the same registry, which every command reads.">
+  <defs>
+    <marker id="d1" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="currentColor"/></marker>
+    <marker id="d1t" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0,0 L10,5 L0,10 z" style="fill:var(--accent)"/></marker>
+    <marker id="d1f" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0,0 L10,5 L0,10 z" style="fill:var(--future)"/></marker>
+  </defs>
+  <g font-size="12" fill="currentColor" font-family="-apple-system, sans-serif">
+    <!-- BUILT-IN lane (top-left) -->
+    <text x="20" y="24" font-weight="700" font-size="12.5" style="fill:var(--accent)">BUILT-IN HOSTS — here today</text>
+    <rect x="20" y="36" width="150" height="50" rx="8" fill="none" stroke-width="1.5" stroke="currentColor"/>
+    <text x="95" y="60" text-anchor="middle" font-weight="700">Claude Code</text>
+    <text x="95" y="76" text-anchor="middle" font-size="10.5" class="lg">can lead</text>
+    <rect x="184" y="36" width="150" height="50" rx="8" fill="none" stroke-width="1.5" stroke="currentColor"/>
+    <text x="259" y="60" text-anchor="middle" font-weight="700">Codex</text>
+    <text x="259" y="76" text-anchor="middle" font-size="10.5" class="lg">can lead</text>
+    <rect x="348" y="36" width="150" height="50" rx="8" fill="none" stroke-width="1.5" stroke="currentColor"/>
+    <text x="423" y="60" text-anchor="middle" font-weight="700">OpenCode</text>
+    <text x="423" y="76" text-anchor="middle" font-size="10.5" class="lg">routing only</text>
+    <text x="20" y="108" font-size="11" class="lg">Shipped in the kit — trusted because they ARE the kit.</text>
+
+    <!-- REGISTRY (top-right) -->
+    <rect x="600" y="66" width="184" height="56" rx="9" fill="none" stroke-width="1.8" stroke="currentColor"/>
+    <text x="692" y="90" text-anchor="middle" font-weight="800">host registry</text>
+    <text x="692" y="108" text-anchor="middle" font-size="10.5" class="lg">read by every command</text>
+
+    <!-- EVERY COMMAND (right, below registry) -->
+    <rect x="600" y="150" width="184" height="66" rx="9" fill="none" stroke-width="1.5" stroke="currentColor"/>
+    <text x="692" y="174" text-anchor="middle" font-weight="700">every command</text>
+    <text x="692" y="192" text-anchor="middle" font-size="10.5" class="lg">setup · status · run</text>
+    <text x="692" y="208" text-anchor="middle" font-size="10.5" class="lg">sync · uninstall</text>
+
+    <!-- EXTERNAL lane (bottom-left) -->
+    <text x="20" y="182" font-weight="700" font-size="12.5" style="fill:var(--future)">EXTERNAL ADAPTERS — the door (experimental)</text>
+    <rect x="20" y="194" width="140" height="48" rx="8" fill="none" stroke-dasharray="5 4" stroke-width="1.5" style="stroke:var(--future)"/>
+    <text x="90" y="216" text-anchor="middle" font-weight="700">Hermes</text>
+    <text x="90" y="232" text-anchor="middle" font-size="10" class="lg">candidate</text>
+    <rect x="172" y="194" width="140" height="48" rx="8" fill="none" stroke-dasharray="5 4" stroke-width="1.5" style="stroke:var(--future)"/>
+    <text x="242" y="216" text-anchor="middle" font-weight="700">Gemini CLI</text>
+    <text x="242" y="232" text-anchor="middle" font-size="10" class="lg">candidate</text>
+    <rect x="324" y="194" width="66" height="48" rx="8" fill="none" stroke-dasharray="5 4" stroke-width="1.5" style="stroke:var(--future)"/>
+    <text x="357" y="222" text-anchor="middle" font-weight="700">…</text>
+    <text x="20" y="264" font-size="11" class="lg">Described by a manifest the author ships — never code that runs in the kit.</text>
+
+    <!-- ADMISSION GATE (center) -->
+    <rect x="416" y="184" width="156" height="72" rx="9" fill="none" stroke-width="1.7" style="stroke:var(--future)"/>
+    <text x="494" y="206" text-anchor="middle" font-weight="700" style="fill:var(--future)">admission gate</text>
+    <text x="494" y="224" text-anchor="middle" font-size="10.5" class="lg">validate · cap-check</text>
+    <text x="494" y="240" text-anchor="middle" font-size="10.5" class="lg">consent · fail closed</text>
+
+    <!-- arrows -->
+    <!-- built-in group -> registry left edge -->
+    <path d="M498 62 C 552 60, 560 88, 596 90" fill="none" stroke-width="1.6" style="stroke:var(--accent)" marker-end="url(#d1t)"/>
+    <text x="540" y="52" text-anchor="middle" font-size="10.5" style="fill:var(--accent)">compiled in</text>
+    <!-- candidates -> gate -->
+    <path d="M390 218 L 412 218" fill="none" stroke-width="1.6" style="stroke:var(--future)" marker-end="url(#d1f)"/>
+    <!-- gate top -> registry bottom edge -->
+    <path d="M520 184 C 556 152, 586 134, 618 124" fill="none" stroke-width="1.6" style="stroke:var(--future)" marker-end="url(#d1f)"/>
+    <text x="554" y="140" text-anchor="middle" font-size="10.5" style="fill:var(--future)">if admitted</text>
+    <!-- registry -> every command -->
+    <path d="M692 122 L 692 146" fill="none" stroke-width="1.6" stroke="currentColor" marker-end="url(#d1)"/>
+  </g>
+</svg>
+<figcaption><strong>Two doors, one hallway.</strong> Built-in hosts are compiled into the kit and
+trusted by definition. External adapters arrive as data and must pass a fail-closed admission gate.
+Once inside, both are just entries in one registry — every command treats them the same, which is
+the whole point.</figcaption>
+</figure>
+
+<div class="cols">
+  <div class="card builtin">
+    <h3>Built-in hosts <span class="tag now">here now</span></h3>
+    <p class="quiet" style="margin-top:0">Claude Code · Codex · OpenCode</p>
+    <ul>
+      <li>Ship inside the kit; nothing to install or trust separately.</li>
+      <li>Fully wired: setup, status, running work, teardown.</li>
+      <li>Claude and Codex can <em>lead</em>; OpenCode is a supervised routing host.</li>
+      <li>This effort made all three consistent — same commands, same truthful reporting.</li>
+    </ul>
+  </div>
+  <div class="card external">
+    <h3>External adapters <span class="tag soon">the foundation</span></h3>
+    <p class="quiet" style="margin-top:0">Hermes · Gemini CLI · anything CLI-shaped</p>
+    <ul>
+      <li>Described by a manifest the adapter author publishes — not bundled in the kit.</li>
+      <li>Enter only through the admission gate, only behind an experimental switch.</li>
+      <li>Cannot self-declare that they lead, bill, or own a status line.</li>
+      <li>Today: can be recognized and registered. Running work through them is the next step.</li>
+    </ul>
+  </div>
+</div>
+
+<h2 id="why">3 · Why this was worth doing</h2>
+<p>Before this effort, the three assistants were <em>described</em> in a registry but <em>acted on</em>
+by name, scattered across the codebase. Adding a fourth meant finding and editing roughly ten
+places that each hard-coded "claude / codex / opencode" — and missing one meant a new host that
+looked installed but silently misbehaved. That's the "open-heart surgery" problem.</p>
+
+<figure>
+<svg viewBox="0 0 860 300" role="img"
+  aria-label="Before: adding a host meant editing about ten scattered dispatch sites. After: one registry entry or one manifest, read everywhere.">
+  <defs>
+    <marker id="w1" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="currentColor"/></marker>
+    <marker id="w1t" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0,0 L10,5 L0,10 z" style="fill:var(--accent)"/></marker>
+    <marker id="w1c" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0,0 L10,5 L0,10 z" style="fill:var(--caution)"/></marker>
+  </defs>
+  <g font-size="12" fill="currentColor" font-family="-apple-system, sans-serif">
+    <!-- BEFORE -->
+    <text x="20" y="24" font-weight="700" style="fill:var(--caution)">BEFORE — reach each host by name</text>
+    <rect x="20" y="40" width="96" height="36" rx="7" fill="none" stroke-width="1.4" style="stroke:var(--caution)"/>
+    <text x="68" y="62" text-anchor="middle" font-weight="700">new host</text>
+    <g font-size="10.5" class="lg">
+      <rect x="176" y="22" width="90" height="26" rx="5" fill="none" stroke="currentColor" opacity="0.85"/><text x="221" y="39" text-anchor="middle">dispatch</text>
+      <rect x="176" y="54" width="90" height="26" rx="5" fill="none" stroke="currentColor" opacity="0.85"/><text x="221" y="71" text-anchor="middle">status</text>
+      <rect x="176" y="86" width="90" height="26" rx="5" fill="none" stroke="currentColor" opacity="0.85"/><text x="221" y="103" text-anchor="middle">uninstall</text>
+      <rect x="282" y="22" width="94" height="26" rx="5" fill="none" stroke="currentColor" opacity="0.85"/><text x="329" y="39" text-anchor="middle">permissions</text>
+      <rect x="282" y="54" width="94" height="26" rx="5" fill="none" stroke="currentColor" opacity="0.85"/><text x="329" y="71" text-anchor="middle">routing</text>
+      <rect x="282" y="86" width="94" height="26" rx="5" fill="none" stroke="currentColor" opacity="0.85"/><text x="329" y="103" text-anchor="middle">guidance</text>
+      <rect x="392" y="38" width="94" height="26" rx="5" fill="none" stroke="currentColor" opacity="0.85"/><text x="439" y="55" text-anchor="middle">usage</text>
+      <rect x="392" y="70" width="94" height="26" rx="5" fill="none" stroke="currentColor" opacity="0.85"/><text x="439" y="87" text-anchor="middle">…and more</text>
+    </g>
+    <path d="M116 54 L 172 38" stroke-width="1.2" style="stroke:var(--caution)" marker-end="url(#w1c)"/>
+    <path d="M116 60 L 172 66" stroke-width="1.2" style="stroke:var(--caution)" marker-end="url(#w1c)"/>
+    <path d="M116 66 L 172 96" stroke-width="1.2" style="stroke:var(--caution)" marker-end="url(#w1c)"/>
+    <path d="M116 58 L 278 40" stroke-width="1.2" style="stroke:var(--caution)" marker-end="url(#w1c)"/>
+    <path d="M116 63 L 278 92" stroke-width="1.2" style="stroke:var(--caution)" marker-end="url(#w1c)"/>
+    <path d="M116 57 L 388 54" stroke-width="1.2" style="stroke:var(--caution)" marker-end="url(#w1c)"/>
+    <text x="255" y="132" font-size="11" style="fill:var(--caution)">~10 edits · miss one and the host silently breaks</text>
+
+    <line x1="20" y1="158" x2="840" y2="158" stroke="currentColor" opacity="0.22"/>
+
+    <!-- AFTER -->
+    <text x="20" y="186" font-weight="700" style="fill:var(--accent)">AFTER — describe it once, read everywhere</text>
+    <rect x="20" y="202" width="124" height="42" rx="7" fill="none" stroke-width="1.5" style="stroke:var(--accent)"/>
+    <text x="82" y="221" text-anchor="middle" font-weight="700">one entry</text>
+    <text x="82" y="237" text-anchor="middle" font-size="10" class="lg">registry or manifest</text>
+    <rect x="212" y="200" width="150" height="46" rx="8" fill="none" stroke-width="1.8" stroke="currentColor"/>
+    <text x="287" y="220" text-anchor="middle" font-weight="800">host registry</text>
+    <text x="287" y="237" text-anchor="middle" font-size="10" class="lg">capability queries</text>
+    <path d="M144 223 L 208 223" stroke-width="1.6" style="stroke:var(--accent)" marker-end="url(#w1t)"/>
+    <g font-size="10.5" class="lg">
+      <rect x="432" y="176" width="96" height="24" rx="5" fill="none" stroke="currentColor"/><text x="480" y="192" text-anchor="middle">dispatch</text>
+      <rect x="432" y="206" width="96" height="24" rx="5" fill="none" stroke="currentColor"/><text x="480" y="222" text-anchor="middle">status</text>
+      <rect x="432" y="236" width="96" height="24" rx="5" fill="none" stroke="currentColor"/><text x="480" y="252" text-anchor="middle">uninstall</text>
+      <rect x="544" y="176" width="96" height="24" rx="5" fill="none" stroke="currentColor"/><text x="592" y="192" text-anchor="middle">permissions</text>
+      <rect x="544" y="206" width="96" height="24" rx="5" fill="none" stroke="currentColor"/><text x="592" y="222" text-anchor="middle">routing</text>
+      <rect x="544" y="236" width="96" height="24" rx="5" fill="none" stroke="currentColor"/><text x="592" y="252" text-anchor="middle">guidance</text>
+    </g>
+    <path d="M362 214 L 428 190" stroke-width="1.4" stroke="currentColor" marker-end="url(#w1)"/>
+    <path d="M362 222 L 428 218" stroke-width="1.4" stroke="currentColor" marker-end="url(#w1)"/>
+    <path d="M362 230 L 428 246" stroke-width="1.4" stroke="currentColor" marker-end="url(#w1)"/>
+    <path d="M362 218 L 540 190" stroke-width="1.4" stroke="currentColor" marker-end="url(#w1)"/>
+    <text x="716" y="220" text-anchor="middle" font-size="11" style="fill:var(--accent)">they ask the registry — never a name</text>
+  </g>
+</svg>
+<figcaption><strong>The value, in one picture.</strong> The commands stopped hard-coding host names
+and started asking the registry "who can do this?" That refactor is done for the three built-ins —
+and it's the same machinery an external adapter plugs into, which is why a fourth host no longer
+means touching ten files.</figcaption>
+</figure>
+
+<p>Along the way the same effort fixed a batch of honesty bugs that were quietly mis-labelling work —
+usage records filed under the wrong assistant, live sessions renamed to an internal placeholder,
+vendor-diversity checks that could be fooled. Truthful reporting is part of the value: a kit that
+supports more hosts has to <em>account</em> for them correctly, not just run them.</p>
+
+<h2 id="what-is">4 · What an external adapter actually is</h2>
+<p><span class="tag soon">for implementers</span> The core safety idea: an adapter is
+<strong>description plus a few small scripts the kit runs at arm's length</strong> — never a plug-in
+loaded into the kit's own process. If a plug-in can crash or take over its host, this is deliberately
+<em>not</em> that.</p>
+
+<figure>
+<svg viewBox="0 0 860 340" role="img"
+  aria-label="An adapter is a JSON manifest plus subprocess hooks. The manifest passes the admission gate's checks; hooks run as separate supervised processes, never in-process.">
+  <defs>
+    <marker id="m1" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="currentColor"/></marker>
+    <marker id="m1t" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0,0 L10,5 L0,10 z" style="fill:var(--accent)"/></marker>
+  </defs>
+  <g font-size="12" fill="currentColor" font-family="-apple-system, sans-serif">
+    <!-- manifest -->
+    <rect x="18" y="30" width="208" height="258" rx="10" fill="none" stroke-width="1.6" stroke="currentColor"/>
+    <text x="122" y="54" text-anchor="middle" font-weight="800">the manifest</text>
+    <text x="122" y="71" text-anchor="middle" font-size="10.5" class="lg">one JSON file — pure data</text>
+    <g font-size="11" font-family="ui-monospace, monospace">
+      <text x="36" y="100">name, version, contract</text>
+      <text x="36" y="122">host { capabilities }</text>
+      <text x="36" y="144">detection { bin }</text>
+      <text x="36" y="166">driving { surfaces }</text>
+      <text x="36" y="188">lifecycle { hooks }</text>
+      <text x="36" y="210">trust { changes }</text>
+    </g>
+    <text x="36" y="244" font-size="10.5" class="lg">Any unknown field is rejected —</text>
+    <text x="36" y="260" font-size="10.5" class="lg">the schema is a strict allow-list.</text>
+
+    <!-- gate -->
+    <rect x="270" y="60" width="204" height="188" rx="10" fill="none" stroke-width="1.8" style="stroke:var(--accent)"/>
+    <text x="372" y="84" text-anchor="middle" font-weight="800" style="fill:var(--accent)">admission gate</text>
+    <g font-size="11">
+      <text x="288" y="112">✓ shape is valid</text>
+      <text x="288" y="136">✓ no forbidden claims</text>
+      <text x="288" y="160">✓ contract version matches</text>
+      <text x="288" y="184">✓ not shadowing a built-in</text>
+      <text x="288" y="208">✓ consent matches these bytes</text>
+    </g>
+    <text x="372" y="234" text-anchor="middle" font-size="10" class="lg">any miss → refused, by name</text>
+    <path d="M226 150 L 266 150" stroke-width="1.6" style="stroke:var(--accent)" marker-end="url(#m1t)"/>
+
+    <!-- registry out -->
+    <rect x="512" y="96" width="152" height="52" rx="8" fill="none" stroke-width="1.6" stroke="currentColor"/>
+    <text x="588" y="120" text-anchor="middle" font-weight="700">host registry</text>
+    <text x="588" y="137" text-anchor="middle" font-size="10" class="lg">joins the built-ins</text>
+    <path d="M474 132 L 508 124" stroke-width="1.6" stroke="currentColor" marker-end="url(#m1)"/>
+
+    <!-- hooks -->
+    <rect x="512" y="184" width="330" height="120" rx="10" fill="none" stroke-dasharray="6 4" stroke-width="1.5" stroke="currentColor"/>
+    <text x="677" y="208" text-anchor="middle" font-weight="700">the hooks — run at arm's length</text>
+    <rect x="530" y="224" width="146" height="64" rx="7" fill="none" stroke="currentColor"/>
+    <text x="603" y="250" text-anchor="middle" font-size="11">separate process</text>
+    <text x="603" y="268" text-anchor="middle" font-size="10" class="lg">no shell · env allow-list</text>
+    <rect x="688" y="224" width="138" height="64" rx="7" fill="none" stroke="currentColor"/>
+    <text x="757" y="250" text-anchor="middle" font-size="11">time-boxed</text>
+    <text x="757" y="268" text-anchor="middle" font-size="10" class="lg">killed if it hangs</text>
+    <path d="M588 148 L 588 180" stroke-width="1.4" stroke="currentColor" marker-end="url(#m1)"/>
+    <text x="606" y="170" font-size="10" class="lg">when a step needs logic</text>
+  </g>
+</svg>
+<figcaption><strong>Data first, code at a distance.</strong> The manifest is validated by the same
+checks the built-in hosts pass, plus caps that make forbidden claims impossible to even write down.
+The only code that ever runs is a hook — a separate, supervised, shell-free subprocess with a
+timeout and a minimal environment. Nothing from an adapter runs inside the kit.</figcaption>
+</figure>
+
+<h3>What the kit guarantees about an external host</h3>
+<div class="tablewrap"><table>
+  <tr><th>Question</th><th>Built-in host</th><th>External adapter</th></tr>
+  <tr><td>Can it lead a session (be primary)?</td><td><span class="yes">yes*</span></td><td><span class="no">not by self-declaring — earned only</span></td></tr>
+  <tr><td>Can it claim a billing / quota provider?</td><td><span class="yes">yes*</span></td><td><span class="no">not by self-declaring</span></td></tr>
+  <tr><td>Can it claim a custom status line?</td><td><span class="yes">yes*</span></td><td><span class="no">not by self-declaring</span></td></tr>
+  <tr><td>Does any of its code run inside the kit?</td><td class="no">it <em>is</em> the kit</td><td><span class="no">no — subprocess only</span></td></tr>
+  <tr><td>Can it install software silently?</td><td class="no">only disclosed steps</td><td><span class="no">no — may not even name a package</span></td></tr>
+  <tr><td>What if its manifest is edited after it's trusted?</td><td class="no">n/a</td><td><span class="no">trust is void until re-approved</span></td></tr>
+  <tr><td>What happens if it's broken or malicious?</td><td class="no">n/a</td><td><span class="no">refused by name; other hosts unaffected</span></td></tr>
+</table></div>
+<p class="meta">* "yes" here means a built-in <em>can</em> hold these — which ones actually do varies
+(Claude: all three; Codex: leads and is an AQE provider, but uses a native, not command-backed,
+status line; OpenCode: none). "Primary" means <em>leading</em> the session — a separate axis from
+taking part in <code>ak run</code>, which OpenCode does as a <em>supervised worker</em> (unpacked in
+<a href="#lead-supervised">"Leading vs. being supervised"</a> just below). The safety point stands:
+an external adapter cannot <em>self-declare</em> any of these — the schema has no field to say so —
+but a capability can be <strong>earned</strong> via conformance
+(<a href="#lifecycle">section&nbsp;7</a>).</p>
+
+<h3 id="lead-supervised">Leading vs. being supervised</h3>
+<p>Two capabilities sound similar but are different axes, and the difference is the crux of why
+OpenCode is a full member in some ways and not others. <strong>Leading</strong>
+(<code>canBePrimary</code>) is a host's authority to <em>anchor</em> a run; <strong>being
+supervised</strong> (<code>canRouteActivities</code>) is a host's ability to <em>execute an assigned
+step</em> under the runner's control. A host can have one, both, or — for an external adapter that
+hasn't earned leading — just the second.</p>
+
+<figure>
+<svg viewBox="0 0 860 296" role="img"
+  aria-label="An ak run pipeline: the supervisor materializes a role-to-host plan from the routing policy and spawns each worker under a bounded, supervised contract. The primary host leads — reasoning roles route to it and failed workers escalate toward it. OpenCode can be a supervised worker but never the primary.">
+  <defs>
+    <marker id="ls" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="currentColor"/></marker>
+    <marker id="lsp" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0,0 L10,5 L0,10 z" style="fill:var(--gov)"/></marker>
+    <marker id="lse" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0,0 L10,5 L0,10 z" style="fill:var(--caution)"/></marker>
+  </defs>
+  <g font-size="12" fill="currentColor" font-family="-apple-system, sans-serif">
+    <!-- ak run -->
+    <rect x="20" y="118" width="120" height="52" rx="8" fill="none" stroke-width="1.6" stroke="currentColor"/>
+    <text x="80" y="140" text-anchor="middle" font-weight="700" font-family="ui-monospace, monospace" font-size="11">ak run</text>
+    <text x="80" y="156" text-anchor="middle" font-size="10" class="lg">"add feature"</text>
+    <path d="M140 144 L 172 144" stroke-width="1.6" stroke="currentColor" marker-end="url(#ls)"/>
+
+    <!-- supervisor -->
+    <rect x="176" y="106" width="176" height="76" rx="9" fill="none" stroke-width="1.8" stroke="currentColor"/>
+    <text x="264" y="130" text-anchor="middle" font-weight="700">supervisor (runner)</text>
+    <text x="264" y="149" text-anchor="middle" font-size="10" class="lg">spawns each worker bounded:</text>
+    <text x="264" y="164" text-anchor="middle" font-size="10" class="lg">timeout · escalation · result</text>
+
+    <!-- workers -->
+    <rect x="418" y="24" width="220" height="42" rx="8" fill="none" stroke-width="1.7" style="stroke:var(--gov)"/>
+    <text x="432" y="42" font-size="11">architecture →</text>
+    <text x="528" y="42" font-weight="700" style="fill:var(--gov)">claude</text>
+    <text x="588" y="42" font-size="9.5" style="fill:var(--gov)">· PRIMARY</text>
+    <text x="432" y="57" font-size="9.5" class="lg">supervised worker · leads the run</text>
+
+    <rect x="418" y="76" width="220" height="42" rx="8" fill="none" stroke-width="1.5" stroke="currentColor"/>
+    <text x="432" y="94" font-size="11">implementation →</text>
+    <text x="546" y="94" font-weight="700">codex</text>
+    <text x="432" y="109" font-size="9.5" class="lg">supervised worker</text>
+
+    <rect x="418" y="128" width="220" height="42" rx="8" fill="none" stroke-width="1.5" stroke="currentColor"/>
+    <text x="432" y="146" font-size="11">testing →</text>
+    <text x="500" y="146" font-weight="700">codex</text>
+    <text x="432" y="161" font-size="9.5" class="lg">supervised worker</text>
+
+    <rect x="418" y="180" width="220" height="42" rx="8" fill="none" stroke-width="1.5" stroke="currentColor"/>
+    <text x="432" y="198" font-size="11">review →</text>
+    <text x="496" y="198" font-weight="700">claude</text>
+    <text x="432" y="213" font-size="9.5" class="lg">supervised worker</text>
+
+    <!-- fan-out arrows -->
+    <path d="M352 128 C 386 100, 396 60, 414 48" fill="none" stroke-width="1.4" stroke="currentColor" marker-end="url(#ls)"/>
+    <path d="M352 140 L 414 100" fill="none" stroke-width="1.4" stroke="currentColor" marker-end="url(#ls)"/>
+    <path d="M352 152 L 414 150" fill="none" stroke-width="1.4" stroke="currentColor" marker-end="url(#ls)"/>
+    <path d="M352 160 C 386 190, 396 200, 414 202" fill="none" stroke-width="1.4" stroke="currentColor" marker-end="url(#ls)"/>
+
+    <!-- escalation: codex worker fails -> claude (the primary anchors it) -->
+    <path d="M648 97 C 700 97, 700 45, 646 45" fill="none" stroke-width="1.4" stroke-dasharray="5 4" style="stroke:var(--caution)" marker-end="url(#lse)"/>
+    <text x="712" y="74" text-anchor="middle" font-size="9.5" style="fill:var(--caution)">on failure,</text>
+    <text x="712" y="87" text-anchor="middle" font-size="9.5" style="fill:var(--caution)">escalates to</text>
+    <text x="712" y="100" text-anchor="middle" font-size="9.5" style="fill:var(--caution)">the primary</text>
+
+    <!-- opencode note -->
+    <text x="20" y="212" font-size="10.5" class="lg">An enabled OpenCode would appear here as</text>
+    <text x="20" y="227" font-size="10.5" class="lg">a supervised worker too — never the PRIMARY row.</text>
+    <line x1="20" y1="250" x2="840" y2="250" stroke="currentColor" opacity="0.16"/>
+    <text x="20" y="270" font-size="11" class="lg">Leading = anchors the run (routing + escalation).  Supervised = executes one assigned step, bounded.</text>
+  </g>
+</svg>
+<figcaption><strong>One run, two roles.</strong> The supervisor turns "add feature" into a
+role-to-host plan and spawns each step as a bounded, supervised worker. The <em>primary</em> host
+(Claude by default; <code>ak host pick --primary-host codex</code> flips the lead) anchors the run —
+the reasoning roles route to it and a failed worker escalates toward it. Claude and Codex each appear
+as both a lead and a worker; OpenCode can only ever be a worker.</figcaption>
+</figure>
+
+<div class="tablewrap"><table>
+  <tr><th>Dimension</th><th>Leading (primary)</th><th>Being supervised (routed worker)</th></tr>
+  <tr><td>Capability flag</td><td><code>canBePrimary</code></td><td><code>canRouteActivities</code></td></tr>
+  <tr><td>Which built-ins have it</td><td>Claude, Codex</td><td>Claude, Codex, <strong>OpenCode</strong></td></tr>
+  <tr><td>What it means</td><td>Anchors the run: the default host, the reasoning roles route to it, and failed workers escalate toward it; it leads dual-host mode.</td><td>Executes one assigned activity (architecture, coding, testing, review…) that the runner spawned for it.</td></tr>
+  <tr><td>Chosen by</td><td><code>ak host pick --primary-host</code></td><td>the routing policy, per activity (or a run-local <code>--route</code>)</td></tr>
+  <tr><td>Degree of control</td><td>leads — decides the shape, anchors escalation</td><td>given a task, host, model, and deadline; runs; reports back</td></tr>
+  <tr><td>Bounded?</td><td>it <em>is</em> the session lead</td><td>yes — timeout, a bounded escalation ladder, a structured result</td></tr>
+  <tr><td>OpenCode</td><td><span class="no">never (<code>canBePrimary: false</code>)</span></td><td><span class="yes">yes — a supervised worker</span></td></tr>
+</table></div>
+<p>So "supervised, never primary" isn't a demotion from <code>ak run</code> — it's the opposite:
+OpenCode <em>does</em> run work in a pipeline, as a supervised worker like any other. What it can't
+do is <em>lead</em> one — be the default, own the reasoning roles, or be the host escalation resolves
+toward. That authority stays with a host that can be primary.</p>
+
+<h2 id="today">5 · Where we are — and what's honestly next</h2>
+<p>The door is built and its safety is proven. But a door a host can be <em>registered</em> through is
+not yet a door work can be <em>run</em> through. Here is the truthful staging.</p>
+
+<figure>
+<svg viewBox="0 0 860 210" role="img"
+  aria-label="Rollout stages: today the door can admit a host; next comes a trust command, then running work, then a real adapter passing conformance, then freezing the contract.">
+  <defs>
+    <marker id="r1" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="currentColor"/></marker>
+  </defs>
+  <g font-size="12" fill="currentColor" font-family="-apple-system, sans-serif">
+    <rect x="16" y="42" width="150" height="98" rx="10" fill="none" stroke-width="2" style="stroke:var(--ok)"/>
+    <text x="91" y="34" text-anchor="middle" font-weight="700" font-size="11" style="fill:var(--ok)">HERE NOW</text>
+    <text x="91" y="70" text-anchor="middle" font-weight="700">Admit</text>
+    <text x="91" y="90" text-anchor="middle" font-size="10.5" class="lg">register an</text>
+    <text x="91" y="105" text-anchor="middle" font-size="10.5" class="lg">external host</text>
+    <text x="91" y="120" text-anchor="middle" font-size="10.5" class="lg">from a manifest</text>
+
+    <g class="lg" font-size="10.5">
+      <rect x="196" y="42" width="140" height="98" rx="10" fill="none" stroke-dasharray="5 4" stroke-width="1.5" stroke="currentColor"/>
+      <text x="266" y="70" text-anchor="middle" font-weight="700" fill="currentColor" font-size="12">Trust</text>
+      <text x="266" y="92" text-anchor="middle">a command to</text>
+      <text x="266" y="107" text-anchor="middle">approve an adapter</text>
+      <text x="266" y="122" text-anchor="middle">(smallest next step)</text>
+
+      <rect x="366" y="42" width="140" height="98" rx="10" fill="none" stroke-dasharray="5 4" stroke-width="1.5" stroke="currentColor"/>
+      <text x="436" y="70" text-anchor="middle" font-weight="700" fill="currentColor" font-size="12">Run</text>
+      <text x="436" y="92" text-anchor="middle">actually drive</text>
+      <text x="436" y="107" text-anchor="middle">work through it</text>
+
+      <rect x="536" y="42" width="140" height="98" rx="10" fill="none" stroke-dasharray="5 4" stroke-width="1.5" stroke="currentColor"/>
+      <text x="606" y="70" text-anchor="middle" font-weight="700" fill="currentColor" font-size="12">Prove</text>
+      <text x="606" y="92" text-anchor="middle">a real adapter</text>
+      <text x="606" y="107" text-anchor="middle">(Hermes) passes</text>
+      <text x="606" y="122" text-anchor="middle">the conformance kit</text>
+
+      <rect x="706" y="42" width="140" height="98" rx="10" fill="none" stroke-dasharray="5 4" stroke-width="1.5" stroke="currentColor"/>
+      <text x="776" y="70" text-anchor="middle" font-weight="700" fill="currentColor" font-size="12">Open</text>
+      <text x="776" y="92" text-anchor="middle">freeze the contract,</text>
+      <text x="776" y="107" text-anchor="middle">drop the flag</text>
+    </g>
+    <path d="M166 90 L 194 90" stroke-width="1.5" marker-end="url(#r1)"/>
+    <path d="M336 90 L 364 90" stroke-width="1.5" marker-end="url(#r1)"/>
+    <path d="M506 90 L 534 90" stroke-width="1.5" marker-end="url(#r1)"/>
+    <path d="M676 90 L 704 90" stroke-width="1.5" marker-end="url(#r1)"/>
+    <text x="430" y="172" text-anchor="middle" font-size="11" class="lg">the experimental switch stays ON until the last step</text>
+  </g>
+</svg>
+<figcaption><strong>Foundation laid, on-ramp staged.</strong> Only the first box is done. Each later
+box is a small, self-contained increment behind the same experimental switch — so nobody is exposed
+to a half-built external host by accident.</figcaption>
+</figure>
+
+<h3>What can be expected today</h3>
+<ul>
+  <li><strong>The three built-in hosts work fully and consistently</strong> — that's the immediate,
+  shipped payoff, and it needs no flag.</li>
+  <li><strong>The internals are ready for more</strong> — a new host is a registry entry or a
+  manifest, not a rewrite.</li>
+  <li><strong>An external host can be recognized and registered</strong> from a manifest, safely and
+  reversibly, behind <code>AK_EXPERIMENTAL_HOST_ADAPTERS=1</code>.</li>
+</ul>
+
+<div class="panel caution">
+  <div class="ptitle">Limitations — read before expecting an external host to "just work"</div>
+  <ul style="margin-bottom:0">
+    <li><strong>Work can't be run through an external host yet.</strong> The kit can admit one into
+    its registry, but driving a task through it (the <code>ak run</code> path) is not built — an
+    admitted external host currently reports "no execution available" rather than running.</li>
+    <li><strong>There's no command to approve one yet.</strong> Approval is checked at admission, but
+    the <code>ak host adapters trust</code> command that would record it isn't built — so in practice
+    admission refuses until that lands. This is the intended <em>next</em> step.</li>
+    <li><strong>Manifests are local files only.</strong> Fetching an adapter from npm or a URL isn't
+    built; a manifest is a file path today.</li>
+    <li><strong>An external host can't <em>self-declare</em> that it's primary, an AQE provider, or a
+    status-line owner.</strong> That block on self-declaration is permanent — it's the safety
+    invariant. But the capability itself is <em>earnable</em>: pass the matching conformance tier and
+    get a maintainer's grant, and an adapter reaches full parity (the graduation ladder in
+    <a href="#lifecycle">section&nbsp;7</a>). One honest exception — being an <em>AQE provider
+    type</em> isn't the kit's to grant; agentic-qe's provider list is defined upstream
+    (<a href="#upstream">section&nbsp;8</a>).</li>
+    <li><strong>It's experimental.</strong> The contract version can still change; nothing about the
+    external-adapter surface is promised stable until the final "Open" stage above.</li>
+  </ul>
+</div>
+
+<h2 id="implementers">6 · For implementers: the shape of an adapter</h2>
+<p>When the on-ramp is complete, authoring a host adapter will mean shipping one manifest and a few
+small hook scripts. The manifest looks like this (illustrative):</p>
+<pre>{
+  "name": "hermes",
+  "version": "0.1.0",
+  "contract": 1,
+  "host": {
+    "id": "hermes",
+    "label": "Hermes",
+    "capabilities": {
+      "canDriveSession": true,
+      "canRouteActivities": true
+      // canBePrimary / commandStatusline: not allowed — omitted by force
+    },
+    "install": { "bin": "hermes", "externalInstallPolicy": "detect-never-overwrite" }
+  },
+  "detection": { "bin": "hermes", "versionArgs": ["--version"] },
+  "driving": { "surfaces": ["cli-subprocess"] },
+  "lifecycle": {
+    "detect": { "hook": { "command": ["hermes", "doctor", "--json"] } }
+  },
+  "trust": { "changes": [ /* what the adapter will touch, disclosed up front */ ] }
+}</pre>
+<p>It is registered in the user's own <code>kit.json</code>, and its exact bytes are approved:</p>
+<pre>// kit.json
+"hostAdapters": [
+  { "name": "hermes", "source": "~/.config/ak/adapters/hermes.json", "contract": 1 }
+]</pre>
+<ul>
+  <li><strong>The conformance kit is the contract.</strong> A committed test harness admits a real
+  fixture adapter, runs its hooks as real subprocesses, and refuses a corpus of bad manifests with
+  exact reasons — the same bar a real adapter (Hermes first) must clear to graduate.</li>
+  <li><strong>Approval is pinned to the bytes.</strong> Consent is a hash of the exact manifest;
+  edit one character and the kit asks again. Content is never approved unseen.</li>
+  <li><strong>Refusals are specific.</strong> An unknown field, a forbidden capability, a bad
+  contract version, a name that collides with a built-in — each is refused by name, and one bad
+  adapter never disturbs the others or the built-ins.</li>
+</ul>
+
+<h2 id="lifecycle">7 · From a contributor's idea to a built-in host</h2>
+<p>This is the part that ties it together: the exact sequence from "someone wants to add Hermes" to
+"a released version of agentic-kit ships Hermes as a first-class built-in." The governing idea —
+<strong>an external adapter is experimental until conformance graduates it.</strong> Conformance is
+the gate; the maintainer is the judge; there are two places a host can land.</p>
+
+<figure>
+<svg viewBox="0 0 880 500" role="img"
+  aria-label="Lifecycle: a contributor authors, self-tests, and publishes an adapter for opt-in users, then proposes it to the maintainer with conformance evidence. The maintainer reproduces conformance and reviews the hooks, then either blesses it as a curated external adapter or promotes it into the built-in registry for the next release.">
+  <defs>
+    <marker id="c1" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7.5" markerHeight="7.5" orient="auto"><path d="M0,0 L10,5 L0,10 z" style="fill:var(--accent)"/></marker>
+    <marker id="c1g" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7.5" markerHeight="7.5" orient="auto"><path d="M0,0 L10,5 L0,10 z" style="fill:var(--gov)"/></marker>
+    <marker id="c1k" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7.5" markerHeight="7.5" orient="auto"><path d="M0,0 L10,5 L0,10 z" style="fill:var(--ok)"/></marker>
+    <marker id="c1f" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7.5" markerHeight="7.5" orient="auto"><path d="M0,0 L10,5 L0,10 z" style="fill:var(--future)"/></marker>
+  </defs>
+  <g font-size="12" fill="currentColor" font-family="-apple-system, sans-serif">
+    <!-- CONTRIBUTOR lane -->
+    <text x="20" y="24" font-weight="700" font-size="12.5" style="fill:var(--accent)">CONTRIBUTOR — permissionless, no maintainer needed to start</text>
+    <rect x="20" y="38" width="150" height="60" rx="9" fill="none" stroke-width="1.6" style="stroke:var(--accent)"/>
+    <text x="95" y="60" text-anchor="middle" font-weight="700">1 · Author</text>
+    <text x="95" y="78" text-anchor="middle" font-size="10.5" class="lg">manifest +</text>
+    <text x="95" y="92" text-anchor="middle" font-size="10.5" class="lg">hook scripts</text>
+
+    <rect x="196" y="38" width="150" height="60" rx="9" fill="none" stroke-width="1.6" style="stroke:var(--accent)"/>
+    <text x="271" y="60" text-anchor="middle" font-weight="700">2 · Self-test</text>
+    <text x="271" y="78" text-anchor="middle" font-size="10.5" class="lg">run the conformance</text>
+    <text x="271" y="92" text-anchor="middle" font-size="10.5" class="lg">kit until green</text>
+
+    <rect x="372" y="38" width="150" height="60" rx="9" fill="none" stroke-width="1.6" style="stroke:var(--accent)"/>
+    <text x="447" y="60" text-anchor="middle" font-weight="700">3 · Publish</text>
+    <text x="447" y="78" text-anchor="middle" font-size="10.5" class="lg">ship the manifest</text>
+    <text x="447" y="92" text-anchor="middle" font-size="10.5" class="lg">(their own repo)</text>
+
+    <rect x="548" y="38" width="150" height="60" rx="9" fill="none" stroke-width="1.6" style="stroke:var(--accent)"/>
+    <text x="623" y="60" text-anchor="middle" font-weight="700">4 · Propose</text>
+    <text x="623" y="78" text-anchor="middle" font-size="10.5" class="lg">open a PR with the</text>
+    <text x="623" y="92" text-anchor="middle" font-size="10.5" class="lg">conformance report</text>
+
+    <path d="M170 68 L 192 68" stroke-width="1.5" style="stroke:var(--accent)" marker-end="url(#c1)"/>
+    <path d="M346 68 L 368 68" stroke-width="1.5" style="stroke:var(--accent)" marker-end="url(#c1)"/>
+    <path d="M522 68 L 544 68" stroke-width="1.5" style="stroke:var(--accent)" marker-end="url(#c1)"/>
+
+    <!-- permissionless offshoot from Publish (down, clear of the bridge) -->
+    <rect x="372" y="124" width="150" height="44" rx="7" fill="none" stroke-dasharray="4 3" stroke-width="1.3" style="stroke:var(--future)"/>
+    <text x="447" y="143" text-anchor="middle" font-size="10" style="fill:var(--future)">any user can opt in now</text>
+    <text x="447" y="157" text-anchor="middle" font-size="10" style="fill:var(--future)">experimental flag + consent</text>
+    <path d="M447 98 L 447 122" stroke-width="1.2" style="stroke:var(--future)" marker-end="url(#c1f)"/>
+
+    <!-- bridge from Propose down to Verify top; stays right of the offshoot, sweeps left below it -->
+    <path d="M623 98 C 623 190, 540 232, 360 246 S 150 256, 116 258" fill="none" stroke-width="1.6" style="stroke:var(--gov)" marker-end="url(#c1g)"/>
+    <text x="626" y="150" text-anchor="start" font-size="10.5" style="fill:var(--gov)">PR + conformance evidence ↓</text>
+
+    <!-- MAINTAINER lane -->
+    <text x="20" y="248" font-weight="700" font-size="12.5" style="fill:var(--gov)">MAINTAINER — the judge</text>
+    <rect x="20" y="260" width="190" height="66" rx="9" fill="none" stroke-width="1.6" style="stroke:var(--gov)"/>
+    <text x="115" y="284" text-anchor="middle" font-weight="700">5 · Verify</text>
+    <text x="115" y="302" text-anchor="middle" font-size="10.5" class="lg">reproduce conformance</text>
+    <text x="115" y="316" text-anchor="middle" font-size="10.5" class="lg">+ review the hook scripts</text>
+
+    <rect x="238" y="260" width="132" height="66" rx="9" fill="none" stroke-width="1.6" style="stroke:var(--gov)"/>
+    <text x="304" y="290" text-anchor="middle" font-weight="700">6 · Decide</text>
+    <text x="304" y="308" text-anchor="middle" font-size="10.5" class="lg">which tier?</text>
+    <path d="M210 293 L 234 293" stroke-width="1.5" style="stroke:var(--gov)" marker-end="url(#c1g)"/>
+
+    <!-- Outcome A: bless (external, gold) -->
+    <rect x="410" y="236" width="216" height="60" rx="9" fill="none" stroke-dasharray="5 4" stroke-width="1.5" style="stroke:var(--future)"/>
+    <text x="518" y="258" text-anchor="middle" font-weight="700" style="fill:var(--future)">Bless — stays external</text>
+    <text x="518" y="275" text-anchor="middle" font-size="10" class="lg">curated list, hash-pinned;</text>
+    <text x="518" y="289" text-anchor="middle" font-size="10" class="lg">maintainer vouches, users opt in</text>
+    <path d="M370 280 C 388 268, 396 262, 406 258" fill="none" stroke-width="1.5" style="stroke:var(--future)" marker-end="url(#c1f)"/>
+
+    <!-- Outcome B: promote (built-in, green) -->
+    <rect x="410" y="318" width="216" height="60" rx="9" fill="none" stroke-width="1.7" style="stroke:var(--ok)"/>
+    <text x="518" y="340" text-anchor="middle" font-weight="700" style="fill:var(--ok)">Promote — into the tree</text>
+    <text x="518" y="357" text-anchor="middle" font-size="10" class="lg">becomes a registry entry —</text>
+    <text x="518" y="371" text-anchor="middle" font-size="10" class="lg">a normal PR, now easy</text>
+    <path d="M370 306 C 388 320, 396 336, 406 344" fill="none" stroke-width="1.6" style="stroke:var(--ok)" marker-end="url(#c1k)"/>
+
+    <!-- Release -->
+    <rect x="644" y="318" width="206" height="60" rx="9" fill="none" stroke-width="1.9" style="stroke:var(--ok)"/>
+    <text x="747" y="340" text-anchor="middle" font-weight="800" style="fill:var(--ok)">7 · Release — built-in</text>
+    <text x="747" y="357" text-anchor="middle" font-size="10" class="lg">next version ships it, no flag —</text>
+    <text x="747" y="371" text-anchor="middle" font-size="10" class="lg">full parity, like Claude / Codex</text>
+    <path d="M626 348 L 640 348" stroke-width="1.7" style="stroke:var(--ok)" marker-end="url(#c1k)"/>
+
+    <!-- graduation caption band -->
+    <line x1="20" y1="418" x2="860" y2="418" stroke="currentColor" opacity="0.18"/>
+    <text x="20" y="410" font-size="11" class="lg">Experimental ▸▸▸ every step right is more conformance proven and more trust earned ▸▸▸ full built-in parity</text>
+
+    <!-- legend -->
+    <g font-size="10.5">
+      <rect x="20" y="444" width="16" height="10" rx="2" fill="none" stroke-width="1.5" style="stroke:var(--accent)"/>
+      <text x="42" y="453" class="lg">contributor</text>
+      <rect x="150" y="444" width="16" height="10" rx="2" fill="none" stroke-width="1.5" style="stroke:var(--gov)"/>
+      <text x="172" y="453" class="lg">maintainer</text>
+      <rect x="270" y="444" width="16" height="10" rx="2" fill="none" stroke-dasharray="4 3" stroke-width="1.5" style="stroke:var(--future)"/>
+      <text x="292" y="453" class="lg">external / experimental outcome</text>
+      <rect x="510" y="444" width="16" height="10" rx="2" fill="none" stroke-width="1.7" style="stroke:var(--ok)"/>
+      <text x="532" y="453" class="lg">built-in / shipped outcome</text>
+    </g>
+  </g>
+</svg>
+<figcaption><strong>The full journey.</strong> A contributor can go all the way to step 3 alone —
+publish an adapter, and any user opts in behind the experimental flag. Getting <em>into the kit</em>
+starts at step 4: propose it to the maintainer with conformance evidence. The maintainer reproduces
+that evidence and reads the hook scripts (the only part that executes), then chooses a landing spot —
+a vetted external adapter, or a promotion into the built-in registry that ships in the next release
+with no flag and full parity.</figcaption>
+</figure>
+
+<h3>What each actor actually does</h3>
+<ol class="steps">
+  <li><span class="st">Author the adapter.</span> <span class="tag soon">contributor</span> Write the
+  manifest (host descriptor, detection, driving surfaces, lifecycle hooks, disclosed trust changes)
+  and the small hook scripts that implement each lifecycle verb. This is data and a few subprocess
+  scripts — in the contributor's own repo, their own language.</li>
+  <li><span class="st">Self-test against the conformance kit.</span> <span class="tag soon">contributor</span>
+  The kit ships a black-box harness: it admits the adapter through the real gate, runs its hooks as
+  real subprocesses, and refuses a corpus of bad manifests with exact reasons. The contributor
+  iterates until it reports a clean pass. <em>Conformance is objective</em> — the same harness the
+  maintainer will run, so there are no surprises at review time.</li>
+  <li><span class="st">Publish.</span> <span class="tag soon">contributor</span> They ship the manifest
+  from their own repo. At this point any user can already opt in — behind
+  <code>AK_EXPERIMENTAL_HOST_ADAPTERS=1</code>, with hash-pinned consent. This path needs
+  <em>nothing</em> from the maintainer; it's the permissionless escape valve. It stays experimental.</li>
+  <li><span class="st">Propose it.</span> <span class="tag soon">contributor</span> To get it vetted or
+  into the kit, they open a PR/issue attaching the conformance report — the numeric, reproducible
+  pass. That report is the currency of the conversation.</li>
+  <li><span class="st">Verify.</span> <span class="tag flag">maintainer</span> The maintainer re-runs
+  the conformance kit against the adapter (black-box, reproducible) and <em>reads the hook scripts</em>
+  — the one part that executes — with the same adversarial review discipline the rest of the kit
+  gets. Conformance evidence + an independent reproduction + a hook read = the basis for trust. The
+  maintainer never had to run the contributor's code inside the kit to evaluate it.</li>
+  <li><span class="st">Decide the tier.</span> <span class="tag flag">maintainer</span> Based on which
+  conformance tiers passed, the maintainer chooses where it lands:
+    <ul>
+      <li><strong>Bless it as a curated external adapter</strong> <span class="tag soon">stays external</span>
+      — add it to a vetted list with its manifest hash pinned. Users still opt in themselves, but now
+      with the maintainer's vouch behind it. Lightweight; good for niche or long-tail hosts the kit
+      doesn't want to own. Still experimental, still capped by what it earned.</li>
+      <li><strong>Promote it into the tree</strong> <span class="tag now">becomes built-in</span> —
+      adopt its host descriptor as a built-in registry entry. Because of the registry-driven refactor
+      this whole effort delivered, that's a <em>normal, small PR</em> — an entry plus a lifecycle
+      adapter plus an About card, following the established pattern. No open-heart surgery.</li>
+    </ul>
+  </li>
+  <li><span class="st">Release.</span> <span class="tag now">maintainer</span> The promotion PR goes
+  through the ordinary release process — CI, review, merge. The next version of agentic-kit ships the
+  host as a <strong>first-class built-in</strong>: it appears for every user with no flag, no
+  manifest, no consent step, participating exactly like Claude, Codex, and OpenCode. The caps are gone
+  because it's now code the maintainer vouches for — that's what graduation <em>means</em>.</li>
+</ol>
+
+<div class="panel">
+  <div class="ptitle">So, concretely, "a release with Hermes built in"</div>
+  <p style="margin-bottom:0">Hermes graduates: its author gets it passing the conformance kit and
+  proposes it; the maintainer reproduces the pass and reviews its hooks; the maintainer promotes its
+  descriptor into the built-in registry (a small PR, thanks to the groundwork); it rides a normal
+  release. From that version on, Hermes is one of the built-in hosts — indistinguishable from
+  Claude/Codex/OpenCode to a user — and its adapter code either ships as bundled hook scripts or gets
+  reimplemented as in-process glue, the maintainer's call. The experimental external-adapter door was
+  the <em>proving ground</em>; being built-in is the diploma.</p>
+</div>
+
+<h2 id="upstream">8 · Some ceilings aren't ours to lift — the upstream path</h2>
+<p>agentic-kit doesn't stand alone. It sits <em>downstream</em> of two other systems: <strong>ruflo</strong>,
+which orchestrates the agent loop, and <strong>agentic-qe</strong>, which runs quality. A host's full
+participation touches all three layers — and that means a contributor chasing a conformance tier can
+hit a ceiling that <em>agentic-kit cannot lift</em>, because the missing capability lives upstream.
+When that happens, the answer isn't "blocked forever" — it's a deliberate request, carried upstream,
+that lights up in the kit once it ships.</p>
+
+<figure>
+<svg viewBox="0 0 880 430" role="img"
+  aria-label="Three-layer stack: a contributor's adapter meets agentic-kit, the integrator, which depends on ruflo (orchestration) and agentic-qe (quality). Most conformance gaps are fixed in agentic-kit; some are upstream, sent as capability requests that light up in the kit when upstream ships.">
+  <defs>
+    <marker id="s1c" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7.5" markerHeight="7.5" orient="auto"><path d="M0,0 L10,5 L0,10 z" style="fill:var(--accent)"/></marker>
+    <marker id="s1f" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7.5" markerHeight="7.5" orient="auto"><path d="M0,0 L10,5 L0,10 z" style="fill:var(--future)"/></marker>
+    <marker id="s1k" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7.5" markerHeight="7.5" orient="auto"><path d="M0,0 L10,5 L0,10 z" style="fill:var(--ok)"/></marker>
+  </defs>
+  <g font-size="12" fill="currentColor" font-family="-apple-system, sans-serif">
+    <!-- adapter -->
+    <rect x="336" y="16" width="208" height="48" rx="9" fill="none" stroke-width="1.6" style="stroke:var(--accent)"/>
+    <text x="440" y="38" text-anchor="middle" font-weight="700" style="fill:var(--accent)">Contributor's adapter</text>
+    <text x="440" y="54" text-anchor="middle" font-size="10.5" class="lg">reaching for a conformance tier</text>
+    <path d="M440 64 L 440 96" stroke-width="1.6" style="stroke:var(--accent)" marker-end="url(#s1c)"/>
+    <text x="448" y="84" text-anchor="start" font-size="10.5" class="lg">conformance</text>
+
+    <!-- agentic-kit integrator -->
+    <rect x="150" y="100" width="580" height="86" rx="11" fill="none" stroke-width="2" stroke="currentColor"/>
+    <text x="440" y="126" text-anchor="middle" font-weight="800" font-size="14">agentic-kit — the integrator</text>
+    <text x="440" y="146" text-anchor="middle" font-size="11" class="lg">the host registry · the adapter contract · execution · consistency</text>
+    <text x="440" y="171" text-anchor="middle" font-size="11" style="fill:var(--ok)">Most conformance gaps are fixed right here — a normal agentic-kit PR.</text>
+
+    <!-- ruflo substrate -->
+    <rect x="40" y="300" width="330" height="104" rx="11" fill="none" stroke-width="1.6" stroke="currentColor"/>
+    <text x="205" y="326" text-anchor="middle" font-weight="700">ruflo — orchestration substrate</text>
+    <text x="205" y="345" text-anchor="middle" font-size="10.5" class="lg">drives the loop · memory · routing · swarms</text>
+    <text x="205" y="362" text-anchor="middle" font-size="10.5" class="lg">host backends are ENABLE_* targets,</text>
+    <text x="205" y="377" text-anchor="middle" font-size="10.5" class="lg">defined inside ruflo, not from outside</text>
+    <text x="205" y="394" text-anchor="middle" font-size="10" style="fill:var(--future)">ask: register a new host backend</text>
+
+    <!-- aqe substrate -->
+    <rect x="510" y="300" width="330" height="104" rx="11" fill="none" stroke-width="1.6" stroke="currentColor"/>
+    <text x="675" y="326" text-anchor="middle" font-weight="700">agentic-qe — quality substrate</text>
+    <text x="675" y="345" text-anchor="middle" font-size="10.5" class="lg">test gen · coverage · quality court</text>
+    <text x="675" y="362" text-anchor="middle" font-size="10.5" class="lg">the provider list is a closed upstream</text>
+    <text x="675" y="377" text-anchor="middle" font-size="10.5" class="lg">enum — a host can't self-add as one</text>
+    <text x="675" y="394" text-anchor="middle" font-size="10" style="fill:var(--future)">ask: a provider-plugin API</text>
+
+    <!-- request down (gold dashed) : ruflo -->
+    <path d="M320 186 C 250 224, 210 256, 195 296" fill="none" stroke-width="1.5" stroke-dasharray="6 4" style="stroke:var(--future)" marker-end="url(#s1f)"/>
+    <text x="150" y="238" text-anchor="middle" font-size="10" style="fill:var(--future)">capability request ↓</text>
+    <!-- ship up (green) : ruflo -->
+    <path d="M245 296 C 275 256, 305 224, 336 188" fill="none" stroke-width="1.5" style="stroke:var(--ok)" marker-end="url(#s1k)"/>
+    <text x="330" y="252" text-anchor="middle" font-size="10" style="fill:var(--ok)">ships → lights up ↑</text>
+
+    <!-- request down : aqe -->
+    <path d="M560 186 C 630 224, 670 256, 685 296" fill="none" stroke-width="1.5" stroke-dasharray="6 4" style="stroke:var(--future)" marker-end="url(#s1f)"/>
+    <text x="730" y="238" text-anchor="middle" font-size="10" style="fill:var(--future)">capability request ↓</text>
+    <!-- ship up : aqe -->
+    <path d="M635 296 C 605 256, 575 224, 544 188" fill="none" stroke-width="1.5" style="stroke:var(--ok)" marker-end="url(#s1k)"/>
+    <text x="550" y="252" text-anchor="middle" font-size="10" style="fill:var(--ok)">ships → lights up ↑</text>
+  </g>
+</svg>
+<figcaption><strong>Downstream, but not powerless.</strong> When a conformance ceiling is really an
+upstream one, the kit doesn't fake it or bury it — it files a specific capability request against
+ruflo or agentic-qe, tracks the tier as "gated on upstream," and exposes the capability the moment
+the upstream release lands. The dashed gold arrows are the ask; the green arrows are the payoff.</figcaption>
+</figure>
+
+<h3>Which layer owns the blocker?</h3>
+<p>The first diagnostic when a conformance tier can't be met: <em>whose capability is missing?</em></p>
+<div class="tablewrap"><table>
+  <tr><th>The blocker</th><th>Owner</th><th>What happens</th></tr>
+  <tr><td>Can't run work through the host; no trust command; local-file manifests only</td>
+      <td><strong style="color:var(--ok)">agentic-kit</strong></td>
+      <td>The kit's to fix — a normal kit PR. This is the on-ramp work, no one to wait on.</td></tr>
+  <tr><td>Host wants to be a recognized <em>AQE provider type</em></td>
+      <td><strong style="color:var(--gov)">agentic-qe</strong></td>
+      <td>Upstream — the provider list is a closed enum. Request a provider-plugin API. <em>Interim:</em> QE works through the model provider underneath the host, so quality isn't blocked, only the host's own AQE identity is.</td></tr>
+  <tr><td>Host wants to be a native ruflo <em>backend</em> (drive the loop, an ENABLE_* target)</td>
+      <td><strong style="color:var(--gov)">ruflo</strong></td>
+      <td>Upstream — backends are defined in ruflo. Request a documented backend-registration path. <em>Interim:</em> the host runs through the kit's own supervised execution, just not as a ruflo-native backend.</td></tr>
+  <tr><td>Host wants to participate in the QE quality gate</td>
+      <td><strong style="color:var(--ok)">agentic-kit</strong></td>
+      <td>Mostly the kit's — adopt an anchor set. Not blocked upstream.</td></tr>
+</table></div>
+
+<div class="panel">
+  <div class="ptitle">The request path, and why it's credible</div>
+  <p style="margin-bottom:0">A capability request isn't a wish into the void. The kit's maintainer
+  <em>champions</em> it upstream — the same maintainer already contributes to these projects — with a
+  concrete extension point named, not a vague "please support us." The pending dependency is recorded
+  against the conformance tier (<code>gated: agentic-qe#NNN</code>), so anyone reading an adapter's
+  status can see exactly what it's waiting on and why. When the upstream release ships the capability,
+  the kit exposes it in the adapter contract and the tier flips from gated to earnable. This is what
+  keeps "no limitations after conformance" honest: the limitations that <em>are</em> real get a
+  documented route to disappear, layer by layer.</p>
+</div>
+
+<h2 id="opencode-example">9 · OpenCode in practice — a worked example</h2>
+<p>All of this becomes concrete with a host that's already here. OpenCode is a <em>built-in</em>, ak
+installs and configures it, and a user can open the OpenCode CLI on a project and get real benefit —
+yet it isn't a full peer on every layer. Here's exactly what it gets, what it doesn't, and — the
+useful part — <em>who owns each gap</em>. It's the whole three-layer story in one host.</p>
+
+<div class="cols">
+  <div class="card" style="border-top:3px solid var(--ok)">
+    <h3 style="color:var(--ok)">What OpenCode gets <span class="tag now">wired by ak</span></h3>
+    <p class="quiet" style="margin-top:0">On an ak-configured project, opening the OpenCode CLI comes with:</p>
+    <ul>
+      <li><strong>Ruflo's full MCP server</strong> — memory, routing, swarm tools, registered in
+      OpenCode's own config and auto-approved.</li>
+      <li><strong>RuvNet Brain MCP</strong> — grounding in rUv source.</li>
+      <li><strong>Ruflo lifecycle hooks</strong> — OpenCode's own edit/tool/task events wired to
+      ruflo, so learning fires as work happens.</li>
+      <li><strong>Managed ruflo agents, skills, and AGENTS.md guidance</strong> projected in.</li>
+    </ul>
+    <p class="meta" style="margin-bottom:0">The orchestration + grounding layers: fully first-class.</p>
+  </div>
+  <div class="card" style="border-top:3px solid var(--caution)">
+    <h3 style="color:var(--caution)">What it doesn't — and who owns it</h3>
+    <ul>
+      <li><strong>It never leads</strong> (never primary) — <span class="quiet">by design; it's a
+      supervised host.</span></li>
+      <li><strong>agentic-qe tools/skills aren't projected in</strong> (unlike Claude &amp; Codex) —
+      <span class="quiet">ak's choice; ak could run aqe's OpenCode installer and doesn't yet.</span></li>
+      <li><strong>It isn't an AQE provider type</strong> (analysis can't run <em>on</em> it) —
+      <span class="quiet">upstream; agentic-qe's provider list is a closed enum.</span></li>
+      <li><strong>No command status-line footer, no quota surface, no cross-host bridge</strong> —
+      <span class="quiet">by design.</span></li>
+    </ul>
+  </div>
+</div>
+
+<div class="panel">
+  <div class="ptitle">The pattern, in one host</div>
+  <p style="margin-bottom:0">OpenCode is a <strong>first-class ruflo + brain host</strong>, a
+  <strong>supervised (never-leading) execution host</strong>, and largely <strong>outside the
+  agentic-qe layer</strong> — and that last gap splits cleanly the way
+  <a href="#upstream">section&nbsp;8</a> describes: "no aqe tools projected in" is <em>ak's</em> to
+  close (a normal kit change), while "can't be an AQE provider type" is an <em>upstream</em> request
+  to agentic-qe. That's the entire model — host layer, lead vs. supervised, and the ak-vs-upstream
+  split — visible in a single assistant available today.</p>
+</div>
+
+<hr class="soft">
+<p class="meta">Built-in host behavior is authoritative in ADR-0016; the external-adapter extension
+point and its safety model are ADR-0029 (which supersedes ADR-0016's original "closed registry"
+stance, narrowly — nothing under a manifest is ever loaded into the kit's process). The graduation
+ladder — experimental external adapter, earned capabilities via conformance tiers, promotion to
+built-in, and the upstream capability-request path to ruflo and agentic-qe — is the proposed next
+decision (a prospective ADR-0031), not yet ratified. Upstream facts (agentic-qe's closed provider
+enum; ruflo's ENABLE_* backend model) are grounded in a source-cited research sweep of
+<code>agentic-qe@3.13.10</code> and <code>ruvnet/ruflo@45e65b5</code>. Hermes and Gemini CLI are named
+here as illustrative candidates for the external door, not as hosts the kit supports today.</p>
+
+</main>
+
+</body>
+</html>

--- a/docs/HOST-PROVIDER-CONSISTENCY.html
+++ b/docs/HOST-PROVIDER-CONSISTENCY.html
@@ -1,0 +1,613 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Host &amp; Provider Consistency — agentic-kit</title>
+<style>
+  :root {
+    --bg: #f5f7f8;
+    --surface: #ffffff;
+    --surface-2: #eef1f3;
+    --ink: #1a222c;
+    --muted: #5b6673;
+    --line: #d9dfe4;
+    --accent: #266e73;
+    --accent-soft: #e2eeef;
+    --sev-blocker: #a93a2c;
+    --sev-blocker-bg: #f7e5e1;
+    --sev-major: #8f6400;
+    --sev-major-bg: #f6edd6;
+    --sev-minor: #4a6180;
+    --sev-minor-bg: #e6ecf3;
+    --sev-ok: #2c7a4b;
+    --sev-ok-bg: #e2f0e7;
+    --code-bg: #eceff1;
+    --shadow: 0 1px 2px rgba(26, 34, 44, 0.06);
+  }
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) {
+      --bg: #14181b;
+      --surface: #1b2126;
+      --surface-2: #21282e;
+      --ink: #e3e8ec;
+      --muted: #96a1ab;
+      --line: #2c343b;
+      --accent: #72c0c5;
+      --accent-soft: #1e3336;
+      --sev-blocker: #e08a7c;
+      --sev-blocker-bg: #3a231f;
+      --sev-major: #d9b25e;
+      --sev-major-bg: #352c17;
+      --sev-minor: #9db4d0;
+      --sev-minor-bg: #232c37;
+      --sev-ok: #85c9a1;
+      --sev-ok-bg: #1d3226;
+      --code-bg: #242b31;
+      --shadow: none;
+    }
+  }
+  :root[data-theme="dark"] {
+    --bg: #14181b;
+    --surface: #1b2126;
+    --surface-2: #21282e;
+    --ink: #e3e8ec;
+    --muted: #96a1ab;
+    --line: #2c343b;
+    --accent: #72c0c5;
+    --accent-soft: #1e3336;
+    --sev-blocker: #e08a7c;
+    --sev-blocker-bg: #3a231f;
+    --sev-major: #d9b25e;
+    --sev-major-bg: #352c17;
+    --sev-minor: #9db4d0;
+    --sev-minor-bg: #232c37;
+    --sev-ok: #85c9a1;
+    --sev-ok-bg: #1d3226;
+    --code-bg: #242b31;
+    --shadow: none;
+  }
+
+  * { box-sizing: border-box; }
+  body {
+    background: var(--bg);
+    color: var(--ink);
+    font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+    line-height: 1.55;
+    margin: 0;
+    font-size: 15.5px;
+  }
+  .wrap { max-width: 920px; margin: 0 auto; padding: 3rem 1.5rem 6rem; }
+  code, .mono {
+    font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    font-size: 0.86em;
+    background: var(--code-bg);
+    border-radius: 3px;
+    padding: 0.08em 0.32em;
+  }
+  th code, td code { white-space: nowrap; }
+  h1, h2, h3, h4 { line-height: 1.25; text-wrap: balance; letter-spacing: -0.01em; }
+  h1 { font-size: 1.9rem; margin: 0.4rem 0 0.6rem; }
+  h2 {
+    font-size: 1.28rem; margin: 3.2rem 0 0.9rem;
+    padding-top: 1.6rem; border-top: 1px solid var(--line);
+  }
+  h3 { font-size: 1.05rem; margin: 1.8rem 0 0.5rem; }
+  p { max-width: 72ch; margin: 0.65rem 0; }
+  ul, ol { max-width: 72ch; padding-left: 1.4rem; }
+  li { margin: 0.3rem 0; }
+  a { color: var(--accent); text-decoration: none; }
+  a:hover, a:focus-visible { text-decoration: underline; }
+  a:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+  .eyebrow {
+    text-transform: uppercase; letter-spacing: 0.12em; font-size: 0.72rem;
+    font-weight: 650; color: var(--accent); margin: 0;
+  }
+  .meta {
+    display: flex; flex-wrap: wrap; gap: 0.4rem 1.4rem;
+    color: var(--muted); font-size: 0.85rem; margin: 0.4rem 0 0;
+  }
+  .lede { font-size: 1.02rem; color: var(--muted); max-width: 68ch; }
+
+  nav.toc {
+    background: var(--surface); border: 1px solid var(--line); border-radius: 8px;
+    padding: 1rem 1.3rem; margin: 1.8rem 0 0; box-shadow: var(--shadow);
+    font-size: 0.9rem; columns: 2; column-gap: 2.5rem;
+  }
+  nav.toc a { display: block; padding: 0.14rem 0; break-inside: avoid; }
+  @media (max-width: 640px) { nav.toc { columns: 1; } }
+
+  .chip {
+    display: inline-block; font-size: 0.68rem; font-weight: 700;
+    text-transform: uppercase; letter-spacing: 0.06em;
+    border-radius: 999px; padding: 0.14em 0.6em; white-space: nowrap;
+  }
+  .chip.blocker { color: var(--sev-blocker); background: var(--sev-blocker-bg); }
+  .chip.major   { color: var(--sev-major);   background: var(--sev-major-bg); }
+  .chip.minor   { color: var(--sev-minor);   background: var(--sev-minor-bg); }
+  .chip.ok      { color: var(--sev-ok);      background: var(--sev-ok-bg); }
+  .chip.today   { color: var(--accent);      background: var(--accent-soft); }
+  .chip.ext     { color: var(--muted);       background: var(--surface-2); }
+
+  .tablewrap { overflow-x: auto; margin: 1rem 0; border: 1px solid var(--line); border-radius: 8px; background: var(--surface); box-shadow: var(--shadow); }
+  table { border-collapse: collapse; width: 100%; font-size: 0.87rem; }
+  th {
+    text-align: left; font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.08em;
+    color: var(--muted); padding: 0.6rem 0.85rem; border-bottom: 1px solid var(--line);
+    background: var(--surface-2); white-space: nowrap;
+  }
+  td { padding: 0.6rem 0.85rem; border-bottom: 1px solid var(--line); vertical-align: top; }
+  tr:last-child td { border-bottom: none; }
+  td.id { font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; font-size: 0.8rem; font-weight: 700; color: var(--accent); white-space: nowrap; }
+  td.nowrap { white-space: nowrap; }
+
+  .decision {
+    background: var(--surface); border: 1px solid var(--line); border-radius: 8px;
+    padding: 1.2rem 1.4rem 1.1rem; margin: 1.4rem 0; box-shadow: var(--shadow);
+  }
+  .decision h3 { margin: 0 0 0.2rem; }
+  .decision .dq { color: var(--muted); font-size: 0.92rem; margin: 0 0 0.8rem; }
+  .opt { margin: 0.55rem 0; padding-left: 1.9rem; position: relative; max-width: 72ch; }
+  .opt b.tag {
+    position: absolute; left: 0; top: 0.1rem; font-size: 0.72rem; font-weight: 750;
+    color: var(--muted); font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  }
+  .rec {
+    margin-top: 0.9rem; padding: 0.7rem 1rem; border-left: 3px solid var(--accent);
+    background: var(--accent-soft); border-radius: 0 6px 6px 0; font-size: 0.93rem;
+    max-width: 72ch;
+  }
+  .rec b:first-child { color: var(--accent); text-transform: uppercase; font-size: 0.72rem; letter-spacing: 0.08em; }
+
+  .phase {
+    border: 1px solid var(--line); border-left: 3px solid var(--accent);
+    border-radius: 0 8px 8px 0; background: var(--surface);
+    padding: 1rem 1.3rem; margin: 1rem 0; box-shadow: var(--shadow);
+  }
+  .phase h3 { margin: 0 0 0.3rem; }
+  .phase .ph-meta { color: var(--muted); font-size: 0.83rem; margin-bottom: 0.5rem; }
+
+  .callout {
+    border: 1px solid var(--line); background: var(--surface-2); border-radius: 8px;
+    padding: 0.9rem 1.2rem; margin: 1.2rem 0; font-size: 0.94rem; max-width: 76ch;
+  }
+  section.brief {
+    background: var(--surface); border: 1px solid var(--line); border-top: 3px solid var(--accent);
+    border-radius: 8px; padding: 1.4rem 1.6rem 1.5rem; margin: 2rem 0 0.5rem;
+    box-shadow: var(--shadow);
+  }
+  section.brief h2 { border-top: none; padding-top: 0; margin: 0 0 0.2rem; }
+  section.brief h3 { font-size: 0.98rem; margin: 1.3rem 0 0.35rem; }
+  section.brief p, section.brief li { font-size: 0.97rem; }
+  section.brief .audience { color: var(--muted); font-size: 0.88rem; margin-top: 0; }
+  .footer { margin-top: 4rem; padding-top: 1.2rem; border-top: 1px solid var(--line); color: var(--muted); font-size: 0.82rem; }
+</style>
+</head>
+<body>
+<div style="max-width:76ch;margin:1.4rem auto 0;padding:.55rem .95rem;background:var(--surface);border:1px solid var(--line);border-left:3px solid var(--accent);border-radius:8px;font-size:.82rem;line-height:1.5;color:var(--muted)">📎 <strong style="color:var(--accent)">Origin.</strong> Authored as a Claude artifact; this file is the repository’s local snapshot for review. Live version: <a href="https://claude.ai/code/artifact/db1bae65-adf9-45f1-80f1-163dcc1af50c" style="color:var(--accent)">https://claude.ai/code/artifact/db1bae65-adf9-45f1-80f1-163dcc1af50c</a></div>
+
+<div class="wrap">
+  <p class="eyebrow">agentic-kit · master consistency document</p>
+  <h1>Host &amp; provider axis — findings, gaps, options, recommendations</h1>
+  <p class="meta">
+    <span>Prepared 2026-08-13 · rev 2 (executive brief added)</span>
+    <span>Trigger: <a href="https://github.com/pacphi/agentic-kit/pull/131">PR #131</a> (ADR-0028/0029/0030, adrianco)</span>
+    <span>Repo: pacphi/agentic-kit @ main (8aad47b)</span>
+  </p>
+  <p class="lede">
+    Every claim below was verified against source: the ak side by a full surface sweep of the
+    repository, the Hermes side against NousResearch/hermes-agent HEAD (v0.20.0, 2026-08-13).
+    Finding IDs (F-nn) and decision IDs (D-n) are stable and cross-referenced by the roadmap
+    and the PR #131 review response.
+  </p>
+
+  <section class="brief" id="brief">
+    <h2>0 · Executive brief — in plain language</h2>
+    <p class="audience">For every consumer of agentic-kit — no engineering background needed.
+    Everything after this section is the technical evidence behind this summary.</p>
+
+    <h3>What agentic-kit is</h3>
+    <p>
+      agentic-kit ("ak") is a set-up and housekeeping tool for AI coding assistants. Today it
+      manages three of them — Claude Code, Codex, and OpenCode. It installs them, keeps their
+      settings consistent, routes different kinds of work to the assistant best suited for it,
+      and reports on what they did and roughly what it cost.
+    </p>
+
+    <h3>The problem</h3>
+    <p>
+      A contributor asked us to support a fourth assistant — Hermes, notable because it drives
+      AI models that run entirely on your own computer instead of in a vendor's cloud. Studying
+      that request exposed something broader: the kit does not treat its three current
+      assistants evenly. Under the hood, roughly half of the kit treats "an assistant" as a
+      generic thing any newcomer could slot into; the other half has the three names written in
+      by hand. In practice, some features quietly apply to only one or two assistants, a
+      newcomer would be invisible to most of the kit — and, worst of all, a few reports file
+      activity from an unrecognized assistant <em>under the wrong name</em> instead of saying
+      "unrecognized."
+    </p>
+
+    <h3>The challenges</h3>
+    <ul>
+      <li><b>Adding an assistant today is open-heart surgery.</b> The last time we added one it
+      touched roughly fourteen files and eight test suites — and permanently made the kit's
+      maintainer responsible for software they don't personally use.</li>
+      <li><b>Assistants differ in ways users must be told about.</b> Example: in unattended
+      mode, Hermes approves every action automatically, by its own design — where OpenCode
+      pauses and asks. The kit has to state differences like that plainly, never average them
+      away.</li>
+      <li><b>The bookkeeping isn't honest yet.</b> Usage and session reports currently mis-file
+      unknown assistants into an existing bucket rather than labeling them truthfully. That is
+      a correctness problem today, not a someday problem.</li>
+      <li><b>Changing course must happen on the record.</b> An earlier design decision
+      deliberately said "no third-party plug-ins." Opening a plug-in door means revisiting that
+      decision explicitly, with its trade-offs written down — not quietly working around it.</li>
+    </ul>
+
+    <h3>The planned work, in phases</h3>
+    <ul>
+      <li><b>Phase 0 — Truthfulness fixes.</b> Stop mis-filing unknown assistants; replace
+      silences with plain labels ("this assistant has no usage report"); remove duplicated and
+      dead configuration. These are owed no matter what else is decided.</li>
+      <li><b>Phase 1 — Local models, generically.</b> Recognize any locally-run model server
+      (LM Studio, llama.cpp, MLX, vLLM, and whatever comes next) — not just one vendor — so
+      people running models on their own machines are first-class citizens.</li>
+      <li><b>Phase 2 — The plug-in door.</b> Rework the kit's insides so an assistant is
+      something the kit <em>looks up</em> rather than something <em>written into it</em>. Then,
+      if the decision to open up is confirmed, publish one well-tested connection point so a
+      new assistant can be added by the people who want it.</li>
+      <li><b>Phase 3 — Hermes, and honest labels everywhere.</b> Hermes arrives as the first
+      plug-in, maintained by its proposer rather than by us. Every status screen learns to say
+      what each assistant can and cannot do — and why.</li>
+      <li><b>Phase 4 — Parked, on purpose.</b> Ideas that need more real-world evidence first
+      (deeper usage reporting for plug-ins, a stronger isolation model) are listed and
+      deferred, not forgotten.</li>
+    </ul>
+
+    <h3>What you get at the end</h3>
+    <p>
+      Whichever assistants you use: the same commands work the same way, reports name things
+      truthfully, and capability differences are stated rather than hidden. Adding tomorrow's
+      assistant no longer depends on one maintainer's spare time. And one thing deliberately
+      does <em>not</em> change: the kit never installs a plug-in on its own — you choose one
+      explicitly, and the kit tells you exactly what it is and what it is allowed to do before
+      anything runs.
+    </p>
+  </section>
+
+  <nav class="toc" aria-label="Contents">
+    <a href="#brief">0 · Executive brief (plain language)</a>
+    <a href="#state">1 · The state model: a bimodal host axis</a>
+    <a href="#tiers">2 · The de-facto host tiers</a>
+    <a href="#findings">3 · Findings inventory (F-01…F-30)</a>
+    <a href="#decisions">4 · Decision areas (D-1…D-7)</a>
+    <a href="#amendments">5 · ADR amendments register</a>
+    <a href="#tests">6 · Test &amp; docs remediation</a>
+    <a href="#roadmap">7 · Sequenced roadmap</a>
+    <a href="#hermes">8 · Appendix: Hermes verification</a>
+  </nav>
+
+  <h2 id="state">1 · The state model: a bimodal host axis</h2>
+  <p>
+    The single most important structural fact: <b>everything that validates a host is generic;
+    nearly everything that acts on a host is hardcoded by name.</b>
+  </p>
+  <p>
+    The registry, capability vocabulary, and all six validators are host-agnostic and already
+    proven against synthetic hosts (<code>capability-derived.test.mjs</code> exercises a
+    <code>future-host</code>; <code>trust-manifest.test.mjs:47-69</code> injects a
+    <code>grok</code> host end-to-end through setup disclosure). But dispatch, presentation,
+    attribution, guidance, teardown, and version tracking each carry literal
+    <code>claude</code>/<code>codex</code>/<code>opencode</code> branches. A conforming
+    fourth host registered today would validate cleanly, appear in exactly two surfaces
+    (the setup/sync install loop and the trust manifest), and be invisible — or actively
+    breaking — everywhere else.
+  </p>
+  <p>
+    This is why "inconsistent UX" is the right frame: the inconsistency is not a Hermes
+    problem. Several gaps below already bite OpenCode, the third <em>built-in</em> host.
+    The extensibility question (D-1) only raises the stakes; it does not create the debt.
+  </p>
+
+  <h2 id="tiers">2 · The de-facto host tiers</h2>
+  <p>
+    Three tiers already exist in behavior but not in vocabulary. The command surface calls all
+    of them "host," and <code>ak host pick</code> means something different at each tier.
+  </p>
+  <div class="tablewrap"><table>
+    <tr><th>Tier</th><th>Hosts</th><th>Can do</th><th>Cannot do</th></tr>
+    <tr>
+      <td class="nowrap"><b>Session host</b></td>
+      <td class="nowrap">claude, codex</td>
+      <td>Drive the ruflo loop (<code>ENABLE_*</code>), be primary, statusline, quota channels, usage scorecard, MCP bridge</td>
+      <td>—</td>
+    </tr>
+    <tr>
+      <td class="nowrap"><b>Supervised execution host</b></td>
+      <td class="nowrap">opencode</td>
+      <td>Route <code>ak run</code> activities; permission events intercepted (<code>permission_required</code>)</td>
+      <td>Primary, AQE provider, statusline, vendor-diversity credit, usage/quota/live-session attribution</td>
+    </tr>
+    <tr>
+      <td class="nowrap"><b>External execution host</b> <span class="chip ext">proposed</span></td>
+      <td class="nowrap">hermes (ADR-0030)</td>
+      <td>Route activities via an externally maintained adapter; host-declared usage sidecar</td>
+      <td>Everything tier 2 cannot, <em>plus</em> no interceptable permission event — <code>hermes&nbsp;-z</code> auto-approves by its own headless contract (disclosed, verified)</td>
+    </tr>
+  </table></div>
+  <p>
+    ADR-0020 already mandates tier 2's shape for OpenCode ("explicit, supervised, non-primary,
+    outside AQE provider routing, absent from vendor-diversity facts"). ADR-0029's capability
+    caps reproduce that shape for external hosts — tested policy, not new policy. What is
+    missing is the <em>vocabulary</em>: no surface tells the user which tier a host is in or why
+    a capability is absent (see D-2).
+  </p>
+
+  <h2 id="findings">3 · Findings inventory</h2>
+  <p>
+    Severity: <span class="chip blocker">blocker</span> crashes or corrupts;
+    <span class="chip major">major</span> wrong or missing behavior a user will hit;
+    <span class="chip minor">minor</span> debt, dead code, or docs drift;
+    <span class="chip ok">healthy</span> baseline worth protecting.
+    Scope: <span class="chip today">today</span> affects built-in hosts now;
+    <span class="chip ext">ext</span> manifests only if extensibility (D-1) proceeds.
+  </p>
+
+  <h3>3.1 Registry &amp; validation — the healthy baseline</h3>
+  <div class="tablewrap"><table>
+    <tr><th>ID</th><th>Finding</th><th>Severity</th><th>Scope</th></tr>
+    <tr><td class="id">F-00</td><td>Registry descriptors, closed capability vocabulary (<code>registries.mjs:6-9,154-225</code>), six host-agnostic validators, <code>validateRegistries</code> at construction, pure capability selectors, graceful runner degradation (<code>runner.mjs:246-252</code>), fully generic trust manifest (<code>trust-manifest.mjs</code>) and footprint install loop (<code>footprint/install.mjs:170-178</code>). Protect this.</td><td><span class="chip ok">healthy</span></td><td><span class="chip today">today</span></td></tr>
+  </table></div>
+
+  <h3>3.2 Dispatch &amp; lifecycle</h3>
+  <div class="tablewrap"><table>
+    <tr><th>ID</th><th>Finding</th><th>Severity</th><th>Scope</th></tr>
+    <tr><td class="id">F-01</td><td><code>EXECUTION_ADAPTERS</code> is a frozen 3-entry Map with a <b>bidirectional invariant that throws at module import</b> (<code>execution/adapters.mjs:8-12,20-30</code>). Any registered routable host outside the Map bricks <code>ak run</code> for everyone. ADR-0018 prose states the invariant in one direction only; the code enforces both. The single hardest extensibility gate — absent from ADR-0029 §8.</td><td><span class="chip blocker">blocker</span></td><td><span class="chip ext">ext</span></td></tr>
+    <tr><td class="id">F-02</td><td>Lifecycle adapter selection is a named import at five call sites (<code>sync.mjs:11,195-197</code>; <code>x/host.mjs:19,326,617-619,642</code>; <code>setup.mjs:15,216</code>). No lifecycle registry, no <code>host.lifecycle</code> field; <code>validateHostAdapter</code> doesn't accept one. A conforming third-party lifecycle has no dispatch path.</td><td><span class="chip major">major</span></td><td><span class="chip ext">ext</span></td></tr>
+    <tr><td class="id">F-03</td><td><code>ak uninstall</code> bypasses <code>runLifecycle</code> entirely — calls <code>retireOpencode(cfg)</code> directly (<code>uninstall.mjs:112-142</code>). Third-party footprint would persist on disk permanently; even for built-ins, teardown has two code paths.</td><td><span class="chip major">major</span></td><td><span class="chip today">today</span></td></tr>
+    <tr><td class="id">F-04</td><td>Setup permission handling authorizes only claude-host rules; <code>removeUndisclosedPermissions</code> (<code>setup.mjs:95,102,120-128</code>) would strip a third-party host's permissions and fail setup.</td><td><span class="chip major">major</span></td><td><span class="chip ext">ext</span></td></tr>
+  </table></div>
+
+  <h3>3.3 Presentation</h3>
+  <div class="tablewrap"><table>
+    <tr><th>ID</th><th>Finding</th><th>Severity</th><th>Scope</th></tr>
+    <tr><td class="id">F-05</td><td><code>status.mjs</code> is split-brained: a generic host loop yields install+auth rows (<code>:500-529</code>), then hand-rolled blocks per host — codex MCP/bridge (<code>:352-382</code>), codex plugins (<code>:387-400</code>), an 88-line opencode block importing 8 symbols (<code>:407-495</code>), codex statusline row (<code>:729-746</code>), a claude-only blocks loop (<code>:670</code>). <code>normalizedFacts</code> is collected but consumed for exactly one field (<code>:505-506</code>) — everything else re-probes. Rendering from <code>normalizedFacts</code> is also the direction of the #129/#133/#136 status-vs-sync projection fixes.</td><td><span class="chip major">major</span></td><td><span class="chip today">today</span></td></tr>
+    <tr><td class="id">F-06</td><td>About directory cards are a frozen literal (<code>dashboard/about-directory.mjs:54-110</code>) with a <b>test-enforced</b> registry↔directory parity invariant (<code>about-directory.test.mjs:118-140,157-161,381-385</code>; <code>ddd/component-directory.md:164-165</code>). Any registered host without an authored card fails CI; card matching also assumes <code>npmPackage</code> is non-null.</td><td><span class="chip major">major</span></td><td><span class="chip ext">ext</span></td></tr>
+    <tr><td class="id">F-07</td><td>Statusline is two host-specific patchers (claude helper, codex TOML) with <code>cfg.statusline.codex</code> as a literal config key; consistent with the <code>commandStatusline</code> cap — but <code>statuslineSupported</code> (<code>hosts.mjs:37,53-55</code>) has zero call sites: a dead capability consumer.</td><td><span class="chip minor">minor</span></td><td><span class="chip today">today</span></td></tr>
+  </table></div>
+
+  <h3>3.4 Attribution &amp; observability</h3>
+  <div class="tablewrap"><table>
+    <tr><th>ID</th><th>Finding</th><th>Severity</th><th>Scope</th></tr>
+    <tr><td class="id">F-08</td><td>Usage scorecard needs seven per-host edits; worse, unknown hosts are <b>misattributed, not omitted</b>: non-codex sessions collapse to <code>claude</code> (<code>usage-index.mjs:1407-1408</code>), <code>parseFile</code>'s 2-branch ternary falls through to <code>parseClaude</code> (<code>:831-848</code>), and a fourth root would collide in the single-flight cache (<code>scanKey</code>, <code>:1169</code>). Aggregation itself is generically string-keyed (<code>:1083</code>) — records just never reach it correctly.</td><td><span class="chip major">major</span></td><td><span class="chip today">today</span></td></tr>
+    <tr><td class="id">F-09</td><td>Live sessions rewrite unknown hosts to <code>'internal'</code> (<code>live/event-schema.mjs:3,107</code>) — namespace collision — and <code>process-sessions.mjs:49-53</code> filters unknown binaries out entirely. No opencode transcript reader exists.</td><td><span class="chip major">major</span></td><td><span class="chip today">today</span></td></tr>
+    <tr><td class="id">F-10</td><td>Quota is a fixed <code>{claude, codex}</code> record (<code>quota.mjs:30-31,252-257</code>). Consistent with ADR-0010's sanctioned channels — but hosts without a quota channel are silent rather than labeled ("no quota surface for this host").</td><td><span class="chip minor">minor</span></td><td><span class="chip today">today</span></td></tr>
+    <tr><td class="id">F-11</td><td><code>qeCourt.vendorOf</code> is a literal prefix table (<code>qeCourt.mjs:24-32</code>); any unregistered host id maps to <code>'unknown'</code>, so N distinct third-party vendors collapse into one bucket — vendor-diversity findings can be spuriously tripped or spuriously satisfied.</td><td><span class="chip major">major</span></td><td><span class="chip ext">ext</span></td></tr>
+    <tr><td class="id">F-12</td><td><code>host.observability</code> is declared-but-dead: <code>OBSERVABILITY_REGISTRY</code> is exported (<code>registries.mjs:250</code>) and imported nowhere; no dispatcher maps an observability id to a collector. It looks like the telemetry extension point and is validation metadata only.</td><td><span class="chip minor">minor</span></td><td><span class="chip today">today</span></td></tr>
+    <tr><td class="id">F-13</td><td>The provider-binding migrator's defaults map is <code>{claude:'anthropic', codex:'openai'}</code> (<code>adapters/config.mjs:64-79</code>); every other host is stamped <code>unknown-via-&lt;host&gt;</code>, provider <code>null</code>, provenance <code>'unknown'</code> on <b>every load</b>. Already affects opencode.</td><td><span class="chip major">major</span></td><td><span class="chip today">today</span></td></tr>
+  </table></div>
+
+  <h3>3.5 Config &amp; schema</h3>
+  <div class="tablewrap"><table>
+    <tr><th>ID</th><th>Finding</th><th>Severity</th><th>Scope</th></tr>
+    <tr><td class="id">F-14</td><td><code>kit.json</code> accepts unknown top-level keys silently (blind spread, <code>config.mjs:99-124</code>; envelope check only asserts <code>integrations.hosts</code> is an object, <code>:52-82</code>). A future <code>hostAdapters</code> key on an older ak round-trips untouched and does nothing — a silent no-op with no warning story.</td><td><span class="chip major">major</span></td><td><span class="chip ext">ext</span></td></tr>
+    <tr><td class="id">F-15</td><td>The DEFAULTS host map <code>{claude:true, codex:false, opencode:false}</code> is triplicated (<code>config.mjs:28</code>, <code>providers.mjs:547</code>, <code>x/host.mjs:334</code>).</td><td><span class="chip minor">minor</span></td><td><span class="chip today">today</span></td></tr>
+    <tr><td class="id">F-16</td><td><code>validateBinding</code> with an <code>unknown-host</code> error code exists (<code>bindings.mjs:72-84</code>) and is called from nowhere in <code>src/</code>. The registry-aware validation the extension point needs is already written and dead.</td><td><span class="chip minor">minor</span></td><td><span class="chip today">today</span></td></tr>
+  </table></div>
+
+  <h3>3.6 Guidance, paths, versions</h3>
+  <div class="tablewrap"><table>
+    <tr><th>ID</th><th>Finding</th><th>Severity</th><th>Scope</th></tr>
+    <tr><td class="id">F-17</td><td>Guidance targets are a closed list of four literal names (<code>blocks.mjs:280-292</code>); <code>customBlocks</code> rows are generic over target names but <code>retiredForTarget</code> force-strips rows naming a fifth (<code>:315</code>). Meanwhile <code>host.legacy.guidanceFile</code> is declared, read once (<code>hosts.mjs:34</code>), and consumed by nothing. ADR-0030 §6 sidesteps this by reusing the <code>agents</code> target — the trap remains for any host whose file differs.</td><td><span class="chip major">major</span></td><td><span class="chip today">today</span></td></tr>
+    <tr><td class="id">F-18</td><td><code>versions.mjs:70</code> hand-mirrors the host npm package list "to avoid an import cycle" — but <code>footprint/install.mjs</code> already imports <code>HOST_REGISTRY</code>, so the cycle is one-directional and solvable. A no-npm host is invisible to the drift nudge.</td><td><span class="chip minor">minor</span></td><td><span class="chip today">today</span></td></tr>
+    <tr><td class="id">F-19</td><td><code>lib/paths.mjs</code> is named per-host constants with no <code>hostDir(id)</code> resolver; the registry carries no path metadata at all, so even a fully-looped consumer has nothing to loop over.</td><td><span class="chip minor">minor</span></td><td><span class="chip ext">ext</span></td></tr>
+    <tr><td class="id">F-20</td><td><code>npmRoot(host.install.npmPackage)</code> is called unguarded in <code>footprint/install.mjs</code>; the first host without an npm package breaks the census. (ADR-0029 §8 names this; trivially fixable independently.)</td><td><span class="chip minor">minor</span></td><td><span class="chip ext">ext</span></td></tr>
+  </table></div>
+
+  <h3>3.7 Routing &amp; run</h3>
+  <div class="tablewrap"><table>
+    <tr><th>ID</th><th>Finding</th><th>Severity</th><th>Scope</th></tr>
+    <tr><td class="id">F-23</td><td>Routing hardcodes <code>HOST_PROVIDER = {claude, codex}</code> (<code>routing.mjs:25</code>), <code>DEFAULT_ROUTES</code> (<code>:203-216</code>), <code>MODEL_CATALOG</code> (<code>:56-72</code>), and a strictly binary escalation swap — <code>host === 'claude' ? 'codex' : 'claude'</code> (<code>:180,193,354</code>). Plan eligibility itself is generic (<code>:584-598</code>). A third routable host is routable in name only: no ladder can name it and no seed includes it.</td><td><span class="chip major">major</span></td><td><span class="chip today">today</span></td></tr>
+    <tr><td class="id">F-24</td><td><code>--primary-host</code> validates generically against <code>PRIMARY_HOSTS</code>, but help text is literal (<code>x/host.mjs:87-90</code>) and the fallback unshifts <code>'claude'</code> (<code>:494</code>).</td><td><span class="chip minor">minor</span></td><td><span class="chip today">today</span></td></tr>
+    <tr><td class="id">F-25</td><td>The Claude↔Codex MCP bridge is literal wiring (<code>providers.mjs:622-681</code>) — correct for a codex-specific feature, but there is no per-host "bridge capability" concept, so the asymmetry (codex delegable via MCP, opencode/hermes not) is nowhere stated to the user.</td><td><span class="chip minor">minor</span></td><td><span class="chip today">today</span></td></tr>
+    <tr><td class="id">F-26</td><td>Managed env emits only <code>ENABLE_CLAUDE_CODE</code>/<code>ENABLE_CODEX</code> (<code>providers.mjs:686-698</code>); hosts with no ruflo backend flag are simply absent, with no capability-derived explanation.</td><td><span class="chip minor">minor</span></td><td><span class="chip today">today</span></td></tr>
+  </table></div>
+
+  <h3>3.8 Provider axis</h3>
+  <div class="tablewrap"><table>
+    <tr><th>ID</th><th>Finding</th><th>Severity</th><th>Scope</th></tr>
+    <tr><td class="id">F-28</td><td><code>providerEntries</code> derives capabilities from identity comparisons inside a <code>.map</code> (<code>modelDiscovery: id === 'ollama'</code>). Does not survive a second local provider. ADR-0028 §4's per-entry-data refactor is correct and needed regardless of the rest of PR #131.</td><td><span class="chip major">major</span></td><td><span class="chip today">today</span></td></tr>
+    <tr><td class="id">F-29</td><td>AQE projection asymmetry: <code>ollama</code> is an AQE provider type; <code>local-openai</code> (ADR-0028) is deliberately not projected. Right call — but it must be stated in the ADR and surfaced in status, or it reads as a bug later.</td><td><span class="chip minor">minor</span></td><td><span class="chip today">today</span></td></tr>
+    <tr><td class="id">F-30</td><td>Hermes factual corrections required in ADR-0028/0030 (verified against source, see <a href="#hermes">appendix</a>): unofficial npm bridge exists; <code>lmstudio</code> is first-class, no <code>mlx</code> alias; <code>api_mode: openai</code> is invalid and silently dropped; <code>--max-turns</code> exists on <code>chat -q</code>; config dispatcher pointer wrong.</td><td><span class="chip minor">minor</span></td><td><span class="chip ext">ext</span></td></tr>
+  </table></div>
+
+  <h2 id="decisions">4 · Decision areas</h2>
+
+  <div class="decision" id="d1">
+    <h3>D-1 · Extensibility posture <span class="chip today">the one genuinely user-owned call</span></h3>
+    <p class="dq">Do we publish host adapters as an extension point (ADR-0029), stay closed, or absorb Hermes in-tree?</p>
+    <p class="opt"><b class="tag">A</b><b>Accept ADR-0029, amended.</b> Publish the seam with the honest gate list (F-01…F-06, F-11, F-14, F-21), formally superseding ADR-0016's closed-registry clause. Cost: the in-tree refactors plus a loader and fixture adapter; contract consumers constrain refactors (bounded by the alpha-instability statement). Benefit: fourth-host requests answered once; conformance evidence about our own abstractions.</p>
+    <p class="opt"><b class="tag">B</b><b>Decline and reaffirm.</b> Keep ADR-0016's closed registry, record the reaffirmation explicitly, and point Hermes at a fork. Cost: the fork drifts, no conformance evidence, the fifth-host request re-litigates this. Benefit: zero contract obligation while alpha churns.</p>
+    <p class="opt"><b class="tag">C</b><b>Absorb Hermes in-tree (ADR-0017 style).</b> ~14 files and ~8 test suites per host, permanent maintainer obligation for a CLI driven by another vendor's daily release cadence (40+ commits/day observed). The contributor themselves argues against this.</p>
+    <p class="rec"><b>Recommendation</b> — Option A, sequenced so the in-tree refactors land first and stand on their own (they delete host-specific code and fix bugs that bite OpenCode today). Critically: <b>Phase 0 hygiene below is owed under every option</b>, including B — misattribution and dead seams are not extensibility problems.</p>
+  </div>
+
+  <div class="decision" id="d2">
+    <h3>D-2 · Host tier vocabulary &amp; UX</h3>
+    <p class="dq">Three behavioral tiers exist (§2) with no product vocabulary. How do we make capability differences legible?</p>
+    <p class="opt"><b class="tag">A</b><b>Capability-derived labels everywhere.</b> Status, about, and help render a tier label and per-capability explanations derived from the registry ("no quota surface for this host", "auto-approving — no permission event to intercept"). No new config; the registry already knows.</p>
+    <p class="opt"><b class="tag">B</b><b>Docs-only tiers.</b> Name the tiers in HOST-SUPPORT.md and leave commands as-is. Cheaper, but the inconsistency the user experiences is in the commands, not the docs.</p>
+    <p class="opt"><b class="tag">C</b><b>Flatten.</b> Pretend all hosts are equal. Rejected: it would misrepresent the Hermes approval posture, which ADR-0030 rightly insists on disclosing.</p>
+    <p class="rec"><b>Recommendation</b> — Option A. Every absence becomes a stated fact instead of silence: this is the single highest-leverage UX consistency move, it consumes the same capability flags the caps enforce, and it revives the dead consumers (F-07, F-12, F-26).</p>
+  </div>
+
+  <div class="decision" id="d3">
+    <h3>D-3 · Dispatch generalization depth</h3>
+    <p class="dq">How far do the in-tree refactors go?</p>
+    <p class="opt"><b class="tag">A</b><b>Minimal:</b> registry-driven lifecycle lookup only (F-02). Unblocks a loader but leaves status, uninstall, and guidance split-brained.</p>
+    <p class="opt"><b class="tag">B</b><b>Full generalization:</b> lifecycle lookup (F-02) + uninstall through <code>runLifecycle undo</code> (F-03) + status rendered from <code>normalizedFacts</code> (F-05) + guidance targets derived from the registry (F-17) + the <code>adapters.mjs</code> invariant softened to built-ins with a merge seam (F-01) + setup permission authorization keyed by host (F-04).</p>
+    <p class="rec"><b>Recommendation</b> — Option B. Each piece deletes host-specific code, and the status refactor continues the #129/#133/#136 single-projection direction — it must preserve the configured-projection + repoRoot scope gate landed there. F-01's softer rule has in-corpus precedent (ADR-0019:75-76: a rung naming a host with no adapter records <code>cli_unavailable</code> and continues).</p>
+  </div>
+
+  <div class="decision" id="d4">
+    <h3>D-4 · Attribution policy for non-first-party hosts</h3>
+    <p class="dq">Usage, live sessions, quota, and vendor facts currently misattribute or erase unknown hosts. What is the policy?</p>
+    <p class="opt"><b class="tag">A</b><b>Exclude-and-label now.</b> Unknown/uninstrumented hosts get an explicit bucket keyed by host id — never collapsed to <code>claude</code> (F-08), never rewritten to <code>internal</code> (F-09), never silently absent from quota (F-10). <code>qeCourt.vendorOf</code> returns a per-id <code>unregistered:&lt;host&gt;</code> verdict that <b>never counts toward vendor diversity</b> (F-11) — consistent with ADR-0020's "absent unless independently observed."</p>
+    <p class="opt"><b class="tag">B</b><b>Ingestion contract later.</b> A v2 adapter contract lets a host declare a usage sidecar (Hermes <code>--usage-file</code> is the model: host-declared, ADR-0021 <code>configured</code>-grade, written even on failure). Real value, but it needs the extension point to exist first and a provenance-grading decision.</p>
+    <p class="opt"><b class="tag">C</b><b>Status quo.</b> Rejected: it is not neutral — it actively corrupts the claude bucket and the <code>internal</code> namespace today.</p>
+    <p class="rec"><b>Recommendation</b> — A immediately (it is a correctness fix for the scorecard you already hardened in PR #60), B as a v2 contract item once D-1/Phase 2 lands.</p>
+  </div>
+
+  <div class="decision" id="d5">
+    <h3>D-5 · Config &amp; schema hygiene</h3>
+    <p class="dq">kit.json silently swallows the unknown; host defaults live in three places.</p>
+    <p class="opt"><b class="tag">A</b><b>Warn-on-unknown top-level keys</b> (F-14) so a <code>hostAdapters</code> block on an older ak is a visible message, not a silent no-op; derive the DEFAULTS host map from the registry once (F-15); wire <code>validateBinding</code> into the load path or delete it (F-16); make the migrator's defaults registry-driven and stop re-stamping <code>unknown-via-&lt;host&gt;</code> on every load (F-13).</p>
+    <p class="opt"><b class="tag">B</b><b>Strict-reject unknown keys.</b> Rejected: breaks forward-compatibility between ak versions sharing a kit.json — warn is the right strength.</p>
+    <p class="rec"><b>Recommendation</b> — Option A, all four items in one hygiene pass; each is small and none depends on D-1.</p>
+  </div>
+
+  <div class="decision" id="d6">
+    <h3>D-6 · Guidance, paths, versions derivation</h3>
+    <p class="dq">Three registry fields are declared and consumed by nothing; three consumers hand-mirror what the registry knows.</p>
+    <p class="opt"><b class="tag">A</b><b>Make the registry the source:</b> guidance targets derived from a real (non-legacy) registry field (F-17); <code>HOST_PKGS</code> derived from <code>install.npmPackage</code> (F-18); add path metadata / a <code>hostDir(id)</code> resolver or explicitly document paths as first-party-only (F-19); either implement observability dispatch or re-document the field as validation metadata (F-12).</p>
+    <p class="opt"><b class="tag">B</b><b>Delete the dead fields.</b> Honest, but forfeits the derivation wins and re-opens each on the next host.</p>
+    <p class="rec"><b>Recommendation</b> — Option A for guidance/versions (both fix real drift hazards ADR-0017 §retrospective already named); for observability and paths, decide per field — a one-line ADR note ("validation metadata only") is an acceptable terminal state if no consumer is planned.</p>
+  </div>
+
+  <div class="decision" id="d7">
+    <h3>D-7 · Provider axis</h3>
+    <p class="dq">ADR-0028 and the provider registry's shape.</p>
+    <p class="opt"><b class="tag">A</b><b>Accept ADR-0028</b> with the <code>api_mode</code> citation fix (F-30) and an explicit note on the AQE projection asymmetry (F-29); land the per-entry capability refactor (F-28) with it.</p>
+    <p class="opt"><b class="tag">B</b><b>Vendor enumeration instead</b> (<code>mlx</code>, <code>lmstudio</code>, …). Rejected in the ADR itself, and our verification strengthens the rejection: MLX has no Hermes alias either — users name their own providers.</p>
+    <p class="rec"><b>Recommendation</b> — Option A. This is the easiest accept in PR #131: small, independent, fixes F-28, and useful to the hosts already shipped.</p>
+  </div>
+
+  <h2 id="amendments">5 · ADR amendments register</h2>
+  <p>The prior decisions this work touches, and what happens to each. Nothing is amended silently.</p>
+  <div class="tablewrap"><table>
+    <tr><th>ADR</th><th>Clause at stake</th><th>Action</th><th>Trigger</th></tr>
+    <tr><td class="nowrap">0016</td><td>"A closed, validated registry of built-in code, not an arbitrary third-party plugin runtime" (:59-61; non-goal :441-442)</td><td><b>Supersede that clause</b> if D-1 = A; <b>reaffirm explicitly</b> if D-1 = B. Either way, decide on the record — ADR-0029 currently routes around it.</td><td class="nowrap">D-1</td></tr>
+    <tr><td class="nowrap">0018</td><td>Routability→adapter invariant stated one-directionally in prose; enforced bidirectionally at import (F-01)</td><td><b>Amend</b> to the decided rule: bidirectional for built-ins, merge seam for registered adapters.</td><td class="nowrap">D-3</td></tr>
+    <tr><td class="nowrap">0019</td><td><code>cli_unavailable</code> graceful degradation (:75-76)</td><td><b>Reaffirm</b>; cite as the degradation norm F-01's softening follows.</td><td class="nowrap">D-3</td></tr>
+    <tr><td class="nowrap">0010</td><td>Sanctioned quota channels (statusline tee, codex app-server)</td><td><b>Amend</b>: quota channels are a per-host capability; hosts without one are labeled, not silent (F-10).</td><td class="nowrap">D-2/D-4</td></tr>
+    <tr><td class="nowrap">0021</td><td>Provenance grades for inference evidence</td><td><b>Extend</b> for host-declared usage sidecars (<code>configured</code> grade; Hermes <code>--usage-file</code> is the reference case).</td><td class="nowrap">D-4 (B)</td></tr>
+    <tr><td class="nowrap">0020</td><td>OpenCode's supervised, non-primary shape</td><td><b>Amend</b> to name the host-tier taxonomy (§2) as product vocabulary.</td><td class="nowrap">D-2</td></tr>
+    <tr><td class="nowrap">0028</td><td>New — local OpenAI-compatible provider</td><td><b>Accept</b> after the <code>api_mode: chat_completions</code> citation fix + F-29 note.</td><td class="nowrap">D-7</td></tr>
+    <tr><td class="nowrap">0029</td><td>New — extension point</td><td><b>Amend then accept</b> (if D-1 = A): full gate list (F-01…F-06, F-11, F-14, F-21), ADR-0016 supersession, older-ak silent no-op mitigation.</td><td class="nowrap">D-1</td></tr>
+    <tr><td class="nowrap">0030</td><td>New — Hermes reference adapter</td><td><b>Correct then accept</b>, contingent on 0029: F-30's four factual fixes. Its safety posture (YOLO disclosure, reverse-bridge exclusion) is verified and right.</td><td class="nowrap">D-1</td></tr>
+    <tr><td class="nowrap">0031 (new)</td><td>—</td><td><b>Author</b>: "Host tiers and attribution surfaces" — records D-2 + D-4(A) as one decision, whichever way D-1 goes.</td><td class="nowrap">D-2/D-4</td></tr>
+  </table></div>
+
+  <h2 id="tests">6 · Test &amp; docs remediation</h2>
+  <h3>Tests that pin the host set (F-21, F-22)</h3>
+  <ul>
+    <li><b>Hard pins (7):</b> <code>hosts.test.mjs:10-11</code> (<code>deepEqual(HOST_IDS, [...])</code>); <code>providers.test.mjs:222-225</code> (test name says "come only from registry capabilities", body hardcodes the set — fix the body to match the name); <code>about-directory.test.mjs:118-140, 157-161, 381-385</code> (parity + order); <code>execution-runner.test.mjs:459-469</code> (pins the import-time invariant); <code>routing-primary.test.mjs:45-48</code> (stays green under the capability cap).</li>
+    <li><b>DEFAULTS literal pins (5):</b> <code>setup-host-flags.test.mjs:93-101</code>, <code>provider-cli.test.mjs:242,279</code>, <code>routing-config.test.mjs:162-163</code>, <code>integration-config.test.mjs:176-177</code>.</li>
+    <li><b>Fix pattern:</b> derive expected sets from the registry (scoped to built-ins where the assertion is about built-ins), never from a fresh literal.</li>
+    <li><b>Sentinel hazard:</b> five negative tests use <code>gemini</code> as the "unknown host" — they silently invert if that id ever registers (<code>hosts.test.mjs:40-41,106-108</code>; <code>setup-host-flags.test.mjs:48-53</code>; <code>routing.test.mjs:155-158,163-169,212-217</code>). Replace with an unmistakably synthetic id.</li>
+  </ul>
+  <h3>Docs stating a closed set as normative (F-27)</h3>
+  <ul>
+    <li><code>docs/HOST-SUPPORT.md</code> — "the three execution hosts" + five fixed-arity matrices; consider generating the matrices from the registry.</li>
+    <li><code>docs/ddd/ubiquitous-language.md:143</code> — defines "host" by enumeration.</li>
+    <li><code>docs/PROVIDERS.md</code> §3.5 — routing table prose.</li>
+    <li><code>docs/ddd/component-directory.md:164-165</code> — the parity invariant that is also test-enforced (F-06).</li>
+  </ul>
+
+  <h2 id="roadmap">7 · Sequenced roadmap</h2>
+
+  <div class="phase">
+    <h3>Phase 0 — Consistency hygiene owed regardless of D-1</h3>
+    <p class="ph-meta">No decisions required · every item bites built-in hosts today · each independently shippable</p>
+    <ul>
+      <li>F-08: unknown-host usage records → explicit per-id bucket, kill the collapse-to-claude and the scanKey collision.</li>
+      <li>F-09: live-session unknown hosts → explicit bucket, not <code>'internal'</code>.</li>
+      <li>F-11: <code>vendorOf</code> → registry-driven with <code>unregistered:&lt;id&gt;</code>, never counted toward diversity.</li>
+      <li>F-13: migrator defaults registry-driven; stop restamping on every load.</li>
+      <li>F-15/F-16: single registry-derived DEFAULTS; wire or delete <code>validateBinding</code>.</li>
+      <li>F-07/F-12: remove or revive the dead capability consumers (<code>statuslineSupported</code>, observability field) — one-line ADR note if terminal.</li>
+      <li>F-20 + the plain-text subprocess capture: tiny, independently useful, and they de-risk Phase 3.</li>
+      <li>F-22: replace the <code>gemini</code> sentinels.</li>
+    </ul>
+  </div>
+
+  <div class="phase">
+    <h3>Phase 1 — Provider axis (D-7)</h3>
+    <p class="ph-meta">Accept ADR-0028 · independent of everything else</p>
+    <ul>
+      <li>F-28: <code>providerEntries</code> → per-entry capability records (matches <code>hostEntries</code>).</li>
+      <li><code>local-openai</code> row + user-declared bindings; F-29 asymmetry stated in ADR and surfaced in status; F-30 <code>api_mode</code> citation fix.</li>
+    </ul>
+  </div>
+
+  <div class="phase">
+    <h3>Phase 2 — The extensibility decision (D-1, D-3) and in-tree generalization</h3>
+    <p class="ph-meta">Gate: ADR-0016 supersession + amended ADR-0029 accepted · refactors delete host-specific code and stand alone even if the loader never ships</p>
+    <ul>
+      <li>F-01: <code>adapters.mjs</code> invariant → built-ins-bidirectional + merge seam (ADR-0019 precedent).</li>
+      <li>F-02: lifecycle registry field + five call sites → registry lookup; OpenCode passes unchanged.</li>
+      <li>F-03: uninstall through <code>runLifecycle undo</code>.</li>
+      <li>F-04: setup permission authorization keyed by host.</li>
+      <li>F-05: status rendered from <code>normalizedFacts</code> — preserving the #129/#133/#136 projection + scope-gate behavior.</li>
+      <li>F-17: guidance targets derived from the registry.</li>
+      <li>F-06: default host card generation or built-in-scoped parity.</li>
+      <li>F-14: warn-on-unknown kit.json keys (the <code>hostAdapters</code> silent no-op mitigation).</li>
+      <li>F-21: test derivations from the registry.</li>
+      <li>The loader: explicit <code>hostAdapters</code> registration, <code>contract: 1</code>, capability caps, per-adapter fail-closed admission, <code>third-party-adapter</code> trust-manifest kind, fixture adapter in <code>tests/</code>.</li>
+    </ul>
+  </div>
+
+  <div class="phase">
+    <h3>Phase 3 — Hermes as first external consumer (ADR-0030) + tier vocabulary (D-2)</h3>
+    <p class="ph-meta">Adapter externally maintained by its proposer · ak carries no hermes-specific code</p>
+    <ul>
+      <li>ADR-0030 corrections (F-30) then acceptance; conformance evidence flows back.</li>
+      <li>D-2 capability-derived tier labels in status/about/help; F-10 quota labeling; F-25/F-26 stated asymmetries.</li>
+      <li>Docs corpus update (§6), HOST-SUPPORT matrices generated from the registry.</li>
+    </ul>
+  </div>
+
+  <div class="phase">
+    <h3>Phase 4 — Deferred, deliberately</h3>
+    <p class="ph-meta">Each needs evidence that doesn't exist yet</p>
+    <ul>
+      <li>D-4 (B): v2 ingestion contract for host-declared usage sidecars (ADR-0021 extension).</li>
+      <li>Subprocess/RPC adapter protocol (sandboxable, language-agnostic) — deferred per ADR-0029 §3 until a second adapter exists to generalize from.</li>
+      <li>Semver stability promise for the adapter contract — a GA-time decision (ADR-0020 companion).</li>
+    </ul>
+  </div>
+
+  <h2 id="hermes">8 · Appendix — Hermes verification summary</h2>
+  <p>
+    Verified against NousResearch/hermes-agent HEAD (v0.20.0, 2026-08-13; the files underlying
+    the claims last changed on or before 2026-08-08, so HEAD matches the ADRs' basis).
+    5 of 7 claim groups confirmed at source level.
+  </p>
+  <div class="tablewrap"><table>
+    <tr><th>Claim group</th><th>Verdict</th><th>Notes</th></tr>
+    <tr><td>Python CLI, pip/uv, no npm</td><td><span class="chip major">partial</span></td><td>Official: correct. But an <b>unofficial npm bridge exists</b> (<code>hermes-agent</code> by wyrtensi, v0.20.0, ships <code>hermes</code>/<code>hermes-agent</code> bins). ADRs must say "no <em>official</em> npm package"; detection must not infer identity/version from npm presence. PyPI carries 0.19.0.</td></tr>
+    <tr><td>YAML config, HERMES_HOME, profiles</td><td><span class="chip major">partial</span></td><td>All confirmed; config actions are a superset (<code>show|edit|get|set|unset|path|env-path|check|migrate</code>). Pointer wrong: dispatcher is <code>cmd_config</code> in <code>hermes_cli/subcommands/config.py</code>, not <code>config_command</code>.</td></tr>
+    <tr><td><code>mcp add</code> EOF-default silent no-op</td><td><span class="chip ok">confirmed</span></td><td>All five sub-claims; stronger than claimed — <b>no</b> <code>hermes mcp</code> subcommand except <code>install</code> can signal failure via exit code (returns swallowed at <code>mcp_config.py:1073</code> → <code>main.py:12872</code>).</td></tr>
+    <tr><td>Oneshot <code>-z</code> behavior</td><td><span class="chip ok">confirmed</span></td><td>YOLO/accept-hooks env, devnull redirect, final-write channel, exit codes 0/1/2 exact, <code>--usage-file</code> on failure too. One correction: <code>--max-turns</code> exists on <code>hermes chat</code> (non-interactive via <code>-q</code>) — just not on <code>-z</code>.</td></tr>
+    <tr><td>Local provider aliases</td><td><span class="chip major">partial</span></td><td><code>ollama</code>/<code>vllm</code>/<code>llamacpp</code> → <code>custom</code>: confirmed (in <code>auth.py</code>, not <code>runtime_provider.py</code>). <b><code>lmstudio</code> is first-class</b> with its own URL normalizer; no <code>mlx</code> alias. And <code>api_mode: openai</code> — as quoted in ADR-0028's reference config — is <b>invalid and silently dropped</b>; the valid value is <code>chat_completions</code> (newer key: <code>transport</code>).</td></tr>
+    <tr><td><code>mcp serve</code> is a messaging bridge</td><td><span class="chip ok">confirmed</span></td><td>Exactly ten tools (<code>conversations_list</code>, <code>messages_send</code>, <code>permissions_respond</code>, …); zero delegation-shaped tools. The reverse-bridge exclusion is the right security call.</td></tr>
+    <tr><td>Docs corroboration</td><td><span class="chip ok">confirmed</span></td><td>Authoritative CLI reference is <code>website/docs/reference/cli-commands.md</code> (not the README). Local-model guides confirm MLX/llama.cpp via custom endpoints.</td></tr>
+  </table></div>
+
+  <div class="callout">
+    <b>Bottom line.</b> The contributor's evidence is accurate where it counts — every claim about
+    ak's internals was confirmed by the surface sweep, and both Hermes safety findings are real.
+    The gap is scope, not honesty: "a loader and two refactors that delete code" is nearer to
+    three blockers, eight majors, twelve test pins, and a docs corpus. Phase 0 is owed today under
+    every posture; the extensibility decision (D-1) is the only call that is genuinely yours alone.
+  </div>
+
+  <p class="footer">
+    Sources: ak surface sweep (file:line citations verified in-repo) · NousResearch/hermes-agent
+    source verification · docs/adr corpus · PR #131 diff. Companion: the PR #131 review response
+    references F-nn / D-n IDs from this document.
+  </p>
+</div>
+</body>
+</html>

--- a/docs/adr/0029-host-adapter-extension-point.md
+++ b/docs/adr/0029-host-adapter-extension-point.md
@@ -2,6 +2,13 @@
 
 - **Status:** Accepted (experimental contract)
 - **Date:** 2026-08-15
+- **Updated:** 2026-08-16
+- **Update note:** [ADR-0031](0031-capability-graduation-and-upstream-requests.md) amends this ADR's
+  "permanent caps" framing. The block on *self-declaring* `canBePrimary` / `aqeProvider` /
+  `commandStatusline` in the manifest is permanent (the safety invariant here), but the *capability*
+  is earnable through a conformance tier plus a maintainer grant recorded outside the manifest — up
+  to promotion to a first-party built-in. The schema, admission gate, consent model, and hook runner
+  in this ADR are unchanged.
 - **Deciders:** agentic-kit maintainers
 - **Related:** [ADR-0016](0016-capability-driven-integration-adapters.md) (closed-registry clause
   superseded — see [Supersession](#supersession-of-adr-0016s-closed-registry-clause)),

--- a/docs/adr/0031-capability-graduation-and-upstream-requests.md
+++ b/docs/adr/0031-capability-graduation-and-upstream-requests.md
@@ -1,0 +1,191 @@
+# ADR-0031 — Capability graduation: earned parity for external host adapters, and the upstream request path
+
+- **Status:** Accepted (governance decision; implementation staged)
+- **Date:** 2026-08-16
+- **Deciders:** agentic-kit maintainers
+- **Related:** [ADR-0016](0016-capability-driven-integration-adapters.md),
+  [ADR-0018](0018-generalized-host-worker-execution.md),
+  [ADR-0019](0019-escalation-in-ak-run.md),
+  [ADR-0023](0023-fail-closed-operations-and-explicit-degradation.md),
+  [ADR-0029](0029-host-adapter-extension-point.md) (amends its "permanent caps" framing — see
+  [Amendment](#amendment-to-adr-0029))
+- **Amends:** ADR-0029, on one point only: the three capability caps are reframed from *permanent*
+  to *not self-declarable, but earnable*.
+
+## Context
+
+[ADR-0029](0029-host-adapter-extension-point.md) admitted external host adapters as a declarative
+manifest plus consented, subprocess-only hooks, behind `AK_EXPERIMENTAL_HOST_ADAPTERS=1`. To make
+the door safe, three capabilities were made **inexpressible** in the manifest schema —
+`canBePrimary`, `aqeProvider`, and `commandStatusline` — and ADR-0029 described that block as
+permanent.
+
+Two things push past that framing:
+
+1. **The product intent is full parity.** A host that clears conformance should be able to
+   participate exactly like a built-in — lead a run, own a status line, be accounted for in
+   quality — not sit permanently behind a glass wall. "Second-class forever" is not the goal;
+   "earn your way to first-class" is.
+
+2. **`ak` is downstream of two other systems.** [ruflo](https://github.com/ruvnet/ruflo)
+   orchestrates the agent loop and [agentic-qe](https://github.com/proffesor-for-testing/agentic-qe)
+   runs quality. Some parity ceilings are genuinely not `ak`'s to lift — they live upstream — and a
+   contributor chasing a conformance tier needs a real route to express what's missing, not a dead
+   end.
+
+This ADR resolves both. It keeps every safety property ADR-0029 established and adds the governance
+model that turns the caps from a wall into a ladder.
+
+## Decision
+
+### 1. Earned, never self-declared
+
+The manifest schema stays a **strict allow-list in which a capped capability is inexpressible**. An
+adapter can never *write down* that it is primary, an AQE provider, or a command-statusline owner.
+This is the safety invariant from ADR-0029 and it is permanent: self-declaration is the attack
+surface, so it stays closed forever.
+
+Parity comes through a **separate channel**. A capability is *earned* by passing a conformance tier
+and *granted* by the maintainer — recorded as a hash-pinned **capability grant** (the same
+edit-invalidation model as adapter consent), never as a field in the adapter's own manifest. The
+adapter never asserts the capability; conformance evidence plus an explicit maintainer grant confers
+it. `hostTierLabel()` and the registry already render behaviour from capabilities, so a granted
+capability lights up at every call site without special-casing.
+
+### 2. Tiered conformance
+
+Conformance becomes tiered rather than pass/fail. Each tier is a black-box test set — spawn the real
+host, assert the real behaviour, against an installed layout — that gates one capability:
+
+| Tier | Gates | Evidence shape |
+| ---- | ----- | -------------- |
+| `admission` | Registration through the fail-closed gate (ADR-0029, shipped) | manifest validates, admits, hooks run |
+| `session-driving` | `canDriveSession` — the host actually drives an interactive/oneshot session | a real session completes and is observed |
+| `activity-routing` | `canRouteActivities` — the host runs a supervised `ak run` worker to a structured result | a worker completes under the runner's contract (ADR-0018) |
+| `primary-eligible` | Grants `canBePrimary` — the host can *lead*: anchor routing, be escalated toward | leads a run and receives an escalation, per ADR-0019 |
+| `statusline` | Grants `commandStatusline` — renders a command-backed footer through supervised hooks | a footer renders and refreshes |
+
+Passing a tier records evidence; the maintainer's grant turns evidence into capability. A tier the
+adapter cannot meet because the capability is upstream is marked **gated** (§4), not failed.
+
+### 3. Two graduation destinations
+
+A conformed adapter lands in one of two places, the maintainer's call:
+
+- **Blessed external adapter** — added to a curated, hash-pinned list. It stays out-of-tree and
+  experimental, holding exactly the capabilities its tiers earned. Right for niche or long-tail
+  hosts the project does not want to own.
+- **Promoted built-in** — its host descriptor is adopted as a first-party registry entry. Because of
+  the registry-driven refactor delivered across Phases&nbsp;0–2, this is a small, ordinary PR (a
+  registry entry, a lifecycle adapter, an About card). Once built-in, the caps no longer apply
+  *because it is now first-party code the maintainer vouches for* — that is what promotion means. Its
+  hook scripts either ship bundled or are reimplemented as in-process glue, the maintainer's choice.
+
+### 4. The upstream capability-request path
+
+When a conformance tier cannot be met, the first question is **whose capability is missing**:
+
+- **`ak`-local** (run execution, the trust CLI, remote manifest sources, quality-gate anchors) — the
+  project's to build. A normal `ak` change; no one to wait on.
+- **Upstream — agentic-qe** — being a recognized **AQE provider type** is not `ak`'s to grant.
+  agentic-qe's provider set is a closed, upstream-defined enumeration (verified against
+  `agentic-qe@3.13.10`: `ALL_PROVIDER_TYPES` plus a `createProvider` switch, extended only by an
+  upstream code change). The path: file a concrete capability request against agentic-qe (a
+  provider-plugin API), record the tier as `gated: agentic-qe#NNN`, and light it up when the upstream
+  release ships. *Interim:* quality still runs through the model provider underneath the host, so QE
+  is not blocked — only the host's own AQE identity is.
+- **Upstream — ruflo** — being a native ruflo **backend** (an `ENABLE_*` target that drives the loop)
+  is defined inside ruflo (grounded against `ruvnet/ruflo@45e65b5`: backend enablement is per-host
+  `ENABLE_CLAUDE_CODE` / `ENABLE_CODEX` / `ENABLE_GEMINI_MCP`, not an outside registration). The path:
+  request a documented backend-registration surface upstream. *Interim:* the host runs through `ak`'s
+  own supervised execution, just not as a ruflo-native backend.
+
+The maintainer champions the request upstream with a named extension point, tracks the gated tier so
+an adapter's status shows exactly what it waits on, and exposes the capability in the adapter contract
+once upstream releases it. This is what keeps "no limitations after conformance" honest: the
+limitations that *are* real get a documented, per-layer route to disappear.
+
+### 5. The contributor-to-built-in lifecycle
+
+Graduation runs on a fixed sequence. A contributor **authors** a manifest and hooks,
+**self-tests** against the conformance kit, and **publishes** — at which point any user may opt in
+behind the experimental flag with hash-pinned consent, needing nothing from the maintainer. To go
+further, the contributor **proposes** it with a conformance report; the maintainer **verifies** by
+re-running the conformance kit and reviewing the hook scripts (the only part that executes),
+**decides** the tier and destination (§3), and **releases**. Conformance is objective; the
+maintainer is the judge; trust rests on reproduced evidence plus a hook read, never on running the
+contributor's code inside `ak`.
+
+### 6. Freeze criteria
+
+`contract: 1` (ADR-0029) freezes and the experimental flag is dropped when a **real** external
+adapter (Hermes first) clears the full conformance kit and survives one release of soak. Graduation
+of a capability tier and the freeze of the contract are distinct: tiers can be earned while the
+contract is still experimental.
+
+## Amendment to ADR-0029
+
+ADR-0029 states the three caps are permanent. This ADR amends that: **the block on
+*self-declaration* is permanent; the *capability* is earnable** through a conformance tier and a
+maintainer grant (§1, §2). ADR-0029's schema, admission gate, consent model, and hook runner are
+unchanged — capability grants are additive and live outside the manifest. A matching update note is
+added to ADR-0029 pointing here.
+
+## Consequences
+
+- An external adapter has a documented, evidence-gated route to full parity, up to and including
+  shipping as a built-in — without ever loading third-party code into the `ak` process and without
+  ever letting a manifest self-assert a capability.
+- The maintainer's review burden is bounded and objective: reproduce a conformance report, read the
+  hooks, grant a tier. No new trust primitive beyond the hash-pinned grant.
+- Real upstream ceilings are neither hidden nor faked: they become tracked capability requests with
+  an honest interim behaviour and a light-up path.
+- `ak` positions itself as the integrator that *shapes* its substrates rather than only consuming
+  them — the upstream-request path is a first-class part of the model, not a footnote.
+
+## Implementation status
+
+Per the ADR discipline this repository adopted (a dated, self-graded table before an Accepted claim
+rests on delivery): the **governance decision** is accepted; the **machinery** is staged and mostly
+unbuilt. This table is the source of truth for what is real.
+
+| Piece | Status (2026-08-16) | Note |
+| ----- | ------------------- | ---- |
+| Admission gate, consent store, hook runner, conformance kit (`admission` tier) | **Working** | ADR-0029, merged (PR #149) |
+| `ak host adapters trust` CLI (records consent/grants) | **Proposed — not built** | Smallest next step; today admission refuses `consent-required` |
+| External execution (`ak run` drives an admitted host) | **Proposed — not built** | The seam is a comment-only lookup today |
+| External lifecycle execution wired into setup/sync/uninstall | **Proposed — not built** | Loops are built-in-scoped by design until generalized |
+| Tiered conformance harness (`session-driving` … `statusline`) | **Proposed — not built** | Extends the single conformance kit |
+| Capability-grant store + promotion command | **Proposed — not built** | Hash-pinned, mirrors consent |
+| Remote manifest sources (npm / URL) + resolve→hash ordering | **Proposed — not built** | File-path manifests only today |
+| Upstream request tracking (`gated: <repo>#NNN` against a tier) | **Proposed — not built** | Needs a place to record per-tier gating |
+| A real external adapter (Hermes) clearing the kit → contract freeze | **Not started** | Freeze criterion (§6) |
+
+## Alternatives considered
+
+- **Keep the caps permanent (ADR-0029 as written).** Rejected: it makes external hosts second-class
+  forever and contradicts the product intent of full parity after conformance.
+- **Let the manifest self-declare capabilities, checked at runtime.** Rejected outright. This is
+  ruflo's own cautionary tale, surfaced in the research sweep behind this work: a fully typed
+  capability-permission system shipped with *zero runtime enforcement*. Runtime checks on a
+  self-asserted capability are exactly the honor-system trap the strict-allow-list schema exists to
+  avoid. Self-declaration stays inexpressible; capability comes from earned evidence plus an explicit
+  grant.
+- **Treat every ceiling as `ak`-local and build around upstream.** Rejected as dishonest and
+  unmaintainable: agentic-qe's provider enum and ruflo's backend model are upstream facts. Faking a
+  local shim (e.g. projecting an unknown host into agentic-qe's config) would fabricate an identity
+  the upstream tool never declared it understands. The upstream-request path (§4) is the honest
+  alternative.
+
+## References
+
+- ADR-0029 (the extension point, schema, admission, consent, hook runner) and its amendment above.
+- ADR-0018 (supervised worker contract), ADR-0019 (bounded escalation) — the substance of the
+  `activity-routing` and `primary-eligible` tiers.
+- Upstream facts grounded in a source-cited research sweep: `agentic-qe@3.13.10`
+  (`ALL_PROVIDER_TYPES`, the `createProvider` switch, the closed provider enum) and
+  `ruvnet/ruflo@45e65b5` (`ENABLE_*` backend model). Re-verify against upstream HEAD before filing an
+  actual capability request.
+- Companion explainer for consumers and implementers:
+  [`docs/HOST-EXTENSIBILITY-EXPLAINER.html`](../HOST-EXTENSIBILITY-EXPLAINER.html); design dossier:
+  [`docs/ADAPTER-CONTRACT-DOSSIER.html`](../ADAPTER-CONTRACT-DOSSIER.html).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -38,6 +38,7 @@ Consequences**, and cites the grounded source it rests on where relevant.
 | [0027](0027-shared-project-census.md) | One project census, four scopes, every count explains itself | Implemented |
 | [0028](0028-local-openai-compatible-providers.md) | One generic local OpenAI-compatible provider, not a vendor enumeration | Accepted |
 | [0029](0029-host-adapter-extension-point.md) | External host adapters: declarative manifest, subprocess hooks | Accepted (experimental contract) |
+| [0031](0031-capability-graduation-and-upstream-requests.md) | Capability graduation: earned parity for external adapters, and the upstream request path | Accepted (governance; implementation staged) |
 
 Theme: ADRs **0001–0006** define **dual-host LLM routing and leadership** — how `ak` lets ruflo route
 each development activity (architecture, implementation, testing, review, …) to the right host (Claude
@@ -213,3 +214,14 @@ routable-host invariant, uninstall-through-undo, permission authorization by hos
 surfaces policy, and kit.json's unknown-key warning — landed in wave 1 and Phase 0; registry↔directory
 test pins remain wave 3), and stays experimental until a real external adapter clears the
 conformance kit and a release of soak.
+
+**0031** amends 0029 on one point and adds the governance around it. The three capability caps
+(`canBePrimary`, `aqeProvider`, `commandStatusline`) stay *inexpressible* in the manifest — that
+block on self-declaration is permanent — but the capability itself becomes *earnable*: passing a
+conformance tier plus an explicit maintainer grant (hash-pinned, outside the manifest) confers it,
+up to and including promotion to a first-party built-in with full parity. It also records the
+upstream-request path: some ceilings are not `ak`'s to lift (being an AQE provider type is
+agentic-qe's closed enum; being a native ruflo backend is ruflo's `ENABLE_*` model), so those become
+tracked capability requests with honest interim behaviour rather than pretended support. Accepted as
+a governance decision; the machinery (the trust CLI, external execution, tiered conformance, the
+grant store) is staged and self-graded in the ADR's implementation-status table.


### PR DESCRIPTION
Ratifies the graduation model and lands the explainer docs locally.

- **ADR-0031** (Accepted, governance; implementation staged) — external adapters reach full parity by *earning* capabilities through tiered conformance + an explicit maintainer grant, never by self-declaring them (that block stays permanent — the ADR-0029 safety invariant, which this amends). Records the two graduation destinations, the contributor→built-in lifecycle, and the **upstream capability-request path** (some ceilings are agentic-qe's closed provider enum or ruflo's ENABLE_* model, not ak's to grant). Carries a dated Working/Proposed self-grade — the machinery is staged, not built. ADR-0029 amended with a pointer.
- **Three local doc snapshots** in `docs/`, each with an origin banner to its live Claude artifact: the host-extensibility explainer, the adapter-contract dossier, and the host/provider consistency master doc.

Full gate green (1,682 tests). Flows into the open #151 (develop→main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)