### PR TITLE
chore(deps): consolidate npm devDeps + paths-filter action bumps

### DIFF
--- a/.github/workflows/devcontainers.yml
+++ b/.github/workflows/devcontainers.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         if: github.event_name == 'pull_request' || github.event_name == 'push'
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         if: github.event_name == 'pull_request' || github.event_name == 'push'
         with:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,13 +14,13 @@ importers:
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1
-        version: 10.0.1(eslint@10.8.0)
+        version: 10.0.1(eslint@10.8.1)
       '@types/node':
         specifier: ^26.1.1
-        version: 26.1.2
+        version: 26.2.0
       eslint:
         specifier: ^10.7.0
-        version: 10.8.0
+        version: 10.8.1
       globals:
         specifier: ^17.7.0
         version: 17.9.0
@@ -129,8 +129,8 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
-  '@types/node@26.1.2':
-    resolution: {integrity: sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==}
+  '@types/node@26.2.0':
+    resolution: {integrity: sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==}
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
@@ -346,8 +346,8 @@ packages:
     resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  eslint@10.8.0:
-    resolution: {integrity: sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==}
+  eslint@10.8.1:
+    resolution: {integrity: sha512-wqA7W2jbsC/BnV9Iv1UZpKVFkO1AdNoSmYW8NWG4HNOBbkAMvIqDZ27pI2f07dqn583NcIC44ckjAcOXDL1QbQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
     hasBin: true
     peerDependencies:
@@ -755,9 +755,9 @@ packages:
 
 snapshots:
 
-  '@eslint-community/eslint-utils@4.10.1(eslint@10.8.0)':
+  '@eslint-community/eslint-utils@4.10.1(eslint@10.8.1)':
     dependencies:
-      eslint: 10.8.0
+      eslint: 10.8.1
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
@@ -778,9 +778,9 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/js@10.0.1(eslint@10.8.0)':
+  '@eslint/js@10.0.1(eslint@10.8.1)':
     optionalDependencies:
-      eslint: 10.8.0
+      eslint: 10.8.1
 
   '@eslint/object-schema@3.0.5': {}
 
@@ -833,7 +833,7 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
-  '@types/node@26.1.2':
+  '@types/node@26.2.0':
     dependencies:
       undici-types: 8.3.0
 
@@ -971,9 +971,9 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@10.8.0:
+  eslint@10.8.1:
     dependencies:
-      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.0)
+      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.1)
       '@eslint-community/regexpp': 4.12.2
       '@eslint/config-array': 0.23.5
       '@eslint/config-helpers': 0.7.0


### PR DESCRIPTION
## Summary

Consolidates the two open Dependabot dependency-bump PRs into a single verified branch. Scope was deliberately limited to actual dependency bumps — #165 (opencode bug fix) and #131 (host-adapter ADR proposal, still under active review) are unrelated PRs and are left open/untouched.

## Superseded PRs

| PR | Package(s) | Bump | Area |
|----|-----------|------|------|
| #164 | `@types/node`, `eslint` (devDependencies) | `@types/node` 26.1.2 → 26.2.0, `eslint` 10.8.0 → 10.8.1 | npm (lockfile-only — both within existing caret ranges `^26.1.1` / `^10.7.0`, so `package.json` is unchanged) |
| #163 | `dorny/paths-filter` | v3 → v4 | GitHub Actions (`.github/workflows/devcontainers.yml`) |

## Pre-existing fixes

None required — the full gate was already green prior to these bumps; no upgrade-caused or pre-existing breakage was found.

## Security audit

- `pnpm audit --audit-level=moderate` → **no known vulnerabilities**.
- `gh api repos/pacphi/agentic-kit/dependabot/alerts` → **0 open alerts**.
- No RUSTSEC/GHSA/CVE research was needed since no findings were surfaced (this repo has no Rust/Cargo component — TypeScript/npm only, per request).

## Verification

Ran the exact gate `.github/workflows/ci.yml` uses, plus the full test suite:

```
pnpm install --frozen-lockfile   # lockfile reproduces cleanly
pnpm run typecheck               # tsc -p tsconfig.json            -> clean
pnpm run lint                    # eslint .                        -> clean
pnpm run lint:md                 # markdownlint-cli2 (61 files)    -> 0 issues
pnpm run build                   # scripts/build-check.mjs         -> OK (148 files, CLI loads, npm pack resolves 173 files)
pnpm test                        # node --test + all *.test.cjs    -> all suites passed, 0 failed
pnpm run test:surface            # dispatch-surface tests          -> 26 passed, 0 failed
pnpm run audit                   # pnpm audit --audit-level=moderate -> no known vulnerabilities
```

No Rust/Cargo steps applicable — this is a pure TypeScript/pnpm repository (no `Cargo.toml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)