### PR TITLE
test(opencode): use compatibility window for stock gateway acceptance

### DIFF
--- a/docs/HOST-SUPPORT.md
+++ b/docs/HOST-SUPPORT.md
@@ -25,6 +25,12 @@ Claude Code `2.1.222`, Codex CLI `0.146.0`, and OpenCode `1.18.x`. Host and
 upstream behavior changes quickly; open issues below are a risk snapshot, not a
 promise that an issue remains open forever.
 
+The stock OpenCode gateway acceptance test currently covers the stable compatibility
+window **`>=1.18.18 <1.19.0`**. This is a tested release-line window, not a claim
+that every future OpenCode release is compatible and not a target for `ak sync` to
+downgrade toward. Expanding the window requires the gateway behavior test to pass
+against the new release line.
+
 ## Reading the matrices
 
 - **Native** means the upstream project ships a host-specific integration.

--- a/tests/kit/helpers/opencode-version-policy.mjs
+++ b/tests/kit/helpers/opencode-version-policy.mjs
@@ -1,0 +1,21 @@
+import { cmpVersions } from '../../../src/lib/versions.mjs';
+
+// This is the stock gateway test window, not an updater constraint. Expanding
+// it requires the gateway behavior test to pass against the new release line.
+export const STOCK_OPENCODE_MIN_VERSION = '1.18.18';
+export const STOCK_OPENCODE_MAX_EXCLUSIVE = '1.19.0';
+export const STOCK_OPENCODE_VERSION_RANGE =
+  `>=${STOCK_OPENCODE_MIN_VERSION} <${STOCK_OPENCODE_MAX_EXCLUSIVE}`;
+
+const VERSION_IN_OUTPUT = /\bv?(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)\b/;
+
+export function extractStockOpenCodeVersion(output) {
+  const match = String(output).match(VERSION_IN_OUTPUT);
+  return match?.[1] ?? null;
+}
+
+export function isSupportedStockOpenCodeVersion(version) {
+  if (!/^\d+\.\d+\.\d+$/.test(String(version))) return false;
+  return cmpVersions(version, STOCK_OPENCODE_MIN_VERSION) >= 0
+    && cmpVersions(version, STOCK_OPENCODE_MAX_EXCLUSIVE) < 0;
+}

--- a/tests/kit/opencode-stock-ruflo-gateway.test.mjs
+++ b/tests/kit/opencode-stock-ruflo-gateway.test.mjs
@@ -8,6 +8,11 @@ import net from 'node:net';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+import {
+  extractStockOpenCodeVersion,
+  isSupportedStockOpenCodeVersion,
+  STOCK_OPENCODE_VERSION_RANGE,
+} from './helpers/opencode-version-policy.mjs';
 
 const harnessRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
 const pkgRoot = process.env.AK_STOCK_PACKAGE_ROOT
@@ -271,9 +276,13 @@ test(`stock OpenCode keeps Ruflo and Agentic QE connected with ${compactProjecti
     fs.rmSync(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
   });
 
-  const version = execFileSync(opencode, ['--version'], { encoding: 'utf8' }).trim();
+  const reportedVersion = execFileSync(opencode, ['--version'], { encoding: 'utf8' }).trim();
   const binarySha256 = createHash('sha256').update(fs.readFileSync(opencode)).digest('hex');
-  assert.match(version, /^1\.18\.18(?:\b|$)/, `acceptance is pinned to stock OpenCode 1.18.18 (${binarySha256})`);
+  const version = extractStockOpenCodeVersion(reportedVersion);
+  assert.equal(
+    isSupportedStockOpenCodeVersion(version), true,
+    `unsupported stock OpenCode version '${reportedVersion}'; supported range is ${STOCK_OPENCODE_VERSION_RANGE} (${binarySha256})`,
+  );
 
   const configHome = path.join(root, 'config');
   const configDir = path.join(configHome, 'opencode');

--- a/tests/kit/opencode-version-policy.test.mjs
+++ b/tests/kit/opencode-version-policy.test.mjs
@@ -1,0 +1,27 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  extractStockOpenCodeVersion,
+  isSupportedStockOpenCodeVersion,
+  STOCK_OPENCODE_VERSION_RANGE,
+} from './helpers/opencode-version-policy.mjs';
+
+test('stock OpenCode policy accepts the tested floor and later patch releases', () => {
+  assert.equal(isSupportedStockOpenCodeVersion('1.18.18'), true);
+  assert.equal(isSupportedStockOpenCodeVersion('1.18.22'), true);
+  assert.equal(STOCK_OPENCODE_VERSION_RANGE, '>=1.18.18 <1.19.0');
+});
+
+test('stock OpenCode policy rejects versions outside the tested stable line', () => {
+  assert.equal(isSupportedStockOpenCodeVersion('1.18.17'), false);
+  assert.equal(isSupportedStockOpenCodeVersion('1.19.0'), false);
+  assert.equal(isSupportedStockOpenCodeVersion('2.0.0'), false);
+  assert.equal(isSupportedStockOpenCodeVersion('1.18.22-beta.1'), false);
+  assert.equal(isSupportedStockOpenCodeVersion('not-a-version'), false);
+});
+
+test('stock OpenCode policy extracts a version from CLI output', () => {
+  assert.equal(extractStockOpenCodeVersion('1.18.22\n'), '1.18.22');
+  assert.equal(extractStockOpenCodeVersion('OpenCode v1.18.22'), '1.18.22');
+  assert.equal(extractStockOpenCodeVersion('OpenCode development build'), null);
+});


### PR DESCRIPTION
Closes #172.

## Summary

- Replace the exact stock OpenCode 1.18.18 assertion with a documented stable compatibility window: >=1.18.18 <1.19.0.
- Accept later compatible patch releases such as the current npm latest 1.18.22 without assuming future minor or major compatibility.
- Emit a clear unsupported-version failure that includes the reported version, supported range, and binary SHA-256 before gateway behavior assertions run.
- Add boundary and CLI-output parsing tests.
- Document that this window is a tested acceptance contract, not an ak sync downgrade target.

## Validation

- Targeted version-policy and stock gateway tests pass against OpenCode 1.18.22.
- pnpm run check passes: typecheck, lint, markdown lint, build, audit, full test suite, and platform-independent checks.
- No updater or package ownership behavior changed.

Future OpenCode release lines must pass the gateway behavior test before the compatibility window is expanded.