### PR TITLE
feat(usage): Matrix A consistent cross-host session metrics

### DIFF
--- a/docs/DASHBOARD.md
+++ b/docs/DASHBOARD.md
@@ -325,13 +325,6 @@ The lifecycle payload is separate from the Usage session/transcript and Observab
 payloads. Public catalogue enrichment cannot rename, re-price, add, or remove a retained session or
 transcript model record.
 
-The Scorecard view also shows a host-neutral **telemetry coverage** panel for Claude, Codex
-transcript evidence, and OpenCode. It reports parsed units and observed prompt/response totals, plus
-capability states (`supported`, `unsupported`, or `unavailable`). A readable source with no observed
-activity is a measured zero; an absent, degraded, or old API response is disclosed as unavailable or
-not reported rather than rendered as zero. The Codex transcript card does not merge the separate
-`codexLedger` corrective source into its coverage counts.
-
 ## Observability
 
 Observability separates navigation scope from playback state:

--- a/docs/DASHBOARD.md
+++ b/docs/DASHBOARD.md
@@ -178,7 +178,9 @@ trends on a different set of days than its neighbours, and says so in its own to
 covers the days you worked, while every other trend covers the days that billed tokens. The second
 row answers unit economics — sessions per active day with its current streak, autonomy (responses
 per prompt you typed, and those same prompts per engaged hour), cost per session, and cost per
-engaged hour. Cost per session is a median over *priced* sessions only; a session with no token
+engaged hour. Session counts, the rhythm histograms and the punchcard all **include delegated
+subagent sessions**, which the harness dispatches rather than you; the how-you-run panel carries the
+main/subagent split, and autonomy is the exception — its denominator is main-thread prompts only. Cost per session is a median over *priced* sessions only; a session with no token
 evidence at all is structurally zero rather than cheap, and folding it in would drag the median
 toward zero for a reason that is not about spend. A real figure under a cent renders `<$0.01`, never
 `$0.00`.
@@ -210,7 +212,9 @@ evidence supports. **Model mix over time** stacks per-day cost by coarse model f
 families coloured and the rest folded into a de-emphasised band.
 
 **Reliability** reports turns that never landed: exceptions per thousand responses, aborted turns,
-and a per-day exceptions sparkline that names the worst single day.
+and a per-day exceptions sparkline that names the worst single day. Aborted turns are **codex-only
+evidence** — no other host records an interrupt — so the count appears only when the window holds a
+codex session, and otherwise reads `—` rather than a zero that would look measured.
 
 `ak usage score` prints the same scorecard figures in a terminal, offline, including the rhythm
 pair, the posture and served-by tables, and the reliability lines.

--- a/docs/DASHBOARD.md
+++ b/docs/DASHBOARD.md
@@ -161,6 +161,70 @@ Each count carries the sentence explaining what it counted; on Intelligence it i
 Usage loads lazily when first opened. Scorecard, Limits, Findings, Sessions, Models, and Transcript share the
 same secondary rail; the 7/14/30-day filters remain aligned to its right.
 
+### Scorecard
+
+Scorecard reads top to bottom as one argument: what the window cost, how you spent it, and what that
+says about the way you work. Every figure is derived from locally retained transcripts, so every
+dollar is API-equivalent list price and never plan billing.
+
+**Two hero rows.** The first carries sessions, api-equivalent cost, tokens, engaged time, and cache
+read. Each tile pairs its figure with a change against the previous window of the same length and a
+per-day sparkline, so the number and its direction arrive together. The change is read
+directionally, not just arithmetically — a falling cost is good, a rising cache share is good, and a
+token count is neither — and the cache delta is stated in percentage points, because a percent of a
+percent would be read as something else. A day that billed no tokens has no share to plot, so the
+sparkline breaks there rather than carrying the previous value forward. **The engaged-time tile
+trends on a different set of days than its neighbours, and says so in its own tooltip:** its trend
+covers the days you worked, while every other trend covers the days that billed tokens. The second
+row answers unit economics — sessions per active day with its current streak, autonomy (responses
+per prompt you typed, and those same prompts per engaged hour), cost per session, and cost per
+engaged hour. Cost per session is a median over *priced* sessions only; a session with no token
+evidence at all is structurally zero rather than cheap, and folding it in would drag the median
+toward zero for a reason that is not about spend. A real figure under a cent renders `<$0.01`, never
+`$0.00`.
+
+**Rhythm & responsiveness** puts two histograms side by side, session length and response latency,
+each with its percentile markers laid over the bars. A percentile that lands in the open-ended
+top bucket renders with a `≥` prefix — the bucket has no upper edge, so the honest claim is a floor
+rather than a point. A window holding no samples reads `not measured` instead of a row of zero bars.
+**Response latency is the gap between a prompt and the response that answered it. It is not
+time-to-first-token**, which no local transcript records.
+
+**How you run** answers permission posture, who drove, and who served. Posture is a closed
+four-value vocabulary — guarded, auto-edit, plan, unrestricted — mapped from each host's own
+evidence; a raw value the taxonomy has not been taught yields **not-recorded**, which is a
+first-class row rendered in the de-emphasis ink rather than a display fallback, because spend with
+no posture evidence must never read as a posture. The delegation donut splits main-thread from
+subagent work, and its two halves are honest in different ways: Claude writes delegated work to its
+own nested transcript, so that cost is discovered, priced, and included, while a Codex subagent
+rollout reads `$0.00` by ledger design — its tokens replay the parent's and are stripped as a
+double-count, so the sessions stay visible and auditable at zero rather than billing the parent
+twice. Served-by ranks cost by inference provider, and `Not recorded` is always offered as a row:
+a transcript host is not a vendor and a configured provider is not an observed one, so spend is
+never bucketed under an assumption.
+
+**Tool mix** ranks tool invocations, top eight with the tail folded into a dimmed `Other` row rather
+than dropped. Names are the host's own — Codex's `CommandExecution` is not renamed to `Bash` —
+because the vocabularies are host-specific and a renamed row would assert a correspondence no
+evidence supports. **Model mix over time** stacks per-day cost by coarse model family, the top
+families coloured and the rest folded into a de-emphasised band.
+
+**Reliability** reports turns that never landed: exceptions per thousand responses, aborted turns,
+and a per-day exceptions sparkline that names the worst single day.
+
+`ak usage score` prints the same scorecard figures in a terminal, offline, including the rhythm
+pair, the posture and served-by tables, and the reliability lines.
+
+### Limits
+
+Limits renders each vendor-reported window as a utilization meter. Every meter that can place one
+also carries a **pace tick** — the mark a steady burn would be sitting on right now, computed from
+the window's own length and reset time, so fill past the tick means ahead of pace. Nothing is
+fetched to draw it. When the arithmetic falls outside the window — a snapshot older than the window
+it describes, or a browser clock that disagrees with the vendor's — the tick is omitted rather than
+pinned to either end, because a mark at 0% or 100% would state a position the data cannot support.
+The legend appears only when at least one row actually carries a tick.
+
 ### Reading a session row
 
 Projects begin collapsed. Expand a project to reveal its session rows. Each row deliberately keeps
@@ -169,8 +233,19 @@ identity axes separate:
 - the compact host badge states only the execution host: Claude Code, Codex, or OpenCode;
 - the leading chevron expands an independent detail strip without opening the transcript;
 - the detail strip reports execution host, inference provider, provider provenance, model or models,
-  classification basis, token details, tools, and flags;
+  permission posture, rhythm, classification basis, token details, tools, and flags;
 - clicking the rest of the row opens the locally retained masked transcript.
+
+The row also carries chips for what that one session measured: its engaged length, its median
+response latency, a **posture badge**, and a **context-fill chip**. Both of the last two are
+evidence-gated. The posture badge appears only when the transcript recorded a posture this taxonomy
+maps, and its tooltip carries the host's own spelling of that value where the transcript recorded
+one, because the mapping is a judgment call and a reader checking it needs the evidence it was made
+from. The `ctx N%` chip
+appears only when **both** halves were observed — the last turn's context tokens and that model's
+window. Codex records a window; Claude Code and OpenCode do not, and the dashboard carries no
+published-window table to fall back on, so the chip is omitted rather than divided by a guessed
+denominator that would render as a fabricated percentage.
 
 Host, inference provider, provenance, and model are independent facts. The dashboard never derives a
 provider from a host name or model string. Codex `session_meta.model_provider` and equivalent

--- a/docs/DASHBOARD.md
+++ b/docs/DASHBOARD.md
@@ -201,9 +201,9 @@ subagent work, and its two halves are honest in different ways: Claude writes de
 own nested transcript, so that cost is discovered, priced, and included, while a Codex subagent
 rollout reads `$0.00` by ledger design — its tokens replay the parent's and are stripped as a
 double-count, so the sessions stay visible and auditable at zero rather than billing the parent
-twice. Served-by ranks cost by inference provider, and `Not recorded` is always offered as a row:
-a transcript host is not a vendor and a configured provider is not an observed one, so spend is
-never bucketed under an assumption.
+twice. The panel does not rank window cost by inference provider: a transcript host is not a vendor,
+and only Codex transcripts record who served the tokens, so that identity is reported per session on
+the Sessions detail strip — beside the provenance backing it — rather than as a window axis.
 
 **Tool mix** ranks tool invocations, top eight with the tail folded into a dimmed `Other` row rather
 than dropped. Names are the host's own — Codex's `CommandExecution` is not renamed to `Bash` —

--- a/docs/TRANSCRIPTS.md
+++ b/docs/TRANSCRIPTS.md
@@ -122,17 +122,19 @@ an equivalence neither host makes — while their bodies still travel in events
 the parser does not render. Codex tool *output* therefore remains outside the
 turn list: a fidelity gap, not an attribution bug.
 
-### 1.3 Cross-host telemetry capability contract
+### 1.3 What these readers normalize, and what the hosts publish
 
-The public host APIs are richer than the historical readers in this module, and
-they are not interchangeable transcript schemas. This distinction is verified
-against the public surfaces available on **2026-08-24**:
+The public host APIs are richer than the readers in this module, and they are
+not interchangeable transcript schemas. What each reader normalizes is
+therefore narrower than what its host offers — a fidelity gap, stated here so a
+missing category is never read as an observed zero. Verified against the public
+surfaces available on **2026-08-24**:
 
-| Host | Public evidence | Historical adapter contract in this repository |
+| Host | Public evidence | What this repository's reader normalizes |
 |---|---|---|
-| Claude Code | Hooks expose `transcript_path`, `tool_name`, tool input/results, and `tool_use_id`; its monitoring surface also documents `claude_code.tool` spans and tool-result events ([hooks reference](https://code.claude.com/docs/en/hooks), [monitoring](https://code.claude.com/docs/en/monitoring-usage)) | `prompts`, `responses`, and normalized `toolCalls` are supported; command/file/MCP/collaboration subcategories remain unclaimed until their cross-host semantics are specified |
-| Codex | The public `codex app-server` protocol documents typed `userMessage`, `agentMessage`, `commandExecution`, `fileChange`, `mcpToolCall`, and `collabToolCall` items ([app-server protocol](https://github.com/openai/codex/blob/main/codex-rs/app-server/README.md)) | Only prompt/response items are normalized into turns. The rollout parser records unknown item kinds diagnostically and tallies four of them onto the session's `tools` map (§1.2) — but `toolCalls` here stays `unsupported`, because a name-and-count tally is not the normalized tool-call record this category claims. Codex activity categories are `unsupported` in this historical adapter, not measured zero |
-| OpenCode | The public SDK returns session messages with `parts`, and its public message model includes tool invocation parts ([SDK](https://github.com/anomalyco/opencode/blob/dev/packages/web/src/content/docs/sdk.mdx), [message model](https://github.com/anomalyco/opencode/blob/dev/packages/opencode/src/session/message.ts)) | `prompts`, `responses`, and persisted `toolCalls` are supported; command/file/MCP/collaboration subcategories remain unclaimed |
+| Claude Code | Hooks expose `transcript_path`, `tool_name`, tool input/results, and `tool_use_id`; its monitoring surface also documents `claude_code.tool` spans and tool-result events ([hooks reference](https://code.claude.com/docs/en/hooks), [monitoring](https://code.claude.com/docs/en/monitoring-usage)) | Prompts, responses, and normalized tool calls. Command, file-change, MCP, and collaboration activity are not normalized until their cross-host semantics are specified |
+| Codex | The public `codex app-server` protocol documents typed `userMessage`, `agentMessage`, `commandExecution`, `fileChange`, `mcpToolCall`, and `collabToolCall` items ([app-server protocol](https://github.com/openai/codex/blob/main/codex-rs/app-server/README.md)) | Only prompt/response items become turns. The rollout parser records unknown item kinds diagnostically and tallies four of them onto the session's `tools` map under their own Codex names (§1.2) — a name-and-count tally, not the normalized tool-call record Claude and OpenCode produce, which is why the two are never added together |
+| OpenCode | The public SDK returns session messages with `parts`, and its public message model includes tool invocation parts ([SDK](https://github.com/anomalyco/opencode/blob/dev/packages/web/src/content/docs/sdk.mdx), [message model](https://github.com/anomalyco/opencode/blob/dev/packages/opencode/src/session/message.ts)) | Prompts, responses, and persisted tool calls. Command, file-change, MCP, and collaboration activity are not normalized |
 
 Three per-session axes are read on all three hosts, but from **different
 evidence of different strength**, which is why each is reported with its own
@@ -151,25 +153,22 @@ and a context-fill percentage is simply omitted where the denominator was never
 recorded rather than divided by an assumed window.
 
 `sourceHealth.<host>.diagnostics.common` is the additive, host-neutral
-coverage envelope. `unitsSeen` counts discovered session candidates in the
-requested window; `unitsParsed` counts candidates parsed successfully;
-`unitsWithUsage`, `unitsWithPrompts`, and `unitsWithResponses` count parsed
-units carrying each kind of evidence; `prompts` and `responses` are observed
-totals. `sourceHealth.<host>.capabilities` uses three states:
+coverage envelope, and every field in it is counted rather than declared.
+`unitsSeen` counts discovered session candidates in the requested window;
+`unitsParsed` counts candidates parsed successfully; `unitsWithUsage`,
+`unitsWithPrompts`, and `unitsWithResponses` count parsed units carrying each
+kind of evidence; `prompts` and `responses` are observed totals.
 
 `unknownKinds` is capped at 32 distinct wire kinds; additional occurrences are
 retained in `unknownKindOverflow` so future schema growth cannot expand the
 diagnostics payload without limit.
 
-* `supported` means this historical adapter can produce the category;
-* `unsupported` means the category is intentionally not claimed by this adapter;
-* `unavailable` means the adapter supports the category in principle, but the
-  source is absent or degraded for this scan.
-
-Therefore a supported source with zero observations is different from an
-absent/degraded source, and neither is silently converted into a host-specific
-metric. Existing status/reason fields and Codex diagnostic keys remain in place
-for compatibility; the common envelope and capability matrix are additive.
+A readable source with zero observations is therefore distinguishable from an
+absent or degraded one — the counters read zero in the first case, and the
+source's own `status`/`reason` says so in the second — and neither is silently
+converted into a host-specific metric. Existing status/reason fields and Codex
+diagnostic keys remain in place for compatibility; the common envelope is
+additive.
 
 ---
 

--- a/docs/TRANSCRIPTS.md
+++ b/docs/TRANSCRIPTS.md
@@ -40,7 +40,7 @@ rewritten; rule 3 of the module header, `usage-index.mjs:22`):
 | Claude Code (subagent) | `~/.claude/projects/<encoded-project-dir>/<sessionId>/subagents/agent-<hash>.jsonl` | `listClaudeSubagents` (`usage-index.mjs:243-255`) — the one nested shape `listClaude` descends into |
 | Codex CLI | `~/.codex/sessions/<yyyy>/<mm>/<dd>/rollout-<ts>-<uuid>.jsonl` | `listCodex` (`usage-index.mjs:276-296`) — the `yyyy/mm/dd` tree walk |
 
-Roots come from `defaultRoots()` (`usage-index.mjs:218-223`) and are injectable
+Roots come from `defaultRoots()` (`usage-index.mjs:252-257`) and are injectable
 for tests. A malformed line is skipped, never fatal (`jsonLines`,
 `usage-parsers.mjs:167-173` — one corrupt line must not cost a whole file).
 
@@ -74,12 +74,15 @@ Each line has a top-level `type`. The parser (`parseClaude`,
 
 A real assistant completion also closes two pieces of per-entry evidence the
 transcript does not state outright. It **closes the latency window** the
-preceding human prompt opened, into one sample of the gap between them
-(`usage-parsers.mjs:410-414`); and it **overwrites `ctxLastTokens`** with the
+preceding human prompt opened, into one `noteLatencySample` call over the gap
+between them (`usage-parsers.mjs:410-414`); and it **conditionally sets `ctxLastTokens`** to the
 tokens actually in the model's window for that turn — fresh input plus what was
 served from cache — so the field always describes the last completion rather
-than a running total (`usage-parsers.mjs:420-424`). Neither is a field Claude
-Code writes; both are derived, per entry, at parse time.
+than a running total (`usage-parsers.mjs:428-429`). That write is
+evidence-gated: an entry whose `message.usage` is absent decodes to all-zeros,
+and a zero is not a measurement of an empty context, so it must not overwrite a
+real prior value. Neither is a field Claude Code writes; both are derived, per
+entry, at parse time.
 
 An assistant entry with `isApiErrorMessage: true` is a **local placeholder**
 Claude Code writes when a request dies before a real completion (connection
@@ -98,7 +101,7 @@ Codex rollout lines carry `type` + `payload`. The parser (`parseCodex`,
 | `type` / `payload.type` | What the parser takes from it |
 |---|---|
 | `session_meta` | Authoritative session id, `cwd`, and `thread_source` (`usage-parsers.mjs:488-497`) — `"subagent"` marks a thread_spawn replay whose tokens are excluded from aggregation (`usage-parsers.mjs:692`; `USAGE-SCORECARD-METRICS.md` Appendix A, Bug B) |
-| `turn_context` | The model id in effect from this point on, plus `approval_policy` and `sandbox_policy` — the permission posture, last evidence winning, since a session may renegotiate mid-run (`usage-parsers.mjs:498-509`) |
+| `turn_context` | The model id in effect from this point on, plus `approval_policy` (a string) and `sandbox_policy` (an **object** keyed `.type`, e.g. `{"type":"danger-full-access"}`) — the permission posture, last evidence winning, since a session may renegotiate mid-run (`usage-parsers.mjs:498-520`) |
 | `event_msg` → `token_count` | A **cumulative** usage snapshot; only the last one is kept (`usage-parsers.mjs:543-552`) |
 | `event_msg` → `task_started` | `model_context_window` — the context-window denominator, which no other host records — and the turn's start time (`usage-parsers.mjs:558-563`) |
 | `event_msg` → `task_complete` | The host's own `duration_ms` for the turn, taken as a latency sample only when no prompt-to-response gap already covered it; a non-null `error` counts as an exception (`usage-parsers.mjs:571-578`) |
@@ -138,7 +141,7 @@ absence rather than folded into one number:
 | Axis | Claude Code | Codex | OpenCode |
 |---|---|---|---|
 | Response latency | derived — the gap from a human prompt to the next real completion (`noteLatencySample`, `usage-parsers.mjs:410-414`) | host-measured `duration_ms` on `task_complete`, used only when no prompt gap covered the turn; the derived gap stays primary (`handleCodexTaskComplete`, `usage-parsers.mjs:571-578`) | derived, same prompt-gap rule as Claude (`noteLatencySample`, `usage-opencode.mjs:227-231`) |
-| Permission posture | `permissionMode`, off the person's own turn (`usage-parsers.mjs:356-357`) | `approval_policy`/`sandbox_policy` off each `turn_context` (`usage-parsers.mjs:505-508`) | `mode` off each assistant message (`normalizeMode`, `usage-opencode.mjs:232-233`) |
+| Permission posture | `permissionMode`, off the person's own turn (`usage-parsers.mjs:356-357`) | `approval_policy` plus `sandbox_policy.type` off each `turn_context` — the sandbox field is an object, and its `.type` is extracted before the taxonomy is consulted (`usage-parsers.mjs:505-519`) | `mode` off each assistant message (`normalizeMode`, `usage-opencode.mjs:232-233`) |
 | Context window | last-turn tokens only; **no window denominator is recorded** | both halves — `model_context_window` on `task_started` and last-turn tokens | last-turn tokens only; no window denominator |
 
 An unmapped or unobserved value on any of these is `not-recorded`, never a
@@ -190,7 +193,11 @@ recorded in `USAGE-SCORECARD-METRICS.md` Appendix A). Schema v11 is that same
 rule applied again: it added `mode`/`modeRaw`, `latHist`/`latCount`,
 `lenSeconds`, `ctxWindow`/`ctxLastTokens` and `aborts` to the record, so every
 session had to be re-derived rather than read back as `undefined`
-(`usage-index.mjs:92-98`).
+(`usage-index.mjs:92-98`). v12 is the rule applied to a *wrong* value rather
+than a missing one: v11 records persisted `modeRaw: "never/[object Object]"`
+and a null `mode` for every Codex session, because `sandbox_policy` is an
+object and was compared against string literals. Re-deriving is what clears
+them (`usage-index.mjs:99-104`).
 
 ---
 
@@ -267,7 +274,7 @@ transcript content leaves the module, and every step is a gate:
 
 1. **Id grammar before any filesystem access** — an id must match one of
    exactly two shapes, or it is rejected with `ERR_INVALID_SESSION_ID`
-   (`invalidId`, `usage-index.mjs:755-761`) before any read happens:
+   (`invalidId`, `usage-index.mjs:919`) before any read happens:
    * `VALID_ID` (`/^[A-Za-z0-9._-]{1,128}$/`, `usage-index.mjs:110`) — a plain
      session id;
    * `VALID_SUBAGENT_ID` (`usage-index.mjs:123`) — a namespaced nested
@@ -276,7 +283,7 @@ transcript content leaves the module, and every step is a gate:
      real on-disk `agent-…` shape. The namespaced grammar is a **narrowing**
      of the plain one, never a loosening: both are the same path-traversal
      guard, and a traversal shape is rejected at either tier.
-2. **Locate by id** across both roots (`locate`, `usage-index.mjs:800`),
+2. **Locate by id** across both roots (`locate`, `usage-index.mjs:852`),
    consulting the scan cache when present but never requiring it —
    `readSession` works with no prior `buildIndex`. A namespaced id resolves
    through `locateSubagent` (`usage-index.mjs:787-795`), which builds the
@@ -438,10 +445,10 @@ Deep links: `#usage/<sessionId>` opens the Transcript view directly
 | Model per assistant turn | per-turn `message.model` | last `turn_context` model in effect |
 | Token usage | per-assistant-turn `usage` object | cumulative `token_count`; last snapshot wins |
 | API-error placeholders | `<synthetic>` / `isApiErrorMessage` → exceptions | none observed |
-| Aborted turns | none recorded | `turn_aborted` → `aborts` |
+| Aborted turns | none recorded — and the surfaces render `—`, not `0`, for a window with no Codex session, since nothing in it could have recorded one | `turn_aborted` → `aborts` |
 | Delegation markers | `isSidechain` → `sidechain` flag; the delegated work is its own nested transcript, discovered and priced like any other | `thread_source: "subagent"` → excluded from aggregation, session kept visible |
-| Permission posture | `permissionMode`, on the person's own turn | `approval_policy`/`sandbox_policy`, per `turn_context` |
-| Response latency | derived from the prompt-to-completion gap | same gap where available, else the host's own `duration_ms` |
+| Permission posture | `permissionMode`, on the person's own turn | `approval_policy` + `sandbox_policy.type` (an object field), per `turn_context` |
+| Response latency | derived from the prompt-to-completion gap | same gap where available, else the host's own `duration_ms` — both capped at 3600 s, since `duration_ms` includes time blocked on an approval prompt |
 | Context window | last-turn tokens only, no denominator | both halves — `model_context_window` and last-turn tokens |
 | Session title | model-written `ai-title`, first-prompt fallback | first prompt clipped |
 

--- a/docs/TRANSCRIPTS.md
+++ b/docs/TRANSCRIPTS.md
@@ -301,7 +301,7 @@ transcript content leaves the module, and every step is a gate:
 
 The file is parsed with `withTurns: true` by the provider's parser
 (`usage-index.mjs:901-906`), and `meta` is assembled by `sessionPayload`
-(`usage-aggregate.mjs:878-905`) with the same fields the Sessions view rows
+(`usage-aggregate.mjs:866-893`) with the same fields the Sessions view rows
 carry — `prompts`, `responses`, `exceptions`, `sidechain`, `threadSource`,
 `models`, `tools`, `skill`/`plugin`, worktree — plus a `cost` priced from the
 same per-model usage rows `aggregate()` uses.
@@ -322,7 +322,7 @@ Every turn body is passed through `maskSecrets` (`usage-aggregate.mjs:133-138` �
 23 secret shapes) **server-side, before
 serialization**, then length-capped at `MAX_TURN_CHARS` (40,000,
 `usage-aggregate.mjs:63`) with the marker appended
-(`usage-aggregate.mjs:913-922`). Two invariants:
+(`usage-aggregate.mjs:901-910`). Two invariants:
 
 * **Presence is the signal.** `truncated`/`originalChars` are emitted only
   when the slice fired, so a complete turn cannot be misread as abridged.
@@ -482,7 +482,7 @@ was wrong before, for the curious.
   assembled `meta` left `cost` undefined, and `fmtUsd(undefined)` renders the
   truthy string `"$0.00"` — a fixed-looking zero on a panel whose whole
   subject is cost. `meta.cost` is now priced via `sessionCost()` from the
-  same per-model usage rows `aggregate()` uses (`usage-aggregate.mjs:903`).
+  same per-model usage rows `aggregate()` uses (`usage-aggregate.mjs:891`).
 * **Aggregate-side incidents** (the v4/v5 cache bumps, the Codex parsing
   defects) are recorded in `USAGE-SCORECARD-METRICS.md` Appendix A.
 

--- a/docs/TRANSCRIPTS.md
+++ b/docs/TRANSCRIPTS.md
@@ -36,11 +36,11 @@ rewritten; rule 3 of the module header, `usage-index.mjs:22`):
 
 | Host | Store | Discovered by |
 |---|---|---|
-| Claude Code | `~/.claude/projects/<encoded-project-dir>/<sessionId>.jsonl` | `listClaude` (`usage-index.mjs:259-273`) — exactly one level of project directories |
+| Claude Code | `~/.claude/projects/<encoded-project-dir>/<sessionId>.jsonl` | `listClaude` (`usage-index.mjs:316-330`) — exactly one level of project directories |
 | Claude Code (subagent) | `~/.claude/projects/<encoded-project-dir>/<sessionId>/subagents/agent-<hash>.jsonl` | `listClaudeSubagents` (`usage-index.mjs:291-296`) — the one nested shape `listClaude` descends into |
-| Codex CLI | `~/.codex/sessions/<yyyy>/<mm>/<dd>/rollout-<ts>-<uuid>.jsonl` | `listCodex` (`usage-index.mjs:276-296`) — the `yyyy/mm/dd` tree walk |
+| Codex CLI | `~/.codex/sessions/<yyyy>/<mm>/<dd>/rollout-<ts>-<uuid>.jsonl` | `listCodex` (`usage-index.mjs:333-353`) — the `yyyy/mm/dd` tree walk |
 
-Roots come from `defaultRoots()` (`usage-index.mjs:252-257`) and are injectable
+Roots come from `defaultRoots()` (`usage-index.mjs:266-271`) and are injectable
 for tests. A malformed line is skipped, never fatal (`jsonLines`,
 `usage-parsers.mjs:167-173` — one corrupt line must not cost a whole file).
 
@@ -96,22 +96,22 @@ first *real* completion that eventually follows is what gets timed.
 ### 1.2 Codex entry vocabulary
 
 Codex rollout lines carry `type` + `payload`. The parser (`parseCodex`,
-`usage-parsers.mjs:724-745`) reads:
+`usage-parsers.mjs:799-817`) reads:
 
 | `type` / `payload.type` | What the parser takes from it |
 |---|---|
-| `session_meta` | Authoritative session id, `cwd`, and `thread_source` — the FIRST such line in the file wins for all three (`usage-parsers.mjs:511-513`); a subagent rollout replays its PARENT thread's own session_meta line later in the same file, and a later-wins rule let that relabel the record `subagent`→`user` and re-key its id to the parent's (`usage-parsers.mjs:493-510`) — `"subagent"` marks a thread_spawn replay whose tokens are excluded from aggregation (`usage-parsers.mjs:771`; `USAGE-SCORECARD-METRICS.md` Appendix A, Bug B) |
-| `turn_context` | The model id in effect from this point on, plus `approval_policy` (a string) and `sandbox_policy` (an **object** keyed `.type`, e.g. `{"type":"danger-full-access"}`) — the permission posture, last evidence winning, since a session may renegotiate mid-run (`usage-parsers.mjs:498-520`) |
-| `event_msg` → `token_count` | A **cumulative** usage snapshot; only the last one is kept (`usage-parsers.mjs:543-552`) |
-| `event_msg` → `task_started` | `model_context_window` — the context-window denominator, which no other host records — and the turn's start time (`usage-parsers.mjs:558-563`) |
-| `event_msg` → `task_complete` | The host's own `duration_ms` for the turn, taken as a latency sample only when no prompt-to-response gap already covered it; a non-null `error` counts as an exception (`usage-parsers.mjs:571-578`) |
-| `event_msg` → `turn_aborted` | An explicit interrupt: counted in `aborts`, and it clears both latency states so an unanswered prompt is never timed against a later, unrelated response (`usage-parsers.mjs:644-654`) |
+| `session_meta` | Authoritative session id, `cwd`, and `thread_source` — the FIRST such line in the file wins for all three, AND for `inferenceProvider`/`providerProvenance` too (`usage-parsers.mjs:523-525`, gate; `:493-522`, why); a subagent rollout replays its PARENT thread's own session_meta line later in the same file, and a later-wins rule let that relabel the record `subagent`→`user` and re-key its id to the parent's — `"subagent"` marks a thread_spawn replay whose tokens are excluded from aggregation (`usage-parsers.mjs:782`; `USAGE-SCORECARD-METRICS.md` Appendix A, Bug B) |
+| `turn_context` | The model id in effect from this point on, plus `approval_policy` (a string) and `sandbox_policy` (an **object** keyed `.type`, e.g. `{"type":"danger-full-access"}`) — the permission posture, last evidence winning, since a session may renegotiate mid-run (`usage-parsers.mjs:535-556`) |
+| `event_msg` → `token_count` | A **cumulative** usage snapshot; only the last one is kept (`usage-parsers.mjs:590-598`) |
+| `event_msg` → `task_started` | `model_context_window` — the context-window denominator, which no other host records — and the turn's start time (`usage-parsers.mjs:605-610`) |
+| `event_msg` → `task_complete` | The host's own `duration_ms` for the turn, taken as a latency sample only when no prompt-to-response gap already covered it; a non-null `error` counts as an exception (`usage-parsers.mjs:622-630`) |
+| `event_msg` → `turn_aborted` | An explicit interrupt: counted in `aborts`, and it clears both latency states so an unanswered prompt is never timed against a later, unrelated response (`usage-parsers.mjs:726-734`) |
 | `event_msg` → `user_message` | A legacy-format prompt CANDIDATE — Codex does not route tool output through this event, but the text still needs the human-prompt gate below before it counts |
 | `event_msg` → `agent_message` | A legacy-format model response |
 | `event_msg` → `item_completed` → `UserMessage` | A current-format prompt candidate; text blocks use the observed lowercase `text` discriminator; also gated below |
 | `event_msg` → `item_completed` → `AgentMessage` | A current-format model response; text blocks use the observed uppercase `Text` discriminator |
-| Human-prompt gate (`isCodexHumanMessage`, `usage-parsers.mjs:637-638`) | Codex carries no discipline of its own for telling a typed prompt apart from harness output or a mirrored cross-host envelope replayed into the rollout rather than typed there. Reuses `HARNESS_OUTPUT_RE` verbatim (Claude's own envelope markers reproduce byte-for-byte inside a mirrored rollout) plus two Codex-specific machine markers (`CODEX_MACHINE_ENVELOPE_RE`, `usage-parsers.mjs:635`): a `<teammate-message` wrapper and the literal `"Another Claude session sent a message:"` prefix cross-session delivery uses. Only a message that passes the gate counts toward `rec.prompts`, sets the session title, or opens the prompt→agent-message latency window; every `user_message`/`UserMessage` still gets a turn row either way, `kind: 'context'` instead of `'prompt'` when gated out — mirroring how a Claude harness-origin `user` entry is kept, not dropped (§3.2). Deliberately narrow: exact-twin cross-host dedup by flush timestamp is a recorded follow-up, not attempted here |
-| `event_msg` → `item_completed` → `CommandExecution`, `McpToolCall`, `FileChange`, `CollabAgentToolCall` | The four item kinds tallied as tool invocations, keyed by their own Codex names (`CODEX_TOOL_ITEM_TYPES`, `usage-parsers.mjs:634`, tallied at `:659-661`) |
+| Human-prompt gate (`isCodexHumanMessage`, `usage-parsers.mjs:648-650`) | Codex carries no discipline of its own for telling a typed prompt apart from harness output or a mirrored cross-host envelope replayed into the rollout rather than typed there. Reuses `HARNESS_OUTPUT_RE` verbatim (Claude's own envelope markers reproduce byte-for-byte inside a mirrored rollout) plus two Codex-specific machine markers (`CODEX_MACHINE_ENVELOPE_RE`, `usage-parsers.mjs:646`): a `<teammate-message` wrapper and the literal `"Another Claude session sent a message:"` prefix cross-session delivery uses. Only a message that passes the gate counts toward `rec.prompts`, sets the session title, or opens the prompt→agent-message latency window (`usage-parsers.mjs:670`); every `user_message`/`UserMessage` still gets a turn row either way, `kind: 'context'` instead of `'prompt'` when gated out (`:673`) — mirroring how a Claude harness-origin `user` entry is kept, not dropped (§3.2). Deliberately narrow: exact-twin cross-host dedup by flush timestamp is a recorded follow-up, not attempted here |
+| `event_msg` → `item_completed` → `CommandExecution`, `McpToolCall`, `FileChange`, `CollabAgentToolCall` | The four item kinds tallied as tool invocations, keyed by their own Codex names (`CODEX_TOOL_ITEM_TYPES`, `usage-parsers.mjs:716`, tallied at `:747-748`) |
 
 The parser normalizes both message generations into the same prompt/response
 turn model. Unknown `item_completed` item types are ignored for those metrics
@@ -143,8 +143,8 @@ absence rather than folded into one number:
 
 | Axis | Claude Code | Codex | OpenCode |
 |---|---|---|---|
-| Response latency | derived — the gap from a human prompt to the next real completion (`noteLatencySample`, `usage-parsers.mjs:410-414`) | host-measured `duration_ms` on `task_complete`, used only when no prompt gap covered the turn; the derived gap stays primary (`handleCodexTaskComplete`, `usage-parsers.mjs:571-578`) | derived, same prompt-gap rule as Claude (`noteLatencySample`, `usage-opencode.mjs:227-231`) |
-| Permission posture | `permissionMode`, off the person's own turn (`usage-parsers.mjs:356-357`) | `approval_policy` plus `sandbox_policy.type` off each `turn_context` — the sandbox field is an object, and its `.type` is extracted before the taxonomy is consulted (`usage-parsers.mjs:505-519`) | `mode` off each assistant message (`normalizeMode`, `usage-opencode.mjs:232-233`) |
+| Response latency | derived — the gap from a human prompt to the next real completion (`noteLatencySample`, `usage-parsers.mjs:410-414`) | host-measured `duration_ms` on `task_complete`, used only when no prompt gap covered the turn; the derived gap stays primary (`handleCodexTaskComplete`, `usage-parsers.mjs:622-630`) | derived, same prompt-gap rule as Claude (`noteLatencySample`, `usage-opencode.mjs:227-231`) |
+| Permission posture | `permissionMode`, off the person's own turn (`usage-parsers.mjs:356-357`) | `approval_policy` plus `sandbox_policy.type` off each `turn_context` — the sandbox field is an object, and its `.type` is extracted before the taxonomy is consulted (`usage-parsers.mjs:541-554`) | `mode` off each assistant message (`normalizeMode`, `usage-opencode.mjs:232-233`) |
 | Context window | last-turn tokens only; **no window denominator is recorded** | both halves — `model_context_window` on `task_started` and last-turn tokens | last-turn tokens only; no window denominator |
 
 An unmapped or unobserved value on any of these is `not-recorded`, never a
@@ -256,8 +256,11 @@ Two deliberate subtleties:
 * **`tool-result` outranks `context`**: a `tool_result` block on an `isMeta`
   entry is still tool feedback.
 
-Codex user turns are `kind: 'prompt'` by construction (`usage-parsers.mjs:584-593`)
-— rollouts only record real prompts as `user_message` events (§1.2).
+Codex user turns are `kind: 'prompt'` when they pass the human-prompt gate,
+`'context'` when a harness or mirrored envelope gates them out
+(`handleCodexUserMessage`, `usage-parsers.mjs:661-675`, §1.2) — rollouts only
+route real prompts AND harness/mirror text through `user_message` events,
+never tool output, so `'tool-result'` never occurs on this host.
 
 Coverage: `tests/kit/usage-index.test.mjs` — "user-role turns carry a kind"
 (both providers, the fixture's real `tool_result` entry) and "isMeta context
@@ -277,7 +280,7 @@ transcript content leaves the module, and every step is a gate:
    (`invalidId`, `usage-index.mjs:919`) before any read happens:
    * `VALID_ID` (`/^[A-Za-z0-9._-]{1,128}$/`, `usage-index.mjs:131`) — a plain
      session id;
-   * `VALID_SUBAGENT_ID` (`usage-index.mjs:123`) — a namespaced nested
+   * `VALID_SUBAGENT_ID` (`usage-index.mjs:147`) — a namespaced nested
      subagent id, EXACTLY `<parentId>/<stem>` with one slash, where the parent
      half reuses `VALID_ID`'s own charset and the child half must match the
      real on-disk `agent-…` shape. The namespaced grammar is a **narrowing**

--- a/docs/TRANSCRIPTS.md
+++ b/docs/TRANSCRIPTS.md
@@ -37,7 +37,7 @@ rewritten; rule 3 of the module header, `usage-index.mjs:22`):
 | Host | Store | Discovered by |
 |---|---|---|
 | Claude Code | `~/.claude/projects/<encoded-project-dir>/<sessionId>.jsonl` | `listClaude` (`usage-index.mjs:259-273`) — exactly one level of project directories |
-| Claude Code (subagent) | `~/.claude/projects/<encoded-project-dir>/<sessionId>/subagents/agent-<hash>.jsonl` | `listClaudeSubagents` (`usage-index.mjs:243-255`) — the one nested shape `listClaude` descends into |
+| Claude Code (subagent) | `~/.claude/projects/<encoded-project-dir>/<sessionId>/subagents/agent-<hash>.jsonl` | `listClaudeSubagents` (`usage-index.mjs:291-296`) — the one nested shape `listClaude` descends into |
 | Codex CLI | `~/.codex/sessions/<yyyy>/<mm>/<dd>/rollout-<ts>-<uuid>.jsonl` | `listCodex` (`usage-index.mjs:276-296`) — the `yyyy/mm/dd` tree walk |
 
 Roots come from `defaultRoots()` (`usage-index.mjs:252-257`) and are injectable
@@ -49,7 +49,7 @@ the parent under `<sessionId>/subagents/`. Discovery is that one nested shape
 and no more — not a recursive walk — so a directory that is not a session-id
 directory with a `subagents` child contributes nothing rather than being
 crawled. Each such record takes a **namespaced** id, `<sessionId>/<stem>`
-(`usage-index.mjs:250`), because Claude Code names every subagent file
+(`usage-index.mjs:296`), because Claude Code names every subagent file
 `agent-<hash>.jsonl` and that stem is not unique across two parent sessions; an
 unnamespaced id would silently collide two unrelated records into one. §4.1
 covers how a namespaced id is validated and resolved back to its file.
@@ -100,16 +100,17 @@ Codex rollout lines carry `type` + `payload`. The parser (`parseCodex`,
 
 | `type` / `payload.type` | What the parser takes from it |
 |---|---|
-| `session_meta` | Authoritative session id, `cwd`, and `thread_source` (`usage-parsers.mjs:488-497`) — `"subagent"` marks a thread_spawn replay whose tokens are excluded from aggregation (`usage-parsers.mjs:692`; `USAGE-SCORECARD-METRICS.md` Appendix A, Bug B) |
+| `session_meta` | Authoritative session id, `cwd`, and `thread_source` — the FIRST such line in the file wins for all three (`usage-parsers.mjs:511-513`); a subagent rollout replays its PARENT thread's own session_meta line later in the same file, and a later-wins rule let that relabel the record `subagent`→`user` and re-key its id to the parent's (`usage-parsers.mjs:493-510`) — `"subagent"` marks a thread_spawn replay whose tokens are excluded from aggregation (`usage-parsers.mjs:771`; `USAGE-SCORECARD-METRICS.md` Appendix A, Bug B) |
 | `turn_context` | The model id in effect from this point on, plus `approval_policy` (a string) and `sandbox_policy` (an **object** keyed `.type`, e.g. `{"type":"danger-full-access"}`) — the permission posture, last evidence winning, since a session may renegotiate mid-run (`usage-parsers.mjs:498-520`) |
 | `event_msg` → `token_count` | A **cumulative** usage snapshot; only the last one is kept (`usage-parsers.mjs:543-552`) |
 | `event_msg` → `task_started` | `model_context_window` — the context-window denominator, which no other host records — and the turn's start time (`usage-parsers.mjs:558-563`) |
 | `event_msg` → `task_complete` | The host's own `duration_ms` for the turn, taken as a latency sample only when no prompt-to-response gap already covered it; a non-null `error` counts as an exception (`usage-parsers.mjs:571-578`) |
 | `event_msg` → `turn_aborted` | An explicit interrupt: counted in `aborts`, and it clears both latency states so an unanswered prompt is never timed against a later, unrelated response (`usage-parsers.mjs:644-654`) |
-| `event_msg` → `user_message` | A legacy-format real human prompt — Codex does not route tool output through this event |
+| `event_msg` → `user_message` | A legacy-format prompt CANDIDATE — Codex does not route tool output through this event, but the text still needs the human-prompt gate below before it counts |
 | `event_msg` → `agent_message` | A legacy-format model response |
-| `event_msg` → `item_completed` → `UserMessage` | A current-format real human prompt; text blocks use the observed lowercase `text` discriminator |
+| `event_msg` → `item_completed` → `UserMessage` | A current-format prompt candidate; text blocks use the observed lowercase `text` discriminator; also gated below |
 | `event_msg` → `item_completed` → `AgentMessage` | A current-format model response; text blocks use the observed uppercase `Text` discriminator |
+| Human-prompt gate (`isCodexHumanMessage`, `usage-parsers.mjs:637-638`) | Codex carries no discipline of its own for telling a typed prompt apart from harness output or a mirrored cross-host envelope replayed into the rollout rather than typed there. Reuses `HARNESS_OUTPUT_RE` verbatim (Claude's own envelope markers reproduce byte-for-byte inside a mirrored rollout) plus two Codex-specific machine markers (`CODEX_MACHINE_ENVELOPE_RE`, `usage-parsers.mjs:635`): a `<teammate-message` wrapper and the literal `"Another Claude session sent a message:"` prefix cross-session delivery uses. Only a message that passes the gate counts toward `rec.prompts`, sets the session title, or opens the prompt→agent-message latency window; every `user_message`/`UserMessage` still gets a turn row either way, `kind: 'context'` instead of `'prompt'` when gated out — mirroring how a Claude harness-origin `user` entry is kept, not dropped (§3.2). Deliberately narrow: exact-twin cross-host dedup by flush timestamp is a recorded follow-up, not attempted here |
 | `event_msg` → `item_completed` → `CommandExecution`, `McpToolCall`, `FileChange`, `CollabAgentToolCall` | The four item kinds tallied as tool invocations, keyed by their own Codex names (`CODEX_TOOL_ITEM_TYPES`, `usage-parsers.mjs:634`, tallied at `:659-661`) |
 
 The parser normalizes both message generations into the same prompt/response
@@ -178,7 +179,7 @@ The same parsers serve two very different callers, switched by `withTurns`:
 
 | Path | Entry point | `withTurns` | Message bodies | Cached? |
 |---|---|---|---|---|
-| **Scan** — the aggregate index behind the Scorecard/Findings/Sessions views | `buildIndex` → `parseFile` (`usage-index.mjs:310`) | `false` | never held — holding them would balloon memory across 3,000+ files (`usage-parsers.mjs:435-438`) | yes: per-file derived records in `~/.config/agentic-kit/usage-index.json`, keyed `(path, mtime, size)`, invalidated wholesale by `SCHEMA_VERSION` (`usage-index.mjs:99`) |
+| **Scan** — the aggregate index behind the Scorecard/Findings/Sessions views | `buildIndex` → `parseFile` (`usage-index.mjs:310`) | `false` | never held — holding them would balloon memory across 3,000+ files (`usage-parsers.mjs:435-438`) | yes: per-file derived records in `~/.config/agentic-kit/usage-index.json`, keyed `(path, mtime, size)`, invalidated wholesale by `SCHEMA_VERSION` (`usage-index.mjs:120`) |
 | **Reader** — one transcript for the Transcript view | `readSession` (`usage-index.mjs:853`) | `true` | full turn list built | **never** — every call re-reads and re-parses the one file |
 
 ![Figure: one parser, two read paths — the scan path (withTurns false) caches per-file records keyed by path, mtime and size; the reader path (withTurns true) builds full turns and is never cached](assets/transcript-read-paths.svg)
@@ -274,7 +275,7 @@ transcript content leaves the module, and every step is a gate:
 1. **Id grammar before any filesystem access** — an id must match one of
    exactly two shapes, or it is rejected with `ERR_INVALID_SESSION_ID`
    (`invalidId`, `usage-index.mjs:919`) before any read happens:
-   * `VALID_ID` (`/^[A-Za-z0-9._-]{1,128}$/`, `usage-index.mjs:110`) — a plain
+   * `VALID_ID` (`/^[A-Za-z0-9._-]{1,128}$/`, `usage-index.mjs:131`) — a plain
      session id;
    * `VALID_SUBAGENT_ID` (`usage-index.mjs:123`) — a namespaced nested
      subagent id, EXACTLY `<parentId>/<stem>` with one slash, where the parent
@@ -293,7 +294,7 @@ transcript content leaves the module, and every step is a gate:
    symlinks; a symlink planted inside a root pointing at `/etc/anything`
    passes a lexical `startsWith` but fails this. Roots are realpath'd too so
    a symlinked dotfiles setup still works.
-4. **Size cap** — `MAX_SESSION_BYTES` (64 MB, `usage-index.mjs:109`): a
+4. **Size cap** — `MAX_SESSION_BYTES` (64 MB, `usage-index.mjs:130`): a
    transcript is read whole and JSON-expands ~5×, so an unbounded read is a
    memory-amplification primitive. Oversized reads as unavailable, not risky.
 

--- a/docs/TRANSCRIPTS.md
+++ b/docs/TRANSCRIPTS.md
@@ -32,16 +32,27 @@ verified against the current source by the test suite
 
 Both supported transcript **hosts** write complete session logs to disk as JSONL — one JSON object
 per line — and the kit reads them **read-only** (transcripts are never
-rewritten; rule 3 of the module header, `usage-index.mjs:22-29`):
+rewritten; rule 3 of the module header, `usage-index.mjs:22`):
 
 | Host | Store | Discovered by |
 |---|---|---|
-| Claude Code | `~/.claude/projects/<encoded-project-dir>/<sessionId>.jsonl` | `listClaude` (`usage-index.mjs:206-218`) — exactly one level of project directories |
-| Codex CLI | `~/.codex/sessions/<yyyy>/<mm>/<dd>/rollout-<ts>-<uuid>.jsonl` | `listCodex` (`usage-index.mjs:221-240`) — the `yyyy/mm/dd` tree walk |
+| Claude Code | `~/.claude/projects/<encoded-project-dir>/<sessionId>.jsonl` | `listClaude` (`usage-index.mjs:259-273`) — exactly one level of project directories |
+| Claude Code (subagent) | `~/.claude/projects/<encoded-project-dir>/<sessionId>/subagents/agent-<hash>.jsonl` | `listClaudeSubagents` (`usage-index.mjs:243-255`) — the one nested shape `listClaude` descends into |
+| Codex CLI | `~/.codex/sessions/<yyyy>/<mm>/<dd>/rollout-<ts>-<uuid>.jsonl` | `listCodex` (`usage-index.mjs:276-296`) — the `yyyy/mm/dd` tree walk |
 
-Roots come from `defaultRoots()` (`usage-index.mjs:198-203`) and are injectable
+Roots come from `defaultRoots()` (`usage-index.mjs:218-223`) and are injectable
 for tests. A malformed line is skipped, never fatal (`jsonLines`,
 `usage-parsers.mjs:167-173` — one corrupt line must not cost a whole file).
+
+A session's **delegated** work is a real transcript of its own, written beside
+the parent under `<sessionId>/subagents/`. Discovery is that one nested shape
+and no more — not a recursive walk — so a directory that is not a session-id
+directory with a `subagents` child contributes nothing rather than being
+crawled. Each such record takes a **namespaced** id, `<sessionId>/<stem>`
+(`usage-index.mjs:250`), because Claude Code names every subagent file
+`agent-<hash>.jsonl` and that stem is not unique across two parent sessions; an
+unnamespaced id would silently collide two unrelated records into one. §4.1
+covers how a namespaced id is validated and resolved back to its file.
 
 Host evidence is not inference-provider proof. A Claude transcript may describe Anthropic-,
 OpenRouter-, or Ollama-served inference. ADR-0016 defines separate
@@ -52,43 +63,61 @@ transcript host/parser identity unless other evidence grounds the inference prov
 ### 1.1 Claude entry vocabulary
 
 Each line has a top-level `type`. The parser (`parseClaude`,
-`usage-parsers.mjs:376-401`) reads:
+`usage-parsers.mjs:440-469`) reads:
 
 | `type` | What the parser takes from it |
 |---|---|
-| `ai-title` | The model-written session title (`usage-parsers.mjs:383`) — preferred over the first-prompt fallback |
-| `user` | A user-**role** turn — which is *not* the same as "the human"; see §3 |
-| `assistant` | A model turn: `model` id, per-turn `usage` token counts, `tool_use` blocks (`usage-parsers.mjs:329-368`) |
-| any | Side-band fields read regardless of type: `attributionSkill`/`attributionPlugin` (`usage-parsers.mjs:384-385`), `isSidechain` (`usage-parsers.mjs:387`), `cwd` for project derivation |
+| `ai-title` | The model-written session title (`usage-parsers.mjs:450`) — preferred over the first-prompt fallback |
+| `user` | A user-**role** turn — which is *not* the same as "the human"; see §3. On a turn that passes `isHumanPrompt`, also its `permissionMode` — the session's permission posture, read on the person's own turn only (`usage-parsers.mjs:356-357`) — and the opening of the response-latency window |
+| `assistant` | A model turn: `model` id, per-turn `usage` token counts, `tool_use` blocks (`usage-parsers.mjs:380-433`) |
+| any | Side-band fields read regardless of type: `attributionSkill`/`attributionPlugin` (`usage-parsers.mjs:451-452`), `isSidechain` (`usage-parsers.mjs:454`), `cwd` for project derivation |
+
+A real assistant completion also closes two pieces of per-entry evidence the
+transcript does not state outright. It **closes the latency window** the
+preceding human prompt opened, into one sample of the gap between them
+(`usage-parsers.mjs:410-414`); and it **overwrites `ctxLastTokens`** with the
+tokens actually in the model's window for that turn — fresh input plus what was
+served from cache — so the field always describes the last completion rather
+than a running total (`usage-parsers.mjs:420-424`). Neither is a field Claude
+Code writes; both are derived, per entry, at parse time.
 
 An assistant entry with `isApiErrorMessage: true` is a **local placeholder**
 Claude Code writes when a request dies before a real completion (connection
 drop, rate limit, auth failure — `model: "<synthetic>"`, all-zero usage). It
 is real engaged time but not a model attempt: counted as an *exception*, never
-pushed into `models` or priced (`usage-parsers.mjs:345-353`; the full story is
-[`USAGE-SCORECARD-METRICS.md`](USAGE-SCORECARD-METRICS.md) §10).
+pushed into `models` or priced (`usage-parsers.mjs:387-408`; the full story is
+[`USAGE-SCORECARD-METRICS.md`](USAGE-SCORECARD-METRICS.md) §10). It is not a
+latency sample either — the pending window is deliberately left open, so the
+first *real* completion that eventually follows is what gets timed.
 
 ### 1.2 Codex entry vocabulary
 
 Codex rollout lines carry `type` + `payload`. The parser (`parseCodex`,
-`usage-parsers.mjs:578-593`) reads:
+`usage-parsers.mjs:724-745`) reads:
 
 | `type` / `payload.type` | What the parser takes from it |
 |---|---|
-| `session_meta` | Authoritative session id, `cwd`, and `thread_source` (`usage-parsers.mjs:421-428`) — `"subagent"` marks a thread_spawn replay whose tokens are excluded from aggregation (`usage-parsers.mjs:546`; `USAGE-SCORECARD-METRICS.md` Appendix A, Bug B) |
-| `turn_context` | The model id in effect from this point on (`usage-parsers.mjs:431-437`) |
-| `event_msg` → `token_count` | A **cumulative** usage snapshot; only the last one is kept (`usage-parsers.mjs:474-480`) |
+| `session_meta` | Authoritative session id, `cwd`, and `thread_source` (`usage-parsers.mjs:488-497`) — `"subagent"` marks a thread_spawn replay whose tokens are excluded from aggregation (`usage-parsers.mjs:692`; `USAGE-SCORECARD-METRICS.md` Appendix A, Bug B) |
+| `turn_context` | The model id in effect from this point on, plus `approval_policy` and `sandbox_policy` — the permission posture, last evidence winning, since a session may renegotiate mid-run (`usage-parsers.mjs:498-509`) |
+| `event_msg` → `token_count` | A **cumulative** usage snapshot; only the last one is kept (`usage-parsers.mjs:543-552`) |
+| `event_msg` → `task_started` | `model_context_window` — the context-window denominator, which no other host records — and the turn's start time (`usage-parsers.mjs:558-563`) |
+| `event_msg` → `task_complete` | The host's own `duration_ms` for the turn, taken as a latency sample only when no prompt-to-response gap already covered it; a non-null `error` counts as an exception (`usage-parsers.mjs:571-578`) |
+| `event_msg` → `turn_aborted` | An explicit interrupt: counted in `aborts`, and it clears both latency states so an unanswered prompt is never timed against a later, unrelated response (`usage-parsers.mjs:644-654`) |
 | `event_msg` → `user_message` | A legacy-format real human prompt — Codex does not route tool output through this event |
 | `event_msg` → `agent_message` | A legacy-format model response |
 | `event_msg` → `item_completed` → `UserMessage` | A current-format real human prompt; text blocks use the observed lowercase `text` discriminator |
 | `event_msg` → `item_completed` → `AgentMessage` | A current-format model response; text blocks use the observed uppercase `Text` discriminator |
+| `event_msg` → `item_completed` → `CommandExecution`, `McpToolCall`, `FileChange`, `CollabAgentToolCall` | The four item kinds tallied as tool invocations, keyed by their own Codex names (`CODEX_TOOL_ITEM_TYPES`, `usage-parsers.mjs:634`, tallied at `:659-661`) |
 
 The parser normalizes both message generations into the same prompt/response
 turn model. Unknown `item_completed` item types are ignored for those metrics
 and counted in Codex source diagnostics; they are not silently reclassified as
-human prompts, model responses, or existing tool metrics. Codex tool calls and
-tool outputs therefore still travel in event types the parser does not surface
-as turns — a fidelity gap, not an attribution bug.
+human prompts, model responses, or existing tool metrics. The four typed kinds
+above are **counted, not surfaced as turns**: they raise Codex's tool tallies
+under their own vocabulary — never renamed to a Claude tool, which would assert
+an equivalence neither host makes — while their bodies still travel in events
+the parser does not render. Codex tool *output* therefore remains outside the
+turn list: a fidelity gap, not an attribution bug.
 
 ### 1.3 Cross-host telemetry capability contract
 
@@ -99,8 +128,24 @@ against the public surfaces available on **2026-08-24**:
 | Host | Public evidence | Historical adapter contract in this repository |
 |---|---|---|
 | Claude Code | Hooks expose `transcript_path`, `tool_name`, tool input/results, and `tool_use_id`; its monitoring surface also documents `claude_code.tool` spans and tool-result events ([hooks reference](https://code.claude.com/docs/en/hooks), [monitoring](https://code.claude.com/docs/en/monitoring-usage)) | `prompts`, `responses`, and normalized `toolCalls` are supported; command/file/MCP/collaboration subcategories remain unclaimed until their cross-host semantics are specified |
-| Codex | The public `codex app-server` protocol documents typed `userMessage`, `agentMessage`, `commandExecution`, `fileChange`, `mcpToolCall`, and `collabToolCall` items ([app-server protocol](https://github.com/openai/codex/blob/main/codex-rs/app-server/README.md)) | Only prompt/response items are normalized today. The rollout parser records unknown item kinds diagnostically; Codex activity categories are `unsupported` in this historical adapter, not measured zero |
+| Codex | The public `codex app-server` protocol documents typed `userMessage`, `agentMessage`, `commandExecution`, `fileChange`, `mcpToolCall`, and `collabToolCall` items ([app-server protocol](https://github.com/openai/codex/blob/main/codex-rs/app-server/README.md)) | Only prompt/response items are normalized into turns. The rollout parser records unknown item kinds diagnostically and tallies four of them onto the session's `tools` map (§1.2) — but `toolCalls` here stays `unsupported`, because a name-and-count tally is not the normalized tool-call record this category claims. Codex activity categories are `unsupported` in this historical adapter, not measured zero |
 | OpenCode | The public SDK returns session messages with `parts`, and its public message model includes tool invocation parts ([SDK](https://github.com/anomalyco/opencode/blob/dev/packages/web/src/content/docs/sdk.mdx), [message model](https://github.com/anomalyco/opencode/blob/dev/packages/opencode/src/session/message.ts)) | `prompts`, `responses`, and persisted `toolCalls` are supported; command/file/MCP/collaboration subcategories remain unclaimed |
+
+Three per-session axes are read on all three hosts, but from **different
+evidence of different strength**, which is why each is reported with its own
+absence rather than folded into one number:
+
+| Axis | Claude Code | Codex | OpenCode |
+|---|---|---|---|
+| Response latency | derived — the gap from a human prompt to the next real completion (`noteLatencySample`, `usage-parsers.mjs:410-414`) | host-measured `duration_ms` on `task_complete`, used only when no prompt gap covered the turn; the derived gap stays primary (`handleCodexTaskComplete`, `usage-parsers.mjs:571-578`) | derived, same prompt-gap rule as Claude (`noteLatencySample`, `usage-opencode.mjs:227-231`) |
+| Permission posture | `permissionMode`, off the person's own turn (`usage-parsers.mjs:356-357`) | `approval_policy`/`sandbox_policy` off each `turn_context` (`usage-parsers.mjs:505-508`) | `mode` off each assistant message (`normalizeMode`, `usage-opencode.mjs:232-233`) |
+| Context window | last-turn tokens only; **no window denominator is recorded** | both halves — `model_context_window` on `task_started` and last-turn tokens | last-turn tokens only; no window denominator |
+
+An unmapped or unobserved value on any of these is `not-recorded`, never a
+guess: the posture taxonomy is a closed vocabulary whose every mapping is a
+recorded judgment ([ADR-0038](adr/0038-consistent-cross-host-session-metrics.md)),
+and a context-fill percentage is simply omitted where the denominator was never
+recorded rather than divided by an assumed window.
 
 `sourceHealth.<host>.diagnostics.common` is the additive, host-neutral
 coverage envelope. `unitsSeen` counts discovered session candidates in the
@@ -131,8 +176,8 @@ The same parsers serve two very different callers, switched by `withTurns`:
 
 | Path | Entry point | `withTurns` | Message bodies | Cached? |
 |---|---|---|---|---|
-| **Scan** — the aggregate index behind the Scorecard/Findings/Sessions views | `buildIndex` → `parseFile` (`usage-index.mjs:255`) | `false` | never held — holding them would balloon memory across 3,000+ files (`usage-parsers.mjs:371-375`) | yes: per-file derived records in `~/.config/agentic-kit/usage-index.json`, keyed `(path, mtime, size)`, invalidated wholesale by `SCHEMA_VERSION` (`usage-index.mjs:92`) |
-| **Reader** — one transcript for the Transcript view | `readSession` (`usage-index.mjs:715`) | `true` | full turn list built | **never** — every call re-reads and re-parses the one file |
+| **Scan** — the aggregate index behind the Scorecard/Findings/Sessions views | `buildIndex` → `parseFile` (`usage-index.mjs:310`) | `false` | never held — holding them would balloon memory across 3,000+ files (`usage-parsers.mjs:435-438`) | yes: per-file derived records in `~/.config/agentic-kit/usage-index.json`, keyed `(path, mtime, size)`, invalidated wholesale by `SCHEMA_VERSION` (`usage-index.mjs:99`) |
+| **Reader** — one transcript for the Transcript view | `readSession` (`usage-index.mjs:853`) | `true` | full turn list built | **never** — every call re-reads and re-parses the one file |
 
 ![Figure: one parser, two read paths — the scan path (withTurns false) caches per-file records keyed by path, mtime and size; the reader path (withTurns true) builds full turns and is never cached](assets/transcript-read-paths.svg)
 
@@ -141,7 +186,11 @@ changes (like the `kind` field, §3) need no `SCHEMA_VERSION` bump**, because
 no turn is ever served from cache — whereas *session-record* fields (like
 `exceptions`) do, since stale cached records would otherwise sum `undefined`
 into totals (`usage-index.mjs:59-65`; the incidents behind that rule are
-recorded in `USAGE-SCORECARD-METRICS.md` Appendix A).
+recorded in `USAGE-SCORECARD-METRICS.md` Appendix A). Schema v11 is that same
+rule applied again: it added `mode`/`modeRaw`, `latHist`/`latCount`,
+`lenSeconds`, `ctxWindow`/`ctxLastTokens` and `aborts` to the record, so every
+session had to be re-derived rather than read back as `undefined`
+(`usage-index.mjs:92-98`).
 
 ---
 
@@ -154,10 +203,10 @@ recorded in `USAGE-SCORECARD-METRICS.md` Appendix A).
 | `role` | all | `"user"` or `"assistant"` — the **Messages-API role**, not the author (see below) |
 | `at` | all | ISO timestamp |
 | `text` | all | Flattened display text (`claudeText`, `telemetry-records.mjs:38-55` — binary payloads dropped: a pasted screenshot renders as `[image]`, a tool result is prefixed `[tool result]`) |
-| `model` | assistant | The model id; the literal string `exception` for an API-error placeholder turn (`usage-parsers.mjs:350`) |
+| `model` | assistant | The model id; the literal string `exception` for an API-error placeholder turn (`usage-parsers.mjs:403`) |
 | `tools` | assistant | Tool names invoked in the turn |
-| `prompt` | user | `isHumanPrompt`'s verdict (`usage-parsers.mjs:262-271`) — drives the **prompt counts** |
-| `kind` | user | `'prompt'` \| `'tool-result'` \| `'context'` — drives the **attribution label** (`userTurnKind`, `usage-parsers.mjs:290-294`) |
+| `prompt` | user | `isHumanPrompt`'s verdict (`usage-parsers.mjs:308-317`) — drives the **prompt counts** |
+| `kind` | user | `'prompt'` \| `'tool-result'` \| `'context'` — drives the **attribution label** (`userTurnKind`, `usage-parsers.mjs:335-340`) |
 | `exception` | assistant | `true` on API-error placeholder turns |
 | `truncated`, `originalChars` | any | Present **only** when the turn was abridged (§4.3) |
 
@@ -177,7 +226,7 @@ story is [Appendix A](#appendix-a--fix-history).)
 
 ### 3.2 `kind` — the attribution field
 
-`userTurnKind` (`usage-parsers.mjs:290-294`) classifies every user-role turn:
+`userTurnKind` (`usage-parsers.mjs:335-340`) classifies every user-role turn:
 
 | `kind` | Test | Meaning |
 |---|---|---|
@@ -200,7 +249,7 @@ Two deliberate subtleties:
 * **`tool-result` outranks `context`**: a `tool_result` block on an `isMeta`
   entry is still tool feedback.
 
-Codex user turns are `kind: 'prompt'` by construction (`usage-parsers.mjs:486-492`)
+Codex user turns are `kind: 'prompt'` by construction (`usage-parsers.mjs:584-593`)
 — rollouts only record real prompts as `user_message` events (§1.2).
 
 Coverage: `tests/kit/usage-index.test.mjs` — "user-role turns carry a kind"
@@ -211,31 +260,42 @@ and image-only pastes get the right kind" (the two edges).
 
 ## 4. The `readSession` pipeline — how one session becomes a payload
 
-`readSession(id, opts)` (`usage-index.mjs:715-770`) is the only way
+`readSession(id, opts)` (`usage-index.mjs:853-909`) is the only way
 transcript content leaves the module, and every step is a gate:
 
 ### 4.1 Locate, contain, bound
 
-1. **Id grammar before any filesystem access** — `VALID_ID`
-   (`/^[A-Za-z0-9._-]{1,128}$/`, `usage-index.mjs:95`) rejects traversal
-   shapes with `ERR_INVALID_SESSION_ID` (`usage-index.mjs:657-662`).
-2. **Locate by id** across both roots (`locate`, `usage-index.mjs:667`),
+1. **Id grammar before any filesystem access** — an id must match one of
+   exactly two shapes, or it is rejected with `ERR_INVALID_SESSION_ID`
+   (`invalidId`, `usage-index.mjs:755-761`) before any read happens:
+   * `VALID_ID` (`/^[A-Za-z0-9._-]{1,128}$/`, `usage-index.mjs:110`) — a plain
+     session id;
+   * `VALID_SUBAGENT_ID` (`usage-index.mjs:123`) — a namespaced nested
+     subagent id, EXACTLY `<parentId>/<stem>` with one slash, where the parent
+     half reuses `VALID_ID`'s own charset and the child half must match the
+     real on-disk `agent-…` shape. The namespaced grammar is a **narrowing**
+     of the plain one, never a loosening: both are the same path-traversal
+     guard, and a traversal shape is rejected at either tier.
+2. **Locate by id** across both roots (`locate`, `usage-index.mjs:800`),
    consulting the scan cache when present but never requiring it —
-   `readSession` works with no prior `buildIndex`.
-3. **Realpath containment** (`usage-index.mjs:736-748`) — the resolved file
+   `readSession` works with no prior `buildIndex`. A namespaced id resolves
+   through `locateSubagent` (`usage-index.mjs:787-795`), which builds the
+   nested path from the two **already-validated capture groups** rather than
+   from raw request text.
+3. **Realpath containment** (`usage-index.mjs:874-888`) — the resolved file
    must live under a transcript root *after* `realpathSync` collapses
    symlinks; a symlink planted inside a root pointing at `/etc/anything`
    passes a lexical `startsWith` but fails this. Roots are realpath'd too so
    a symlinked dotfiles setup still works.
-4. **Size cap** — `MAX_SESSION_BYTES` (64 MB, `usage-index.mjs:102`): a
+4. **Size cap** — `MAX_SESSION_BYTES` (64 MB, `usage-index.mjs:109`): a
    transcript is read whole and JSON-expands ~5×, so an unbounded read is a
    memory-amplification primitive. Oversized reads as unavailable, not risky.
 
 ### 4.2 Parse and price
 
 The file is parsed with `withTurns: true` by the provider's parser
-(`usage-index.mjs:762-766`), and `meta` is assembled
-(`usage-aggregate.mjs:477-495`) with the same fields the Sessions view rows
+(`usage-index.mjs:901-906`), and `meta` is assembled by `sessionPayload`
+(`usage-aggregate.mjs:878-905`) with the same fields the Sessions view rows
 carry — `prompts`, `responses`, `exceptions`, `sidechain`, `threadSource`,
 `models`, `tools`, `skill`/`plugin`, worktree — plus a `cost` priced from the
 same per-model usage rows `aggregate()` uses.
@@ -256,7 +316,7 @@ Every turn body is passed through `maskSecrets` (`usage-aggregate.mjs:133-138` �
 23 secret shapes) **server-side, before
 serialization**, then length-capped at `MAX_TURN_CHARS` (40,000,
 `usage-aggregate.mjs:63`) with the marker appended
-(`usage-aggregate.mjs:502-511`). Two invariants:
+(`usage-aggregate.mjs:913-922`). Two invariants:
 
 * **Presence is the signal.** `truncated`/`originalChars` are emitted only
   when the slice fired, so a complete turn cannot be misread as abridged.
@@ -378,7 +438,11 @@ Deep links: `#usage/<sessionId>` opens the Transcript view directly
 | Model per assistant turn | per-turn `message.model` | last `turn_context` model in effect |
 | Token usage | per-assistant-turn `usage` object | cumulative `token_count`; last snapshot wins |
 | API-error placeholders | `<synthetic>` / `isApiErrorMessage` → exceptions | none observed |
-| Delegation markers | `isSidechain` → `sidechain` flag | `thread_source: "subagent"` → excluded from aggregation, session kept visible |
+| Aborted turns | none recorded | `turn_aborted` → `aborts` |
+| Delegation markers | `isSidechain` → `sidechain` flag; the delegated work is its own nested transcript, discovered and priced like any other | `thread_source: "subagent"` → excluded from aggregation, session kept visible |
+| Permission posture | `permissionMode`, on the person's own turn | `approval_policy`/`sandbox_policy`, per `turn_context` |
+| Response latency | derived from the prompt-to-completion gap | same gap where available, else the host's own `duration_ms` |
+| Context window | last-turn tokens only, no denominator | both halves — `model_context_window` and last-turn tokens |
 | Session title | model-written `ai-title`, first-prompt fallback | first prompt clipped |
 
 **OpenRouter boundary:** the supported activity API has account-level date/model/provider/token/
@@ -412,7 +476,7 @@ was wrong before, for the curious.
   assembled `meta` left `cost` undefined, and `fmtUsd(undefined)` renders the
   truthy string `"$0.00"` — a fixed-looking zero on a panel whose whole
   subject is cost. `meta.cost` is now priced via `sessionCost()` from the
-  same per-model usage rows `aggregate()` uses (`usage-aggregate.mjs:494`).
+  same per-model usage rows `aggregate()` uses (`usage-aggregate.mjs:903`).
 * **Aggregate-side incidents** (the v4/v5 cache bumps, the Codex parsing
   defects) are recorded in `USAGE-SCORECARD-METRICS.md` Appendix A.
 
@@ -447,4 +511,6 @@ the ADRs:
 | Masking, truncation, no-reveal transcript rules (§4–§6) | [ADR-0009](adr/0009-usage-scorecard-local-transcript-analytics.md) §8 |
 | Turn-`kind` attribution (§3) | ADR-0009 §8 (amendment 2026-07-26) |
 | Session-expander classification fields (§6.1) | ADR-0009 §5 |
+| Permission posture, response latency, context window (§1.1–§1.3, §7) | [ADR-0038](adr/0038-consistent-cross-host-session-metrics.md) |
+| Nested subagent discovery and namespaced ids (§1, §4.1) | ADR-0038 |
 | Dashboard HTTP guards — loopback bind, `Host` guard, fetch metadata (§5) | ADR-0005, ADR-0007 |

--- a/docs/USAGE-SCORECARD-METRICS.md
+++ b/docs/USAGE-SCORECARD-METRICS.md
@@ -186,7 +186,7 @@ responses = Σ over included sessions of session.responses
 (`usage-parsers.mjs:380-385`); Codex increments per `agent_message` event
 (`usage-parsers.mjs:615-620`).
 - Totals: `totals.responses += s.responses` per included session
-(`usage-aggregate.mjs:574`).
+(`usage-aggregate.mjs:563`).
 - Render: `kpi("sessions", fmtNum(t.sessions), fmtNum(t.responses)+" assistant
   turns", "")` (`dashboard/client.mjs`).
 
@@ -461,10 +461,10 @@ session data, and each needs its own fix:
   `IDLE_GAP_MS`; "a run of one timestamp yields a zero-length interval and so
   contributes nothing" (comment, `usage-parsers.mjs:243-248`).
 - Aggregation: `totals.engagedSeconds = mergeIntervals(sessions.flatMap(s =>
-  s._active))` (`usage-aggregate.mjs:666`); `totals.spanUnionSeconds =
-  mergeIntervals(sessions.map(s => s._span))` (`usage-aggregate.mjs:665`);
+  s._active))` (`usage-aggregate.mjs:654`); `totals.spanUnionSeconds =
+  mergeIntervals(sessions.map(s => s._span))` (`usage-aggregate.mjs:653`);
   `totals.spanMinutes` is a running sum of `s._span[1] - s._span[0]` across
-  the loop (`usage-aggregate.mjs:585`, finalized `usage-aggregate.mjs:664`).
+  the loop (`usage-aggregate.mjs:574`, finalized `usage-aggregate.mjs:652`).
 - Render: `fmtHours()` (`dashboard/client.mjs`, `≥10h` rounds to the
   nearest hour, else one decimal place) and `fmtMins()`
   (`dashboard/client.mjs`, `≥60min` rounds to hours, else whole
@@ -548,7 +548,7 @@ renders "no sessions in window" instead of zeroed figures
 
 **Formula:** identical aggregation to every other bucket
 (`byHost[s.host]`, populated via `addTo()`, `usage-aggregate.mjs:285-294`,
-  called once per session at `usage-aggregate.mjs:587`), keyed by the literal string
+  called once per session at `usage-aggregate.mjs:576`), keyed by the literal string
 `"claude"` or `"codex"` assigned at parse time
 (`blankSession(id, 'claude')` / `blankSession(id, 'codex')`,
 `usage-parsers.mjs:441`, `:725`, `parseClaude`/`parseCodex` entry points).
@@ -566,10 +566,10 @@ aggregation — never a defect in the aggregation itself, since both hosts
 share it. [Appendix A](#appendix-a--fix-history) documents two real defects
 of exactly that kind, both in `parseCodex`.
 
-**Three identity maps, and why `byProvider` is not `byInferenceProvider`.** The
-aggregate ships three separate bucket maps, and reading one as another is the
-mistake this split exists to prevent (`usage-aggregate.mjs:560-561`,
-`usage-aggregate.mjs:587-592`):
+**Two identity maps, and the axis that is deliberately not one.** The aggregate
+buckets window spend by two identities, and reading one as the other is the
+mistake this split exists to prevent (`usage-aggregate.mjs:549`,
+`usage-aggregate.mjs:576-577`):
 
 - **`byHost`** — the execution host: which CLI wrote the transcript
   (`claude`, `codex`, `opencode`). This is what the two cards above render.
@@ -579,28 +579,21 @@ mistake this split exists to prevent (`usage-aggregate.mjs:560-561`,
   `s.provider ?? 'unknown'`. This map keeps its historical name and its
   historical shape for callers that want the raw string, whatever its
   evidence. A session that recorded no provider keys to `'unknown'`.
-- **`byInferenceProvider`** — the same identity, **provenance-gated**. Its key
-  is the provider only when `s.providerProvenance === 'observed'`; anything
-  else keys to `'not-recorded'` (`providerKey`, `usage-aggregate.mjs:538-540`).
-  This is the map the "inference provider" panel and `ak usage score`'s
-  `served by` table read.
 
-The gate is the whole point: `'not-recorded'` is a first-class key, not a
-display fallback, so spend whose provenance was never observed is held apart
-instead of being attributed to an assumption. A provider string that was
-merely *configured* is an assumption; only an *observed* one is evidence.
-Today the Codex parser is the only source that sets `rec.inferenceProvider`
-and `rec.providerProvenance` together
-(`usage-parsers.mjs:492-495`, `:501-503`); Claude and OpenCode transcripts name
-no provider at all, and so their spend lands in `'not-recorded'` — correctly,
-since neither transcript records who served it.
+There is deliberately **no window bucket for the observed inference provider**.
+Only the Codex parser sets `rec.inferenceProvider` and `rec.providerProvenance`
+together (`usage-parsers.mjs:492-495`, `:501-503`); Claude and OpenCode
+transcripts name no provider at all. A window axis over that evidence would put
+most of its spend in a single unattributed row, which reads as a finding about
+providers rather than what it is — an absence of provider evidence in two of the
+three transcript formats. Provider identity is therefore reported per session,
+on the session row, beside the provenance that backs it (§16).
 
 **What this does not model:** a workflow that hands off between Claude and
 Codex mid-task (e.g. `ak run`) produces two separate session records, one per
 host, each aggregated under its own host rather than blended into one record.
-That API-equivalent estimate is still not proof of the provider that served
-either execution — which is exactly what `byInferenceProvider` declines to
-guess.
+That API-equivalent estimate is still not proof of which provider served either
+execution.
 
 ---
 
@@ -619,7 +612,7 @@ punchcard[dow + "-" + hour] += 1   per assistant/agent_message response, at its 
 **Source:** incremented once per Claude assistant turn
 (`usage-parsers.mjs:383-385`, keyed by `punchKey(at)`) and once per Codex
 `agent_message` (`usage-parsers.mjs:618-620`), merged into the window-level
-`punchcard` object per session (`usage-aggregate.mjs:605`). Cell intensity is
+`punchcard` object per session (`usage-aggregate.mjs:593`). Cell intensity is
 linear against the single busiest cell in the window:
 `v = pcMax ? n/pcMax : 0` (`dashboard/client.mjs`) — this is a
 **relative**, not absolute, scale, so the heatmap's brightest cell is always
@@ -699,7 +692,7 @@ time, someone was genuinely waiting on it — but it is never pushed into
 `rec.models` and `addUsage()` is never called for it, so it can no longer
 create a `byModel` row of any kind. It increments a separate
 `rec.exceptions` counter instead (`usage-parsers.mjs:400`), rolled up into
-`totals.exceptions` (`usage-aggregate.mjs:579`) and surfaced per-session
+`totals.exceptions` (`usage-aggregate.mjs:568`) and surfaced per-session
 (`usage-aggregate.mjs:452-453`, alongside the existing `sidechain`/`threadSource`
 flags — inspectable in the Sessions tab, never hidden). When
 `totals.exceptions > 0`, the panel header shows a small `"· N
@@ -1053,7 +1046,7 @@ Codex ≥0.140 maintains its own SQLite thread ledger (`~/.codex/state_N.sqlite`
 — the `N` is a migration generation, so `codexStateDb` (`codex-state.mjs:41`)
 globs and takes the newest). `readCodexState` (`:62`) reads per-thread
 `thread_source` (`user` vs `subagent`) plus `thread_spawn_edges`, and
-`applyCodexLedger` (`usage-aggregate.mjs:862-874`) overlays that onto parsed
+`applyCodexLedger` (`usage-aggregate.mjs:850-862`) overlays that onto parsed
 sessions: a ledger-identified subagent has its token usage stripped — its
 rollout replays the parent's entire token history (ccusage/ccusage#950
 measured up to 91× inflation) — while the session record stays visible. The
@@ -1088,9 +1081,10 @@ the same list:
   with `≥`, and an unmeasured one is `null` rather than `0` (§15).
 - [x] A latency figure is never called TTFT: it is a prompt-to-answer gap or
   a host-measured turn duration, and neither transcript records TTFT (§15).
-- [x] Permission posture and inference provider both keep `not-recorded` as a
-  first-class bucket — unmapped evidence is never folded into a real posture,
-  and unobserved provenance is never attributed to a vendor (§8, §16).
+- [x] Permission posture keeps `not-recorded` as a first-class bucket —
+  unmapped evidence is never folded into a real posture — and the inference
+  provider gets no window bucket at all, because two of three transcript
+  formats never record one (§8, §16).
 - [x] Autonomy divides by prompts a human typed; the cost-per-session median
   excludes sessions that are `$0` by construction rather than by cheapness
   (§17).
@@ -1140,7 +1134,7 @@ p(q), over N samples, landing in bucket i (count n_i, running total `cum` before
 - Session length: `seal` derives each session's `lenSeconds` from its own
   active intervals (`usage-parsers.mjs:266-271`) — the §6 engaged figure for
   one session, never its first-to-last span.
-- Window merge: `buildRhythm` (`usage-aggregate.mjs:682-702`) adds the
+- Window merge: `buildRhythm` (`usage-aggregate.mjs:670-690`) adds the
   per-session `latHist` slot-wise and buckets each session's `lenSeconds`.
 - Percentiles: `percentileFromBuckets` (`usage-aggregate.mjs:206-223`). The
   browser re-implementation `bucketPercentile` (`usage-rhythm.mjs:106-126`) is
@@ -1267,12 +1261,11 @@ Neither transcript store records it, so no panel here may borrow the name.
 
 ## 16. How you run
 
-**Displayed as:** the `how you run` strip, subtitled `permission posture · who
-drove · who served`. Three panels: `posture, by day` (api-equivalent cost
-stacked by posture, one column per day), `main vs subagent` (a two-slice donut
-whose centre reads the main-thread share), and `inference provider` (ranked
-cost rows). `ak usage score` prints two tables, `mode — permission posture` and
-`served by — inference provider`.
+**Displayed as:** the `How you run` strip, subtitled `permission posture · who
+drove`. Two panels: `posture, by day` (api-equivalent cost stacked by posture,
+one column per day) and `main vs subagent` (a two-slice donut whose centre reads
+the main-thread share). `ak usage score` prints the matching
+`mode — permission posture` table.
 
 ### 16.1 Permission posture
 
@@ -1289,14 +1282,14 @@ mode                      = normalizeMode(host, raw evidence)  or 'not-recorded'
 folding is `addCost(d.byMode, rec.mode ?? 'not-recorded', rowCost)`
 (`usage-aggregate.mjs:386`) — in the usage-row pass, because only a row knows
 which day its dollars landed on. The window bucket is
-`addTo(bucket(byMode, s.mode ?? 'not-recorded'), s)` (`usage-aggregate.mjs:591`).
+`addTo(bucket(byMode, s.mode ?? 'not-recorded'), s)` (`usage-aggregate.mjs:580`).
 The evidence each parser reads: Claude's `permissionMode`, off the human prompt
 only (`usage-parsers.mjs:356-357`); Codex's `approval_policy`/`sandbox_policy`
 off each `turn_context`, last one wins since a session may renegotiate mid-run
 (`usage-parsers.mjs:505-508`); OpenCode's `mode` off each assistant message
 (`usage-opencode.mjs:232-233`). Render is `modeChart` in
 `src/lib/dashboard/client/usage.mjs`; the CLI table is `printScoreModeTable`
-(`src/commands/usage.mjs:230-232`).
+(`src/commands/usage.mjs:234-236`).
 
 **The mapping table**, in full (`usage-modes.mjs:6-17`), pinned value-by-value
 by `normalizeMode` assertions in `tests/kit/usage-modes.test.mjs:9-52`, and the
@@ -1351,8 +1344,8 @@ The raw string is kept beside the normalized one as `modeRaw`
 (`usage-parsers.mjs:196`) precisely because the mapping is a judgement call and
 a reader checking it needs the evidence it was made from. `not-recorded` is a
 first-class bucket key rather than a display fallback
-(`usage-aggregate.mjs:589-591`), it is always offered as a row by the CLI table
-even at zero (`printBucketTable`, `src/commands/usage.mjs:221-228`), and
+(`usage-aggregate.mjs:578-580`), it is always offered as a row by the CLI table
+even at zero (`printBucketTable`, `src/commands/usage.mjs:225-232`), and
 `segColor` forces it to the de-emphasis ink rather than letting a palette give
 it a series colour (`usage-rhythm.mjs:183-186`) — spend with no posture
 evidence must never read as a posture.
@@ -1368,8 +1361,8 @@ bySource[k].cost    = Σ over sessions with that source of session.cost
 centre of the donut = round(main / (main + subagent) × 100) %
 ```
 
-**Source:** `sourceKey` (`usage-aggregate.mjs:544-546`). Both rows are created
-before the fold (`usage-aggregate.mjs:570`) so "no subagent sessions" renders
+**Source:** `sourceKey` (`usage-aggregate.mjs:533-535`). Both rows are created
+before the fold (`usage-aggregate.mjs:559`) so "no subagent sessions" renders
 as a zero rather than a row the UI silently drops. Claude's evidence is the
 `isSidechain` flag on any entry in the file (`usage-parsers.mjs:454`, decoded at
 `telemetry-records.mjs:244`); Codex's is the ledger-backed `thread_source`
@@ -1390,7 +1383,7 @@ not delegated work that was free.
 
 **Codex — structurally `$0`, by ledger design.** A ledger-identified subagent
 has its usage rows removed outright (`applyCodexLedger`,
-`usage-aggregate.mjs:869-872`) and `finalizeCodexUsage` never writes one in the
+`usage-aggregate.mjs:857-860`) and `finalizeCodexUsage` never writes one in the
 first place (`usage-parsers.mjs:718`), because a subagent rollout replays its
 parent's entire cumulative token history and keeping it would bill the parent
 twice (§13c, **[C7]**). The record stays visible and auditable; its cost is zero
@@ -1425,25 +1418,12 @@ sidechain-only (6,924 assistant turns), 150 were main-only (2,738 turns), and
 **none mixed the two** — which is what makes "any `isSidechain` entry marks the
 whole record" safe, since there is no parent's spend in the file to mis-attribute.
 
-### 16.3 Served by — inference provider
-
-**Formula:** `byInferenceProvider[k].cost`, where `k` is the session's provider
-string **only when its provenance was observed**, and `'not-recorded'`
-otherwise (`providerKey`, `usage-aggregate.mjs:538-540`).
-
-**Source:** the bucket is filled at `usage-aggregate.mjs:592`; render is
-`providerRows` in `src/lib/dashboard/client/usage.mjs` (which prints
-`not-recorded` as `Not recorded` and dims the row), and
-`printScoreProviderTable` (`src/commands/usage.mjs:234-240`) adds
-`'not-recorded'` to the CLI key set unconditionally, so the honest bucket
-appears even in a window where every session was attributed.
-
-This is the observed-provenance gate, and §8 states the rule and its
-distinction from the legacy `byProvider` map in full. The short version: a
-transcript host is not a vendor, a configured provider is not an observed one,
-and spend is never bucketed under an assumption.
-
-**What §16 does not model:** posture is the last evidence a session recorded,
+**What §16 does not model:** who served the tokens. There is no window bucket
+for the inference provider — §8 says why: two of the three transcript formats
+record no provider at all, so an aggregate axis over that evidence would read
+as a claim about providers rather than as the absence it is. A session's
+provider and the provenance backing it stay on its own row in the Sessions
+detail strip. Posture is likewise the last evidence a session recorded,
 not a timeline — a session that started in `plan` and ended in `auto-edit`
 reports only the latter, and its whole cost stacks under it. The `main`/
 `subagent` split is per session, so a main-thread session that dispatched
@@ -1475,23 +1455,23 @@ costPerSessionP90    = nearest-rank P90 of the same set
 cacheSavedUsd        = Σ rows  (costOf(1M as input) - costOf(1M as cacheRead)) × cacheRead / 1e6
 ```
 
-**Source:** the derived block is `finishTotals` (`usage-aggregate.mjs:661-675`),
+**Source:** the derived block is `finishTotals` (`usage-aggregate.mjs:649-663`),
 which the previous-window projection calls too so a baseline is never derived a
 second, drifting way. `median` and `percentile` are exact over the values
-(`usage-aggregate.mjs:619-624`, `:629-634`), unlike §15's bucketed percentiles.
+(`usage-aggregate.mjs:607-612`, `:617-622`), unlike §15's bucketed percentiles.
 Active days come from `byDay`'s key count and the streak from `activeStreak` in
 `src/lib/dashboard/client/usage.mjs`; the tiles are `cadenceCells` there, and
 `printScoreCadence` (`src/commands/usage.mjs:187-206`) in the CLI.
 
 **Autonomy divides by prompts a human typed, and only those.** The denominator
 is `totals.humanPrompts`, accumulated under an explicit main-thread guard
-(`usage-aggregate.mjs:578`): a subagent's prompts are written by the harness,
+(`usage-aggregate.mjs:567`): a subagent's prompts are written by the harness,
 so counting them would report a person as having typed work nobody asked for by
 hand — and would grow the denominator exactly in the windows where delegation
 was heaviest, making autonomy fall as automation rose. `totals.prompts` still
-records every prompt beside it (`usage-aggregate.mjs:574`); the two are
+records every prompt beside it (`usage-aggregate.mjs:563`); the two are
 different questions and both are on the wire. Touch rate is those same human
-prompts per engaged hour (`usage-aggregate.mjs:669`), so both per-prompt figures
+prompts per engaged hour (`usage-aggregate.mjs:657`), so both per-prompt figures
 share one denominator. A rate whose denominator is zero is `null`, never `0`
 — no engaged time means the rate was never measured, which is not what "zero
 per hour" claims.
@@ -1513,7 +1493,7 @@ reader has nothing to hover.
 
 **Cost per session is a median over priced sessions only.** A session carries
 `_priced` when it had any usage rows at all (`usage-aggregate.mjs:478`), and
-only those costs enter the distribution (`usage-aggregate.mjs:584`). A session
+only those costs enter the distribution (`usage-aggregate.mjs:573`). A session
 with no usage rows costs `$0` *structurally* — nothing was ever measured for it,
 the common case being a Codex subagent rollout whose tokens were stripped as a
 double-count (§16.2) — and letting those in would report "the typical session
@@ -1548,7 +1528,7 @@ this row              =  $4.50 × 2,000,000 / 1e6       = $9.00
 ```
 
 The window total is the sum of those per-row figures
-(`usage-aggregate.mjs:583`), carried on each session row as `cacheSavedUsd`
+(`usage-aggregate.mjs:572`), carried on each session row as `cacheSavedUsd`
 (`usage-aggregate.mjs:460`) so it is auditable a row at a time rather than only
 in aggregate, and rendered in the cache tile's subtitle as `saved ≈ $X vs
 uncached`.
@@ -1556,10 +1536,10 @@ uncached`.
 **Deltas: what "the previous window" is, exactly.** For a displayed window of
 `d` days ending at `now`, the baseline is the equal-length window immediately
 before it — the half-open interval `[now − 2d, now − d)`
-(`previousWindow`, `usage-aggregate.mjs:764-774`). Both bounds are derived from
+(`previousWindow`, `usage-aggregate.mjs:752-762`). Both bounds are derived from
 `now` and `d`, the window the UI is *showing*, and never from the parse cutoff:
 the caller widens that cutoff on purpose so older records survive to be
-aggregated here (`lookbackDays: days * 2` at `src/commands/usage.mjs:304` and
+aggregated here (`lookbackDays: days * 2` at `src/commands/usage.mjs:295` and
 `src/lib/dashboard-server.mjs:1361`), and deriving the baseline from a widened
 bound would silently stretch it to whatever lookback the caller happened to
 pass. A delta against an unknown-length window is not a delta. The upper bound
@@ -1570,7 +1550,7 @@ older records were never read off disk — and every chip self-suppresses
 against it rather than claiming a change it cannot measure. Leaving `previous`
 off entirely leaves `agg.previous` as `null` — "not requested",
 which a zeroed totals object would misreport as "measured nothing"
-(`usage-aggregate.mjs:842`). A chip self-suppresses when the baseline is null
+(`usage-aggregate.mjs:830`). A chip self-suppresses when the baseline is null
 or zero, and a magnitude that rounds to zero prints flat rather than drawing an
 arrow the printed number does not support (`deltaChip`,
 `usage-rhythm.mjs:36-53`; `fmtDelta`, `src/commands/usage.mjs:152-163`).
@@ -1581,9 +1561,9 @@ landed on that day (`dayBucket`, `usage-aggregate.mjs:307-320`) — and that is
 what the active-day count and the streak above are counted from. Engaged time
 does not share that key set: a session that runs past midnight, or a day spent
 reading, produces worked time on a day that billed nothing. So
-`buildEngagedByDay` (`usage-aggregate.mjs:738-746`) keys its own map, cutting
+`buildEngagedByDay` (`usage-aggregate.mjs:726-734`) keys its own map, cutting
 each active interval at every local midnight it crosses
-(`splitAtLocalMidnight`, `usage-aggregate.mjs:716-724`) and unioning the pieces
+(`splitAtLocalMidnight`, `usage-aggregate.mjs:704-712`) and unioning the pieces
 per day, which makes the map sum exactly to `totals.engagedSeconds`. Folding it
 into `byDay` would have forced one of two lies: inventing zero-token `byDay`
 rows, or dropping real worked time. The consequence is visible on the tiles —
@@ -1618,10 +1598,10 @@ byDay[day].exceptions += session.exceptions   attributed to the session's FIRST 
 ```
 
 **Source:** `totals.exceptions` and `totals.aborts` accumulate together at
-`usage-aggregate.mjs:579`; the per-day series lands on `byDay[s._day].exceptions`
-(`usage-aggregate.mjs:601-604`). Render is
+`usage-aggregate.mjs:568`; the per-day series lands on `byDay[s._day].exceptions`
+(`usage-aggregate.mjs:589-592`). Render is
 `relRate`/`relStat`/`relTrend` in `src/lib/dashboard/client/usage.mjs`;
-`printScoreReliability` (`src/commands/usage.mjs:242-256`) prints the CLI pair.
+`printScoreReliability` (`src/commands/usage.mjs:238-264`) prints the CLI pair.
 
 **Evidence, per host.** An "exception" is a turn that never resolved to a
 model, and each host signals that differently:
@@ -1656,7 +1636,7 @@ treatment `latHist` (§15) and the context chip (§16) already get.
 
 **Exceptions ride the session's first-billed day.** The per-day series uses the
 same attribution as the session count — `byDay[s._day].exceptions += s.exceptions`
-(`usage-aggregate.mjs:601-604`) — which is *not* the moment a turn dropped: a session spanning midnight lands all of its
+(`usage-aggregate.mjs:589-592`) — which is *not* the moment a turn dropped: a session spanning midnight lands all of its
 exceptions on the day its tokens first billed. That keeps the reliability trend
 and the session trend drawn on one convention — the alternative, attributing
 each exception to its own timestamp, would have made the two lines disagree
@@ -1701,7 +1681,7 @@ byTool[name]                  += session.tools[name]      summed across sessions
 byDay[day].byModelFamily[fam] += rowCost                  fam = modelFamily(row.model)
 ```
 
-**Source:** the tool tally is folded into `byTool` at `usage-aggregate.mjs:606`;
+**Source:** the tool tally is folded into `byTool` at `usage-aggregate.mjs:594`;
 the per-day family split is `addCost(d.byModelFamily, modelFamily(row.model),
 rowCost)` (`usage-aggregate.mjs:387`), inside the usage-row pass because only a
 row knows its day. Render is `toolRows`/`modelMix` in

--- a/docs/USAGE-SCORECARD-METRICS.md
+++ b/docs/USAGE-SCORECARD-METRICS.md
@@ -1267,7 +1267,7 @@ Neither transcript store records it, so no panel here may borrow the name.
 drove`. Two panels: `posture, by day` (api-equivalent cost stacked by posture,
 one column per day) and `main vs subagent` (a two-slice donut whose centre reads
 the main-thread share). `ak usage score` prints the matching
-`mode — permission posture` table.
+`Mode — permission posture` table.
 
 ### 16.1 Permission posture
 
@@ -1442,7 +1442,7 @@ own record is attributed to `subagent`.
 $0-by-construction`, note `P90 $…`), and `cost / engaged hour`. Each of the
 five KPI tiles above them additionally carries a footer: a delta chip against
 the previous window and a per-day sparkline. `ak usage score` prints the same
-four under `cadence`.
+four under `Cadence`.
 
 **Formulas:**
 
@@ -1587,8 +1587,8 @@ Two stats — `exceptions / 1k responses` (subtitle `N of M responses`, plus a
 worded flag comparing it to the previous window) and `aborted turns` (subtitle
 `X per 1k codex responses`, or an em dash when the window holds no Codex
 session) — over an `exceptions by day` sparkline that names the single worst
-day. `ak usage score` prints both under its own
-`reliability — turns that never landed` heading, colouring the exception
+day. `ak usage score` prints both under its
+`Reliability — turns that never landed` heading, colouring the exception
 line by whether any fired.
 
 **Formula:**

--- a/docs/USAGE-SCORECARD-METRICS.md
+++ b/docs/USAGE-SCORECARD-METRICS.md
@@ -86,7 +86,7 @@ contributes nothing rather than being crawled. Each subagent record takes a
 Code names every such file `agent-<hash>.jsonl` and that stem is not guaranteed
 unique across two parents; an unnamespaced id would silently collide two
 unrelated subagent records into one. `locateSubagent`
-(`usage-index.mjs:787-795`) resolves that id back to the nested path when a
+(`usage-index.mjs:839-846`) resolves that id back to the nested path when a
 reader opens the session, building the candidate path from the two validated
 capture groups rather than from raw request input.
 
@@ -185,7 +185,7 @@ responses = Σ over included sessions of session.responses
   (`usage-aggregate.mjs:497`).
 - `responses` accumulation: Claude increments per assistant message
 (`usage-parsers.mjs:380-385`); Codex increments per `agent_message` event
-(`usage-parsers.mjs:595-600`).
+(`usage-parsers.mjs:615-620`).
 - Totals: `totals.responses += s.responses` per included session
 (`usage-aggregate.mjs:574`).
 - Render: `kpi("sessions", fmtNum(t.sessions), fmtNum(t.responses)+" assistant
@@ -363,7 +363,7 @@ per row is **gross input minus cached input** — Claude's parser reads
 `cache_read_input_tokens` and `cache_creation_input_tokens` as separate fields
 the provider already reports separately (`telemetry-records.mjs:216-224`); Codex's
 parser subtracts `cached_input_tokens` from `input_tokens` explicitly
-(`usage-parsers.mjs:690-707`, `input: Math.max(0, gross - cacheRead)`) because
+(`usage-parsers.mjs:718-735`, `input: Math.max(0, gross - cacheRead)`) because
 Codex's own `input_tokens` field **includes** cached tokens and would
 double-count them against the separately-reported `cacheRead` figure if left
 as-is. This is asserted by test:
@@ -516,7 +516,7 @@ byDay[day].sessionsActive = count of distinct sessions with any usage row that d
 
 **Source:** the day key is the row's own `row.day`, computed once at parse
 time as **local calendar day**, not UTC
-(`usage-parsers.mjs:419`/`usage-parsers.mjs:696` call `localDay(at)`) — so a
+(`usage-parsers.mjs:419`/`usage-parsers.mjs:724` call `localDay(at)`) — so a
 session that runs from 23:58 local to 00:05 local is billed to the day its
 *first* row landed on (test:
 `tests/kit/usage-index.test.mjs:651`, "a session that opens before midnight
@@ -619,7 +619,7 @@ punchcard[dow + "-" + hour] += 1   per assistant/agent_message response, at its 
 
 **Source:** incremented once per Claude assistant turn
 (`usage-parsers.mjs:383-385`, keyed by `punchKey(at)`) and once per Codex
-`agent_message` (`usage-parsers.mjs:598-600`), merged into the window-level
+`agent_message` (`usage-parsers.mjs:618-620`), merged into the window-level
 `punchcard` object per session (`usage-aggregate.mjs:605`). Cell intensity is
 linear against the single busiest cell in the window:
 `v = pcMax ? n/pcMax : 0` (`dashboard/client.mjs`) — this is a
@@ -633,6 +633,15 @@ tooltip on each cell).
 time — a hint at rhythm, not at engaged-time distribution (that's §6). A hint
 that reads as heavy weekend activity, for instance, does not by itself imply
 long weekend sessions, only frequent ones.
+
+It also **includes responses from delegated subagent sessions** (§16.2), which
+are machine-driven: a long agentic run dispatching subagents at 3am fills those
+cells even though nobody was typing. The panel is titled `when you work`, and
+what it actually charts is when *work happened on your behalf* — on the
+reference corpus, Claude subagent responses (17,863) outnumber main-thread ones
+(11,480). The `how you run` panel carries the main/subagent split; whether the
+punchcard should filter or split by source is recorded as an open question in
+ADR-0038's deferred list.
 
 ---
 
@@ -1051,7 +1060,7 @@ rollout replays the parent's entire token history (ccusage/ccusage#950
 measured up to 91× inflation) — while the session record stays visible. The
 rollout's own `session_meta.thread_source` sniff remains as the fallback when
 the ledger is absent or migrated beyond recognition. Codex sessions also carry
-`reasoningOutput` (`usage-parsers.mjs:706`) — reasoning tokens are a **subset**
+`reasoningOutput` (`usage-parsers.mjs:734`) — reasoning tokens are a **subset**
 of output tokens and are annotation only, never added to any sum.
 
 ## 14. Known limitations, restated as a single checklist
@@ -1183,17 +1192,24 @@ same way, and the panel says so rather than implying a single clock:
 
 | Host | How a latency sample is produced |
 |---|---|
-| codex | **Host-measured.** `task_started` remembers the turn's start (`usage-parsers.mjs:558-563`) and `task_complete` samples Codex's own `duration_ms` (`usage-parsers.mjs:571-578`) — but only if no prompt-gap already covered that turn, so a turn is never sampled twice. |
+| codex | **Host-measured.** `task_started` remembers the turn's start (`usage-parsers.mjs:558-563`) and `task_complete` samples Codex's own `duration_ms` (`usage-parsers.mjs:571-586`) — but only if no prompt-gap already covered that turn (so a turn is never sampled twice) and only within the same 3600 s cap the derived paths apply. |
 | codex | Also derives a prompt-gap when one is available: a `user_message` opens the window (`usage-parsers.mjs:591`) and the next `agent_message` closes it, clearing `turnStartedAt` so the `duration_ms` fallback cannot double-fire (`usage-parsers.mjs:601-608`). |
 | claude | **Derived from event gaps.** A human prompt sets `latState.pendingMs` (`usage-parsers.mjs:355`); the first real assistant turn closes that gap into a `noteLatencySample` call (`usage-parsers.mjs:410-414`). |
 | opencode | Derived the same way from its message stream — `rec.pendingPromptMs`, closed by `noteLatencySample` (`usage-opencode.mjs:227-231`). |
 
-Only the derived path is capped: a gap above `MAX_LATENCY_SAMPLE_SECONDS`
+**Every** path is capped: a sample above `MAX_LATENCY_SAMPLE_SECONDS`
 (3600 s, `usage-parsers.mjs:234`) is an idle resume — the person walked away
 and came back — not a wait for a reply, so it is dropped from sampling
 entirely rather than parked in the overflow bucket beside genuinely slow turns.
-Codex's host-measured `duration_ms` needs no such cap: it is the host's own
-turn duration, not a gap between two events that may have nothing between them.
+That includes Codex's host-measured `duration_ms`. An earlier ruling exempted
+it on the grounds that a host's own turn duration is a different kind of figure
+from a gap between two events; that was overturned (ADR-0038 §2). `duration_ms`
+is turn wall-clock and **includes time blocked on an approval prompt**, so a
+turn left awaiting approval overnight arrives as a multi-hour "response
+latency" — the same idle stretch the prompt-gap path discards. Measured on the
+reference corpus before the fix: 12 of 835 durations exceeded the cap, the
+largest 94,079,450 ms ≈ 26.1 hours, all of them landing in the `≥60s` overflow
+bucket and dragging `latP95` into it.
 An interrupted turn contributes nothing at all — `turn_aborted` clears both
 pending states (`usage-parsers.mjs:644-654`), so a prompt that was never
 answered can never be timed against a later, unrelated reply. A dropped API
@@ -1216,6 +1232,21 @@ Neither transcript store records it, so no panel here may borrow the name.
 
 **What this does not model:**
 
+- **it includes delegated subagent sessions and responses.** The panel is
+  titled `your rhythm`, but both histograms are built from every session in
+  the window — and since nested Claude subagent transcripts began being
+  ingested (§16.2), a substantial share of them are harness-driven rather than
+  typed by you: on the reference corpus, 178 Claude subagent sessions / 17,863
+  responses against 265 main sessions / 11,480. So subagent session lengths
+  shape `session length`, and subagent turn gaps are a large part of
+  `response latency`. Every number is true as computed; the label is what
+  overclaims. The `how you run` panel carries the main/subagent split.
+  (Prompt-based denominators are the exception — they use a main-thread-only
+  denominator, because a subagent's prompts are written by the harness, §17.)
+  Whether rhythm should instead *filter* to main-thread sessions, or show the
+  two side by side, is recorded as an open question in ADR-0038's deferred
+  list; it is a behavior change that needs its own ruling and tests, and
+  disclosure is what ships here;
 - the samples' exact values are gone once bucketed; a percentile is a linear
   interpolation inside one bucket, which is the only assumption the surviving
   counts support. A distribution that is heavily skewed *within* a bucket will
@@ -1269,7 +1300,10 @@ off each `turn_context`, last one wins since a session may renegotiate mid-run
 (`src/commands/usage.mjs:230-232`).
 
 **The mapping table**, in full (`usage-modes.mjs:6-17`), pinned value-by-value
-by `normalizeMode` assertions in `tests/kit/usage-modes.test.mjs:9-52`:
+by `normalizeMode` assertions in `tests/kit/usage-modes.test.mjs:9-52`, and the
+Codex arm pinned again end-to-end through `parseCodex` in the **real object
+shape** (`tests/kit/usage-index-v6.test.mjs`, the five
+`the object form of sandbox_policy` cases):
 
 | Host | Recorded evidence | Mode |
 |---|---|---|
@@ -1277,13 +1311,30 @@ by `normalizeMode` assertions in `tests/kit/usage-modes.test.mjs:9-52`:
 | claude | `permissionMode: acceptEdits` / `auto` / `dontAsk` | `auto-edit` |
 | claude | `permissionMode: plan` | `plan` |
 | claude | `permissionMode: bypassPermissions` | `unrestricted` |
-| codex | sandbox `read-only`, whatever the approval policy | `plan` |
-| codex | approval `never` + sandbox `danger-full-access` | `unrestricted` |
-| codex | approval `never` + sandbox `workspace-write` | `auto-edit` |
+| codex | sandbox `.type` `read-only`, whatever the approval policy | `plan` |
+| codex | approval `never` + sandbox `.type` `danger-full-access` | `unrestricted` |
+| codex | approval `never` + sandbox `.type` `workspace-write` | `auto-edit` |
 | codex | approval `on-request` / `on-failure` / `untrusted` | `guarded` |
 | opencode | `build` | `auto-edit` |
 | opencode | `plan` | `plan` |
 | any | anything else, or no evidence at all | `null` → `not-recorded` |
+
+**Codex writes `sandbox_policy` as an object, and the parser extracts its
+`.type` before consulting that table.** The rollout carries
+`"sandbox_policy":{"type":"danger-full-access"}` — or `{"type":"read-only"}`,
+or `{"type":"workspace-write", …}` with sibling fields such as
+`network_access` — never the bare string the taxonomy is written against. A
+survey of this machine's rollouts (400 files, 2026-08-28) found 1,110 object
+occurrences and **zero** string ones. `handleCodexTurnContext`
+(`usage-parsers.mjs:505-519`) therefore reads `sandbox_policy.type` and passes
+that to `normalizeMode`, which is unchanged and still accepts the string form.
+Before this extraction the object reached `normalizeMode` intact, matched no
+rule, and stringified into `modeRaw` as `"never/[object Object]"`: the `plan`,
+`auto-edit` and `unrestricted` rows of the Codex arm below could not fire at
+all on live data, only the approval-only `guarded` rule could, and
+`detectUnrestrictedMode` (§18) was blind to Codex's most permissive posture.
+An object carrying no `.type` yields no sandbox evidence rather than a guess.
+Cached records from before the fix re-derive on the schema v12 bump (§1).
 
 Two rulings in that table are worth reading twice. The **read-only sandbox
 check runs first** (`usage-modes.mjs:10`), so `never` + `read-only` is `plan`,
@@ -1341,7 +1392,7 @@ not delegated work that was free.
 **Codex — structurally `$0`, by ledger design.** A ledger-identified subagent
 has its usage rows removed outright (`applyCodexLedger`,
 `usage-aggregate.mjs:869-872`) and `finalizeCodexUsage` never writes one in the
-first place (`usage-parsers.mjs:692`), because a subagent rollout replays its
+first place (`usage-parsers.mjs:718`), because a subagent rollout replays its
 parent's entire cumulative token history and keeping it would bill the parent
 twice (§13c, **[C7]**). The record stays visible and auditable; its cost is zero
 because nothing was measured for it, not because the work was cheap — which is
@@ -1446,6 +1497,21 @@ share one denominator. A rate whose denominator is zero is `null`, never `0`
 — no engaged time means the rate was never measured, which is not what "zero
 per hour" claims.
 
+**Sessions per active day counts delegated subagent sessions too, and an
+"active day" is a day that BILLED.** The numerator is every session in the
+window, harness-dispatched subagent transcripts included (§16.2) — on the
+reference corpus those are roughly a quarter of all sessions — so this is the
+run rate of the whole system working on your behalf, not a count of times you
+sat down. The `how you run` panel carries the main/subagent split. The
+denominator is `byDay`'s key count, and `byDay`'s presence contract is
+**days that billed tokens** — which is why the aggregate keeps a separate
+`engagedByDay` map (§6): the two sets genuinely differ (a session running past
+midnight, a day spent reading, a day worked entirely in stripped Codex
+subagent sessions that billed nothing). A day worked but never billed is not
+an active day here, and it breaks the streak. Both surfaces say so: the
+browser in the tile's tooltip, `ak usage score` inline, since a terminal
+reader has nothing to hover.
+
 **Cost per session is a median over priced sessions only.** A session carries
 `_priced` when it had any usage rows at all (`usage-aggregate.mjs:478`), and
 only those costs enter the distribution (`usage-aggregate.mjs:584`). A session
@@ -1494,7 +1560,7 @@ before it — the half-open interval `[now − 2d, now − d)`
 (`previousWindow`, `usage-aggregate.mjs:764-774`). Both bounds are derived from
 `now` and `d`, the window the UI is *showing*, and never from the parse cutoff:
 the caller widens that cutoff on purpose so older records survive to be
-aggregated here (`lookbackDays: days * 2` at `src/commands/usage.mjs:288` and
+aggregated here (`lookbackDays: days * 2` at `src/commands/usage.mjs:304` and
 `src/lib/dashboard-server.mjs:1361`), and deriving the baseline from a widened
 bound would silently stretch it to whatever lookback the caller happened to
 pass. A delta against an unknown-length window is not a delta. The upper bound
@@ -1538,15 +1604,17 @@ rather than leaving a reader to infer it from a broken streak.
 **Displayed as:** the `reliability` strip, subtitled `turns that never landed`.
 Two stats — `exceptions / 1k responses` (subtitle `N of M responses`, plus a
 worded flag comparing it to the previous window) and `aborted turns` (subtitle
-`X per 1k responses`) — over an `exceptions by day` sparkline that names the
-single worst day. `ak usage score` prints both under `reliability`, colouring
-the exception line by whether any fired.
+`X per 1k codex responses`, or an em dash when the window holds no Codex
+session) — over an `exceptions by day` sparkline that names the single worst
+day. `ak usage score` prints both under `reliability`, colouring the exception
+line by whether any fired.
 
 **Formula:**
 
 ```text
 exceptionRate = totals.exceptions / totals.responses × 1000     null when no responses
-abortRate     = totals.aborts     / totals.responses × 1000
+abortRate     = totals.aborts / byHost.codex.responses × 1000   — and the count
+                itself is shown only when byHost.codex.sessions > 0
 byDay[day].exceptions += session.exceptions   attributed to the session's FIRST BILLED day
 ```
 
@@ -1572,6 +1640,20 @@ report a deliberate interruption as a reliability problem and move a number
 that is supposed to mean "how often did this break". They are counted, carried
 (`aborts`, `usage-aggregate.mjs:435`) and displayed side by side, with the
 distinction stated on the tile rather than left to the label.
+
+**Aborts are CODEX-ONLY evidence, and both surfaces say so.** `turn_aborted` is
+the only interrupt signal any transcript store writes: Claude Code and OpenCode
+record nothing when you stop a turn (see the capability matrix in
+`TRANSCRIPTS.md`). The field therefore defaults to `0` for those hosts, and a
+plain `0` on the tile would read as a measurement — "you never interrupted a
+turn" — when the truth is that nothing in the window could have recorded one.
+So the count is rendered only when the window contains at least one Codex
+session, and otherwise reads `—` with the reason beside it; the rate divides by
+**Codex** responses, because dividing Codex aborts by every host's responses
+dilutes the figure by an arbitrary amount that depends on host mix. The same
+rule applies per row in the session detail strip, where a claude/opencode row
+reads `aborts not recorded for this host`. This is the same absent-is-not-zero
+treatment `latHist` (§15) and the context chip (§16) already get.
 
 **Exceptions ride the session's first-billed day.** The per-day series uses the
 same attribution as the session count — `byDay[s._day].exceptions += s.exceptions`
@@ -1630,7 +1712,7 @@ row knows its day. Render is `toolRows`/`modelMix` in
 the `tool_use` block's own `name` (`collectClaudeToolNames`,
 `usage-parsers.mjs:366-375`). Codex's four tallied item types —
 `CommandExecution`, `McpToolCall`, `FileChange`, `CollabAgentToolCall`
-(`CODEX_TOOL_ITEM_TYPES`, `usage-parsers.mjs:634`, tallied at `:659-661`) —
+(`CODEX_TOOL_ITEM_TYPES`, `usage-parsers.mjs:654`, tallied at `:685-687`) —
 keep those exact spellings in the ranking. Mapping `CommandExecution` onto
 `Bash`, or `FileChange` onto `Edit`, would be a claim about equivalence that
 neither host makes: the vocabularies are host-specific, the semantics do not

--- a/docs/USAGE-SCORECARD-METRICS.md
+++ b/docs/USAGE-SCORECARD-METRICS.md
@@ -67,7 +67,7 @@ Every metric section below follows the same shape:
 
 Two transcript stores, read-only, parsed at most once per file (cache keyed by
 `(path, mtime, size)`; `SCHEMA_VERSION` invalidates the whole cache on a
-schema change — `src/lib/usage-index.mjs:10`, `:99`):
+schema change — `src/lib/usage-index.mjs:10`, `:120`):
 
 | Transcript host | Store | Format |
 |---|---|---|
@@ -78,11 +78,11 @@ schema change — `src/lib/usage-index.mjs:10`, `:99`):
 Discovery is **one level of project directories plus that one nested shape**,
 not a recursive walk: `listClaude` (`usage-index.mjs:259-273`) descends into a
 session-id directory only through `listClaudeSubagents`
-(`usage-index.mjs:243-255`), which reads exactly
+(`usage-index.mjs:291-296`), which reads exactly
 `<projectDir>/<sessionId>/subagents/*.jsonl`. A directory that is not a
 session-id dir with a `subagents` child — Claude Code's own `memory` dir, say —
 contributes nothing rather than being crawled. Each subagent record takes a
-**namespaced** id, `<sessionId>/<stem>` (`usage-index.mjs:250`), because Claude
+**namespaced** id, `<sessionId>/<stem>` (`usage-index.mjs:296`), because Claude
 Code names every such file `agent-<hash>.jsonl` and that stem is not guaranteed
 unique across two parents; an unnamespaced id would silently collide two
 unrelated subagent records into one. `locateSubagent`
@@ -91,7 +91,7 @@ reader opens the session, building the candidate path from the two validated
 capture groups rather than from raw request input.
 
 The parsers are `parseClaude` (`usage-parsers.mjs:440-469`) and `parseCodex`
-(`usage-parsers.mjs:724-745`). Both are pure functions over the raw file bytes —
+(`usage-parsers.mjs:788-810`). Both are pure functions over the raw file bytes —
 no network, no clock dependency beyond the transcript's own timestamps — so
 every downstream number traces back to bytes already on the user's disk.
 Nothing in this transcript pipeline calls a provider API or a billing endpoint; **no transcript
@@ -184,7 +184,7 @@ responses = Σ over included sessions of session.responses
   (`usage-aggregate.mjs:497`).
 - `responses` accumulation: Claude increments per assistant message
 (`usage-parsers.mjs:380-385`); Codex increments per `agent_message` event
-(`usage-parsers.mjs:615-620`).
+(`usage-parsers.mjs:666-670`).
 - Totals: `totals.responses += s.responses` per included session
 (`usage-aggregate.mjs:563`).
 - Render: `kpi("sessions", fmtNum(t.sessions), fmtNum(t.responses)+" assistant
@@ -201,13 +201,20 @@ reply (e.g. immediately abandoned) is invisible to every Scorecard number —
 by design, not oversight, since a session with no response has nothing to
 attribute cost or category to.
 
-**What "prompts" excludes (since SCHEMA_VERSION 5):** user-role entries whose
-text the harness wrote — task notifications, `bash-stdout`/
-`local-command-stdout` dumps, caveats — are not human prompts and no longer
-count as such (`isHumanPrompt` + `HARNESS_OUTPUT_RE`; the full envelope
-taxonomy is [`TRANSCRIPTS.md`](TRANSCRIPTS.md) §3.2). A `! command` the
-person typed (`bash-input`) still counts. (The correction this rule shipped
-with is recorded in [Appendix A](#appendix-a--fix-history).)
+**What "prompts" excludes (Claude since SCHEMA_VERSION 5, Codex since
+SCHEMA_VERSION 13):** user-role entries whose text the harness wrote — task
+notifications, `bash-stdout`/`local-command-stdout` dumps, caveats — are not
+human prompts and no longer count as such on Claude (`isHumanPrompt` +
+`HARNESS_OUTPUT_RE`; the full envelope taxonomy is
+[`TRANSCRIPTS.md`](TRANSCRIPTS.md) §3.2). A `! command` the person typed
+(`bash-input`) still counts. Codex has no discipline of its own for the same
+distinction — a `user_message`/`item_completed` `UserMessage` event is gated
+the same way before it counts (`isCodexHumanMessage`, reusing
+`HARNESS_OUTPUT_RE` plus two Codex-specific markers for mirrored cross-host
+envelopes: a `<teammate-message` wrapper and the literal `"Another Claude
+session sent a message:"` prefix — see [`TRANSCRIPTS.md`](TRANSCRIPTS.md)
+§1.2). (The correction this rule shipped with is recorded in
+[Appendix A](#appendix-a--fix-history).)
 
 ---
 
@@ -362,7 +369,7 @@ per row is **gross input minus cached input** — Claude's parser reads
 `cache_read_input_tokens` and `cache_creation_input_tokens` as separate fields
 the provider already reports separately (`telemetry-records.mjs:216-224`); Codex's
 parser subtracts `cached_input_tokens` from `input_tokens` explicitly
-(`usage-parsers.mjs:718-735`, `input: Math.max(0, gross - cacheRead)`) because
+(`usage-parsers.mjs:769-785`, `input: Math.max(0, gross - cacheRead)`) because
 Codex's own `input_tokens` field **includes** cached tokens and would
 double-count them against the separately-reported `cacheRead` figure if left
 as-is. This is asserted by test:
@@ -515,7 +522,7 @@ byDay[day].sessionsActive = count of distinct sessions with any usage row that d
 
 **Source:** the day key is the row's own `row.day`, computed once at parse
 time as **local calendar day**, not UTC
-(`usage-parsers.mjs:419`/`usage-parsers.mjs:724` call `localDay(at)`) — so a
+(`usage-parsers.mjs:419`/`usage-parsers.mjs:775` call `localDay(at)`) — so a
 session that runs from 23:58 local to 00:05 local is billed to the day its
 *first* row landed on (test:
 `tests/kit/usage-index.test.mjs:651`, "a session that opens before midnight
@@ -551,7 +558,7 @@ renders "no sessions in window" instead of zeroed figures
   called once per session at `usage-aggregate.mjs:576`), keyed by the literal string
 `"claude"` or `"codex"` assigned at parse time
 (`blankSession(id, 'claude')` / `blankSession(id, 'codex')`,
-`usage-parsers.mjs:441`, `:725`, `parseClaude`/`parseCodex` entry points).
+`usage-parsers.mjs:441`, `:804`, `parseClaude`/`parseCodex` entry points).
 OpenCode's SQLite reader builds the same record shape and contributes a third
 host key.
 
@@ -611,7 +618,7 @@ punchcard[dow + "-" + hour] += 1   per assistant/agent_message response, at its 
 
 **Source:** incremented once per Claude assistant turn
 (`usage-parsers.mjs:383-385`, keyed by `punchKey(at)`) and once per Codex
-`agent_message` (`usage-parsers.mjs:618-620`), merged into the window-level
+`agent_message` (`usage-parsers.mjs:666-670`), merged into the window-level
 `punchcard` object per session (`usage-aggregate.mjs:593`). Cell intensity is
 linear against the single busiest cell in the window:
 `v = pcMax ? n/pcMax : 0` (`dashboard/client.mjs`) — this is a
@@ -1023,7 +1030,7 @@ both credential-free for ak:
 `windowDurationMins: 10080` (the weekly). Windows are therefore keyed and
 labelled by duration (`windowLabel`, `quota.mjs:51`), never by slot name. The
 same rule applies to the historical snapshots parsed out of rollouts: the
-normalizer at `usage-parsers.mjs:511-530` keeps a flat `windows` list keyed by
+normalizer at `usage-parsers.mjs:553-566` keeps a flat `windows` list keyed by
 `window_minutes`.
 
 **Freshness is part of the number.** Both sides carry `fetchedAt`; the view
@@ -1054,7 +1061,7 @@ rollout replays the parent's entire token history (ccusage/ccusage#950
 measured up to 91× inflation) — while the session record stays visible. The
 rollout's own `session_meta.thread_source` sniff remains as the fallback when
 the ledger is absent or migrated beyond recognition. Codex sessions also carry
-`reasoningOutput` (`usage-parsers.mjs:734`) — reasoning tokens are a **subset**
+`reasoningOutput` (`usage-parsers.mjs:785`) — reasoning tokens are a **subset**
 of output tokens and are annotation only, never added to any sum.
 
 ## 14. Known limitations, restated as a single checklist
@@ -1187,7 +1194,7 @@ same way, and the panel says so rather than implying a single clock:
 
 | Host | How a latency sample is produced |
 |---|---|
-| codex | **Host-measured.** `task_started` remembers the turn's start (`usage-parsers.mjs:558-563`) and `task_complete` samples Codex's own `duration_ms` (`usage-parsers.mjs:571-586`) — but only if no prompt-gap already covered that turn (so a turn is never sampled twice) and only within the same 3600 s cap the derived paths apply. |
+| codex | **Host-measured.** `task_started` remembers the turn's start (`usage-parsers.mjs:594-598`) and `task_complete` samples Codex's own `duration_ms` (`usage-parsers.mjs:571-586`) — but only if no prompt-gap already covered that turn (so a turn is never sampled twice) and only within the same 3600 s cap the derived paths apply. |
 | codex | Also derives a prompt-gap when one is available: a `user_message` opens the window (`usage-parsers.mjs:591`) and the next `agent_message` closes it, clearing `turnStartedAt` so the `duration_ms` fallback cannot double-fire (`usage-parsers.mjs:601-608`). |
 | claude | **Derived from event gaps.** A human prompt sets `latState.pendingMs` (`usage-parsers.mjs:355`); the first real assistant turn closes that gap into a `noteLatencySample` call (`usage-parsers.mjs:410-414`). |
 | opencode | Derived the same way from its message stream — `rec.pendingPromptMs`, closed by `noteLatencySample` (`usage-opencode.mjs:227-231`). |
@@ -1206,7 +1213,7 @@ reference corpus before the fix: 12 of 835 durations exceeded the cap, the
 largest 94,079,450 ms ≈ 26.1 hours, all of them landing in the `≥60s` overflow
 bucket and dragging `latP95` into it.
 An interrupted turn contributes nothing at all — `turn_aborted` clears both
-pending states (`usage-parsers.mjs:644-654`), so a prompt that was never
+pending states (`usage-parsers.mjs:715-723`), so a prompt that was never
 answered can never be timed against a later, unrelated reply. A dropped API
 turn is likewise never a sample: the error branch returns before the latency
 block and deliberately leaves `pendingMs` set, so the first real completion
@@ -1376,7 +1383,7 @@ slice is telling two different truths at once.
 
 **Claude — real, priced, included.** A session's delegated work is written to
 its own transcript under `<project>/<sessionId>/subagents/`, and those files are
-discovered by `listClaudeSubagents` (`usage-index.mjs:243-255`, §1) and parsed
+discovered by `listClaudeSubagents` (`usage-index.mjs:291-296`, §1) and parsed
 like any other. `parseClaude` already prices those bytes and marks the record
 `sidechain` from its own `isSidechain` entries, so the cost is real, is included
 in `totals.cost`, and the session opens in the Sessions tab like a main-thread
@@ -1386,7 +1393,7 @@ not delegated work that was free.
 **Codex — structurally `$0`, by ledger design.** A ledger-identified subagent
 has its usage rows removed outright (`applyCodexLedger`,
 `usage-aggregate.mjs:857-860`) and `finalizeCodexUsage` never writes one in the
-first place (`usage-parsers.mjs:718`), because a subagent rollout replays its
+first place (`usage-parsers.mjs:769`), because a subagent rollout replays its
 parent's entire cumulative token history and keeping it would bill the parent
 twice (§13c, **[C7]**). The record stays visible and auditable; its cost is zero
 because nothing was measured for it, not because the work was cheap — which is
@@ -1613,7 +1620,7 @@ model, and each host signals that differently:
 |---|---|
 | claude | The API-error placeholder — Claude Code synthesizes a local turn with no completion behind it when a connection drops, a rate limit rejects, or auth fails. The decoder sets `isApiError` from either `isApiErrorMessage` or the literal `<synthetic>` model marker (`telemetry-records.mjs:246`), because the flag is not set on every build that emits the placeholder; the parser counts it and returns before any model or usage attribution (`usage-parsers.mjs:399-408`). |
 | codex | A `task_complete` event carrying a non-null `error` (`usage-parsers.mjs:577`). |
-| codex | `turn_aborted` is counted **separately**, into `rec.aborts` (`usage-parsers.mjs:644-654`) — not into exceptions. |
+| codex | `turn_aborted` is counted **separately**, into `rec.aborts` (`usage-parsers.mjs:715-723`) — not into exceptions. |
 | opencode | An assistant message carrying a non-null `error` (`usage-opencode.mjs:224-226`). |
 
 **Aborts are held apart from exceptions on purpose.** An aborted turn is a
@@ -1694,7 +1701,7 @@ row knows its day. Render is `toolRows`/`modelMix` in
 the `tool_use` block's own `name` (`collectClaudeToolNames`,
 `usage-parsers.mjs:366-375`). Codex's four tallied item types —
 `CommandExecution`, `McpToolCall`, `FileChange`, `CollabAgentToolCall`
-(`CODEX_TOOL_ITEM_TYPES`, `usage-parsers.mjs:654`, tallied at `:685-687`) —
+(`CODEX_TOOL_ITEM_TYPES`, `usage-parsers.mjs:705`, tallied at `:736-737`) —
 keep those exact spellings in the ranking. Mapping `CommandExecution` onto
 `Bash`, or `FileChange` onto `Edit`, would be a claim about equivalence that
 neither host makes: the vocabularies are host-specific, the semantics do not
@@ -1849,7 +1856,7 @@ promise.
   `byModel` on the first run after the change, purely because the cache
   predated it; every unit test still passed, since tests only exercise a
   fresh parse. `SCHEMA_VERSION` went to `4` specifically to force the one-time
-  re-parse; the constant now reads `11` (`usage-index.mjs:99`), each bump since
+  re-parse; the constant now reads `13` (`usage-index.mjs:120`), each bump since
   having forced its own re-parse the same way.
   Re-querying the same live server after the bump returned
   `totals.exceptions: 20` with `<synthetic>` absent from `byModel` —

--- a/docs/USAGE-SCORECARD-METRICS.md
+++ b/docs/USAGE-SCORECARD-METRICS.md
@@ -72,7 +72,23 @@ schema change — `src/lib/usage-index.mjs:10`, `:99`):
 | Transcript host | Store | Format |
 |---|---|---|
 | Claude Code | `~/.claude/projects/<project>/<sessionId>.jsonl` | one JSON object per line: `user`/`assistant` turns, each assistant turn carrying its own `usage` object |
+| Claude Code (subagent) | `~/.claude/projects/<project>/<sessionId>/subagents/agent-<hash>.jsonl` | the same per-line format. A session's own delegated work, written to its own file beside the parent — cost-bearing, and marked `sidechain` by its own entries |
 | Codex CLI | `~/.codex/sessions/<yyyy>/<mm>/<dd>/rollout-<ts>-<sessionId>.jsonl` | one JSON object per line: `session_meta`, `turn_context`, and `event_msg` records; the latter carry **cumulative** `token_count` snapshots plus legacy messages or newer `item_completed` envelopes |
+
+Discovery is **one level of project directories plus that one nested shape**,
+not a recursive walk: `listClaude` (`usage-index.mjs:259-273`) descends into a
+session-id directory only through `listClaudeSubagents`
+(`usage-index.mjs:243-255`), which reads exactly
+`<projectDir>/<sessionId>/subagents/*.jsonl`. A directory that is not a
+session-id dir with a `subagents` child — Claude Code's own `memory` dir, say —
+contributes nothing rather than being crawled. Each subagent record takes a
+**namespaced** id, `<sessionId>/<stem>` (`usage-index.mjs:250`), because Claude
+Code names every such file `agent-<hash>.jsonl` and that stem is not guaranteed
+unique across two parents; an unnamespaced id would silently collide two
+unrelated subagent records into one. `locateSubagent`
+(`usage-index.mjs:787-795`) resolves that id back to the nested path when a
+reader opens the session, building the candidate path from the two validated
+capture groups rather than from raw request input.
 
 The parsers are `parseClaude` (`usage-parsers.mjs:440-469`) and `parseCodex`
 (`usage-parsers.mjs:724-745`). Both are pure functions over the raw file bytes —
@@ -816,6 +832,13 @@ Every rate lives in the `PRICES` table (`src/lib/pricing.mjs:65-125`) and carrie
 the table's own last-verified date, `PRICES_AS_OF = '2026-08-25'`
 (`pricing.mjs:18`). Each subsection below dates its own source check separately.
 
+**The code is the authority for a rate; this section is a reading of it.** The
+Anthropic transcription in §13.1 matches `pricing.mjs:67-89` value for value.
+The OpenAI transcription in §13.2 does **not** currently match
+`pricing.mjs:112-124`, and the sourcing note there is likewise out of step with
+the file's own comment. Price a row from `pricing.mjs`, not from §13.2's table,
+until the two are reconciled.
+
 ### 13.1 Anthropic — primary source, directly verified
 
 Fetched in full from **[C1]** on 2026-07-25. The table below is Anthropic's
@@ -1201,10 +1224,14 @@ Neither transcript store records it, so no panel here may borrow the name.
   deliberate choice to keep one distribution rather than two thin ones, and it
   means a window dominated by one host is really reporting that host's
   instrument;
-- the parsers' edge constants are a second, independent literal from the
-  aggregate's. The browser copy is pinned to the server's by test; the parser
-  copy is not, so a change made in one place and not the other would re-label
-  buckets silently.
+- the bucketing *function* is implemented twice: the parsers export
+  `bucketIndex` (`usage-parsers.mjs:214-217`) and the aggregate keeps a private
+  copy of the same loop (`usage-aggregate.mjs:187-190`), because the dependency
+  between the two modules is deliberately one-way. The *edges* they run on are
+  pinned equal by test — `AGG_LAT_EDGES` against `LAT_BUCKET_EDGES`
+  (`tests/kit/usage-index.test.mjs:1686-1692`) — but the two function bodies
+  are not, so a boundary rule changed in one and not the other would go
+  unnoticed.
 
 ---
 
@@ -1298,27 +1325,55 @@ as a zero rather than a row the UI silently drops. Claude's evidence is the
 `telemetry-records.mjs:244`); Codex's is the ledger-backed `thread_source`
 (§13c). Render is `sourceDonut` in `src/lib/dashboard/client/usage.mjs`.
 
-**Subagent cost can honestly read `$0`, and that is not a defect.** On the Codex
-side it is the design: a ledger-identified subagent has its usage rows removed
-outright (`applyCodexLedger`, `usage-aggregate.mjs:869-872`) and
-`finalizeCodexUsage` never writes one in the first place
-(`usage-parsers.mjs:692`), because a subagent rollout replays its parent's
-entire cumulative token history and keeping it would bill the parent twice
-(§13c, **[C7]**). The session record stays visible and auditable; its cost is
-structurally zero, and §17 explains why such sessions are also kept out of the
-cost-per-session distribution.
+**The two hosts reach the `subagent` row by different routes, and only one of
+them arrives at `$0`.** They are worth reading apart, because the same donut
+slice is telling two different truths at once.
 
-Whether the *Claude* side contributes any subagent spend is a property of the
-corpus on the machine, not of the code — and on this one it does. In the census
-of §13.3 (the 200 most recently modified local Claude transcripts, measured
-2026-08-28), **50 files were sidechain-only** and carried 6,924 assistant turns
-between them, against 150 main-only files carrying 2,738; **no file mixed the
-two**. That last figure is what makes the rule sound: because Claude writes a
-sidechain session to its own transcript, "any `isSidechain` entry marks the
-whole record" cannot mis-attribute a parent's spend to a subagent. A window
-drawn from that corpus therefore shows a genuinely non-zero subagent slice, and
-a `$0` slice would be the surprising reading — the opposite of the Codex case,
-where `$0` is expected.
+**Claude — real, priced, included.** A session's delegated work is written to
+its own transcript under `<project>/<sessionId>/subagents/`, and those files are
+discovered by `listClaudeSubagents` (`usage-index.mjs:243-255`, §1) and parsed
+like any other. `parseClaude` already prices those bytes and marks the record
+`sidechain` from its own `isSidechain` entries, so the cost is real, is included
+in `totals.cost`, and the session opens in the Sessions tab like a main-thread
+one. A `$0` Claude subagent slice would mean no delegated work in the window,
+not delegated work that was free.
+
+**Codex — structurally `$0`, by ledger design.** A ledger-identified subagent
+has its usage rows removed outright (`applyCodexLedger`,
+`usage-aggregate.mjs:869-872`) and `finalizeCodexUsage` never writes one in the
+first place (`usage-parsers.mjs:692`), because a subagent rollout replays its
+parent's entire cumulative token history and keeping it would bill the parent
+twice (§13c, **[C7]**). The record stays visible and auditable; its cost is zero
+because nothing was measured for it, not because the work was cheap — which is
+also why §17 keeps such sessions out of the cost-per-session distribution.
+
+**Worked example**, one machine's own 14-day window — every figure below taken
+from a single aggregate generated 2026-08-29T00:00Z, so the parts add up. It is
+one corpus, so the *shape* is the point, not the totals:
+
+| Source | Host | Sessions | Api-equivalent cost | Responses |
+|---|---|---|---|---|
+| subagent | claude | 178 | $2,376.13 | 17,863 |
+| subagent | codex | 156 | $0.00 | 1,356 |
+| main | claude | 265 | $2,904.54 | 11,480 |
+| main | codex | 682 | $802.97 | 56,543 |
+
+`bySource` therefore reads `main` 947 sessions / $3,707.50 and `subagent` **334
+sessions / $2,376.13**, which sum exactly to the window's $6,083.63 across 1,281
+sessions. Delegated work is **39.1% of the window's cost, and every dollar of it
+is Claude's.** The Codex row is the honest zero described above: 156 sessions and
+1,356 responses are visible, and their cost is `$0.00` because their tokens were
+stripped as a double-count. Both rows exist because both are pre-created before
+the fold; neither is a row the UI invented. (The four host rows are each rounded
+to the cent independently, so reading them as a column sums a cent high against
+`bySource` — the buckets, not the display, are what the totals are built from.)
+
+That a `subagent` slice is non-zero at all rests on one property of the store:
+Claude writes a sidechain session to its **own** file. Measured over the 200
+most recently modified local Claude transcripts on 2026-08-28, 50 files were
+sidechain-only (6,924 assistant turns), 150 were main-only (2,738 turns), and
+**none mixed the two** — which is what makes "any `isSidechain` entry marks the
+whole record" safe, since there is no parent's spend in the file to mis-attribute.
 
 ### 16.3 Served by — inference provider
 
@@ -1440,7 +1495,7 @@ before it — the half-open interval `[now − 2d, now − d)`
 `now` and `d`, the window the UI is *showing*, and never from the parse cutoff:
 the caller widens that cutoff on purpose so older records survive to be
 aggregated here (`lookbackDays: days * 2` at `src/commands/usage.mjs:288` and
-`src/lib/dashboard-server.mjs:1356`), and deriving the baseline from a widened
+`src/lib/dashboard-server.mjs:1361`), and deriving the baseline from a widened
 bound would silently stretch it to whatever lookback the caller happened to
 pass. A delta against an unknown-length window is not a delta. The upper bound
 is exclusive so a session ending exactly at the boundary belongs to the current
@@ -1662,8 +1717,9 @@ example) but performed **no de-duplication** against a parent session a
 subagent file might be replaying. **Fix:** the parser now reads
 `session_meta.thread_source` (`telemetry-records.mjs:101-110`, confirmed as a real
 Codex rollout field by **[C7]**) and skips the `addUsage()` call entirely
-when its value is `'subagent'` (`usage-parsers.mjs:692`, guard condition
-`rec.threadSource !== 'subagent'`). The session record itself is **not**
+when its value is `'subagent'` — `finalizeCodexUsage` returns early on
+`if (!lastUsage || rec.threadSource === 'subagent')`
+(`usage-parsers.mjs:692`). The session record itself is **not**
 dropped — it remains visible in the Sessions tab with `threadSource`
 surfaced (mirroring the existing `sidechain` flag Claude sessions already
 carry, `usage-parsers.mjs:454`), so a maintainer auditing the raw data can
@@ -1728,8 +1784,9 @@ promise.
   `totals.exceptions: null` and still showed the `<synthetic>` row in
   `byModel` on the first run after the change, purely because the cache
   predated it; every unit test still passed, since tests only exercise a
-  fresh parse. `SCHEMA_VERSION` went to `4` (`usage-index.mjs:99`; since
-  superseded by `5`, above) specifically to force the one-time re-parse.
+  fresh parse. `SCHEMA_VERSION` went to `4` specifically to force the one-time
+  re-parse; the constant now reads `11` (`usage-index.mjs:99`), each bump since
+  having forced its own re-parse the same way.
   Re-querying the same live server after the bump returned
   `totals.exceptions: 20` with `<synthetic>` absent from `byModel` —
   measured, not projected.

--- a/docs/USAGE-SCORECARD-METRICS.md
+++ b/docs/USAGE-SCORECARD-METRICS.md
@@ -20,12 +20,22 @@ verified against the current source by the test suite
 (`tests/kit/doc-citations.test.mjs`): an identifier named beside the citation
 must appear at the cited lines. A passing build means the citations match the
 code you have; upkeep is covered in
-[Appendix B](#appendix-b--verification-methodology).
+[Appendix B](#appendix-b--verification-methodology). One file is cited by
+function name and no line number: the browser bundle
+`src/lib/dashboard/client/usage.mjs` shares a basename with the CLI command
+module `src/commands/usage.mjs`, and the checker keys on basenames, so a
+`usage.mjs:NNN` citation would silently resolve to the wrong file.
 
-**Scope.** This document covers the **Scorecard** tab only — the five hero KPIs
-(Sessions, API-Equivalent, Tokens, Engaged Time, Cache Read) and the six
-supporting panels (cost per day, by host, token composition bar, when you work,
-models in play, projects, what you worked on). The **Findings**, **Sessions**,
+**Scope.** This document covers the **Scorecard** tab — both the surface it
+renders in the dashboard and the same figures printed offline by
+`ak usage score`. That is the five hero KPIs (Sessions, API-Equivalent, Tokens,
+Engaged Time, Cache Read); the second KPI row of cadence and unit economics
+(sessions per active day, autonomy, cost per session, cost per engaged hour);
+and the supporting panels — cost per day, by host, token composition bar, your
+rhythm, how you run, when you work, models in play, tool mix, model mix over
+time, reliability, projects, what you worked on. Two adjacent surfaces are
+documented here because they answer questions the Scorecard raises: the Limits
+view (§13b) and the Codex thread ledger (§13c). The **Findings**, **Sessions**,
 and **Transcript** tabs are governed by separate rules and are out of scope
 here except where they share a data source with a Scorecard metric.
 
@@ -57,15 +67,15 @@ Every metric section below follows the same shape:
 
 Two transcript stores, read-only, parsed at most once per file (cache keyed by
 `(path, mtime, size)`; `SCHEMA_VERSION` invalidates the whole cache on a
-schema change — `src/lib/usage-index.mjs:10`):
+schema change — `src/lib/usage-index.mjs:10`, `:99`):
 
 | Transcript host | Store | Format |
 |---|---|---|
 | Claude Code | `~/.claude/projects/<project>/<sessionId>.jsonl` | one JSON object per line: `user`/`assistant` turns, each assistant turn carrying its own `usage` object |
 | Codex CLI | `~/.codex/sessions/<yyyy>/<mm>/<dd>/rollout-<ts>-<sessionId>.jsonl` | one JSON object per line: `session_meta`, `turn_context`, and `event_msg` records; the latter carry **cumulative** `token_count` snapshots plus legacy messages or newer `item_completed` envelopes |
 
-The parsers are `parseClaude` (`usage-index.mjs:480-563`) and `parseCodex`
-(`usage-index.mjs:580-681`). Both are pure functions over the raw file bytes —
+The parsers are `parseClaude` (`usage-parsers.mjs:440-469`) and `parseCodex`
+(`usage-parsers.mjs:724-745`). Both are pure functions over the raw file bytes —
 no network, no clock dependency beyond the transcript's own timestamps — so
 every downstream number traces back to bytes already on the user's disk.
 Nothing in this transcript pipeline calls a provider API or a billing endpoint; **no transcript
@@ -154,21 +164,21 @@ responses = Σ over included sessions of session.responses
 **Source:**
 
 - Filter: a parsed record with zero assistant turns is dropped entirely — "no
-  assistant turn → not a session" (`usage-aggregate.mjs:307`) — and a record whose
+  assistant turn → not a session" (`usage-aggregate.mjs:496`) — and a record whose
   last activity falls outside the requested window is dropped too
-  (`usage-aggregate.mjs:308`).
+  (`usage-aggregate.mjs:497`).
 - `responses` accumulation: Claude increments per assistant message
-(`usage-parsers.mjs:328-333`); Codex increments per `agent_message` event
-(`usage-parsers.mjs:494-500`).
+(`usage-parsers.mjs:380-385`); Codex increments per `agent_message` event
+(`usage-parsers.mjs:595-600`).
 - Totals: `totals.responses += s.responses` per included session
-(`usage-aggregate.mjs:358`).
+(`usage-aggregate.mjs:574`).
 - Render: `kpi("sessions", fmtNum(t.sessions), fmtNum(t.responses)+" assistant
   turns", "")` (`dashboard/client.mjs`).
 
 **Worked example.** A session with 3 user turns and 2 assistant turns
 contributes `sessions += 1, responses += 2` — prompts (user turns) are tracked
 separately and never appear in this KPI. Verified in
-`tests/kit/usage-index.test.mjs:330` (`s.responses === 2, s.prompts === 1` for
+`tests/kit/usage-index.test.mjs:385-386` (`s.responses === 2, s.prompts === 1` for
 a fixture with exactly that shape).
 
 **What this does not model:** a session that opened but received no assistant
@@ -200,7 +210,7 @@ cost = (inputUnits × rate_in + output × rate_out) / 1,000,000
 
 summed across every row in the window.
 
-**Source:** `costOf()`, `src/lib/pricing.mjs:253-259`, reproduced verbatim:
+**Source:** `costOf()`, `src/lib/pricing.mjs:262-268`, reproduced verbatim:
 
 ```js
 export function costOf(usage) {
@@ -214,17 +224,17 @@ export function costOf(usage) {
 ```
 
 `CACHE_READ_MULTIPLIER = 0.1`, `CACHE_WRITE_MULTIPLIER = 1.25`
-(`pricing.mjs:160-161`) — see §13 for why these two numbers are correct for
+(`pricing.mjs:169-170`) — see §13 for why these two numbers are correct for
 **both** Anthropic and OpenAI, which is why `costOf` needs no per-provider
 branch on the multiplier (only on the base `rate_in`/`rate_out`, resolved by
-`priceFor`, `pricing.mjs:220-233`).
+`priceFor`, `pricing.mjs:229-242`).
 
 Rate resolution is **longest-prefix match** on a normalized model id
-(`pricing.mjs:169-178`), so a dated release (`claude-haiku-4-5-20251001`)
+(`pricing.mjs:178-187`), so a dated release (`claude-haiku-4-5-20251001`)
 resolves to the same entry as its bare alias, and a more specific entry
 (`gpt-5.6-sol`) is never shadowed by a shorter one (`gpt-5.6`). An id matching
 nothing gets `FALLBACK_PRICE` — Sonnet-class rate, `$3`/`$15`
-(`pricing.mjs:157`) — rather than `$0`, so an unrecognized model can never be
+(`pricing.mjs:166`) — rather than `$0`, so an unrecognized model can never be
 silently free; `matched: false` travels with the result so a maintainer can
 find fallback-priced rows if the table needs a new entry.
 
@@ -234,12 +244,12 @@ Each table entry is a **schedule** — an ordered list of periods, each with the
 day it takes effect. Nearly every entry has exactly one period that has always
 applied (`anthropic(5, 25)` builds that shape); an entry whose rate the vendor
 has *published* a change to carries more than one (`schedule`,
-`pricing.mjs:41-55`). `periodOn` (`pricing.mjs:193`) picks the last period
+`pricing.mjs:41-55`). `periodOn` (`pricing.mjs:202`) picks the last period
 already in effect on the given day, comparing ISO date strings
 lexicographically so no `Date` parsing is involved and the module stays
 clock-free.
 
-`aggregate()` passes each usage row's own `day` (`usage-aggregate.mjs:228-229`), which
+`aggregate()` passes each usage row's own `day` (`usage-aggregate.mjs:368-371`), which
 it already has because rows are keyed by `(day, model)`. **This is the whole
 point:** tokens metered in August must still read as August's rate when the
 panel is opened in December. Pricing by *today's* date instead would restate a
@@ -261,7 +271,7 @@ Two rules bound the mechanism:
   Codex promo would be a one-line edit rather than new machinery. Rates that
   vary by *how* a request was served — regional uplift, large-prompt surcharge,
   service tiers — are a different axis, are deliberately **not** expressible
-  here, and remain in `UNMODELLED_PRICING_FACTORS` (`pricing.mjs:148-150`)
+  here, and remain in `UNMODELLED_PRICING_FACTORS` (`pricing.mjs:157-159`)
   because a transcript does not record the endpoint or tier.
 
 A `priceFor` call with no day prices as of `PRICES_AS_OF`, the table's
@@ -321,9 +331,9 @@ tokens = input + output + cacheRead + cacheWrite   (summed across all rows in wi
 ```
 
 **Source:** `t.tokens` from `totals`, accumulated per row at
-`usage-aggregate.mjs:236` (`rowTokens = row.input + row.output + row.cacheRead +
+`usage-aggregate.mjs:376` (`rowTokens = row.input + row.output + row.cacheRead +
 row.cacheWrite`) and rolled into `totals.tokens` via `addTo`
-(`usage-aggregate.mjs:201-208`). Rendered with `fmtTok()`
+(`usage-aggregate.mjs:285-294`). Rendered with `fmtTok()`
 (`dashboard/client.mjs`): `≥1e9` → `"X.XB"`, `≥1e6` → `"X.XM"`,
 `≥1e3` → `"X.XK"`, else the rounded integer.
 
@@ -337,11 +347,11 @@ per row is **gross input minus cached input** — Claude's parser reads
 `cache_read_input_tokens` and `cache_creation_input_tokens` as separate fields
 the provider already reports separately (`telemetry-records.mjs:216-224`); Codex's
 parser subtracts `cached_input_tokens` from `input_tokens` explicitly
-(`usage-parsers.mjs:544-561`, `input: Math.max(0, gross - cacheRead)`) because
+(`usage-parsers.mjs:690-707`, `input: Math.max(0, gross - cacheRead)`) because
 Codex's own `input_tokens` field **includes** cached tokens and would
 double-count them against the separately-reported `cacheRead` figure if left
 as-is. This is asserted by test:
-`tests/kit/usage-index.test.mjs:330-350` ("Codex tokens come from the LAST
+`tests/kit/usage-index.test.mjs:366-395` ("Codex tokens come from the LAST
 token_count event, never the sum") pins a fixture where the naive sum of two
 cumulative snapshots (4000/1600/400) would be wrong, and the correct
 last-event-only answer (3000/1200/300, split into `input: 1800, cacheRead:
@@ -408,8 +418,8 @@ separate interval-union operations:
 
 The asserted invariant is `engagedSeconds ≤ spanUnionSeconds ≤
 spanMinutes×60`, and it is checked directly by test
-(`tests/kit/usage-index.test.mjs`, the `mergeIntervals` suite starting around
-line 97, plus the aggregate-level tests around lines 495-509).
+(the `mergeIntervals` suite, `tests/kit/usage-index.test.mjs:103-144`, plus the
+aggregate-level engaged-time tests, `tests/kit/usage-index.test.mjs:474-534`).
 
 **Why three tiers instead of one.** Two independent distortions stack in raw
 session data, and each needs its own fix:
@@ -422,7 +432,7 @@ session data, and each needs its own fix:
    human, or genuinely idle) donates its *entire* idle stretch to the span,
    even though no work happened during it. Fix: split each session into
    active sub-intervals wherever the gap between two consecutive timestamps
-   exceeds `IDLE_GAP_MS` (15 minutes, `usage-parsers.mjs:21`), then union
+   exceeds `IDLE_GAP_MS` (15 minutes, `usage-parsers.mjs:22`), then union
    *those* sub-intervals — this is `engagedSeconds`.
 
 **Source:**
@@ -431,15 +441,15 @@ session data, and each needs its own fix:
   sorts intervals and merges any two that overlap **or exactly touch**
   (`s <= curEnd`, `usage-aggregate.mjs:46`), returning total covered seconds
   rounded to the nearest second.
-- `activeIntervals()` (`usage-parsers.mjs:206-217`) — splits one session's
+- `activeIntervals()` (`usage-parsers.mjs:249-261`) — splits one session's
   sorted timestamp list into sub-intervals wherever a gap exceeds
   `IDLE_GAP_MS`; "a run of one timestamp yields a zero-length interval and so
-  contributes nothing" (comment, `usage-parsers.mjs:200-204`).
+  contributes nothing" (comment, `usage-parsers.mjs:243-248`).
 - Aggregation: `totals.engagedSeconds = mergeIntervals(sessions.flatMap(s =>
-  s._active))` (`usage-aggregate.mjs:423`); `totals.spanUnionSeconds =
-  mergeIntervals(sessions.map(s => s._span))` (`usage-aggregate.mjs:422`);
+  s._active))` (`usage-aggregate.mjs:666`); `totals.spanUnionSeconds =
+  mergeIntervals(sessions.map(s => s._span))` (`usage-aggregate.mjs:665`);
   `totals.spanMinutes` is a running sum of `s._span[1] - s._span[0]` across
-  the loop (`usage-aggregate.mjs:362`, finalized `usage-aggregate.mjs:421`).
+  the loop (`usage-aggregate.mjs:585`, finalized `usage-aggregate.mjs:664`).
 - Render: `fmtHours()` (`dashboard/client.mjs`, `≥10h` rounds to the
   nearest hour, else one decimal place) and `fmtMins()`
   (`dashboard/client.mjs`, `≥60min` rounds to hours, else whole
@@ -490,12 +500,12 @@ byDay[day].sessionsActive = count of distinct sessions with any usage row that d
 
 **Source:** the day key is the row's own `row.day`, computed once at parse
 time as **local calendar day**, not UTC
-(`usage-parsers.mjs:360`/`usage-parsers.mjs:550` call `localDay(at)`) — so a
+(`usage-parsers.mjs:419`/`usage-parsers.mjs:696` call `localDay(at)`) — so a
 session that runs from 23:58 local to 00:05 local is billed to the day its
 *first* row landed on (test:
-`tests/kit/usage-index.test.mjs:634`, "a session that opens before midnight
+`tests/kit/usage-index.test.mjs:651`, "a session that opens before midnight
 is counted on its first billed day"). Accumulation:
-`byDay[row.day].cost += rowCost` (`usage-aggregate.mjs:239`). Bar height:
+`byDay[row.day].cost += rowCost` (`usage-aggregate.mjs:377-382`). Bar height:
 `h = maxDay ? max(2, cost/maxDay*100) : 2` (`dashboard/client.mjs`) —
 every non-empty day gets a visually nonzero bar (floor of 2%), so a very
 cheap day is never rendered as invisible.
@@ -522,11 +532,13 @@ renders "no sessions in window" instead of zeroed figures
 (`dashboard/client.mjs`).
 
 **Formula:** identical aggregation to every other bucket
-(`byProvider[s.provider]`, populated via `addTo()`, `usage-aggregate.mjs:201-209`,
-  called once per session at `usage-aggregate.mjs:365`), keyed by the literal string
+(`byHost[s.host]`, populated via `addTo()`, `usage-aggregate.mjs:285-294`,
+  called once per session at `usage-aggregate.mjs:587`), keyed by the literal string
 `"claude"` or `"codex"` assigned at parse time
 (`blankSession(id, 'claude')` / `blankSession(id, 'codex')`,
-`usage-parsers.mjs:180-191`, `parseClaude`/`parseCodex` entry points).
+`usage-parsers.mjs:441`, `:725`, `parseClaude`/`parseCodex` entry points).
+OpenCode's SQLite reader builds the same record shape and contributes a third
+host key.
 
 **Why this pairing is the one under the most scrutiny.** Both providers'
 tokens are summed into the *same* `tokens`/`cost` fields using the *same*
@@ -539,13 +551,41 @@ aggregation — never a defect in the aggregation itself, since both hosts
 share it. [Appendix A](#appendix-a--fix-history) documents two real defects
 of exactly that kind, both in `parseCodex`.
 
-**What this does not model:** the by-host cards do not yet carry a separate
-inference-provider dimension. The legacy session record has exactly one `provider`
-field, currently used as host/parser identity. A
-workflow that hands off between Claude and Codex mid-task (e.g. `ak run`) produces two separate
-session records, one per host, each correctly
-aggregated under the current transcript-host schedule rather than one blended record. That
-API-equivalent estimate is not proof of the provider that actually served either execution.
+**Three identity maps, and why `byProvider` is not `byInferenceProvider`.** The
+aggregate ships three separate bucket maps, and reading one as another is the
+mistake this split exists to prevent (`usage-aggregate.mjs:560-561`,
+`usage-aggregate.mjs:587-592`):
+
+- **`byHost`** — the execution host: which CLI wrote the transcript
+  (`claude`, `codex`, `opencode`). This is what the two cards above render.
+  It is a fact about the file's provenance on disk, and it proves nothing
+  about which vendor served the tokens.
+- **`byProvider`** — the inference-provider string **as recorded**, ungated:
+  `s.provider ?? 'unknown'`. This map keeps its historical name and its
+  historical shape for callers that want the raw string, whatever its
+  evidence. A session that recorded no provider keys to `'unknown'`.
+- **`byInferenceProvider`** — the same identity, **provenance-gated**. Its key
+  is the provider only when `s.providerProvenance === 'observed'`; anything
+  else keys to `'not-recorded'` (`providerKey`, `usage-aggregate.mjs:538-540`).
+  This is the map the "inference provider" panel and `ak usage score`'s
+  `served by` table read.
+
+The gate is the whole point: `'not-recorded'` is a first-class key, not a
+display fallback, so spend whose provenance was never observed is held apart
+instead of being attributed to an assumption. A provider string that was
+merely *configured* is an assumption; only an *observed* one is evidence.
+Today the Codex parser is the only source that sets `rec.inferenceProvider`
+and `rec.providerProvenance` together
+(`usage-parsers.mjs:492-495`, `:501-503`); Claude and OpenCode transcripts name
+no provider at all, and so their spend lands in `'not-recorded'` — correctly,
+since neither transcript records who served it.
+
+**What this does not model:** a workflow that hands off between Claude and
+Codex mid-task (e.g. `ak run`) produces two separate session records, one per
+host, each aggregated under its own host rather than blended into one record.
+That API-equivalent estimate is still not proof of the provider that served
+either execution — which is exactly what `byInferenceProvider` declines to
+guess.
 
 ---
 
@@ -562,9 +602,9 @@ punchcard[dow + "-" + hour] += 1   per assistant/agent_message response, at its 
 ```
 
 **Source:** incremented once per Claude assistant turn
-(`usage-parsers.mjs:328-333`, keyed by `punchKey(at)`) and once per Codex
-`agent_message` (`usage-parsers.mjs:494-500`), merged into the window-level
-`punchcard` object per session (`usage-aggregate.mjs:370`). Cell intensity is
+(`usage-parsers.mjs:383-385`, keyed by `punchKey(at)`) and once per Codex
+`agent_message` (`usage-parsers.mjs:598-600`), merged into the window-level
+`punchcard` object per session (`usage-aggregate.mjs:605`). Cell intensity is
 linear against the single busiest cell in the window:
 `v = pcMax ? n/pcMax : 0` (`dashboard/client.mjs`) — this is a
 **relative**, not absolute, scale, so the heatmap's brightest cell is always
@@ -597,9 +637,9 @@ byModel[model].sessions  = count of DISTINCT sessions whose s.models includes th
 ```
 
 **Source:** cost/tokens/responses accumulate inside the usage-row loop
-(`usage-aggregate.mjs:227-246`); the `sessions` count is deliberately computed
+(`usage-aggregate.mjs:367-394`); the `sessions` count is deliberately computed
 **separately**, once per session over its `s.models` array
-(`usage-aggregate.mjs:321-328`) rather than inside the cost loop, precisely
+(`usage-aggregate.mjs:511-518`) rather than inside the cost loop, precisely
 **so that a model can appear in `byModel` — with a nonzero session count —
 even in a session that contributed zero cost/tokens/responses for that
 model.** This is not an edge case invented for this document: it is the
@@ -609,11 +649,11 @@ excluded subagent-replay session still shows up as "used," at zero cost,
 rather than vanishing.
 
 `byModel[...].responses` is populated from `row.responses`
-(`usage-aggregate.mjs:243`), which in turn comes from the `responses` field
+(`usage-aggregate.mjs:391`), which in turn comes from the `responses` field
 passed into `addUsage()` at the call site — `1` per Claude assistant turn
-(`usage-parsers.mjs:357-360`), or `rec.responses` (the session's whole response
+(`usage-parsers.mjs:419`), or `rec.responses` (the session's whole response
 count) once per Codex session, passed at the single point Codex calls
-`addUsage` (`usage-parsers.mjs:550-556`).
+`addUsage` (`usage-parsers.mjs:696-702`).
 
 **Render:** `bar(name, fmtUsd(cost), fmtTok(tokens)+" · "+fmtNum(responses)+"
 resp", pct(cost, topModelCost), false)` (`dashboard/client.mjs`),
@@ -629,14 +669,14 @@ split `server_error` 27, `authentication_failed` 3, `rate_limit` 3 — three
 distinct underlying causes, one placeholder shape).
 
 The parser branches on `isApiErrorMessage === true`
-(`usage-parsers.mjs:345-353`): the turn still increments `rec.responses`
-and the punchcard (`usage-parsers.mjs:328-333`) — it *is* real engaged
+(`usage-parsers.mjs:399-408`): the turn still increments `rec.responses`
+and the punchcard (`usage-parsers.mjs:382-385`) — it *is* real engaged
 time, someone was genuinely waiting on it — but it is never pushed into
 `rec.models` and `addUsage()` is never called for it, so it can no longer
 create a `byModel` row of any kind. It increments a separate
-`rec.exceptions` counter instead (`usage-parsers.mjs:346`), rolled up into
-`totals.exceptions` (`usage-aggregate.mjs:358`) and surfaced per-session
-(`usage-aggregate.mjs:278-279`, alongside the existing `sidechain`/`threadSource`
+`rec.exceptions` counter instead (`usage-parsers.mjs:400`), rolled up into
+`totals.exceptions` (`usage-aggregate.mjs:579`) and surfaced per-session
+(`usage-aggregate.mjs:452-453`, alongside the existing `sidechain`/`threadSource`
 flags — inspectable in the Sessions tab, never hidden). When
 `totals.exceptions > 0`, the panel header shows a small `"· N
 dropped/errored turns excluded"` note (`dashboard/client.mjs`);
@@ -772,8 +812,9 @@ since it is opt-in and not part of a default Scorecard render.
 
 ## 13. Provider pricing tables — verified rates
 
-Every rate in `src/lib/pricing.mjs:30-80` as of `PRICES_AS_OF = '2026-07-25'`
-(`pricing.mjs:18`), checked against the sources below on 2026-07-25.
+Every rate lives in the `PRICES` table (`src/lib/pricing.mjs:65-125`) and carries
+the table's own last-verified date, `PRICES_AS_OF = '2026-08-25'`
+(`pricing.mjs:18`). Each subsection below dates its own source check separately.
 
 ### 13.1 Anthropic — primary source, directly verified
 
@@ -790,7 +831,7 @@ own published table, not a transcription from a secondary source:
 | Claude Sonnet 4.6 / 4.5 | $3/MTok | $3.75/MTok | $6/MTok | $0.30/MTok | $15/MTok |
 | Claude Haiku 4.5 | $1/MTok | $1.25/MTok | $2/MTok | $0.10/MTok | $5/MTok |
 
-Every value in `pricing.mjs`'s Anthropic entries (`pricing.mjs:74-114`) matches
+Every value in `pricing.mjs`'s Anthropic entries (`pricing.mjs:67-89`) matches
 this table's "Base input" and "Output" columns exactly. Note that the two Sonnet
 5 rows above are not a documentation convenience — they are exactly what the
 code encodes, as the two periods of that entry's schedule (§3a), so the table
@@ -811,11 +852,11 @@ Anthropic's own prompt-caching documentation **[C2]** states the multipliers
 in prose, independent of the pricing table: *"5-minute cache write tokens are
 1.25 times the base input tokens price... Cache read tokens are 0.1 times the
 base input tokens price."* This is the second, independent confirmation of
-`CACHE_READ_MULTIPLIER`/`CACHE_WRITE_MULTIPLIER` (`pricing.mjs:160-161`).
+`CACHE_READ_MULTIPLIER`/`CACHE_WRITE_MULTIPLIER` (`pricing.mjs:169-170`).
 
 ### 13.2 OpenAI (Codex) — hand-maintained, no canonical machine-readable source
 
-`pricing.mjs`'s own comment (`pricing.mjs:52-66`) records that
+`pricing.mjs`'s own comment (`pricing.mjs:91-94`) records that
 `~/.codex/models_cache.json` was checked directly and contains **zero**
 price-related keys — Codex CLI does not ship pricing data locally, unlike
 Anthropic which publishes a fetchable pricing document. OpenAI's rates in
@@ -860,18 +901,21 @@ hand-maintained and drift-prone, not vendor-confirmed via automated fetch.
 
 ### 13.3 What the pricing table deliberately does not model
 
-Recorded verbatim from `pricing.mjs:131-147` (`UNMODELLED_PRICING_FACTORS`,
-`pricing.mjs:148-150`) because listing known gaps is what makes the
+Recorded verbatim from `pricing.mjs:127-156` (`UNMODELLED_PRICING_FACTORS`,
+`pricing.mjs:157-159`) because listing known gaps is what makes the
 *modelled* factors credible:
 
 - **Regional-processing uplift.** OpenAI charges +10% on data-residency
   endpoints for models released on/after 2026-03-05; Codex CLI does not use
-  those endpoints by default and a transcript does not record which endpoint
-  served a given request, so this cannot be detected from local data.
-  (Anthropic's own equivalent — the `inference_geo: "us"` 1.1× multiplier,
-  confirmed in **[C1]** §"Inference geography" — is likewise unmodelled for
-  the same reason: a Claude transcript does not record which `inference_geo`
-  value a request used.)
+  those endpoints by default and a Codex rollout carries no field naming the
+  endpoint that served a given request, so this cannot be detected from local
+  data. Anthropic's own equivalent is the `inference_geo` 1.1× multiplier on
+  `"us"`-pinned inference, confirmed in **[C1]** §"Inference geography". A
+  Claude transcript *does* carry `usage.inference_geo` on essentially every
+  assistant turn (see the key-presence census below) — but the only value the
+  local corpus records is the literal string `"not_available"`, which names no
+  geography and so selects no multiplier. The key is present; the evidence
+  is not.
 - **Large-prompt surcharge.** A reported 2× input / 1.5× output surcharge
   above ~272K input tokens for the GPT-5.6 line is not restated on OpenAI's
   current canonical pricing page as far as this audit could confirm, so it
@@ -887,9 +931,42 @@ Recorded verbatim from `pricing.mjs:131-147` (`UNMODELLED_PRICING_FACTORS`,
   documented 50% input/output discount **[C1]** §"Batch processing"; Claude
   Managed Agents sessions additionally bill **session runtime** at
   $0.08/session-hour on top of tokens **[C1]** §"Claude Managed Agents
-  pricing" — neither transcript store records which billing surface (plain
-  Messages API, Batch, or Managed Agents) produced a given session, so none
-  of these are modelled.
+  pricing". Neither transcript store records which **billing surface** (plain
+  Messages API, Batch, or Managed Agents) produced a given session, so that
+  distinction is undetectable. The narrower tier fields *are* recorded —
+  `usage.service_tier` and `usage.speed` on Claude assistant turns, and a
+  `thread_settings.service_tier` on newer Codex rollouts — and are
+  nonetheless left unpriced, for the reasons below.
+
+**Key-presence census.** Measured 2026-08-28 over the 200 most recently
+modified of the 1,159 Claude transcripts under `~/.claude/projects` (file
+mtimes 2026-08-26 → 2026-08-28; Claude Code CLI versions 2.1.245–2.1.251 in
+that slice), and over 400 of the 1,026 rollouts under `~/.codex/sessions`:
+
+| Field | Turns carrying it | Distinct values observed |
+|---|---|---|
+| Claude `usage.service_tier` | 9,661 of 9,662 (100.0%) | `"standard"` |
+| Claude `usage.inference_geo` | 9,661 of 9,662 (100.0%) | `"not_available"` |
+| Claude `usage.speed` | 3,002 of 9,662 (31.1%) | `"standard"` |
+| Codex `thread_settings.service_tier` | 85 of 400 rollouts | `"default"` |
+
+Codex rollouts carry no `inference_geo` or `speed` key at all; their
+`token_count` payload is `input_tokens` / `cached_input_tokens` /
+`output_tokens` / `reasoning_output_tokens` / `total_tokens` and nothing else.
+
+**Why they stay unpriced.** Availability was never the blocker; *semantics*
+is, on three counts. Each field's corpus holds exactly **one** distinct value,
+so nothing here shows how a non-standard value would be spelled — a mapping
+from a recorded string to a published multiplier could not be checked against
+any evidence, only asserted. `inference_geo`'s single value is
+`"not_available"`, so the field that would carry the 1.1× decision carries no
+region. And the Codex field is a *thread setting* — configured intent — not a
+record of the tier that actually served a request; only the second could price
+a row. Encoding a multiplier on any of that would manufacture precision the
+data does not support, the same failure §14 names as an invented denominator,
+so the three factors remain listed in `UNMODELLED_PRICING_FACTORS` and
+`costOf()` is unchanged. This is a scope note about *this* corpus and these
+CLI versions, not a claim about every install.
 
 ---
 
@@ -905,22 +982,22 @@ both credential-free for ak:
   `used_percentage` + `resets_at`) into every statusLine invocation on Pro/Max.
   The kit's managed statusline footer tees that JSON to
   `~/.config/agentic-kit/claude-rate-limits.json` (throttled, atomic, 0600) —
-  the `quota tee` block in `statusline-footer.cjs:9`. The dashboard reads the
-  tee via `normalizeClaudeLimits` (`quota.mjs:62`), which maps `five_hour` /
+  the `quota tee` block in `statusline-footer.cjs:22`. The dashboard reads the
+  tee via `normalizeClaudeLimits` (`quota.mjs:69`), which maps `five_hour` /
   `seven_day` / `seven_day_<model>` keys to duration-labelled windows.
 - **Codex** — one `initialize` → `account/rateLimits/read` JSON-RPC exchange
   with a spawned `codex app-server`, implemented by `codexAppServerRateLimits`
-  (`quota.mjs:165`) and TTL-cached (`CODEX_TTL_MS`, `:36`) by
-  `collectCodexLimits` (`:220`). Lanes come from `rateLimitsByLimitId` in
-  `normalizeCodexLimits` (`:106`), including per-model pools and
+  (`quota.mjs:176`) and TTL-cached (`CODEX_TTL_MS`, `:43`) by
+  `collectCodexLimits` (`:231`). Lanes come from `rateLimitsByLimitId` in
+  `normalizeCodexLimits` (`:113`), including per-model pools and
   rate-limit reset credits.
 
 **The primary/secondary trap.** Codex's `primary` window is *not* reliably the
 5-hour window — a live `prolite` account reported `primary` with
 `windowDurationMins: 10080` (the weekly). Windows are therefore keyed and
-labelled by duration (`windowLabel`, `quota.mjs:44`), never by slot name. The
+labelled by duration (`windowLabel`, `quota.mjs:51`), never by slot name. The
 same rule applies to the historical snapshots parsed out of rollouts: the
-normalizer at `usage-parsers.mjs:446-458` keeps a flat `windows` list keyed by
+normalizer at `usage-parsers.mjs:511-530` keeps a flat `windows` list keyed by
 `window_minutes`.
 
 **Freshness is part of the number.** Both sides carry `fetchedAt`; the view
@@ -929,7 +1006,7 @@ ages the moment sessions stop). The `/api/limits` route lives in
 `dashboard-server.mjs`; `renderLimits` and `limRow` in `dashboard/client.mjs`
 render and color each bar by proximity to its cap.
 
-**Limit-aware findings.** `detectLimitInsights` (`usage-insights.mjs:625`)
+**Limit-aware findings.** `detectLimitInsights` (`usage-insights.mjs:771`)
 applies the same evidence rules as every other detector — vendor percentages
 are the user's own data; no dollar impact is ever claimed from a percentage;
 "now" is the payload's `generatedAt`, never a clock. Detectors: pacing
@@ -942,22 +1019,23 @@ subscription tier. They stay absent rather than approximated.
 ## 13c. Codex thread ledger — authoritative subagent attribution
 
 Codex ≥0.140 maintains its own SQLite thread ledger (`~/.codex/state_N.sqlite`
-— the `N` is a migration generation, so `codexStateDb` (`codex-state.mjs:30`)
-globs and takes the newest). `readCodexState` (`:49`) reads per-thread
+— the `N` is a migration generation, so `codexStateDb` (`codex-state.mjs:41`)
+globs and takes the newest). `readCodexState` (`:62`) reads per-thread
 `thread_source` (`user` vs `subagent`) plus `thread_spawn_edges`, and
-`applyCodexLedger` (`usage-aggregate.mjs:454-466`) overlays that onto parsed
+`applyCodexLedger` (`usage-aggregate.mjs:862-874`) overlays that onto parsed
 sessions: a ledger-identified subagent has its token usage stripped — its
 rollout replays the parent's entire token history (ccusage/ccusage#950
 measured up to 91× inflation) — while the session record stays visible. The
 rollout's own `session_meta.thread_source` sniff remains as the fallback when
 the ledger is absent or migrated beyond recognition. Codex sessions also carry
-`reasoningOutput` (`usage-parsers.mjs:560`) — reasoning tokens are a **subset**
+`reasoningOutput` (`usage-parsers.mjs:706`) — reasoning tokens are a **subset**
 of output tokens and are annotation only, never added to any sum.
 
 ## 14. Known limitations, restated as a single checklist
 
 For a reviewer who wants the "does this number lie to me" answer without
-reading every section above:
+reading every section — the panels documented in §15–§19 below are covered by
+the same list:
 
 - [x] Cost is always an **API-list-price equivalent**, never a claim about
   actual billing (§3, §14 pricing gaps above).
@@ -975,6 +1053,565 @@ reading every section above:
   evidence of a **parsing** defect upstream, not a pricing defect — see
   [Appendix A](#appendix-a--fix-history) for two real examples found via
   this same reasoning.
+- [x] A percentile taken from the overflow bucket of a histogram is printed
+  with `≥`, and an unmeasured one is `null` rather than `0` (§15).
+- [x] A latency figure is never called TTFT: it is a prompt-to-answer gap or
+  a host-measured turn duration, and neither transcript records TTFT (§15).
+- [x] Permission posture and inference provider both keep `not-recorded` as a
+  first-class bucket — unmapped evidence is never folded into a real posture,
+  and unobserved provenance is never attributed to a vendor (§8, §16).
+- [x] Autonomy divides by prompts a human typed; the cost-per-session median
+  excludes sessions that are `$0` by construction rather than by cheapness
+  (§17).
+- [x] Deltas compare equal-length adjacent windows, and a chip self-suppresses
+  when there is no baseline to compare against (§17).
+- [x] Aborted turns are counted apart from exceptions — an abort is a choice,
+  not a failure (§18).
+- [x] Tool names are the host's own and are never renamed across hosts; a
+  top-N list folds its tail rather than dropping it (§19).
+
+---
+
+## 15. Rhythm & responsiveness
+
+**Displayed as:** the `your rhythm` strip — two cards side by side. `session
+length` heads with `median 9m · P90 ≥2h`; `response latency` with `p50 7.5s ·
+p95 ≥60s · n 12,480`. Each card is a bar histogram with dashed percentile
+markers laid over the bars, and reads `not measured` rather than a row of zero
+bars when the window holds no samples. `ak usage score` prints the same two
+figures as its `SESSION LENGTH` and `RESPONSE LATENCY` lines.
+
+**Formula:**
+
+```text
+latHist[i] = number of latency samples in bucket i   edges (s) [2, 5, 10, 30, 60]
+lenHist[i] = number of sessions in bucket i          edges (s) [300, 900, 2700, 7200]
+bucket(v)  = first i where v <= edges[i], else edges.length      ← the OVERFLOW slot
+
+p(q), over N samples, landing in bucket i (count n_i, running total `cum` before it):
+    lo   = (i == 0) ? 0 : edges[i-1]
+    p(q) = lo + (edges[i] - lo) × (q×N - cum) / n_i     when i <  edges.length
+    p(q) = lo                                           when i == edges.length  ← FLOOR
+    p(q) = null                                         when N == 0
+```
+
+**Source:**
+
+- Edges: `LAT_BUCKET_EDGES` and `LEN_BUCKET_EDGES` (`usage-aggregate.mjs:177`, `:180`).
+  The parsers carry their own copies (`usage-parsers.mjs:206`, `:209`) and the
+  browser bundle a third pair (`LAT_EDGES`/`LEN_EDGES`), because the payload
+  ships bucket *counts* and never the edges they were binned on.
+- Slotting: `bucketIndex` (`usage-parsers.mjs:214-217`) — one definition of a
+  boundary, shared by every histogram built on these edges.
+- Sampling: `noteLatencySample` (`usage-parsers.mjs:223-228`) allocates
+  `latHist` lazily, so a session that never observed a latency keeps
+  `latHist: null` — absent, not a fabricated row of zeroes.
+- Session length: `seal` derives each session's `lenSeconds` from its own
+  active intervals (`usage-parsers.mjs:266-271`) — the §6 engaged figure for
+  one session, never its first-to-last span.
+- Window merge: `buildRhythm` (`usage-aggregate.mjs:682-702`) adds the
+  per-session `latHist` slot-wise and buckets each session's `lenSeconds`.
+- Percentiles: `percentileFromBuckets` (`usage-aggregate.mjs:206-223`). The
+  browser re-implementation `bucketPercentile` (`usage-rhythm.mjs:106-126`) is
+  pinned to byte-identical output, and the browser's edge copies to the server
+  constants, by `tests/kit/dashboard-usage-telemetry.test.mjs:285-298` and
+  `:387-388`.
+- Render: `lengthCard`/`latencyCard` and the `≥` prefix helper `fmtAtLeast` in
+  `src/lib/dashboard/client/usage.mjs` (that bundle shares a basename with the
+  CLI command module, so its render sites are cited by function name rather
+  than by line); the CLI's own `fmtAtLeast` is `src/commands/usage.mjs:143-146`
+  and `printScoreRhythm` (`src/commands/usage.mjs:208-215`) prints the pair.
+
+**Worked example**, latency, computable by hand. `latHist = [10, 30, 20, 25,
+10, 5]`, so N = 100.
+
+```text
+p50: target 50. Running total is 10 after bucket 0, 40 after bucket 1;
+     bucket 2 (n = 20) is where the 50th sample lands.
+     lo = edges[1] = 5, edges[2] = 10
+     p50 = 5 + (10 - 5) × (50 - 40)/20 = 5 + 2.5 = 7.5 s      → prints "7.5s"
+
+p95: target 95. Running total is 85 after bucket 3; bucket 4 (n = 10) crosses.
+     lo = edges[3] = 30, edges[4] = 60
+     p95 = 30 + (60 - 30) × (95 - 85)/10 = 30 + 30 = 60.0 s   → prints "≥60s"
+```
+
+Session length behaves the same way: `lenHist = [40, 25, 15, 12, 8]`, N = 100,
+median target 50 lands in bucket 1 (running total 40, n = 25), giving
+`300 + (900 - 300) × (50 - 40)/25 = 540 s`, printed `9m`.
+
+**Overflow floors, and why `≥` is not decoration.** The last bucket of either
+histogram has no upper edge to interpolate towards, so a percentile landing in
+it reports that bucket's **floor** and nothing more —
+`if (i >= edges.length) return round(lo, 2)` (`usage-aggregate.mjs:217`).
+A p95 printed as `≥60s` therefore means *at least 60 seconds* — the counts
+cannot say whether the real figure is 61 seconds or 61 minutes, and printing a
+bare `60s` would state a precision they do not carry. Both renderers apply the
+prefix by the same rule (`v >= lastEdge`), so a value that reaches the last
+edge by interpolation and one that came from the overflow slot print
+identically — the two are the same claim. An empty histogram is `null`, never
+`0` (`usage-aggregate.mjs:209`): "nothing was measured" and "measured zero" are
+different statements and only the first is true, so the cards print
+`not measured` and the CLI prints `no samples`.
+
+**Per-host measurement — the same axis, not the same instrument.** The window
+merges every host's samples into one histogram, but they are not gathered the
+same way, and the panel says so rather than implying a single clock:
+
+| Host | How a latency sample is produced |
+|---|---|
+| codex | **Host-measured.** `task_started` remembers the turn's start (`usage-parsers.mjs:558-563`) and `task_complete` samples Codex's own `duration_ms` (`usage-parsers.mjs:571-578`) — but only if no prompt-gap already covered that turn, so a turn is never sampled twice. |
+| codex | Also derives a prompt-gap when one is available: a `user_message` opens the window (`usage-parsers.mjs:591`) and the next `agent_message` closes it, clearing `turnStartedAt` so the `duration_ms` fallback cannot double-fire (`usage-parsers.mjs:601-608`). |
+| claude | **Derived from event gaps.** A human prompt sets `latState.pendingMs` (`usage-parsers.mjs:355`); the first real assistant turn closes that gap into a `noteLatencySample` call (`usage-parsers.mjs:410-414`). |
+| opencode | Derived the same way from its message stream — `rec.pendingPromptMs`, closed by `noteLatencySample` (`usage-opencode.mjs:227-231`). |
+
+Only the derived path is capped: a gap above `MAX_LATENCY_SAMPLE_SECONDS`
+(3600 s, `usage-parsers.mjs:234`) is an idle resume — the person walked away
+and came back — not a wait for a reply, so it is dropped from sampling
+entirely rather than parked in the overflow bucket beside genuinely slow turns.
+Codex's host-measured `duration_ms` needs no such cap: it is the host's own
+turn duration, not a gap between two events that may have nothing between them.
+An interrupted turn contributes nothing at all — `turn_aborted` clears both
+pending states (`usage-parsers.mjs:644-654`), so a prompt that was never
+answered can never be timed against a later, unrelated reply. A dropped API
+turn is likewise never a sample: the error branch returns before the latency
+block and deliberately leaves `pendingMs` set, so the first real completion
+that eventually follows is what gets timed (`usage-parsers.mjs:399-408`).
+
+**This figure is never labeled TTFT, in any surface.** Time-to-first-token
+measures when a stream *starts*; every figure here measures when a turn
+*finished* — a prompt-to-answer wall-clock gap, or the host's own turn
+duration. The two differ by the whole generation, and on an agentic turn that
+ran tools they differ by orders of magnitude. Both tooltips say so in words —
+`LAT_TIP` and the session-drawer latency tip in
+`src/lib/dashboard/client/usage.mjs` each carry the phrase "not streaming
+TTFT" beside the per-host note it qualifies. A true
+TTFT exists for Claude Code, but only as a span in its opt-in OpenTelemetry
+beta ([monitoring](https://code.claude.com/docs/en/monitoring-usage)) — a
+different, non-transcript evidence class that this scorecard does not read.
+Neither transcript store records it, so no panel here may borrow the name.
+
+**What this does not model:**
+
+- the samples' exact values are gone once bucketed; a percentile is a linear
+  interpolation inside one bucket, which is the only assumption the surviving
+  counts support. A distribution that is heavily skewed *within* a bucket will
+  read slightly off, and no amount of arithmetic here can recover it;
+- host-measured and gap-derived samples share one histogram. That is a
+  deliberate choice to keep one distribution rather than two thin ones, and it
+  means a window dominated by one host is really reporting that host's
+  instrument;
+- the parsers' edge constants are a second, independent literal from the
+  aggregate's. The browser copy is pinned to the server's by test; the parser
+  copy is not, so a change made in one place and not the other would re-label
+  buckets silently.
+
+---
+
+## 16. How you run
+
+**Displayed as:** the `how you run` strip, subtitled `permission posture · who
+drove · who served`. Three panels: `posture, by day` (api-equivalent cost
+stacked by posture, one column per day), `main vs subagent` (a two-slice donut
+whose centre reads the main-thread share), and `inference provider` (ranked
+cost rows). `ak usage score` prints two tables, `mode — permission posture` and
+`served by — inference provider`.
+
+### 16.1 Permission posture
+
+**Formula:**
+
+```text
+byMode[mode].cost         = Σ over sessions with that mode of session.cost
+byDay[day].byMode[mode]  += rowCost   for each usage row, by the row's own day
+mode                      = normalizeMode(host, raw evidence)  or 'not-recorded'
+```
+
+**Source:** `normalizeMode` (`usage-modes.mjs:23-35`) is the whole taxonomy;
+`MODES` (`usage-modes.mjs:4`) is the closed four-value vocabulary. Per-day
+folding is `addCost(d.byMode, rec.mode ?? 'not-recorded', rowCost)`
+(`usage-aggregate.mjs:386`) — in the usage-row pass, because only a row knows
+which day its dollars landed on. The window bucket is
+`addTo(bucket(byMode, s.mode ?? 'not-recorded'), s)` (`usage-aggregate.mjs:591`).
+The evidence each parser reads: Claude's `permissionMode`, off the human prompt
+only (`usage-parsers.mjs:356-357`); Codex's `approval_policy`/`sandbox_policy`
+off each `turn_context`, last one wins since a session may renegotiate mid-run
+(`usage-parsers.mjs:505-508`); OpenCode's `mode` off each assistant message
+(`usage-opencode.mjs:232-233`). Render is `modeChart` in
+`src/lib/dashboard/client/usage.mjs`; the CLI table is `printScoreModeTable`
+(`src/commands/usage.mjs:230-232`).
+
+**The mapping table**, in full (`usage-modes.mjs:6-17`), pinned value-by-value
+by `normalizeMode` assertions in `tests/kit/usage-modes.test.mjs:9-52`:
+
+| Host | Recorded evidence | Mode |
+|---|---|---|
+| claude | `permissionMode: default` | `guarded` |
+| claude | `permissionMode: acceptEdits` / `auto` / `dontAsk` | `auto-edit` |
+| claude | `permissionMode: plan` | `plan` |
+| claude | `permissionMode: bypassPermissions` | `unrestricted` |
+| codex | sandbox `read-only`, whatever the approval policy | `plan` |
+| codex | approval `never` + sandbox `danger-full-access` | `unrestricted` |
+| codex | approval `never` + sandbox `workspace-write` | `auto-edit` |
+| codex | approval `on-request` / `on-failure` / `untrusted` | `guarded` |
+| opencode | `build` | `auto-edit` |
+| opencode | `plan` | `plan` |
+| any | anything else, or no evidence at all | `null` → `not-recorded` |
+
+Two rulings in that table are worth reading twice. The **read-only sandbox
+check runs first** (`usage-modes.mjs:10`), so `never` + `read-only` is `plan`,
+not `unrestricted` — a session that cannot write is not permissive however its
+approval policy is spelled. And **approval evidence alone is sufficient for
+`guarded`** (`usage-modes.mjs:13-15`, the ADR-0038 ruling): human-in-the-loop
+*is* the posture, so a Codex session that recorded an approval policy and no
+sandbox policy still maps, rather than falling to `not-recorded` for want of a
+second field.
+
+**Unmapped is `not-recorded`, never a guess.** Every lookup is `?? null`
+(`usage-modes.mjs:25`, `:32`), so an unrecognised raw value — a future
+`permissionMode`, a policy this taxonomy has not been taught — yields no mode.
+The raw string is kept beside the normalized one as `modeRaw`
+(`usage-parsers.mjs:196`) precisely because the mapping is a judgement call and
+a reader checking it needs the evidence it was made from. `not-recorded` is a
+first-class bucket key rather than a display fallback
+(`usage-aggregate.mjs:589-591`), it is always offered as a row by the CLI table
+even at zero (`printBucketTable`, `src/commands/usage.mjs:221-228`), and
+`segColor` forces it to the de-emphasis ink rather than letting a palette give
+it a series colour (`usage-rhythm.mjs:183-186`) — spend with no posture
+evidence must never read as a posture.
+
+### 16.2 Delegation — main vs subagent
+
+**Formula:**
+
+```text
+source              = (session.sidechain || session.threadSource == 'subagent')
+                      ? 'subagent' : 'main'
+bySource[k].cost    = Σ over sessions with that source of session.cost
+centre of the donut = round(main / (main + subagent) × 100) %
+```
+
+**Source:** `sourceKey` (`usage-aggregate.mjs:544-546`). Both rows are created
+before the fold (`usage-aggregate.mjs:570`) so "no subagent sessions" renders
+as a zero rather than a row the UI silently drops. Claude's evidence is the
+`isSidechain` flag on any entry in the file (`usage-parsers.mjs:454`, decoded at
+`telemetry-records.mjs:244`); Codex's is the ledger-backed `thread_source`
+(§13c). Render is `sourceDonut` in `src/lib/dashboard/client/usage.mjs`.
+
+**Subagent cost can honestly read `$0`, and that is not a defect.** On the Codex
+side it is the design: a ledger-identified subagent has its usage rows removed
+outright (`applyCodexLedger`, `usage-aggregate.mjs:869-872`) and
+`finalizeCodexUsage` never writes one in the first place
+(`usage-parsers.mjs:692`), because a subagent rollout replays its parent's
+entire cumulative token history and keeping it would bill the parent twice
+(§13c, **[C7]**). The session record stays visible and auditable; its cost is
+structurally zero, and §17 explains why such sessions are also kept out of the
+cost-per-session distribution.
+
+Whether the *Claude* side contributes any subagent spend is a property of the
+corpus on the machine, not of the code — and on this one it does. In the census
+of §13.3 (the 200 most recently modified local Claude transcripts, measured
+2026-08-28), **50 files were sidechain-only** and carried 6,924 assistant turns
+between them, against 150 main-only files carrying 2,738; **no file mixed the
+two**. That last figure is what makes the rule sound: because Claude writes a
+sidechain session to its own transcript, "any `isSidechain` entry marks the
+whole record" cannot mis-attribute a parent's spend to a subagent. A window
+drawn from that corpus therefore shows a genuinely non-zero subagent slice, and
+a `$0` slice would be the surprising reading — the opposite of the Codex case,
+where `$0` is expected.
+
+### 16.3 Served by — inference provider
+
+**Formula:** `byInferenceProvider[k].cost`, where `k` is the session's provider
+string **only when its provenance was observed**, and `'not-recorded'`
+otherwise (`providerKey`, `usage-aggregate.mjs:538-540`).
+
+**Source:** the bucket is filled at `usage-aggregate.mjs:592`; render is
+`providerRows` in `src/lib/dashboard/client/usage.mjs` (which prints
+`not-recorded` as `Not recorded` and dims the row), and
+`printScoreProviderTable` (`src/commands/usage.mjs:234-240`) adds
+`'not-recorded'` to the CLI key set unconditionally, so the honest bucket
+appears even in a window where every session was attributed.
+
+This is the observed-provenance gate, and §8 states the rule and its
+distinction from the legacy `byProvider` map in full. The short version: a
+transcript host is not a vendor, a configured provider is not an observed one,
+and spend is never bucketed under an assumption.
+
+**What §16 does not model:** posture is the last evidence a session recorded,
+not a timeline — a session that started in `plan` and ended in `auto-edit`
+reports only the latter, and its whole cost stacks under it. The `main`/
+`subagent` split is per session, so a main-thread session that dispatched
+subagents still counts its own tokens as main-thread work; only the subagent's
+own record is attributed to `subagent`.
+
+---
+
+## 17. Cadence & unit economics
+
+**Displayed as:** the second hero row, four tiles — `sessions / active day`
+(subtitle `N active days`, note `streak N days`), `autonomy` (`3.4×`, subtitle
+`1.8 prompts / engaged hour`), `cost / session` (subtitle `median · excludes
+$0-by-construction`, note `P90 $…`), and `cost / engaged hour`. Each of the
+five KPI tiles above them additionally carries a footer: a delta chip against
+the previous window and a per-day sparkline. `ak usage score` prints the same
+four under `cadence`.
+
+**Formulas:**
+
+```text
+sessionsPerActiveDay = totals.sessions / count(keys of byDay)
+streak               = consecutive active days ending at the most recent one
+autonomy             = totals.responses    / totals.humanPrompts
+touchRate            = totals.humanPrompts / engagedHours
+costPerEngagedHour   = totals.cost         / engagedHours       engagedHours = engagedSeconds/3600
+costPerSessionMedian = median(cost of PRICED sessions)
+costPerSessionP90    = nearest-rank P90 of the same set
+cacheSavedUsd        = Σ rows  (costOf(1M as input) - costOf(1M as cacheRead)) × cacheRead / 1e6
+```
+
+**Source:** the derived block is `finishTotals` (`usage-aggregate.mjs:661-675`),
+which the previous-window projection calls too so a baseline is never derived a
+second, drifting way. `median` and `percentile` are exact over the values
+(`usage-aggregate.mjs:619-624`, `:629-634`), unlike §15's bucketed percentiles.
+Active days come from `byDay`'s key count and the streak from `activeStreak` in
+`src/lib/dashboard/client/usage.mjs`; the tiles are `cadenceCells` there, and
+`printScoreCadence` (`src/commands/usage.mjs:187-206`) in the CLI.
+
+**Autonomy divides by prompts a human typed, and only those.** The denominator
+is `totals.humanPrompts`, accumulated under an explicit main-thread guard
+(`usage-aggregate.mjs:578`): a subagent's prompts are written by the harness,
+so counting them would report a person as having typed work nobody asked for by
+hand — and would grow the denominator exactly in the windows where delegation
+was heaviest, making autonomy fall as automation rose. `totals.prompts` still
+records every prompt beside it (`usage-aggregate.mjs:574`); the two are
+different questions and both are on the wire. Touch rate is those same human
+prompts per engaged hour (`usage-aggregate.mjs:669`), so both per-prompt figures
+share one denominator. A rate whose denominator is zero is `null`, never `0`
+— no engaged time means the rate was never measured, which is not what "zero
+per hour" claims.
+
+**Cost per session is a median over priced sessions only.** A session carries
+`_priced` when it had any usage rows at all (`usage-aggregate.mjs:478`), and
+only those costs enter the distribution (`usage-aggregate.mjs:584`). A session
+with no usage rows costs `$0` *structurally* — nothing was ever measured for it,
+the common case being a Codex subagent rollout whose tokens were stripped as a
+double-count (§16.2) — and letting those in would report "the typical session
+cost nothing" when the truth is "the typical session was not measured". The
+median rather than the mean because session cost is heavy-tailed: one 12-hour
+refactor can outweigh forty short sessions, and a mean would describe that one
+session rather than the run of them. P90 rides beside it precisely so the tail
+stays visible instead of being hidden by the choice of a robust centre. A
+positive figure that rounds away at two decimals prints `<$0.01`, never
+`$0.00` (`fmtUsdMin`, `src/commands/usage.mjs:96-99`) — "less than a cent" and
+"nothing" are different claims.
+
+**What the cache saved, asked as a difference.** `cacheSavingPerMillion`
+(`usage-aggregate.mjs:345-354`) prices one million tokens twice through the
+*injected* pricer — once as fresh input, once as cache reads — and takes the
+gap; `cacheSavedFor` (`usage-aggregate.mjs:358-361`) scales that to the tokens
+a row actually read from cache. Nothing in that path knows what the cache
+multiplier is, so the saving cannot drift out of step with §3's table the way a
+hard-coded "0.9 × input" would the day the multiplier changed. Both probes
+carry the row's own model, provider and **day**, so the saving is priced from
+the same schedule, at the same date, as the cost printed beside it.
+
+**Worked example**, one row, hand-computable against §13.1's table. A
+`claude-opus-5` row ($5/MTok in, $25/MTok out) that read 2,000,000 tokens from
+cache:
+
+```text
+priced as fresh input:  1,000,000 × $5           / 1e6 = $5.00   per million
+priced as cache reads:  1,000,000 × $5 × 0.1     / 1e6 = $0.50   per million
+saved per million     =  $5.00 - $0.50                 = $4.50
+this row              =  $4.50 × 2,000,000 / 1e6       = $9.00
+```
+
+The window total is the sum of those per-row figures
+(`usage-aggregate.mjs:583`), carried on each session row as `cacheSavedUsd`
+(`usage-aggregate.mjs:460`) so it is auditable a row at a time rather than only
+in aggregate, and rendered in the cache tile's subtitle as `saved ≈ $X vs
+uncached`.
+
+**Deltas: what "the previous window" is, exactly.** For a displayed window of
+`d` days ending at `now`, the baseline is the equal-length window immediately
+before it — the half-open interval `[now − 2d, now − d)`
+(`previousWindow`, `usage-aggregate.mjs:764-774`). Both bounds are derived from
+`now` and `d`, the window the UI is *showing*, and never from the parse cutoff:
+the caller widens that cutoff on purpose so older records survive to be
+aggregated here (`lookbackDays: days * 2` at `src/commands/usage.mjs:288` and
+`src/lib/dashboard-server.mjs:1356`), and deriving the baseline from a widened
+bound would silently stretch it to whatever lookback the caller happened to
+pass. A delta against an unknown-length window is not a delta. The upper bound
+is exclusive so a session ending exactly at the boundary belongs to the current
+window and is not counted in both (`usage-aggregate.mjs:498`). Asking for
+`previous` without widening the lookback yields an all-zero baseline — the
+older records were never read off disk — and every chip self-suppresses
+against it rather than claiming a change it cannot measure. Leaving `previous`
+off entirely leaves `agg.previous` as `null` — "not requested",
+which a zeroed totals object would misreport as "measured nothing"
+(`usage-aggregate.mjs:842`). A chip self-suppresses when the baseline is null
+or zero, and a magnitude that rounds to zero prints flat rather than drawing an
+arrow the printed number does not support (`deltaChip`,
+`usage-rhythm.mjs:36-53`; `fmtDelta`, `src/commands/usage.mjs:152-163`).
+
+**Engaged time by day is a sibling map, not a `byDay` field.** `byDay`'s
+presence contract is **billed days only** — a key exists exactly when tokens
+landed on that day (`dayBucket`, `usage-aggregate.mjs:307-320`) — and that is
+what the active-day count and the streak above are counted from. Engaged time
+does not share that key set: a session that runs past midnight, or a day spent
+reading, produces worked time on a day that billed nothing. So
+`buildEngagedByDay` (`usage-aggregate.mjs:738-746`) keys its own map, cutting
+each active interval at every local midnight it crosses
+(`splitAtLocalMidnight`, `usage-aggregate.mjs:716-724`) and unioning the pieces
+per day, which makes the map sum exactly to `totals.engagedSeconds`. Folding it
+into `byDay` would have forced one of two lies: inventing zero-token `byDay`
+rows, or dropping real worked time. The consequence is visible on the tiles —
+the engaged-time sparkline is drawn from a different day set than every other
+trend, and the tile says so.
+
+**What this does not model:** an active day is a *billed* day, so a day spent
+entirely on work that never billed a token breaks the streak even though the
+person worked. That follows from `byDay`'s contract rather than from a
+judgement about what counts as a day of work, and the tile's tooltip states it
+rather than leaving a reader to infer it from a broken streak.
+
+---
+
+## 18. Reliability
+
+**Displayed as:** the `reliability` strip, subtitled `turns that never landed`.
+Two stats — `exceptions / 1k responses` (subtitle `N of M responses`, plus a
+worded flag comparing it to the previous window) and `aborted turns` (subtitle
+`X per 1k responses`) — over an `exceptions by day` sparkline that names the
+single worst day. `ak usage score` prints both under `reliability`, colouring
+the exception line by whether any fired.
+
+**Formula:**
+
+```text
+exceptionRate = totals.exceptions / totals.responses × 1000     null when no responses
+abortRate     = totals.aborts     / totals.responses × 1000
+byDay[day].exceptions += session.exceptions   attributed to the session's FIRST BILLED day
+```
+
+**Source:** `totals.exceptions` and `totals.aborts` accumulate together at
+`usage-aggregate.mjs:579`; the per-day series lands on `byDay[s._day].exceptions`
+(`usage-aggregate.mjs:601-604`). Render is
+`relRate`/`relStat`/`relTrend` in `src/lib/dashboard/client/usage.mjs`;
+`printScoreReliability` (`src/commands/usage.mjs:242-256`) prints the CLI pair.
+
+**Evidence, per host.** An "exception" is a turn that never resolved to a
+model, and each host signals that differently:
+
+| Host | What is counted, and where |
+|---|---|
+| claude | The API-error placeholder — Claude Code synthesizes a local turn with no completion behind it when a connection drops, a rate limit rejects, or auth fails. The decoder sets `isApiError` from either `isApiErrorMessage` or the literal `<synthetic>` model marker (`telemetry-records.mjs:246`), because the flag is not set on every build that emits the placeholder; the parser counts it and returns before any model or usage attribution (`usage-parsers.mjs:399-408`). |
+| codex | A `task_complete` event carrying a non-null `error` (`usage-parsers.mjs:577`). |
+| codex | `turn_aborted` is counted **separately**, into `rec.aborts` (`usage-parsers.mjs:644-654`) — not into exceptions. |
+| opencode | An assistant message carrying a non-null `error` (`usage-opencode.mjs:224-226`). |
+
+**Aborts are held apart from exceptions on purpose.** An aborted turn is a
+person pressing stop; an exception is the turn failing. Summing them would
+report a deliberate interruption as a reliability problem and move a number
+that is supposed to mean "how often did this break". They are counted, carried
+(`aborts`, `usage-aggregate.mjs:435`) and displayed side by side, with the
+distinction stated on the tile rather than left to the label.
+
+**Exceptions ride the session's first-billed day.** The per-day series uses the
+same attribution as the session count — `byDay[s._day].exceptions += s.exceptions`
+(`usage-aggregate.mjs:601-604`) — which is *not* the moment a turn dropped: a session spanning midnight lands all of its
+exceptions on the day its tokens first billed. That keeps the reliability trend
+and the session trend drawn on one convention — the alternative, attributing
+each exception to its own timestamp, would have made the two lines disagree
+about which day a session belonged to. A session that never billed has no day
+to attribute to and appears in neither the trend nor the per-day counts; it is
+the same silence `byDay` keeps everywhere else, not a different one. The panel
+says all of this in a note under the chart, because a reader will otherwise
+read a spike as "something broke that afternoon".
+
+**Worked example.** A window with 20 exceptions over 12,480 responses reports
+`20 / 12,480 × 1000 = 1.6` exceptions per 1k responses. The reference-corpus
+measurement behind §10 breaks 33 such placeholder turns down as `server_error`
+27, `authentication_failed` 3, `rate_limit` 3 — three distinct causes, one
+placeholder shape, which is why the panel counts them together and §10 excludes
+them from the model ranking rather than showing a `$0` model row.
+
+**What this does not model:** the rate's denominator is *responses*, which
+includes the exception turns themselves (they increment `rec.responses` before
+the error branch returns, `usage-parsers.mjs:382`) — they were real engaged
+time, someone was genuinely waiting on them. A retry that eventually succeeded
+appears as one exception plus one successful response, not as a single
+recovered turn; nothing in either transcript links the two. And the worst-day
+flag names the day with the most exceptions without inventing a threshold for
+what counts as a spike, because any constant chosen here would be a judgement
+the data never made.
+
+---
+
+## 19. Tool mix & model families
+
+**Displayed as:** two panels. `tool mix` (`invocations · top 8, tail folded`)
+is a ranked row list of tool names by invocation count, with a dimmed
+`Other (N tools)` row folding the tail. `model mix over time`
+(`api-equivalent cost by model family`) is a per-day stacked bar of cost by
+coarse model family, top four families coloured and the rest folded into a
+de-emphasised `other` band.
+
+**Formula:**
+
+```text
+byTool[name]                  += session.tools[name]      summed across sessions
+byDay[day].byModelFamily[fam] += rowCost                  fam = modelFamily(row.model)
+```
+
+**Source:** the tool tally is folded into `byTool` at `usage-aggregate.mjs:606`;
+the per-day family split is `addCost(d.byModelFamily, modelFamily(row.model),
+rowCost)` (`usage-aggregate.mjs:387`), inside the usage-row pass because only a
+row knows its day. Render is `toolRows`/`modelMix` in
+`src/lib/dashboard/client/usage.mjs`.
+
+**Tool names are the host's own, never renamed.** Claude's tally is keyed by
+the `tool_use` block's own `name` (`collectClaudeToolNames`,
+`usage-parsers.mjs:366-375`). Codex's four tallied item types —
+`CommandExecution`, `McpToolCall`, `FileChange`, `CollabAgentToolCall`
+(`CODEX_TOOL_ITEM_TYPES`, `usage-parsers.mjs:634`, tallied at `:659-661`) —
+keep those exact spellings in the ranking. Mapping `CommandExecution` onto
+`Bash`, or `FileChange` onto `Edit`, would be a claim about equivalence that
+neither host makes: the vocabularies are host-specific, the semantics do not
+line up one-to-one, and a renamed row would quietly assert a correspondence no
+evidence supports. Every other Codex item type is left to the unknown-item
+diagnostic rather than tallied as a tool. The tail is **folded, never dropped**
+— a top-8 list that silently loses the rest misstates the total every share
+above it is read against — and the fold row is dimmed because `Other` is a
+residue, not a tool.
+
+**Model-family folding, with the rules pinned.** `modelFamily`
+(`usage-aggregate.mjs:237-244`) lowercases the id, keeps only the segment after
+the last `/` so a namespaced id still ends on the same tokens, then:
+
+| Rule | Example id | Family |
+|---|---|---|
+| contains an Anthropic family name (`CLAUDE_FAMILIES`, `usage-aggregate.mjs:229`) | `claude-opus-5-20260401` | `opus` |
+| — matched by containment, not position, since the id shape has moved | `claude-3-5-sonnet-20241022` | `sonnet` |
+| — and after the last slash, so a namespaced id still folds | `openrouter/anthropic/claude-haiku-4-5` | `haiku` |
+| otherwise matches `gpt-(\d+)` | `gpt-5.6-sol` | `gpt-5` |
+| anything else | `some-local-model` | `other` |
+
+`other` is a real bucket, not a discard: an unrecognised id's spend still has
+to land somewhere, and it is never assigned a guessed family. In the chart it
+is excluded from competing for a top-four colour slot regardless of size — it
+is the residue bucket by definition — and painted in de-emphasis ink at the
+base of the stack.
+
+**What this does not model:** the tool tally counts *invocations*, not time or
+cost, and a host that does not report tool calls contributes nothing here
+rather than a zero — the telemetry-coverage surface (§1) says which hosts
+report them at all, so an empty panel is readable as "not reported" rather than
+"none happened". The family fold is coarse by design: it separates `opus` from
+`sonnet` but not one Opus generation from another, and `gpt-5.6-sol` from
+`gpt-5.6-luna` not at all. §10's per-model ranking is the surface that keeps
+the full id.
 
 ---
 
@@ -996,14 +1633,14 @@ commit `540be18` on this branch.
 
 `parseCodex`'s single `addUsage()` call never included a `responses` field —
 Claude's parser passes `responses: 1` per assistant turn
-(`usage-parsers.mjs:360`, the current equivalent), but Codex's call
+(`usage-parsers.mjs:419`, the current equivalent), but Codex's call
 passed no such field at all. Because `byModel[model].responses` is summed
-directly from each usage row's `responses` field (`usage-aggregate.mjs:243`,
+directly from each usage row's `responses` field (`usage-aggregate.mjs:391`,
 `m.responses += row.responses`), **every** Codex model in §10's "Models in
 Play" list displayed `0 resp` regardless of real token/cost volume or actual
 `agent_message` count. **Fix:** `parseCodex` now passes `responses:
 rec.responses` (the session's own tallied response count,
-`usage-parsers.mjs:555`) on its `addUsage()` call.
+`usage-parsers.mjs:701`) on its `addUsage()` call.
 
 #### Bug B — subagent thread-replay could double-bill tokens
 
@@ -1025,11 +1662,11 @@ example) but performed **no de-duplication** against a parent session a
 subagent file might be replaying. **Fix:** the parser now reads
 `session_meta.thread_source` (`telemetry-records.mjs:101-110`, confirmed as a real
 Codex rollout field by **[C7]**) and skips the `addUsage()` call entirely
-when its value is `'subagent'` (`usage-parsers.mjs:546`, guard condition
+when its value is `'subagent'` (`usage-parsers.mjs:692`, guard condition
 `rec.threadSource !== 'subagent'`). The session record itself is **not**
 dropped — it remains visible in the Sessions tab with `threadSource`
 surfaced (mirroring the existing `sidechain` flag Claude sessions already
-carry, `usage-parsers.mjs:184`), so a maintainer auditing the raw data can
+carry, `usage-parsers.mjs:454`), so a maintainer auditing the raw data can
 still see it; it simply contributes zero tokens/cost, exactly as intended by
 the "models still shows up in §10's list, with zero cost" mechanism §10
 describes.
@@ -1091,7 +1728,7 @@ promise.
   `totals.exceptions: null` and still showed the `<synthetic>` row in
   `byModel` on the first run after the change, purely because the cache
   predated it; every unit test still passed, since tests only exercise a
-  fresh parse. `SCHEMA_VERSION` went to `4` (`usage-index.mjs:36-51`; since
+  fresh parse. `SCHEMA_VERSION` went to `4` (`usage-index.mjs:99`; since
   superseded by `5`, above) specifically to force the one-time re-parse.
   Re-querying the same live server after the bump returned
   `totals.exceptions: 20` with `<synthetic>` absent from `byModel` —
@@ -1105,8 +1742,9 @@ promise.
 
 ## Appendix B — Verification methodology
 
-Every code citation above was read directly from the source files at commit
-`540be18` (not recalled from memory or summarized secondhand); every
+Every code citation above is read directly from the source files in the working
+tree, and re-verified against them on every run of the suite (not recalled from
+memory or summarized secondhand — see "Citation upkeep" below); every
 external pricing claim was either fetched directly (Anthropic, §13.1) or
 corroborated across multiple independent third-party sources with the
 sourcing tier disclosed rather than implied (OpenAI, §13.2); every GitHub
@@ -1159,4 +1797,4 @@ Where a main-body section implements a recorded decision:
 - **[C7]** GitHub — `ccusage/ccusage#950`, *Bug: Massive token overcounting for Codex subagent sessions (91x inflation)*. `https://github.com/ccusage/ccusage/issues/950`. Documents `thread_spawn` subagent rollout files replaying the parent thread's entire token history as duplicate, re-timestamped events; measured a 91× real-world cost inflation (reported ~$9,041 against actual spend of ~$100) from a parent session with 12 spawned subagents. Also the source that identifies `session_meta.thread_source` / `source.subagent.thread_spawn` as the detectable field for this pattern. Source for Appendix A's Bug B.
 - **[C8]** GitHub — `openai/codex#23001`, *Codex App upgrade can break opening older local threads when rollout session_meta lacks thread_source*. `https://github.com/openai/codex/issues/23001`. Confirms `thread_source` is a genuine, if not universally-present, `session_meta` field in real Codex rollout files (older/pre-upgrade rollouts may lack it entirely, which is why Appendix A's Bug B fix treats an absent `thread_source` as `'user'`-equivalent — i.e. included — rather than excluded).
 - **ADR-0009** — [`docs/adr/0009-usage-scorecard-local-transcript-analytics.md`](adr/0009-usage-scorecard-local-transcript-analytics.md). The design record this document's formulas implement; source of every reference-corpus figure quoted above (582–584 sessions, 96.3% cache share, 100.7h/230.8h/296.4h engaged-time ladder, 93%/100%/8%/13% classification signal coverage).
-- **In-repo source files**, all pinned to commit `540be18`: `src/lib/usage-index.mjs`, `src/lib/pricing.mjs`, `src/lib/usage-classify.mjs`, `src/lib/dashboard-server.mjs`, `tests/kit/usage-index.test.mjs`.
+- **In-repo source files**, cited against the working tree rather than a pinned commit (the citation test is what keeps them honest): `src/lib/usage-index.mjs`, `src/lib/usage-parsers.mjs`, `src/lib/usage-aggregate.mjs`, `src/lib/usage-modes.mjs`, `src/lib/pricing.mjs`, `src/lib/usage-classify.mjs`, `src/lib/usage-opencode.mjs`, `src/lib/telemetry-records.mjs`, `src/lib/quota.mjs`, `src/lib/codex-state.mjs`, `src/lib/dashboard/client/usage.mjs`, `src/lib/dashboard/client/usage-rhythm.mjs`, `src/commands/usage.mjs`, `tests/kit/usage-index.test.mjs`, `tests/kit/usage-modes.test.mjs`, `tests/kit/dashboard-usage-telemetry.test.mjs`.

--- a/docs/USAGE-SCORECARD-METRICS.md
+++ b/docs/USAGE-SCORECARD-METRICS.md
@@ -31,9 +31,9 @@ renders in the dashboard and the same figures printed offline by
 `ak usage score`. That is the five hero KPIs (Sessions, API-Equivalent, Tokens,
 Engaged Time, Cache Read); the second KPI row of cadence and unit economics
 (sessions per active day, autonomy, cost per session, cost per engaged hour);
-and the supporting panels — cost per day, by host, token composition bar, your
-rhythm, how you run, when you work, models in play, tool mix, model mix over
-time, reliability, projects, what you worked on. Two adjacent surfaces are
+and the supporting panels — Cost per day, By host, the token composition bar,
+Your rhythm, How you run, When you work, Models in play, Tool mix, Model mix
+over time, Reliability, Projects, What you worked on. Two adjacent surfaces are
 documented here because they answer questions the Scorecard raises: the Limits
 view (§13b) and the Codex thread ledger (§13c). The **Findings**, **Sessions**,
 and **Transcript** tabs are governed by separate rules and are out of scope
@@ -628,10 +628,10 @@ long weekend sessions, only frequent ones.
 
 It also **includes responses from delegated subagent sessions** (§16.2), which
 are machine-driven: a long agentic run dispatching subagents at 3am fills those
-cells even though nobody was typing. The panel is titled `when you work`, and
+cells even though nobody was typing. The panel is titled `When you work`, and
 what it actually charts is when *work happened on your behalf* — on the
 reference corpus, Claude subagent responses (17,863) outnumber main-thread ones
-(11,480). The `how you run` panel carries the main/subagent split; whether the
+(11,480). The `How you run` panel carries the main/subagent split; whether the
 punchcard should filter or split by source is recorded as an open question in
 ADR-0038's deferred list.
 
@@ -1099,7 +1099,7 @@ the same list:
 
 ## 15. Rhythm & responsiveness
 
-**Displayed as:** the `your rhythm` strip — two cards side by side. `session
+**Displayed as:** the `Your rhythm` strip — two cards side by side. `session
 length` heads with `median 9m · P90 ≥2h`; `response latency` with `p50 7.5s ·
 p95 ≥60s · n 12,480`. Each card is a bar histogram with dashed percentile
 markers laid over the bars, and reads `not measured` rather than a row of zero
@@ -1226,14 +1226,14 @@ Neither transcript store records it, so no panel here may borrow the name.
 **What this does not model:**
 
 - **it includes delegated subagent sessions and responses.** The panel is
-  titled `your rhythm`, but both histograms are built from every session in
+  titled `Your rhythm`, but both histograms are built from every session in
   the window — and since nested Claude subagent transcripts began being
   ingested (§16.2), a substantial share of them are harness-driven rather than
   typed by you: on the reference corpus, 178 Claude subagent sessions / 17,863
   responses against 265 main sessions / 11,480. So subagent session lengths
   shape `session length`, and subagent turn gaps are a large part of
   `response latency`. Every number is true as computed; the label is what
-  overclaims. The `how you run` panel carries the main/subagent split.
+  overclaims. The `How you run` panel carries the main/subagent split.
   (Prompt-based denominators are the exception — they use a main-thread-only
   denominator, because a subagent's prompts are written by the harness, §17.)
   Whether rhythm should instead *filter* to main-thread sessions, or show the
@@ -1481,7 +1481,7 @@ per hour" claims.
 window, harness-dispatched subagent transcripts included (§16.2) — on the
 reference corpus those are roughly a quarter of all sessions — so this is the
 run rate of the whole system working on your behalf, not a count of times you
-sat down. The `how you run` panel carries the main/subagent split. The
+sat down. The `How you run` panel carries the main/subagent split. The
 denominator is `byDay`'s key count, and `byDay`'s presence contract is
 **days that billed tokens** — which is why the aggregate keeps a separate
 `engagedByDay` map (§6): the two sets genuinely differ (a session running past
@@ -1667,9 +1667,9 @@ the data never made.
 
 ## 19. Tool mix & model families
 
-**Displayed as:** two panels. `tool mix` (`invocations · top 8, tail folded`)
+**Displayed as:** two panels. `Tool mix` (`invocations · top 8, tail folded`)
 is a ranked row list of tool names by invocation count, with a dimmed
-`Other (N tools)` row folding the tail. `model mix over time`
+`Other (N tools)` row folding the tail. `Model mix over time`
 (`api-equivalent cost by model family`) is a per-day stacked bar of cost by
 coarse model family, top four families coloured and the rest folded into a
 de-emphasised `other` band.

--- a/docs/USAGE-SCORECARD-METRICS.md
+++ b/docs/USAGE-SCORECARD-METRICS.md
@@ -91,7 +91,7 @@ reader opens the session, building the candidate path from the two validated
 capture groups rather than from raw request input.
 
 The parsers are `parseClaude` (`usage-parsers.mjs:440-469`) and `parseCodex`
-(`usage-parsers.mjs:788-810`). Both are pure functions over the raw file bytes —
+(`usage-parsers.mjs:799-817`). Both are pure functions over the raw file bytes —
 no network, no clock dependency beyond the transcript's own timestamps — so
 every downstream number traces back to bytes already on the user's disk.
 Nothing in this transcript pipeline calls a provider API or a billing endpoint; **no transcript
@@ -184,7 +184,7 @@ responses = Σ over included sessions of session.responses
   (`usage-aggregate.mjs:497`).
 - `responses` accumulation: Claude increments per assistant message
 (`usage-parsers.mjs:380-385`); Codex increments per `agent_message` event
-(`usage-parsers.mjs:666-670`).
+(`usage-parsers.mjs:677-682`).
 - Totals: `totals.responses += s.responses` per included session
 (`usage-aggregate.mjs:563`).
 - Render: `kpi("sessions", fmtNum(t.sessions), fmtNum(t.responses)+" assistant
@@ -209,7 +209,10 @@ human prompts and no longer count as such on Claude (`isHumanPrompt` +
 [`TRANSCRIPTS.md`](TRANSCRIPTS.md) §3.2). A `! command` the person typed
 (`bash-input`) still counts. Codex has no discipline of its own for the same
 distinction — a `user_message`/`item_completed` `UserMessage` event is gated
-the same way before it counts (`isCodexHumanMessage`, reusing
+for machine markers before it counts (`isCodexHumanMessage`), but not for the
+full set Claude's `isHumanPrompt` checks: Claude's gate additionally excludes
+`isMeta` entries, entries carrying a `tool_result` block, and empty text,
+none of which `isCodexHumanMessage` inspects — it is markers-only. Reuses
 `HARNESS_OUTPUT_RE` plus two Codex-specific markers for mirrored cross-host
 envelopes: a `<teammate-message` wrapper and the literal `"Another Claude
 session sent a message:"` prefix — see [`TRANSCRIPTS.md`](TRANSCRIPTS.md)
@@ -369,7 +372,7 @@ per row is **gross input minus cached input** — Claude's parser reads
 `cache_read_input_tokens` and `cache_creation_input_tokens` as separate fields
 the provider already reports separately (`telemetry-records.mjs:216-224`); Codex's
 parser subtracts `cached_input_tokens` from `input_tokens` explicitly
-(`usage-parsers.mjs:769-785`, `input: Math.max(0, gross - cacheRead)`) because
+(`usage-parsers.mjs:780-796`, `input: Math.max(0, gross - cacheRead)`) because
 Codex's own `input_tokens` field **includes** cached tokens and would
 double-count them against the separately-reported `cacheRead` figure if left
 as-is. This is asserted by test:
@@ -522,7 +525,7 @@ byDay[day].sessionsActive = count of distinct sessions with any usage row that d
 
 **Source:** the day key is the row's own `row.day`, computed once at parse
 time as **local calendar day**, not UTC
-(`usage-parsers.mjs:419`/`usage-parsers.mjs:775` call `localDay(at)`) — so a
+(`usage-parsers.mjs:419`/`usage-parsers.mjs:786` call `localDay(at)`) — so a
 session that runs from 23:58 local to 00:05 local is billed to the day its
 *first* row landed on (test:
 `tests/kit/usage-index.test.mjs:651`, "a session that opens before midnight
@@ -558,7 +561,7 @@ renders "no sessions in window" instead of zeroed figures
   called once per session at `usage-aggregate.mjs:576`), keyed by the literal string
 `"claude"` or `"codex"` assigned at parse time
 (`blankSession(id, 'claude')` / `blankSession(id, 'codex')`,
-`usage-parsers.mjs:441`, `:804`, `parseClaude`/`parseCodex` entry points).
+`usage-parsers.mjs:441`, `:815`, `parseClaude`/`parseCodex` entry points).
 OpenCode's SQLite reader builds the same record shape and contributes a third
 host key.
 
@@ -618,7 +621,7 @@ punchcard[dow + "-" + hour] += 1   per assistant/agent_message response, at its 
 
 **Source:** incremented once per Claude assistant turn
 (`usage-parsers.mjs:383-385`, keyed by `punchKey(at)`) and once per Codex
-`agent_message` (`usage-parsers.mjs:666-670`), merged into the window-level
+`agent_message` (`usage-parsers.mjs:677-682`), merged into the window-level
 `punchcard` object per session (`usage-aggregate.mjs:593`). Cell intensity is
 linear against the single busiest cell in the window:
 `v = pcMax ? n/pcMax : 0` (`dashboard/client.mjs`) — this is a
@@ -1030,7 +1033,7 @@ both credential-free for ak:
 `windowDurationMins: 10080` (the weekly). Windows are therefore keyed and
 labelled by duration (`windowLabel`, `quota.mjs:51`), never by slot name. The
 same rule applies to the historical snapshots parsed out of rollouts: the
-normalizer at `usage-parsers.mjs:553-566` keeps a flat `windows` list keyed by
+normalizer at `usage-parsers.mjs:564-577` keeps a flat `windows` list keyed by
 `window_minutes`.
 
 **Freshness is part of the number.** Both sides carry `fetchedAt`; the view
@@ -1058,10 +1061,20 @@ globs and takes the newest). `readCodexState` (`:62`) reads per-thread
 `applyCodexLedger` (`usage-aggregate.mjs:850-862`) overlays that onto parsed
 sessions: a ledger-identified subagent has its token usage stripped — its
 rollout replays the parent's entire token history (ccusage/ccusage#950
-measured up to 91× inflation) — while the session record stays visible. The
-rollout's own `session_meta.thread_source` sniff remains as the fallback when
-the ledger is absent or migrated beyond recognition. Codex sessions also carry
-`reasoningOutput` (`usage-parsers.mjs:785`) — reasoning tokens are a **subset**
+measured up to 91× inflation) — while the session record stays visible.
+**The parser is primary, the ledger is the fallback**: `rec.threadSource ??
+t?.threadSource ?? fromEdges` (`usage-aggregate.mjs:860`) reads the rollout's
+own `session_meta.thread_source` first, and only consults the ledger when
+that line is missing entirely. This is sound because `thread_source` is now
+the FIRST session_meta line's value (§1.2) rather than whichever meta
+happened to be last — identity read off the rollout's own first-written line
+is a fact about that specific file, while the ledger's coverage depends on
+the Codex build (`state_N.sqlite` first shipped in ≥0.140) and which
+migration generation its `N` reflects; a rollout the ledger cannot resolve
+(an older Codex build, a migrated-beyond-recognition state file) still gets
+a correct `threadSource` straight from its own transcript rather than
+falling through unclassified. Codex sessions also carry
+`reasoningOutput` (`usage-parsers.mjs:796`) — reasoning tokens are a **subset**
 of output tokens and are annotation only, never added to any sum.
 
 ## 14. Known limitations, restated as a single checklist
@@ -1194,8 +1207,8 @@ same way, and the panel says so rather than implying a single clock:
 
 | Host | How a latency sample is produced |
 |---|---|
-| codex | **Host-measured.** `task_started` remembers the turn's start (`usage-parsers.mjs:594-598`) and `task_complete` samples Codex's own `duration_ms` (`usage-parsers.mjs:571-586`) — but only if no prompt-gap already covered that turn (so a turn is never sampled twice) and only within the same 3600 s cap the derived paths apply. |
-| codex | Also derives a prompt-gap when one is available: a `user_message` opens the window (`usage-parsers.mjs:591`) and the next `agent_message` closes it, clearing `turnStartedAt` so the `duration_ms` fallback cannot double-fire (`usage-parsers.mjs:601-608`). |
+| codex | **Host-measured.** `task_started` remembers the turn's start (`usage-parsers.mjs:605-610`) and `task_complete` samples Codex's own `duration_ms` (`usage-parsers.mjs:612-630`) — but only if no prompt-gap already covered that turn (so a turn is never sampled twice) and only within the same 3600 s cap the derived paths apply. |
+| codex | Also derives a prompt-gap when one is available: a `user_message` opens the window (`usage-parsers.mjs:670`) and the next `agent_message` closes it, clearing `turnStartedAt` so the `duration_ms` fallback cannot double-fire (`usage-parsers.mjs:683-689`). |
 | claude | **Derived from event gaps.** A human prompt sets `latState.pendingMs` (`usage-parsers.mjs:355`); the first real assistant turn closes that gap into a `noteLatencySample` call (`usage-parsers.mjs:410-414`). |
 | opencode | Derived the same way from its message stream — `rec.pendingPromptMs`, closed by `noteLatencySample` (`usage-opencode.mjs:227-231`). |
 
@@ -1213,7 +1226,7 @@ reference corpus before the fix: 12 of 835 durations exceeded the cap, the
 largest 94,079,450 ms ≈ 26.1 hours, all of them landing in the `≥60s` overflow
 bucket and dragging `latP95` into it.
 An interrupted turn contributes nothing at all — `turn_aborted` clears both
-pending states (`usage-parsers.mjs:715-723`), so a prompt that was never
+pending states (`usage-parsers.mjs:726-734`), so a prompt that was never
 answered can never be timed against a later, unrelated reply. A dropped API
 turn is likewise never a sample: the error branch returns before the latency
 block and deliberately leaves `pendingMs` set, so the first real completion
@@ -1295,7 +1308,7 @@ which day its dollars landed on. The window bucket is
 The evidence each parser reads: Claude's `permissionMode`, off the human prompt
 only (`usage-parsers.mjs:356-357`); Codex's `approval_policy`/`sandbox_policy`
 off each `turn_context`, last one wins since a session may renegotiate mid-run
-(`usage-parsers.mjs:505-508`); OpenCode's `mode` off each assistant message
+(`usage-parsers.mjs:535-540`); OpenCode's `mode` off each assistant message
 (`usage-opencode.mjs:232-233`). Render is `modeChart` in
 `src/lib/dashboard/client/usage.mjs`; the CLI table is `printScoreModeTable`
 (`src/commands/usage.mjs:234-236`).
@@ -1327,7 +1340,7 @@ or `{"type":"workspace-write", …}` with sibling fields such as
 `network_access` — never the bare string the taxonomy is written against. A
 survey of this machine's rollouts (400 files, 2026-08-28) found 1,110 object
 occurrences and **zero** string ones. `handleCodexTurnContext`
-(`usage-parsers.mjs:505-519`) therefore reads `sandbox_policy.type` and passes
+(`usage-parsers.mjs:541-554`) therefore reads `sandbox_policy.type` and passes
 that to `normalizeMode`, which is unchanged and still accepts the string form.
 Before this extraction the object reached `normalizeMode` intact, matched no
 rule, and stringified into `modeRaw` as `"never/[object Object]"`: the `plan`,
@@ -1393,7 +1406,7 @@ not delegated work that was free.
 **Codex — structurally `$0`, by ledger design.** A ledger-identified subagent
 has its usage rows removed outright (`applyCodexLedger`,
 `usage-aggregate.mjs:857-860`) and `finalizeCodexUsage` never writes one in the
-first place (`usage-parsers.mjs:769`), because a subagent rollout replays its
+first place (`usage-parsers.mjs:780`), because a subagent rollout replays its
 parent's entire cumulative token history and keeping it would bill the parent
 twice (§13c, **[C7]**). The record stays visible and auditable; its cost is zero
 because nothing was measured for it, not because the work was cheap — which is
@@ -1619,8 +1632,8 @@ model, and each host signals that differently:
 | Host | What is counted, and where |
 |---|---|
 | claude | The API-error placeholder — Claude Code synthesizes a local turn with no completion behind it when a connection drops, a rate limit rejects, or auth fails. The decoder sets `isApiError` from either `isApiErrorMessage` or the literal `<synthetic>` model marker (`telemetry-records.mjs:246`), because the flag is not set on every build that emits the placeholder; the parser counts it and returns before any model or usage attribution (`usage-parsers.mjs:399-408`). |
-| codex | A `task_complete` event carrying a non-null `error` (`usage-parsers.mjs:577`). |
-| codex | `turn_aborted` is counted **separately**, into `rec.aborts` (`usage-parsers.mjs:715-723`) — not into exceptions. |
+| codex | A `task_complete` event carrying a non-null `error` (`usage-parsers.mjs:629`). |
+| codex | `turn_aborted` is counted **separately**, into `rec.aborts` (`usage-parsers.mjs:726-734`) — not into exceptions. |
 | opencode | An assistant message carrying a non-null `error` (`usage-opencode.mjs:224-226`). |
 
 **Aborts are held apart from exceptions on purpose.** An aborted turn is a
@@ -1701,7 +1714,7 @@ row knows its day. Render is `toolRows`/`modelMix` in
 the `tool_use` block's own `name` (`collectClaudeToolNames`,
 `usage-parsers.mjs:366-375`). Codex's four tallied item types —
 `CommandExecution`, `McpToolCall`, `FileChange`, `CollabAgentToolCall`
-(`CODEX_TOOL_ITEM_TYPES`, `usage-parsers.mjs:705`, tallied at `:736-737`) —
+(`CODEX_TOOL_ITEM_TYPES`, `usage-parsers.mjs:716`, tallied at `:747-748`) —
 keep those exact spellings in the ranking. Mapping `CommandExecution` onto
 `Bash`, or `FileChange` onto `Edit`, would be a claim about equivalence that
 neither host makes: the vocabularies are host-specific, the semantics do not

--- a/docs/USAGE-SCORECARD-METRICS.md
+++ b/docs/USAGE-SCORECARD-METRICS.md
@@ -1139,8 +1139,8 @@ p(q), over N samples, landing in bucket i (count n_i, running total `cum` before
 - Percentiles: `percentileFromBuckets` (`usage-aggregate.mjs:206-223`). The
   browser re-implementation `bucketPercentile` (`usage-rhythm.mjs:106-126`) is
   pinned to byte-identical output, and the browser's edge copies to the server
-  constants, by `tests/kit/dashboard-usage-telemetry.test.mjs:285-298` and
-  `:387-388`.
+  constants, by `tests/kit/dashboard-usage-telemetry.test.mjs:292-310` and
+  `:390-398`.
 - Render: `lengthCard`/`latencyCard` and the `≥` prefix helper `fmtAtLeast` in
   `src/lib/dashboard/client/usage.mjs` (that bundle shares a basename with the
   CLI command module, so its render sites are cited by function name rather
@@ -1580,12 +1580,13 @@ rather than leaving a reader to infer it from a broken streak.
 
 ## 18. Reliability
 
-**Displayed as:** the `reliability` strip, subtitled `turns that never landed`.
+**Displayed as:** the `Reliability` strip, subtitled `turns that never landed`.
 Two stats — `exceptions / 1k responses` (subtitle `N of M responses`, plus a
 worded flag comparing it to the previous window) and `aborted turns` (subtitle
 `X per 1k codex responses`, or an em dash when the window holds no Codex
 session) — over an `exceptions by day` sparkline that names the single worst
-day. `ak usage score` prints both under `reliability`, colouring the exception
+day. `ak usage score` prints both under its own
+`reliability — turns that never landed` heading, colouring the exception
 line by whether any fired.
 
 **Formula:**

--- a/docs/USAGE-SCORECARD-METRICS.md
+++ b/docs/USAGE-SCORECARD-METRICS.md
@@ -1011,10 +1011,12 @@ both credential-free for ak:
   `seven_day` / `seven_day_<model>` keys to duration-labelled windows.
 - **Codex** — one `initialize` → `account/rateLimits/read` JSON-RPC exchange
   with a spawned `codex app-server`, implemented by `codexAppServerRateLimits`
-  (`quota.mjs:176`) and TTL-cached (`CODEX_TTL_MS`, `:43`) by
-  `collectCodexLimits` (`:231`). Lanes come from `rateLimitsByLimitId` in
-  `normalizeCodexLimits` (`:113`), including per-model pools and
-  rate-limit reset credits.
+  (`quota.mjs:209`) and TTL-cached (`CODEX_TTL_MS`, `:43`) by
+  `collectCodexLimits` (`:264`). Lanes come from `rateLimitsByLimitId` in
+  `normalizeCodexLimits` (`:145`), including per-model pools and
+  rate-limit reset credits. A pool reported under both a named lane and the
+  legacy generic `codex` lane — same duration, reset instant, and utilization —
+  is kept once, on the named lane (`dedupeGenericLane`, `:127-137`).
 
 **The primary/secondary trap.** Codex's `primary` window is *not* reliably the
 5-hour window — a live `prolite` account reported `primary` with
@@ -1139,8 +1141,8 @@ p(q), over N samples, landing in bucket i (count n_i, running total `cum` before
 - Percentiles: `percentileFromBuckets` (`usage-aggregate.mjs:206-223`). The
   browser re-implementation `bucketPercentile` (`usage-rhythm.mjs:106-126`) is
   pinned to byte-identical output, and the browser's edge copies to the server
-  constants, by `tests/kit/dashboard-usage-telemetry.test.mjs:292-310` and
-  `:390-398`.
+  constants, by `tests/kit/dashboard-usage-telemetry.test.mjs:308-326` and
+  `:406-414`.
 - Render: `lengthCard`/`latencyCard` and the `≥` prefix helper `fmtAtLeast` in
   `src/lib/dashboard/client/usage.mjs` (that bundle shares a basename with the
   CLI command module, so its render sites are cited by function name rather

--- a/docs/USAGE-SCORECARD-METRICS.md
+++ b/docs/USAGE-SCORECARD-METRICS.md
@@ -130,11 +130,10 @@ empty or complete usage.
 The additive `sourceHealth.<host>.diagnostics.common` envelope makes coverage
 comparable without pretending the hosts have the same wire format: it reports
 discovered and parsed units, units with usage/prompts/responses, observed prompt
-and response totals, warnings, and unknown kinds. The companion
-`sourceHealth.<host>.capabilities` matrix distinguishes `supported`,
-`unsupported`, and `unavailable`. This is intentionally the historical adapter
-contract, not a claim that the hosts lack richer public APIs: Claude documents
-tool hooks and OpenTelemetry tool spans ([hooks](https://code.claude.com/docs/en/hooks),
+and response totals, warnings, and unknown kinds. Every field is counted — the
+envelope reports what was read, never what a parser could read in principle.
+That is narrower than what the hosts publish: Claude documents tool hooks and
+OpenTelemetry tool spans ([hooks](https://code.claude.com/docs/en/hooks),
 [monitoring](https://code.claude.com/docs/en/monitoring-usage)); Codex documents
 typed command, file-change, MCP, and collaboration items in app-server
 ([protocol](https://github.com/openai/codex/blob/main/codex-rs/app-server/README.md));

--- a/docs/adr/0009-usage-scorecard-local-transcript-analytics.md
+++ b/docs/adr/0009-usage-scorecard-local-transcript-analytics.md
@@ -40,6 +40,8 @@ The implemented boundary is therefore additive and evidence-graded:
 - `sourceHealth.<host>.capabilities` reports `supported`, `unsupported`, or `unavailable` for
   prompts, responses, tool calls, command executions, file changes, MCP calls, and collaboration.
   A supported source with zero observations is not the same as an absent or degraded source.
+  **[Superseded 2026-08-29: the capabilities matrix was removed with the telemetry-coverage
+  panel — see [ADR-0038](0038-consistent-cross-host-session-metrics.md).]**
 - Existing source status/reason fields and Codex-specific diagnostics remain unchanged for callers;
   the new fields are additive. The Usage dashboard renders the common coverage and capability
   states, including the distinction between unsupported and unavailable.

--- a/docs/adr/0023-fail-closed-operations-and-explicit-degradation.md
+++ b/docs/adr/0023-fail-closed-operations-and-explicit-degradation.md
@@ -186,6 +186,10 @@ than the colored-outline chip style originally shipped.
 
 #### 7.1 Cross-host telemetry coverage is additive and evidence-graded (2026-08-24)
 
+**[Superseded 2026-08-29: the capabilities matrix was removed with the telemetry-coverage panel —
+see [ADR-0038](0038-consistent-cross-host-session-metrics.md). `diagnostics.common` and the
+source-health pill described below still ship.]**
+
 Usage adds `sourceHealth.<host>.diagnostics.common` and
 `sourceHealth.<host>.capabilities` without changing existing status/reason or Codex-specific
 diagnostic fields. `supported`, `unsupported`, and `unavailable` are capability states, not

--- a/docs/adr/0038-consistent-cross-host-session-metrics.md
+++ b/docs/adr/0038-consistent-cross-host-session-metrics.md
@@ -216,7 +216,7 @@ cannot drift out of step with the pricing table the day that multiplier changes.
 the row's own model, provider, and **day**, so a saving is priced from the same table at the same
 date as the cost sitting beside it; the result is memoised per `(model, provider, day)`.
 
-### 11. Schema v11 (then v12), and nested subagent transcripts are ingested
+### 11. Schema v11 (then v12, then v13), and nested subagent transcripts are ingested
 
 `SCHEMA_VERSION` moves to 11 in one bump, adding `mode`/`modeRaw`, `latHist`/`latCount`,
 `lenSeconds`, `ctxWindow`/`ctxLastTokens`, and `aborts` to every session record. A v10-cached record
@@ -228,6 +228,15 @@ A second bump to **v12** lands before merge, for a *wrong* cached value rather t
 v11 records persisted `modeRaw: "never/[object Object]"` and a null `mode` for every Codex session
 (decision 1). Re-deriving is the only thing that clears them, and the one-time re-parse cost is
 accepted for the same reason every earlier bump accepted it.
+
+A third bump to **v13** corrects two more parseCodex defects, both inflating persisted figures
+rather than merely missing them: `session_meta` was last-wins, so a subagent rollout's replayed
+parent meta relabeled its `threadSource` and re-keyed its `id`, letting up to 155 of 318 observed
+subagent rollouts escape the finalizeCodexUsage guard and double-bill the parent; and `prompts`
+counted every `user_message`/`UserMessage` regardless of origin, with no Codex-side equivalent of
+the harness/mirror gate Claude has had since v5. Both are corrected in `parseCodex`
+(`usage-parsers.mjs:493-513`, `:637-638`); the schema bump forces every cached Codex record to
+re-derive rather than keep the inflated counts.
 
 Discovery gains exactly one nested shape: `listClaudeSubagents` reads
 `<projectDir>/<sessionId>/subagents/*.jsonl` and nothing else. It is deliberately not a recursive
@@ -338,6 +347,13 @@ session id touches the transcript reader's path-traversal guard, so the gate is 
   Parked as a latent trap rather than a live bug — production never injects `deps`, and tests
   sandbox `roots`/`cachePath` per test — with the comment at `readIndex` corrected to state the
   omission instead of implying it was fixed.
+- **Exact-twin cross-host mirror dedup.** The v13 human-prompt gate (decision 11) excludes clear
+  machine envelopes from Codex `prompts`, but deliberately does not attempt the harder claim: some
+  Codex rollouts replay an entire Claude conversation's `user_message` stream in one sub-second flush,
+  so a genuinely human prompt is counted once under Codex AND again, verbatim, under Claude. Detecting
+  that requires a flush-timestamp/exact-text-twin heuristic across BOTH hosts' sessions at aggregation
+  time, not a per-parser gate, and is deliberately out of scope for a fix that only touches
+  `parseCodex`. Left as a recorded follow-up rather than attempted here.
 
 ## Verification
 

--- a/docs/adr/0038-consistent-cross-host-session-metrics.md
+++ b/docs/adr/0038-consistent-cross-host-session-metrics.md
@@ -67,6 +67,24 @@ Two of those judgments are load-bearing:
   unknown renders `guarded` rather than not-recorded. Every other Codex mapping still requires both
   fields.
 
+**The taxonomy takes strings; the Codex parser extracts them.** Codex writes `sandbox_policy` as an
+object keyed `.type` — `{"type":"danger-full-access"}`, `{"type":"read-only"}`,
+`{"type":"workspace-write", …}` — and a survey of the reference machine's rollouts (400 files,
+2026-08-28) found 1,110 object occurrences and zero string ones. `normalizeMode` stays a
+string-to-string mapping (one vocabulary, host-shape-agnostic); `handleCodexTurnContext` reads
+`sandbox_policy.type` before calling it. An object carrying no `.type` contributes no sandbox
+evidence rather than a guess.
+
+This was shipped broken and caught by review: passing the object through matched no rule, so on live
+data the `plan`, `auto-edit` and `unrestricted` arms of the Codex mapping could not fire at all —
+only the approval-only `guarded` rule could — and `modeRaw` persisted the failed stringification
+`"never/[object Object]"` into the cache, `/api/usage` and `ak usage score --json`. The consequence
+that made this Important rather than cosmetic: `detectUnrestrictedMode` was blind to Codex's
+riskiest posture, `never` + `danger-full-access`, which is the reference machine's own current
+setting. The degradation direction was at least honest — not-recorded, never a guess. Schema v12
+re-derives the affected records; a client-side band-aid that refused to render any spelling
+containing `"[object "` was removed with the cause.
+
 ### 2. An unmapped value is `not-recorded`, and that is a first-class bucket
 
 Every lookup is `?? null`. A raw value this taxonomy has not been taught — a future
@@ -78,6 +96,14 @@ because the mapping is a judgment and a reader auditing it needs the evidence it
 fold, offered as a row by the CLI table even at zero, and forced to the de-emphasis ink in the UI so
 that spend with no posture evidence can never read as a posture.
 
+**But "unmapped" and "unobserved" are different facts, and the session detail strip now says which
+it is.** Rendering "no posture evidence in this transcript" over a row that carries a `modeRaw` is a
+fabrication in the opposite direction from the usual one — denying data that exists, when the whole
+point of retaining `modeRaw` is that the mapping is a judgment a reader may want to audit. So a row
+with `mode: null` and a `modeRaw` present shows the host's own spelling, labelled *unrecognized* so
+it can never be read as a classified posture. The aggregate still folds both cases into
+`byMode['not-recorded']`; separating them there is a wire-shape change and is deferred below.
+
 ### 3. Response latency means prompt-to-response, and is never called time-to-first-token
 
 The primary sample on every host is the gap between a human prompt and the completion that answered
@@ -88,9 +114,21 @@ latency states, so an unanswered prompt is never timed against a later, unrelate
 API-error placeholder is never a sample — its pending window is deliberately left open so the first
 real completion that follows is what gets timed.
 
-The `MAX_LATENCY_SAMPLE_SECONDS` ceiling of 3600s applies to the **derived prompt-gap path only**.
-A derived gap that large is overwhelmingly a person who walked away, not a model that took an hour;
-a host-measured duration that large is a real turn, and the open-ended top bucket absorbs it.
+The `MAX_LATENCY_SAMPLE_SECONDS` ceiling of 3600s applies to **every** sampling path, the
+host-measured fallback included.
+
+*This reverses an earlier ruling on this same branch,* which exempted the fallback on the grounds
+that a host-measured duration that large is a real turn the open-ended top bucket can absorb. That
+reasoning does not survive contact with what `duration_ms` measures: it is turn wall-clock and
+**includes time blocked on an approval prompt**, so under `approval_policy: on-request` a turn left
+awaiting approval overnight is recorded as a ~26-hour turn. Through the prompt-gap path that same
+wait is discarded; through the fallback it became a latency sample. Measured on the reference
+corpus: 12 of 835 durations exceeded the cap, the largest 94,079,450 ms ≈ 26.1 hours, all of them
+in the `≥60s` overflow bucket and dragging `latP95` into it — enough, on their own, to move
+`detectLatencyRegression`'s relative and absolute gates. The cap's stated purpose ("an idle resume
+is excluded from sampling **entirely**, rather than merely landing in the overflow bucket alongside
+genuinely slow turns") applies with full force to a blocked approval. Cost of the original ruling:
+none shipped — it was caught pre-merge.
 
 This figure is deliberately never labelled TTFT anywhere in the code, the docs, or the UI. No local
 transcript records the arrival of a first token; conflating the two would misname a measurement that
@@ -177,13 +215,18 @@ cannot drift out of step with the pricing table the day that multiplier changes.
 the row's own model, provider, and **day**, so a saving is priced from the same table at the same
 date as the cost sitting beside it; the result is memoised per `(model, provider, day)`.
 
-### 11. Schema v11, and nested subagent transcripts are ingested
+### 11. Schema v11 (then v12), and nested subagent transcripts are ingested
 
 `SCHEMA_VERSION` moves to 11 in one bump, adding `mode`/`modeRaw`, `latHist`/`latCount`,
 `lenSeconds`, `ctxWindow`/`ctxLastTokens`, and `aborts` to every session record. A v10-cached record
 carries none of them, so the whole cache is invalidated rather than letting new fields read back as
 `undefined` and sum into totals as `NaN` — the same rule, and the same reason, as the v4 and v5
 bumps ADR-0009 records.
+
+A second bump to **v12** lands before merge, for a *wrong* cached value rather than a missing one:
+v11 records persisted `modeRaw: "never/[object Object]"` and a null `mode` for every Codex session
+(decision 1). Re-deriving is the only thing that clears them, and the one-time re-parse cost is
+accepted for the same reason every earlier bump accepted it.
 
 Discovery gains exactly one nested shape: `listClaudeSubagents` reads
 `<projectDir>/<sessionId>/subagents/*.jsonl` and nothing else. It is deliberately not a recursive
@@ -197,10 +240,19 @@ unnamespaced id would silently collide two unrelated records into one. Admitting
 session id touches the transcript reader's path-traversal guard, so the gate is designed to
 **narrow, not loosen**:
 
-- `VALID_SUBAGENT_ID` matches exactly `<parentId>/<stem>`, one slash, with the parent half reusing
+- `matchSubagentId` matches exactly `<parentId>/<stem>`, one slash, with the parent half reusing
   `VALID_ID`'s own charset — a namespaced id's parent segment can never be more permissive than a
   plain id already is — and the child half constrained to the real on-disk shape,
-  `agent-[A-Za-z0-9_-]{1,100}`, derived from the corpus rather than invented.
+  `agent-[A-Za-z0-9_-]{1,100}`, derived from the corpus rather than invented. It **also rejects
+  `.` and `..` as the parent segment**, which the charset alone does not: `.` is inside it, and the
+  parent is the only place in that module where caller-shaped text becomes a path *segment* rather
+  than a filename stem, so `readSession('../agent-x')` reached
+  `<claudeRoot>/subagents/agent-x.jsonl` — still inside the transcript root, therefore invisible to
+  the realpath containment check, but outside the shape the grammar exists to enforce. Never
+  reachable over HTTP (the route tier rejected every encoding), but `readSession` is an exported
+  library API whose doc block claimed parity with that tier. The two tiers now accept identical id
+  sets, and discovery applies the same grammar so a transcript the API will not serve is never
+  indexed as a clickable row.
 - Resolution builds the candidate path from the two **already-validated capture groups**, never by
   joining raw request input.
 - Realpath containment, the size cap, masking, and truncation are unchanged and still apply; the new
@@ -257,13 +309,43 @@ session id touches the transcript reader's path-traversal guard, so the gate is 
   rates and its primary-source claim disagree with `pricing.mjs`. It is a pre-existing
   discrepant-docs item, and it is explicitly **not** to be closed by editing one side to match the
   other: the mandate on that follow-up is to establish which is true and correct whichever is wrong.
+- **Whether rhythm and the punchcard should filter or split main vs subagent sessions.** Once nested
+  Claude subagent transcripts were ingested (decision 11), roughly a quarter of the sessions in a
+  window — and on the reference corpus a *majority* of Claude responses, 17,863 subagent against
+  11,480 main — became harness-driven. They flow into `rhythm.lenHist`, `rhythm.latHist`,
+  `sessions / active day` and the punchcard, all of which sit under labels reading "your rhythm" and
+  "when you work". Every number is true as computed; the labels overclaim. This branch ships
+  **disclosure** — one sentence in §15/§17/§9 and in the matching tooltips — because filtering or
+  splitting is a behavior change that deserves its own ruling and its own RED tests, not a late
+  patch in a fix wave. Note the asymmetry it leaves: prompt-based denominators already got a
+  main-thread-only rule (decision 7) on exactly this reasoning, and length/latency/punchcard did
+  not, because the T6 ruling predates the ingestion discovery and was never revisited. Resolving
+  that asymmetry deliberately is the follow-up.
+- **The `unclassified` posture bucket.** An observed-but-unmapped `modeRaw` now renders as such in
+  the session detail strip, but the aggregate still folds it into `byMode['not-recorded']` beside
+  sessions that recorded no posture at all — which overstates how much evidence is missing. A fourth
+  bucket key (`unclassified`) would separate them, at the cost of a wire-shape change rippling
+  through `byMode`'s consumers, the CLI table's key list and the docs. Rendering was fixed here;
+  the bucket split is left to a deliberate data-shape decision.
+- **`scanKey` omits `deps` and `codexState`.** Both hold live objects (functions, Maps) that do not
+  serialize, so keying on them means minting identity tokens through a WeakMap. Two calls differing
+  only by an injected pricer or ledger therefore coalesce in the single-flight map and the memo.
+  Parked as a latent trap rather than a live bug — production never injects `deps`, and tests
+  sandbox `roots`/`cachePath` per test — with the comment at `readIndex` corrected to state the
+  omission instead of implying it was fixed.
 
 ## Verification
 
 Every mapping row in §1 is asserted value-by-value against `normalizeMode`, including the rows the
 first implementation left untested (`dontAsk`, `on-failure`, `untrusted`, and unrecognised Codex and
-OpenCode values), and the raw `approval/sandbox` spelling is pinned because the Sessions detail strip
-renders it. Bucket arithmetic is pinned at every edge and in the overflow slot, with the browser's
+OpenCode values). The Codex arm is pinned a second time **end-to-end through `parseCodex` in the
+real object wire shape**, because unit-testing `normalizeMode` alone is exactly what let the
+`[object Object]` defect ship: the taxonomy was correct and the value reaching it was not. That
+second pin is also what makes the raw `approval/sandbox` spelling a real claim — the Sessions detail
+strip renders it, and before the extraction what it had to render was a failed toString. The latency
+cap is pinned in both directions (a 26.1-hour `duration_ms` takes no sample at all; a 45-second one
+still samples through the fallback), and the id grammar by a `readSession('../agent-x')` rejection
+at the module's own tier. Bucket arithmetic is pinned at every edge and in the overflow slot, with the browser's
 re-implementation asserted byte-identical to the server's. The `engagedByDay` invariant, the
 display-window baseline, the priced-only cost distribution, and the main-thread ratio denominators
 each carry their own regression test. The nested-ingestion change is covered by namespaced-id

--- a/docs/adr/0038-consistent-cross-host-session-metrics.md
+++ b/docs/adr/0038-consistent-cross-host-session-metrics.md
@@ -318,8 +318,8 @@ session id touches the transcript reader's path-traversal guard, so the gate is 
   Claude subagent transcripts were ingested (decision 11), roughly a quarter of the sessions in a
   window — and on the reference corpus a *majority* of Claude responses, 17,863 subagent against
   11,480 main — became harness-driven. They flow into `rhythm.lenHist`, `rhythm.latHist`,
-  `sessions / active day` and the punchcard, all of which sit under labels reading "your rhythm" and
-  "when you work". Every number is true as computed; the labels overclaim. This branch ships
+  `sessions / active day` and the punchcard, all of which sit under labels reading "Your rhythm" and
+  "When you work". Every number is true as computed; the labels overclaim. This branch ships
   **disclosure** — one sentence in §15/§17/§9 and in the matching tooltips — because filtering or
   splitting is a behavior change that deserves its own ruling and its own RED tests, not a late
   patch in a fix wave. Note the asymmetry it leaves: prompt-based denominators already got a

--- a/docs/adr/0038-consistent-cross-host-session-metrics.md
+++ b/docs/adr/0038-consistent-cross-host-session-metrics.md
@@ -188,16 +188,17 @@ machine output per human touch — and `humanPromptsPerHour` is those same promp
 `totals.humanPrompts` ships beside `totals.prompts` so the distinction is auditable rather than
 implicit.
 
-### 8. `byInferenceProvider` is gated on observed provenance; `byProvider` stays what it was
+### 8. There is no window bucket for the inference provider
 
-Cost is bucketed under a provider only when that session's provenance was **observed**; otherwise it
-lands in `not-recorded`, which is added to the CLI's key set unconditionally so the honest bucket
-appears even in a window where everything was attributed. This is the ADR-0021 rule applied to
-spend: a transcript host is not a vendor, and a configured route is assignment intent rather than
-evidence of what served a request.
+Window cost is bucketed by execution host, not by the vendor that served the tokens. Only Codex
+transcripts record an inference provider together with the provenance backing it; Claude and
+OpenCode transcripts name none at all. An aggregate axis over that evidence would put most of a
+window's spend in one unattributed row, which a reader takes as a finding about providers rather
+than as what it is — an absence of provider evidence in two of the three formats.
 
-The legacy `byProvider` map is left alone, keyed by transcript host as it always was. Two maps with
-two contracts is clearer than one map that changes meaning.
+Provider identity is therefore per-session evidence, reported on the session row beside its
+provenance, which is where ADR-0021's rule already applies it. The legacy `byProvider` map is left
+alone, keyed by transcript host as it always was.
 
 ### 9. Tool names are the host's own, never translated
 
@@ -292,6 +293,10 @@ session id touches the transcript reader's path-traversal guard, so the gate is 
   browser bundle — because the payload ships bucket *counts* and never the edges they were binned
   on, and the import direction forbids the aggregate importing from the parsers. Equality-pinning
   tests hold the three copies together.
+- An earlier draft of this ADR shipped a provenance-gated `byInferenceProvider` bucket and a
+  "served by" panel over it. The aggregate provider axis was removed on maintainer review before
+  merge (§8): host-level attribution lives in `byHost`, and session-level provider provenance
+  remains on the session rows.
 
 ### Deferred, deliberately
 

--- a/docs/adr/0038-consistent-cross-host-session-metrics.md
+++ b/docs/adr/0038-consistent-cross-host-session-metrics.md
@@ -1,0 +1,293 @@
+# ADR-0038 — Consistent cross-host session metrics
+
+- **Status:** Accepted
+- **Date:** 2026-08-29
+- **Deciders:** agentic-kit maintainers
+- **Related:** [ADR-0009](0009-usage-scorecard-local-transcript-analytics.md),
+  [ADR-0010](0010-provider-mediated-quota-reads.md),
+  [ADR-0016](0016-capability-driven-integration-adapters.md),
+  [ADR-0017](0017-opencode-host.md),
+  [ADR-0021](0021-inference-provider-provenance.md)
+
+## Context
+
+ADR-0009 established the usage scorecard as local transcript analytics with graded evidence: it
+answers what a window cost and what produced the cost. It does not answer how the work was *run* —
+under what permission posture, how fast the model answered, how full its context window was, whether
+a person or a delegated agent drove, and which vendor actually served the inference.
+
+Two research passes established what the retained transcripts can and cannot answer. A metric
+evidence matrix enumerated every candidate metric against the fields each host actually writes; a
+scorecard mockup fixed which of the survivors earn panel space and what each panel must say when its
+evidence is missing. The finding that shaped everything below is that **the three hosts record these
+things asymmetrically, and with different strength of evidence**:
+
+- Claude Code writes a `permissionMode` on user entries but no turn timing and no context-window
+  size; latency and context pressure have to be *derived* from the entries themselves.
+- Codex writes `approval_policy`/`sandbox_policy` per `turn_context`, a `model_context_window` on
+  `task_started`, and its own host-measured `duration_ms` on `task_complete` — the only
+  host-measured turn duration and the only recorded context-window denominator in the corpus.
+- OpenCode writes a `mode` per assistant message and enough per-message timing to derive a latency,
+  but no window size.
+
+Folding that asymmetry into one number per metric would state a claim the evidence does not support.
+Every decision below is a rule for keeping the shapes comparable *without* pretending the evidence
+behind them is uniform.
+
+One further problem surfaced during implementation rather than research, and is recorded here
+because it changed what the delegation metric means. A delegation panel was built, reviewed, and
+found to be reporting a subagent slice the pipeline could not produce. The root cause was in
+discovery, not in the panel: `listClaude` walked exactly one level of project directories, while
+Claude Code writes sidechain transcripts one level deeper, at
+`<project>/<sessionId>/subagents/agent-*.jsonl`. Real, cost-bearing delegated work had never entered
+the index at all. Three separate censuses had appeared to disagree about how much sidechain work
+existed; they were measuring different things — 51 nested files on disk against 0 ingested by the
+pipeline. Shipping a knowingly blind delegation metric behind a disclaimer was judged below the
+standard for this work when the fix was one contained discovery function.
+
+## Decision
+
+### 1. Permission posture is one closed vocabulary; every mapping is a recorded judgment
+
+`src/lib/usage-modes.mjs` holds the whole taxonomy and nothing else. `MODES` is exactly four values
+— `guarded`, `auto-edit`, `plan`, `unrestricted` — and `normalizeMode({host, permissionMode,
+approvalPolicy, sandboxPolicy, opencodeMode})` is the only mapping from a host's raw evidence into
+them. Every row of that table is pinned value-by-value by tests, because each row is a judgment call
+rather than a derivation.
+
+Two of those judgments are load-bearing:
+
+- **The read-only sandbox check runs first.** Codex `approval: never` + sandbox `read-only` is
+  `plan`, not `unrestricted`: a session that cannot write is not permissive however its approval
+  policy is spelled.
+- **Approval evidence alone is sufficient for `guarded`, and only for `guarded`.** Human-in-the-loop
+  *is* the posture, so a Codex session recording `on-request`/`on-failure`/`untrusted` and no
+  sandbox policy maps to `guarded` rather than falling to not-recorded for want of a second field.
+  The cost of this ruling is bounded and disclosed: a Codex session whose sandbox is genuinely
+  unknown renders `guarded` rather than not-recorded. Every other Codex mapping still requires both
+  fields.
+
+### 2. An unmapped value is `not-recorded`, and that is a first-class bucket
+
+Every lookup is `?? null`. A raw value this taxonomy has not been taught — a future
+`permissionMode`, a policy spelling that has not shipped yet — yields no mode, never a nearest
+guess. The host's own spelling is retained beside the normalized value as `modeRaw`, precisely
+because the mapping is a judgment and a reader auditing it needs the evidence it was made from.
+
+`not-recorded` is a bucket key in the aggregate, not a display fallback: it is created before the
+fold, offered as a row by the CLI table even at zero, and forced to the de-emphasis ink in the UI so
+that spend with no posture evidence can never read as a posture.
+
+### 3. Response latency means prompt-to-response, and is never called time-to-first-token
+
+The primary sample on every host is the gap between a human prompt and the completion that answered
+it. Codex's host-measured `task_complete.duration_ms` is a **fallback**, used only when no
+prompt-gap sample already covered that turn; the turn-start marker is cleared the moment a gap
+sample fires, so a turn is never double-sampled. An aborted turn (`turn_aborted`) clears both
+latency states, so an unanswered prompt is never timed against a later, unrelated response, and an
+API-error placeholder is never a sample — its pending window is deliberately left open so the first
+real completion that follows is what gets timed.
+
+The `MAX_LATENCY_SAMPLE_SECONDS` ceiling of 3600s applies to the **derived prompt-gap path only**.
+A derived gap that large is overwhelmingly a person who walked away, not a model that took an hour;
+a host-measured duration that large is a real turn, and the open-ended top bucket absorbs it.
+
+This figure is deliberately never labelled TTFT anywhere in the code, the docs, or the UI. No local
+transcript records the arrival of a first token; conflating the two would misname a measurement that
+is easy to misread as vendor-side latency.
+
+### 4. Percentiles come from bucket histograms, and an overflow percentile reports its floor
+
+Latency and session length are stored per session as fixed-edge histograms
+(`LAT_BUCKET_EDGES = [2, 5, 10, 30, 60]` seconds, `LEN_BUCKET_EDGES = [300, 900, 2700, 7200]`
+seconds) rather than as raw sample arrays, so a window merges slot-wise and the payload never
+carries per-turn timings. `percentileFromBuckets` interpolates within a bounded bucket and returns
+the bucket's **lower edge** when the percentile lands in the open-ended overflow slot.
+
+Because that value is a floor rather than a point, every renderer of it — dashboard and CLI alike —
+prefixes it with `≥`. Rendering `60s` where the honest claim is `≥60s` would be false precision.
+A window with no samples reads `not measured`; a session that never observed a latency keeps a null
+histogram rather than a fabricated row of zeroes.
+
+### 5. `engagedByDay` is a sibling map, because `byDay` has a presence contract
+
+Per-day engaged seconds do **not** become a field on `byDay` rows. `byDay`'s documented contract is
+that a key exists only for a day that billed tokens, and detectors, sparklines, and the active-day
+arithmetic all depend on that. Adding engaged time to it would have created keys for worked-but-
+unbilled days and quietly changed what every existing consumer counts.
+
+Engaged time instead ships as a top-level sibling map keyed the same way, with an invariant test
+that its values sum to `totals.engagedSeconds`. The visible consequence is that the engaged-time
+tile's trend covers a different set of days than its neighbours' trends, so the tile's tooltip says
+so rather than implying comparability the data does not have.
+
+### 6. Window arithmetic: deltas come from the display window, discovery from a widened one
+
+The previous-window baseline is derived from the window the UI is **showing**: with
+`windowStart = now − days`, the baseline is `[windowStart − days, windowStart)`. It is never derived
+from the (possibly widened) discovery cutoff. Callers widen that cutoff — `lookbackDays: days * 2`
+in both the dashboard route and `ak usage score` — precisely so records older than the displayed
+window survive to be aggregated into the baseline; deriving the baseline from the widened bound
+would make it silently stretch to whatever lookback the caller happened to ask for, and a delta
+against an unknown-length window is not a delta. `buildIndex` therefore passes the aggregate a
+display cutoff while discovery uses the lookback cutoff, and the scan cache key folds both — plus
+`previous` — so two callers asking different questions cannot share one cached answer.
+
+### 7. Cost distribution excludes structurally-$0 sessions; ratios use main-thread prompts
+
+`costPerSessionMedian` and `costPerSessionP90` are computed over **priced sessions only**. A session
+with no token evidence at all — a Codex subagent rollout whose tokens were stripped as a
+double-count, say — is structurally zero rather than cheap, and folding it in would drag the median
+toward zero for a reason that is not about spend. The exclusion is stated in the UI subtitle and its
+tooltip, not just in the code; a real figure below a cent renders `<$0.01` rather than `$0.00`,
+which beside an "excludes $0-by-construction" subtitle would read as a contradiction. Session
+*length* percentiles stay inclusive — the length of a $0 session is honest.
+
+Prompt-derived ratios use **main-thread prompts** as their denominator: a subagent's prompts are
+written by the harness, not typed by a person, so counting them would inflate the denominator with
+work nobody asked for by hand. `responsesPerPrompt` is all responses over main-thread prompts —
+machine output per human touch — and `humanPromptsPerHour` is those same prompts per engaged hour.
+`totals.humanPrompts` ships beside `totals.prompts` so the distinction is auditable rather than
+implicit.
+
+### 8. `byInferenceProvider` is gated on observed provenance; `byProvider` stays what it was
+
+Cost is bucketed under a provider only when that session's provenance was **observed**; otherwise it
+lands in `not-recorded`, which is added to the CLI's key set unconditionally so the honest bucket
+appears even in a window where everything was attributed. This is the ADR-0021 rule applied to
+spend: a transcript host is not a vendor, and a configured route is assignment intent rather than
+evidence of what served a request.
+
+The legacy `byProvider` map is left alone, keyed by transcript host as it always was. Two maps with
+two contracts is clearer than one map that changes meaning.
+
+### 9. Tool names are the host's own, never translated
+
+Codex's four tallied `item_completed` kinds — `CommandExecution`, `McpToolCall`, `FileChange`,
+`CollabAgentToolCall` — keep those exact spellings in every ranking. Mapping `CommandExecution` onto
+`Bash`, or `FileChange` onto `Edit`, would assert an equivalence neither host makes: the
+vocabularies are host-specific and the semantics do not line up one-to-one. Every other Codex item
+type is left to the unknown-item diagnostic rather than tallied as a tool.
+
+### 10. Cache savings are priced by differencing the pricer, never by a multiplier
+
+`cacheSavedUsd` prices 1M tokens as fresh input and the same 1M as cache reads through the injected
+pricer, and takes the gap. No cache multiplier constant exists in the aggregate, so the figure
+cannot drift out of step with the pricing table the day that multiplier changes. Both probes carry
+the row's own model, provider, and **day**, so a saving is priced from the same table at the same
+date as the cost sitting beside it; the result is memoised per `(model, provider, day)`.
+
+### 11. Schema v11, and nested subagent transcripts are ingested
+
+`SCHEMA_VERSION` moves to 11 in one bump, adding `mode`/`modeRaw`, `latHist`/`latCount`,
+`lenSeconds`, `ctxWindow`/`ctxLastTokens`, and `aborts` to every session record. A v10-cached record
+carries none of them, so the whole cache is invalidated rather than letting new fields read back as
+`undefined` and sum into totals as `NaN` — the same rule, and the same reason, as the v4 and v5
+bumps ADR-0009 records.
+
+Discovery gains exactly one nested shape: `listClaudeSubagents` reads
+`<projectDir>/<sessionId>/subagents/*.jsonl` and nothing else. It is deliberately not a recursive
+walk — a directory that is not a session-id directory with a `subagents` child contributes nothing
+rather than being crawled — and an unreadable or absent nested directory degrades silently through
+the same `readDirSafe` convention every other per-directory read in that module uses.
+
+Each nested record takes a **namespaced** id, `<sessionId>/<stem>`, because Claude Code names every
+such file `agent-<hash>.jsonl` and that stem is not unique across two parent sessions; an
+unnamespaced id would silently collide two unrelated records into one. Admitting a slash into a
+session id touches the transcript reader's path-traversal guard, so the gate is designed to
+**narrow, not loosen**:
+
+- `VALID_SUBAGENT_ID` matches exactly `<parentId>/<stem>`, one slash, with the parent half reusing
+  `VALID_ID`'s own charset — a namespaced id's parent segment can never be more permissive than a
+  plain id already is — and the child half constrained to the real on-disk shape,
+  `agent-[A-Za-z0-9_-]{1,100}`, derived from the corpus rather than invented.
+- Resolution builds the candidate path from the two **already-validated capture groups**, never by
+  joining raw request input.
+- Realpath containment, the size cap, masking, and truncation are unchanged and still apply; the new
+  grammar is an additional accepted shape, not a bypass of any existing gate.
+
+## Consequences
+
+### Positive
+
+- The scorecard can now answer how a window was worked, not only what it cost, with each answer
+  carrying its own absence: `not-recorded` posture, an omitted context chip, `not measured` rhythm.
+- Ingesting nested subagent transcripts made a large, previously invisible slice of real spend
+  visible. On the reference machine's 14-day window at the time of the fix, 333 of 1,278 sessions
+  (26%) and $2,339 of $6,026 (39%) had never entered the index. Totals moved upward, which is the
+  honest direction, and delegation stopped being a metric the pipeline could not produce.
+- Because posture, latency, and context are per-session record fields, the Sessions view gets them
+  for free as row chips and detail lines, with no new route and no second fetch.
+
+### Negative, and honestly stated
+
+- A Codex session that records an approval policy and no sandbox policy renders `guarded` on
+  approval evidence alone (§1). Bounded and disclosed, but it is a mapping on partial evidence.
+- Posture is the **last** evidence a session recorded, not a timeline. A session that began in
+  `plan` and ended in `auto-edit` reports only the latter, and its whole cost stacks under it.
+- The `main`/`subagent` split is per session: a main-thread session that dispatched subagents still
+  counts its own tokens as main-thread work; only the subagent's own record is attributed to
+  `subagent`.
+- The two hosts reach the `subagent` row by different routes and only one arrives at a real figure.
+  Claude's delegated work is discovered, priced, and included. A Codex subagent rollout reads
+  `$0.00` **by ledger design** — it replays its parent's cumulative token history, so keeping it
+  would bill the parent twice — and its sessions and responses stay visible at zero cost. A `$0`
+  Claude subagent slice means no delegated work in the window; a `$0` Codex one does not.
+- Bucket histograms trade exactness for a bounded payload. A percentile inside a bucket is
+  interpolated, and one in the overflow bucket is a floor. This is why the `≥` prefix is mandatory
+  rather than cosmetic.
+- Latency and length edge constants are stated in three places — the parsers, the aggregate, and the
+  browser bundle — because the payload ships bucket *counts* and never the edges they were binned
+  on, and the import direction forbids the aggregate importing from the parsers. Equality-pinning
+  tests hold the three copies together.
+
+### Deferred, deliberately
+
+- **Limits history sparkline for both hosts.** Codex embeds quota snapshots in its own rollouts, so
+  a utilization series is reconstructable offline; Claude's quota arrives only through the
+  statusline push (ADR-0010) and has no retained local history to plot. A both-host history sparkline
+  waits on a retention decision for that push, which is a quota-channel question rather than a
+  scorecard one.
+- **Splitting the dashboard usage client, and a shared format module.** `client/usage.mjs` has grown
+  past the point where its panel builders belong in one file, and `fmtUsd`-family helpers are
+  restated between the CLI and the browser bundle. Values agree today and both restatements are
+  tested; the `usage-rhythm.mjs` dual bundle-and-import pattern shows a shared `usage-format.mjs` is
+  feasible, and one coherent refactor is worth more than a cross-lane patch now.
+- **Reconciling the OpenAI rate table (`USAGE-SCORECARD-METRICS.md` §13.2).** That section's dated
+  rates and its primary-source claim disagree with `pricing.mjs`. It is a pre-existing
+  discrepant-docs item, and it is explicitly **not** to be closed by editing one side to match the
+  other: the mandate on that follow-up is to establish which is true and correct whichever is wrong.
+
+## Verification
+
+Every mapping row in §1 is asserted value-by-value against `normalizeMode`, including the rows the
+first implementation left untested (`dontAsk`, `on-failure`, `untrusted`, and unrecognised Codex and
+OpenCode values), and the raw `approval/sandbox` spelling is pinned because the Sessions detail strip
+renders it. Bucket arithmetic is pinned at every edge and in the overflow slot, with the browser's
+re-implementation asserted byte-identical to the server's. The `engagedByDay` invariant, the
+display-window baseline, the priced-only cost distribution, and the main-thread ratio denominators
+each carry their own regression test. The nested-ingestion change is covered by namespaced-id
+uniqueness, an integration test asserting non-zero subagent cost, degrade-alone behavior, and
+both-tier traversal rejection at the id gate.
+
+Both citation-bearing reference documents are machine-checked: every `file:line` citation in
+`USAGE-SCORECARD-METRICS.md` and `TRANSCRIPTS.md` is verified against the current source on every
+test run by `tests/kit/doc-citations.test.mjs`.
+
+## References
+
+- Research: [Metric evidence matrix](https://claude.ai/code/artifact/1682c1ea-2bbd-4970-8cdd-2cc5e17efcdf)
+  — every candidate metric against the fields each host actually writes.
+- Research: [Scorecard additions](https://claude.ai/code/artifact/36adf798-625a-4d44-a84b-1dba7093e752)
+  — the panel mockup and the absence rules each panel must honour.
+- Plan: `docs/superpowers/plans/2026-08-28-scorecard-matrix-a.md`
+- `src/lib/usage-modes.mjs` (the taxonomy), `src/lib/usage-parsers.mjs` and
+  `src/lib/usage-opencode.mjs` (per-host evidence), `src/lib/usage-aggregate.mjs` (percentiles,
+  buckets, window arithmetic, cache differencing), `src/lib/usage-index.mjs` (`SCHEMA_VERSION`,
+  nested discovery, the id gates)
+- `src/lib/dashboard/client/usage.mjs` and `src/lib/dashboard/client/usage-rhythm.mjs` (render),
+  `src/commands/usage.mjs` (`ak usage score`)
+- [Usage scorecard metrics](../USAGE-SCORECARD-METRICS.md) §15–§19 —
+  the per-metric formulas and sources
+- [Transcripts & session detail](../TRANSCRIPTS.md) §1 — the per-host evidence contract
+- [Dashboard user guide](../DASHBOARD.md) — the shipped panels

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -45,6 +45,7 @@ Consequences**, and cites the grounded source it rests on where relevant.
 | [0035](0035-managed-deja-vu-companion.md) | Manage deja-vu as an opt-in session-history companion | Accepted; implementation tracked by issue #114 |
 | [0036](0036-dashboard-client-modularization-and-shared-loopback-server.md) | Dashboard client modularization and shared loopback server | Implemented |
 | [0037](0037-complexity-program-structural-patterns.md) | Complexity program: structural patterns and gates | Implemented |
+| [0038](0038-consistent-cross-host-session-metrics.md) | Consistent cross-host session metrics | Accepted |
 
 Theme: ADRs **0001–0006** define **dual-host LLM routing and leadership** — how `ak` lets ruflo route
 each development activity (architecture, implementation, testing, review, …) to the right host (Claude
@@ -275,3 +276,20 @@ status/writer parity test (closing the issue #129 class), the `telemetry-records
 layer shared by batch and live telemetry, statusline segment providers, and the complexity
 lint warnings (25/5/1000 over `src`+`bin`) that ratchet to errors as areas come clean — plus
 the honestly-stated residual backlog it did not take on.
+
+**0038** extends 0009's scorecard from what a window cost to how it was worked, across three hosts
+that record that evidence asymmetrically. It fixes one closed four-value permission-posture
+vocabulary whose every mapping is a pinned judgment (approval evidence alone suffices for `guarded`,
+and only for `guarded`), makes an unmapped value a first-class `not-recorded` bucket rather than a
+guess or a display fallback, defines response latency as prompt-to-response — never
+time-to-first-token — with Codex's host-measured duration as a fallback only, and derives
+percentiles from bucket histograms whose overflow slot reports a floor rendered `≥`. It keeps
+`byDay`'s billed-days presence contract by putting per-day engaged time in a sibling map, derives
+previous-window deltas from the display window while discovery widens its own cutoff, excludes
+structurally-$0 sessions from the cost distribution, gates `byInferenceProvider` on observed
+provenance (0021's rule applied to spend), keeps host-native tool names, and prices cache savings by
+differencing the pricer instead of a multiplier. Schema v11 carries the new record fields, and
+discovery gains exactly one nested shape — Claude Code's `<sessionId>/subagents/` sidechain
+transcripts, whose absence had made a quarter of the sessions and 39% of the cost in a reference
+window invisible — behind a namespaced id grammar that narrows the traversal guard rather than
+loosening it.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -286,9 +286,10 @@ time-to-first-token — with Codex's host-measured duration as a fallback only, 
 percentiles from bucket histograms whose overflow slot reports a floor rendered `≥`. It keeps
 `byDay`'s billed-days presence contract by putting per-day engaged time in a sibling map, derives
 previous-window deltas from the display window while discovery widens its own cutoff, excludes
-structurally-$0 sessions from the cost distribution, gates `byInferenceProvider` on observed
-provenance (0021's rule applied to spend), keeps host-native tool names, and prices cache savings by
-differencing the pricer instead of a multiplier. Schema v11 carries the new record fields, and
+structurally-$0 sessions from the cost distribution, declines to bucket window spend by inference
+provider at all (only one of three transcript formats records one — 0021's rule applied to spend),
+keeps host-native tool names, and prices cache savings by differencing the pricer instead of a
+multiplier. Schema v11 carries the new record fields, and
 discovery gains exactly one nested shape — Claude Code's `<sessionId>/subagents/` sidechain
 transcripts, whose absence had made a quarter of the sessions and 39% of the cost in a reference
 window invisible — behind a namespaced id grammar that narrows the traversal guard rather than

--- a/docs/superpowers/plans/2026-08-28-scorecard-matrix-a.md
+++ b/docs/superpowers/plans/2026-08-28-scorecard-matrix-a.md
@@ -1,0 +1,550 @@
+# Scorecard Matrix A Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the "Matrix A" consistent cross-host session metrics — hero deltas + sparklines, cadence/unit-cost KPIs, rhythm & responsiveness (session length + response latency), the How-you-run axes (mode / delegation / observed provider), tool mix, model mix over time, reliability, session chips, Limits pace tick — across parser → aggregate → dashboard UI → `ak usage score` CLI, plus the docs corrections the research surfaced.
+
+**Architecture:** Evidence flows one way: parsers record raw per-session evidence (new fields, bounded histograms), `usage-aggregate` folds it into window buckets (`byMode`, `byInferenceProvider`, rhythm histograms, per-day series, a previous-window pass for deltas), `dashboard-server` exposes it on `/api/usage`, and two consumers render it (dashboard client panels; `ak usage score`). Absent evidence is always `not-recorded` — never inferred. A new pure module `usage-modes.mjs` owns the cross-host mode taxonomy so the judgment calls live in one doc-citable place.
+
+**Tech Stack:** Node ESM (`.mjs`), `node --test` (run via `pnpm test`), no new dependencies, hand-rolled dashboard client (no chart lib).
+
+**Spec:** The two research artifacts — Metric Evidence Matrix (https://claude.ai/code/artifact/1682c1ea-2bbd-4970-8cdd-2cc5e17efcdf) and Scorecard Additions mockup (https://claude.ai/code/artifact/36adf798-625a-4d44-a84b-1dba7093e752). Everything an executor needs is restated inline below; the artifacts are reference, not required reading.
+
+## Global Constraints
+
+- All work on branch `feat/scorecard-matrix-a`; **unit commits** (one task = one or two commits); conventional-commit subjects (`feat:`, `fix:`, `docs:`, `test:`).
+- **Never `git add -A` / `git add .`** — stage named files only (untracked `.ruvector/`, `mise.toml`, and any ruflo-injected `AGENTS.md` drift must never enter a commit).
+- **No `Co-Authored-By` trailer** on commits (machine rule).
+- ESLint `complexity` warns at 25 — keep every new function under it; keep new files under ~500 lines; prefer a new focused module over growing a 50KB one.
+- TDD: the failing test is written and run before the implementation, per task.
+- `SCHEMA_VERSION` in `src/lib/usage-index.mjs:92` bumps 10 → 11 exactly once (Task 2). Any task that changes what parsers persist rides that one bump.
+- Evidence honesty (ADR-0023 house rule): a missing field renders **not-recorded**; an unmapped raw value maps to `null`, never to a guessed category. No metric is ever labeled "TTFT". OpenCode's observed `costObserved` precedence must not regress.
+- Docs are machine-checked: every `file:line` citation added to `docs/USAGE-SCORECARD-METRICS.md` must name an identifier present at that line (`tests/kit/doc-citations.test.mjs`). Docs tasks therefore run **after** code tasks are frozen.
+- Full gate before push: `pnpm run check` (typecheck + lint + markdown lint + build + test) green.
+- Limits **history sparkline is explicitly deferred** for both hosts (the Claude lane needs a new statusline-tee retention; the Codex lane needs per-day snapshot assembly) — this plan ships only the pace tick, which uses data the limits payload already carries. Record the deferral in ADR-0038.
+
+## File Ownership Lanes (collision rules)
+
+One file has exactly one lane; a lane's tasks run **serially in order**; different lanes may run in parallel only where the wave says so.
+
+| Lane | Files owned | Tasks |
+|---|---|---|
+| **P** (parsers) | `src/lib/usage-parsers.mjs`, `src/lib/usage-index.mjs`, `src/lib/usage-opencode.mjs`, `src/lib/usage-modes.mjs` (new) | T1–T5 |
+| **A** (aggregate/server) | `src/lib/usage-aggregate.mjs`, `src/lib/dashboard-server.mjs` | T6–T7 |
+| **UI** | `src/lib/dashboard/client/usage-rhythm.mjs` (new), `src/lib/dashboard/client/usage.mjs`, `src/lib/dashboard/client.mjs`, `src/lib/dashboard/styles/usage.mjs` | T8–T9 |
+| **CLI** | `src/commands/usage.mjs`, `tests/kit/usage-cli.test.mjs` | T10 |
+| **INS** | `src/lib/usage-insights.mjs`, `tests/kit/usage-insights.test.mjs` | T11 |
+| **D** (docs) | `docs/USAGE-SCORECARD-METRICS.md`, `docs/DASHBOARD.md`, `docs/TRANSCRIPTS.md`, `docs/adr/0038-*.md`, `src/lib/pricing.mjs` (comment text only) | T12–T13 |
+
+**Waves:** W1 = T1 ∥ (T2→T3→T4→T4b→T5). W2 = T6→T7 (starts when W1 lands). W3 = T8→T9 ∥ T10 ∥ T11 (starts when T7 lands; T11 only needs T6). W4 = T12 ∥ T13 (starts when W3 lands — line numbers must be final). W5 = QE review → remediation → gate → push → PR (lead session).
+
+---
+
+### Task 1: Mode taxonomy module (`usage-modes.mjs`)
+
+**Files:**
+- Create: `src/lib/usage-modes.mjs`
+- Test: `tests/kit/usage-modes.test.mjs`
+
+**Interfaces:**
+- Produces: `MODES = ['guarded','auto-edit','plan','unrestricted']`; `normalizeMode({ host, permissionMode, approvalPolicy, sandboxPolicy, opencodeMode }) → { mode: string|null, raw: string|null }`. `mode` is `null` whenever evidence is absent **or unrecognized** (never guessed); `raw` preserves the exact wire value(s) for the Sessions detail strip.
+
+The full mapping table (pinned by tests; recorded in ADR-0038):
+
+| Host evidence | → mode |
+|---|---|
+| CC `permissionMode`: `default` | guarded |
+| CC `acceptEdits`, `auto`, `dontAsk` | auto-edit |
+| CC `plan` | plan |
+| CC `bypassPermissions` | unrestricted |
+| CX `sandbox_policy` read-only (any approval) | plan |
+| CX `approval_policy` `on-request`/`on-failure`/`untrusted` (writable sandbox) | guarded |
+| CX `approval_policy` `never` + `workspace-write` | auto-edit |
+| CX `approval_policy` `never` + `danger-full-access` | unrestricted |
+| OC `mode` `plan` | plan |
+| OC `mode` `build` | auto-edit |
+| anything else | `null` (not recorded) |
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+// tests/kit/usage-modes.test.mjs
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { MODES, normalizeMode } from '../../src/lib/usage-modes.mjs';
+
+test('MODES is the closed four-value taxonomy', () => {
+  assert.deepEqual(MODES, ['guarded', 'auto-edit', 'plan', 'unrestricted']);
+});
+
+test('claude permissionMode maps per table', () => {
+  assert.equal(normalizeMode({ host: 'claude', permissionMode: 'default' }).mode, 'guarded');
+  assert.equal(normalizeMode({ host: 'claude', permissionMode: 'acceptEdits' }).mode, 'auto-edit');
+  assert.equal(normalizeMode({ host: 'claude', permissionMode: 'auto' }).mode, 'auto-edit');
+  assert.equal(normalizeMode({ host: 'claude', permissionMode: 'plan' }).mode, 'plan');
+  assert.equal(normalizeMode({ host: 'claude', permissionMode: 'bypassPermissions' }).mode, 'unrestricted');
+});
+
+test('codex approval x sandbox maps per table, read-only sandbox wins as plan', () => {
+  assert.equal(normalizeMode({ host: 'codex', approvalPolicy: 'never', sandboxPolicy: 'danger-full-access' }).mode, 'unrestricted');
+  assert.equal(normalizeMode({ host: 'codex', approvalPolicy: 'never', sandboxPolicy: 'workspace-write' }).mode, 'auto-edit');
+  assert.equal(normalizeMode({ host: 'codex', approvalPolicy: 'on-request', sandboxPolicy: 'workspace-write' }).mode, 'guarded');
+  assert.equal(normalizeMode({ host: 'codex', approvalPolicy: 'never', sandboxPolicy: 'read-only' }).mode, 'plan');
+});
+
+test('opencode mode maps build/plan', () => {
+  assert.equal(normalizeMode({ host: 'opencode', opencodeMode: 'build' }).mode, 'auto-edit');
+  assert.equal(normalizeMode({ host: 'opencode', opencodeMode: 'plan' }).mode, 'plan');
+});
+
+test('absent or unrecognized evidence is null, raw preserved, never guessed', () => {
+  assert.equal(normalizeMode({ host: 'claude' }).mode, null);
+  const odd = normalizeMode({ host: 'claude', permissionMode: 'superSafe9000' });
+  assert.equal(odd.mode, null);
+  assert.equal(odd.raw, 'superSafe9000');
+});
+```
+
+- [ ] **Step 2: Run it — expect FAIL (module not found)**: `node --test tests/kit/usage-modes.test.mjs`
+- [ ] **Step 3: Implement `src/lib/usage-modes.mjs`**
+
+```js
+// usage-modes.mjs — the cross-host permission-posture taxonomy (ADR-0038).
+// One closed vocabulary; every mapping is a recorded judgment call pinned by
+// tests. An unmapped raw value is null (not recorded), NEVER a guess.
+export const MODES = ['guarded', 'auto-edit', 'plan', 'unrestricted'];
+
+const CC = { default: 'guarded', acceptEdits: 'auto-edit', auto: 'auto-edit', dontAsk: 'auto-edit', plan: 'plan', bypassPermissions: 'unrestricted' };
+const OC = { build: 'auto-edit', plan: 'plan' };
+
+function codexMode(approval, sandbox) {
+  if (sandbox === 'read-only') return 'plan';
+  if (approval === 'never' && sandbox === 'danger-full-access') return 'unrestricted';
+  if (approval === 'never' && sandbox === 'workspace-write') return 'auto-edit';
+  if (['on-request', 'on-failure', 'untrusted'].includes(approval)) return 'guarded';
+  return null;
+}
+
+export function normalizeMode({ host, permissionMode, approvalPolicy, sandboxPolicy, opencodeMode } = {}) {
+  if (host === 'claude' && typeof permissionMode === 'string') {
+    return { mode: CC[permissionMode] ?? null, raw: permissionMode };
+  }
+  if (host === 'codex' && (approvalPolicy || sandboxPolicy)) {
+    const raw = [approvalPolicy, sandboxPolicy].filter(Boolean).join('/');
+    return { mode: codexMode(approvalPolicy, sandboxPolicy), raw };
+  }
+  if (host === 'opencode' && typeof opencodeMode === 'string') {
+    return { mode: OC[opencodeMode] ?? null, raw: opencodeMode };
+  }
+  return { mode: null, raw: null };
+}
+```
+
+- [ ] **Step 4: Run test — expect PASS**: `node --test tests/kit/usage-modes.test.mjs`
+- [ ] **Step 5: Commit**: `git add src/lib/usage-modes.mjs tests/kit/usage-modes.test.mjs && git commit -m "feat(usage): cross-host mode taxonomy module"`
+
+---
+
+### Task 2: Session record v11 — shape, histogram helpers, schema bump
+
+**Files:**
+- Modify: `src/lib/usage-parsers.mjs` (blankSession ~line 180; add helpers near `noteSpan`)
+- Modify: `src/lib/usage-index.mjs:92` (`SCHEMA_VERSION` 10 → 11)
+- Test: `tests/kit/usage-index.test.mjs` (append)
+
+**Interfaces (produces — every later task relies on these exact names):**
+
+```js
+// blankSession() gains, all serialization-safe defaults:
+mode: null, modeRaw: null,          // from usage-modes.normalizeMode
+latHist: null,                      // number[6] counts | null — response latency
+latCount: 0,                        // total latency samples
+lenSeconds: 0,                      // engaged seconds for THIS session (set at finish from active intervals)
+ctxWindow: null,                    // model context window (tokens) when host states it
+ctxLastTokens: null,                // last turn's input+cacheRead estimate
+aborts: 0                           // explicit user-aborted turns (codex)
+// exported constants + helpers:
+export const LAT_BUCKET_EDGES = [2, 5, 10, 30, 60];        // seconds; 6th bucket = >60
+export const LEN_BUCKET_EDGES = [300, 900, 2700, 7200];    // seconds; 5th bucket = >2h
+export function noteLatencySample(rec, seconds) // increments latHist bucket + latCount
+export function bucketIndex(edges, v)           // shared: first i with v <= edges[i], else edges.length
+```
+
+- [ ] **Step 1: Failing test** (append to `tests/kit/usage-index.test.mjs`):
+
+```js
+test('noteLatencySample buckets on the shared edges', () => {
+  const rec = blankSession('s1', 'claude');
+  noteLatencySample(rec, 1.2);   // bucket 0 (<2s)
+  noteLatencySample(rec, 8.4);   // bucket 2 (5-10s)
+  noteLatencySample(rec, 700);   // bucket 5 (>60s)
+  assert.deepEqual(rec.latHist, [1, 0, 1, 0, 0, 1]);
+  assert.equal(rec.latCount, 3);
+});
+
+test('blankSession v11 fields default honest-absent', () => {
+  const rec = blankSession('s1', 'codex');
+  assert.equal(rec.mode, null);
+  assert.equal(rec.ctxWindow, null);
+  assert.equal(rec.aborts, 0);
+});
+```
+
+- [ ] **Step 2: Run — FAIL** (`noteLatencySample` not exported): `node --test tests/kit/usage-index.test.mjs`
+- [ ] **Step 3: Implement** — extend `blankSession` with the fields above; add:
+
+```js
+export const LAT_BUCKET_EDGES = [2, 5, 10, 30, 60];
+export const LEN_BUCKET_EDGES = [300, 900, 2700, 7200];
+export function bucketIndex(edges, v) {
+  for (let i = 0; i < edges.length; i++) if (v <= edges[i]) return i;
+  return edges.length;
+}
+export function noteLatencySample(rec, seconds) {
+  if (!Number.isFinite(seconds) || seconds < 0) return;
+  rec.latHist ??= new Array(LAT_BUCKET_EDGES.length + 1).fill(0);
+  rec.latHist[bucketIndex(LAT_BUCKET_EDGES, seconds)]++;
+  rec.latCount++;
+}
+```
+
+In the record-finishing function (the one that derives `active` from `stamps`, `usage-parsers.mjs:220` area), set `rec.lenSeconds = Math.round(rec.active.reduce((n, [a, b]) => n + (b - a), 0) / 1000)`. Mirror the same `lenSeconds` line in `usage-opencode.mjs` `parseSession` where it computes `rec.active`. Bump `SCHEMA_VERSION` to 11.
+
+- [ ] **Step 4: Run — PASS**, then full parser suites: `node --test tests/kit/usage-index.test.mjs tests/kit/usage-opencode.test.mjs`
+- [ ] **Step 5: Commit**: `git add src/lib/usage-parsers.mjs src/lib/usage-index.mjs src/lib/usage-opencode.mjs tests/kit/usage-index.test.mjs && git commit -m "feat(usage): session record v11 — latency/length/mode/ctx fields, schema 11"`
+
+---
+
+### Task 3: parseClaude — mode, latency, context pressure
+
+**Files:**
+- Modify: `src/lib/usage-parsers.mjs` (`parseClaude`, ~lines 376–401 entry loop; assistant handling ~328–368)
+- Test: `tests/kit/usage-index.test.mjs`
+
+**Interfaces:**
+- Consumes: T1 `normalizeMode`, T2 helpers.
+- Produces: Claude sessions carry `mode`/`modeRaw` (last human-turn `permissionMode` seen wins), `latHist`/`latCount` (gap human-prompt → next assistant entry), `ctxLastTokens` (last assistant turn's `input + cacheRead`).
+
+Measurement rules (restated from the spec): a latency sample is taken **only** for entries that pass the existing `isHumanPrompt` filter; the sample is the gap to the **first** assistant-role entry that follows it (skip `isApiErrorMessage` placeholders — a dropped request is an exception, not a latency); cap samples at 3600s (a gap longer than an hour is an idle resume, not a response). `permissionMode` is read off human user entries only.
+
+- [ ] **Step 1: Failing test** — extend the existing parseClaude fixture in `tests/kit/usage-index.test.mjs` (the fixture with 3 user / 2 assistant turns around line 330) with timestamps 10s apart and `permissionMode: 'acceptEdits'` on a user entry:
+
+```js
+test('parseClaude derives latency, mode, ctx from entries', () => {
+  const lines = [
+    JSON.stringify({ type: 'user', timestamp: T0, permissionMode: 'acceptEdits', message: { role: 'user', content: 'do it' } }),
+    JSON.stringify({ type: 'assistant', timestamp: plusSec(T0, 8), message: { role: 'assistant', model: 'claude-opus-5', usage: { input_tokens: 1000, cache_read_input_tokens: 150000, output_tokens: 50 }, content: [] } }),
+  ].join('\n');
+  const rec = parseClaude('sess-lat', lines);
+  assert.equal(rec.mode, 'auto-edit');
+  assert.equal(rec.modeRaw, 'acceptEdits');
+  assert.equal(rec.latCount, 1);
+  assert.equal(rec.latHist[2], 1);            // 8s → 5-10s bucket
+  assert.equal(rec.ctxLastTokens, 151000);    // input + cacheRead of last turn
+});
+```
+
+(Reuse the file's existing fixture helpers for timestamps; if none exist, `const T0 = '2026-08-20T10:00:00.000Z'` and `plusSec` built with `new Date(Date.parse(t) + s * 1000).toISOString()`.)
+
+- [ ] **Step 2: Run — FAIL**: `node --test tests/kit/usage-index.test.mjs`
+- [ ] **Step 3: Implement** inside `parseClaude`'s entry loop: track `pendingPromptMs` (set when a human prompt is recorded; cleared when consumed); on each non-error assistant entry, if `pendingPromptMs` is set, `noteLatencySample(rec, (ms - pendingPromptMs) / 1000)` when ≤ 3600, then clear. Read `e.permissionMode` on human user entries → `const m = normalizeMode({ host: 'claude', permissionMode: e.permissionMode }); if (m.raw) { rec.mode = m.mode; rec.modeRaw = m.raw; }`. On each assistant entry with usage, set `rec.ctxLastTokens = tokens(u.input_tokens) + tokens(u.cache_read_input_tokens)` (overwrites; last turn wins).
+- [ ] **Step 4: Run — PASS**, plus the whole file: `node --test tests/kit/usage-index.test.mjs`
+- [ ] **Step 5: Commit**: `git add src/lib/usage-parsers.mjs tests/kit/usage-index.test.mjs && git commit -m "feat(usage): parseClaude records mode, response latency, context pressure"`
+
+---
+
+### Task 4: parseCodex — approval mode, host-measured timing, aborts/errors, ctx window, typed-item tools
+
+**Files:**
+- Modify: `src/lib/usage-parsers.mjs` (`parseCodex` ~578–681; `turn_context` handling ~431–437; `event_msg` dispatch)
+- Test: `tests/kit/usage-index-v6.test.mjs` (append — this file owns Codex-detail coverage)
+
+**Interfaces:**
+- Consumes: T1, T2.
+- Produces: Codex sessions carry `mode`/`modeRaw` (from `turn_context.approval_policy` + `sandbox_policy`, last wins), `latHist` (from `task_started.started_at` → first agent message, else `task_complete.duration_ms` as the whole-turn fallback sample), `aborts` (count of `turn_aborted`), `exceptions` += `task_complete` events whose `error` is non-null, `ctxWindow` (from `task_started.model_context_window`, last wins), and `rec.tools` counts from `item_completed` items, keyed by the item's own type name — `CommandExecution`, `McpToolCall`, `FileChange`, `CollabAgentToolCall`. Tool names are host vocabularies: never rename Codex activity to Claude tool names; the UI ranks names as-is.
+
+- [ ] **Step 1: Failing test** (append to `tests/kit/usage-index-v6.test.mjs`, following its existing rollout-fixture style):
+
+```js
+test('parseCodex v11: mode, duration, aborts, ctx window, typed tools', () => {
+  const lines = [
+    JSON.stringify({ type: 'session_meta', payload: { id: 'cx1', cwd: '/tmp/p', thread_source: 'user' }, timestamp: T0 }),
+    JSON.stringify({ type: 'turn_context', payload: { model: 'gpt-5.6', approval_policy: 'never', sandbox_policy: 'workspace-write' }, timestamp: T0 }),
+    JSON.stringify({ type: 'event_msg', payload: { type: 'task_started', started_at: T0, model_context_window: 272000, turn_id: 't1' }, timestamp: T0 }),
+    JSON.stringify({ type: 'event_msg', payload: { type: 'user_message', message: 'go' }, timestamp: T0 }),
+    JSON.stringify({ type: 'event_msg', payload: { type: 'agent_message', message: 'done' }, timestamp: plusSec(T0, 6) }),
+    JSON.stringify({ type: 'event_msg', payload: { type: 'item_completed', item: { type: 'CommandExecution' } }, timestamp: plusSec(T0, 7) }),
+    JSON.stringify({ type: 'event_msg', payload: { type: 'task_complete', duration_ms: 9000, error: null, turn_id: 't1' }, timestamp: plusSec(T0, 9) }),
+    JSON.stringify({ type: 'event_msg', payload: { type: 'turn_aborted', reason: 'user_interrupt', turn_id: 't2' }, timestamp: plusSec(T0, 20) }),
+    JSON.stringify({ type: 'event_msg', payload: { type: 'token_count', info: { total_token_usage: { input_tokens: 5000, cached_input_tokens: 4000, output_tokens: 300 } } }, timestamp: plusSec(T0, 21) }),
+  ].join('\n');
+  const rec = parseCodex('cx1', lines);
+  assert.equal(rec.mode, 'auto-edit');
+  assert.equal(rec.modeRaw, 'never/workspace-write');
+  assert.equal(rec.latCount, 1);
+  assert.equal(rec.latHist[2], 1);           // 6s prompt→agent gap
+  assert.equal(rec.aborts, 1);
+  assert.equal(rec.ctxWindow, 272000);
+  assert.equal(rec.tools.CommandExecution, 1);
+});
+```
+
+- [ ] **Step 2: Run — FAIL**: `node --test tests/kit/usage-index-v6.test.mjs`
+- [ ] **Step 3: Implement** in `parseCodex`: extend the `turn_context` branch to call `normalizeMode({ host: 'codex', approvalPolicy: p.approval_policy, sandboxPolicy: p.sandbox_policy })`; add `event_msg` cases: `task_started` (record `model_context_window` when finite; remember `started_at`), `task_complete` (if no prompt-gap sample was taken this turn and `duration_ms` finite, `noteLatencySample(rec, duration_ms / 1000)`; `if (p.error != null) rec.exceptions++`), `turn_aborted` (`rec.aborts++`), and in the `item_completed` handler count `item.type` into `rec.tools` for the four types listed above. Prompt-gap latency reuses the same `pendingPromptMs` pattern as Task 3 (set on `user_message`/`UserMessage`, consumed by the first `agent_message`/`AgentMessage`). Keep the existing subagent exclusion untouched (`threadSource === 'subagent'` still skips usage — mode/latency fields may still record; they are excluded at aggregate time with the rest of the session).
+- [ ] **Step 4: Run — PASS**, plus regression: `node --test tests/kit/usage-index-v6.test.mjs tests/kit/usage-index.test.mjs`
+- [ ] **Step 5: Commit**: `git add src/lib/usage-parsers.mjs tests/kit/usage-index-v6.test.mjs && git commit -m "feat(usage): parseCodex mode, host-measured timing, aborts, ctx window, typed tool items"`
+
+---
+
+### Task 4b: OpenCode — mode/agent, latency, error, ctx derivation input
+
+**Files:**
+- Modify: `src/lib/usage-opencode.mjs` (`processMessageRow` / `recordAssistantMessage`, lines ~194–213)
+- Test: `tests/kit/usage-opencode.test.mjs` (append, using its existing in-memory sqlite fixture helpers)
+
+**Interfaces:**
+- Consumes: T1, T2.
+- Produces: OpenCode sessions carry `mode`/`modeRaw` (from message `data.mode`, last wins), `latHist` (user message → next assistant message gap), `exceptions` (messages with a non-null `data.error`), `ctxLastTokens` (last assistant `tokens.input + tokens.cache.read`).
+
+- [ ] **Step 1: Failing test** — extend the existing fixture db with one user message at `t`, one assistant at `t+4s` carrying `{ mode: 'build', tokens: { input: 900, cache: { read: 20000 }, output: 10 } }`, and one assistant with `error: { name: 'ProviderAuthError' }`:
+
+```js
+assert.equal(session.mode, 'auto-edit');
+assert.equal(session.modeRaw, 'build');
+assert.equal(session.latHist[1], 1);        // 4s → 2-5s bucket
+assert.equal(session.exceptions, 1);
+assert.equal(session.ctxLastTokens, 20900);
+```
+
+- [ ] **Step 2: Run — FAIL**: `node --test tests/kit/usage-opencode.test.mjs`
+- [ ] **Step 3: Implement** — in `processMessageRow` track `pendingPromptMs` on user rows; in `recordAssistantMessage` sample the gap, apply `normalizeMode({ host: 'opencode', opencodeMode: data.mode })`, `if (data.error != null) rec.exceptions++`, set `rec.ctxLastTokens`.
+- [ ] **Step 4: Run — PASS**: `node --test tests/kit/usage-opencode.test.mjs`
+- [ ] **Step 5: Commit**: `git add src/lib/usage-opencode.mjs tests/kit/usage-opencode.test.mjs && git commit -m "feat(usage): opencode mode, latency, errors, ctx input"`
+
+---
+
+### Task 5: Index carry-through + 2× lookback for deltas
+
+**Files:**
+- Modify: `src/lib/usage-index.mjs` (`buildIndex` ~402; the cached-entry projection)
+- Test: `tests/kit/usage-index.test.mjs`
+
+**Interfaces:**
+- Produces: cached session entries round-trip the v11 fields (they ride the same record object — verify the cache projection does not strip unknown fields; if it whitelists, extend the whitelist). `buildIndex({ days, lookbackDays })`: when `lookbackDays` (default `days * 2`) is passed by the server, sessions are parsed back to the longer cutoff so a previous-window aggregate has data. Aggregation windows stay governed by `aggregate`'s own `cutoff`.
+
+- [ ] **Step 1: Failing test** — round-trip: build an index over a fixture root twice (second run hits cache) and assert `mode`/`latHist` survive the cached read; assert `buildIndex({ days: 7, lookbackDays: 14 })` includes a session 10 days old.
+- [ ] **Step 2: Run — FAIL**, **Step 3: implement**, **Step 4: PASS** (`node --test tests/kit/usage-index.test.mjs`)
+- [ ] **Step 5: Commit**: `git add src/lib/usage-index.mjs tests/kit/usage-index.test.mjs && git commit -m "feat(usage): index round-trips v11 fields, optional 2x lookback"`
+
+---
+
+### Task 6: Aggregate — buckets, histograms, percentiles, per-day engaged, previous window
+
+**Files:**
+- Modify: `src/lib/usage-aggregate.mjs` (`aggregate` ~400, `buildSessionRows` ~304, totals block ~346)
+- Test: `tests/kit/usage-index.test.mjs` (aggregate suites live here)
+
+**Interfaces:**
+- Consumes: v11 session fields (T2–T5), `MODES` (T1).
+- Produces on the aggregate result:
+
+```js
+byMode:              { [mode|'not-recorded']: bucket }     // same bucket shape as byHost (addTo)
+byInferenceProvider: { [provider|'not-recorded']: bucket } // key = s.inferenceProvider only when providerProvenance === 'observed'
+bySource:            { main: bucket, subagent: bucket }    // subagent = s.sidechain || s.threadSource === 'subagent'
+byTool:              { [toolName]: number }                // Σ s.tools maps (raw names; UI caps top 8 + Other)
+rhythm: {
+  latHist: number[6], latCount, latP50, latP95,            // seconds|null when latCount === 0
+  lenHist: number[5], lenMedianSeconds, lenP90Seconds,     // from per-session lenSeconds
+}
+totals: { ...existing, aborts, humanPromptsPerHour, responsesPerPrompt, costPerSessionMedian, costPerEngagedHour, cacheSavedUsd }
+                                                            // cacheSavedUsd = Σ over usage rows of 0.9 × cacheRead × rate_in(day) — tested against a hand-worked row
+byDay[day].engagedSeconds                                   // per-local-day union of active intervals
+byDay[day].byMode                                           // { [mode|'not-recorded']: cost } for the stacked mode-by-day chart
+byDay[day].byModelFamily                                    // { [family]: cost } via modelFamily(id)
+previous: null | { totals, rhythm }                         // when opts.previous === true: same aggregation over [cutoff - windowMs, cutoff)
+export function percentileFromBuckets(counts, edges, q)     // linear interpolation inside the bucket; null when empty
+export function modelFamily(id)                             // 'claude-opus-5-20260115' → 'opus'; 'gpt-5.6-sol' → 'gpt-5'; unknown → 'other' — pinned by test
+```
+
+- [ ] **Step 1: Failing tests** (three focused tests):
+
+```js
+test('percentileFromBuckets interpolates and handles empty', () => {
+  assert.equal(percentileFromBuckets([0, 0, 0, 0, 0, 0], LAT_BUCKET_EDGES, 0.5), null);
+  // 10 samples all in 5-10s bucket → p50 sits mid-bucket
+  const p = percentileFromBuckets([0, 0, 10, 0, 0, 0], LAT_BUCKET_EDGES, 0.5);
+  assert.ok(p > 5 && p <= 10);
+});
+
+test('byMode and byInferenceProvider bucket honestly', () => {
+  // three fixture sessions: mode 'auto-edit' observed openai; mode null; provenance 'unknown'
+  const a = aggregate(records, { days: 14, now, cutoff, deps });
+  assert.ok(a.byMode['auto-edit'].sessions === 1);
+  assert.ok(a.byMode['not-recorded'].sessions === 2);
+  assert.ok(a.byInferenceProvider['openai'].sessions === 1);
+  assert.ok(a.byInferenceProvider['not-recorded'].sessions === 2);
+});
+
+test('previous window aggregates the prior equal span only', () => {
+  const a = aggregate(records, { days: 7, now, cutoff, deps, previous: true });
+  assert.ok(a.previous.totals.sessions === /* fixture sessions aged 7-14d */ 2);
+});
+```
+
+- [ ] **Step 2: Run — FAIL**: `node --test tests/kit/usage-index.test.mjs`
+- [ ] **Step 3: Implement** — `buildSessionRows` gains an optional `endMs` (exclusive upper bound: `if (endMs && rec.end >= endMs) continue`); the main pass folds `s.mode ?? 'not-recorded'`, the provenance-gated provider key, and `bySource` (main vs subagent) with the existing `addTo`, and sums `s.tools` into `byTool`; merge `latHist` arrays; build `lenHist` from `LEN_BUCKET_EDGES`/`bucketIndex` over `s.lenSeconds`; medians via `percentileFromBuckets` (length/latency) and exact median over the per-session cost array (`costPerSessionMedian` — sort once); `cacheSavedUsd` accumulates `0.9 × cacheRead × rate_in(day)` inside the existing priced-row loop; `byDay.engagedSeconds` by splitting each active interval at local midnight (reuse `localDay`) and unioning per day with `mergeIntervals`; `byDay[*].byMode` and `byDay[*].byModelFamily` (via the new `modelFamily(id)` helper, pinned by its own test cases from the interface block) accumulate cost inside the same byDay loop; `previous` runs the same fold over `[cutoff - days*86400e3, cutoff)` records with a totals+rhythm-only projection. Keep every new helper under complexity 25 (small pure functions).
+- [ ] **Step 4: Run — PASS** + whole suite: `pnpm test`
+- [ ] **Step 5: Commit**: `git add src/lib/usage-aggregate.mjs tests/kit/usage-index.test.mjs && git commit -m "feat(usage): byMode/byInferenceProvider buckets, rhythm histograms, per-day engaged, previous window"`
+
+---
+
+### Task 7: `/api/usage` payload
+
+**Files:**
+- Modify: `src/lib/dashboard-server.mjs` (the `/api/usage` route handler — locate `aggregate(` call)
+- Test: `tests/kit/dashboard-usage-telemetry.test.mjs` (append)
+
+**Interfaces:**
+- Produces: the JSON payload adds `previous`, `rhythm`, `byMode`, `byInferenceProvider`, and `byDay[*].engagedSeconds`, passing `previous: true` and `lookbackDays: days * 2` down. Nothing existing is renamed; `byProvider` (legacy host identity) is untouched.
+
+- [ ] **Step 1: Failing test** — extend the existing payload test to assert `payload.rhythm.latHist.length === 6`, `payload.byMode` has only keys from `[...MODES, 'not-recorded']`, and `payload.previous.totals` exists when two windows of fixture data are present.
+- [ ] **Step 2: FAIL** → **Step 3: implement** → **Step 4: PASS**: `node --test tests/kit/dashboard-usage-telemetry.test.mjs`
+- [ ] **Step 5: Commit**: `git add src/lib/dashboard-server.mjs tests/kit/dashboard-usage-telemetry.test.mjs && git commit -m "feat(dashboard): usage payload carries rhythm, mode, provider, previous window"`
+
+---
+
+### Task 8: Client render module `usage-rhythm.mjs` + styles
+
+**Files:**
+- Create: `src/lib/dashboard/client/usage-rhythm.mjs`
+- Modify: `src/lib/dashboard/styles/usage.mjs` (append component CSS)
+- Test: `tests/kit/dashboard-usage-telemetry.test.mjs` (string-shape smoke tests — these modules are pure string builders)
+
+**Interfaces (exact exported names; T9 wires them):**
+
+```js
+export function deltaChip(curr, prev, { downIsGood = false, neutral = false, unit = '' }) → string  // '' when prev absent
+export function sparklineSvg(series /* number[] */, { w = 130, h = 24 }) → string                    // '' when < 2 points
+export function histogram({ counts, labels, markers /* [{atPct, label}] */ }) → string
+export function stackedDays({ days /* [{day, parts: {key: value}}] */, order, palette }) → string
+export function donut2({ aLabel, aValue, bLabel, bValue, centerLabel }) → string
+export function rankedRows(rows /* [{label, value, share, dim}] */) → string
+```
+
+Mark rules (from the mockup): bars 4px top radius; 2px gaps between stacked segments; direct labels; `not-recorded`/Other always the de-emphasis token (`--dim`-equivalent in usage styles), never a series color; sparkline = de-emphasis stroke + accent endpoint dot; every chart carries text labels (no color-alone identity).
+
+- [ ] **Step 1: Failing smoke test** — import the module in the node test, assert `deltaChip(584, 540, {})` contains `▲` and `8%`, `deltaChip(5, null, {})` is `''`, `sparklineSvg([1,2,3])` contains `<svg` and `polyline`, `donut2` output contains both labels.
+- [ ] **Step 2: FAIL** → **Step 3: implement** (pure template-string builders; escape all interpolated text with the client's existing `esc` helper pattern — copy it locally, no DOM access) → **Step 4: PASS**.
+- [ ] **Step 5: Commit**: `git add src/lib/dashboard/client/usage-rhythm.mjs src/lib/dashboard/styles/usage.mjs tests/kit/dashboard-usage-telemetry.test.mjs && git commit -m "feat(dashboard): rhythm/mode chart primitives for the usage client"`
+
+---
+
+### Task 9: Wire the panels — hero deltas, new rows/panels, session chips, limits pace tick
+
+**Files:**
+- Modify: `src/lib/dashboard/client/usage.mjs` (hero `kpi(...)` call sites; panel sequence noted at ~line 338), `src/lib/dashboard/client.mjs` (`renderLimits`/`limRow`), `src/lib/dashboard/client/bootstrap.mjs` only if the new module needs registration (follow how `usage-orchestrators.mjs` is included)
+
+**Interfaces:** Consumes T7 payload fields + T8 renderers, exactly as named above.
+
+Deliverables, all per the mockup (artifact 36adf798…):
+1. Hero tiles: append `deltaChip` (cost + cache: `downIsGood`/up-good pt; tokens: `neutral: true`) and `sparklineSvg` over `byDay` series (cost/day, sessions/day, tokens/day, engagedSeconds/day, cache-share/day). Cache tile subtitle renders `saved ≈ $N vs uncached` from `totals.cacheSavedUsd` (T6).
+2. Second KPI row: sessions/active-day + streak, autonomy (`responses/prompts`) + touch rate, cost/session median + P90, cost/engaged-hour — all from `totals`.
+3. Rhythm panel: two `histogram(...)` blocks with median/P90 and p50/p95 markers; the latency card's tooltip carries the measurement note ("codex host-measured · claude/opencode derived from event gaps — not streaming TTFT").
+4. How-you-run panel: `stackedDays` over `byDay[*].byMode` cost (T6), `donut2` over `bySource` main-vs-subagent cost (T6), `rankedRows` for byInferenceProvider with `not-recorded` as `dim: true`.
+5. Tool mix panel: `rankedRows` top 8 + Other from T6's `byTool`.
+6. Model mix over time: `stackedDays` over `byDay[*].byModelFamily` (T6's `modelFamily` fold).
+7. Reliability strip: error rate `exceptions/responses × 1000` + per-day exceptions line, icon + label on the spike.
+8. Sessions rows: chips for `lenSeconds` (fmt), per-session `p50` (from `latHist`), mode badge (`modeRaw` in tooltip), ctx % (`ctxLastTokens/ctxWindow` when both present; `ctxWindow` null → derive against the bundled published window only if the model record exposes it — otherwise omit the chip; never guess).
+9. Limits: pace tick at the window's elapsed share on each `limRow` meter (data already present in the limits payload).
+
+- [ ] **Step 1:** Implement in the order above, one commit per numbered deliverable group (1–2, 3–4, 5–7, 8, 9): subjects `feat(dashboard): hero deltas + cadence row`, `feat(dashboard): rhythm and how-you-run panels`, `feat(dashboard): tool/model mix and reliability`, `feat(dashboard): session row chips`, `feat(dashboard): limits pace tick`.
+- [ ] **Step 2: Verify each group**: `pnpm test`, then `pnpm run check`; then launch `ak dashboard --no-open`, fetch the page + `/api/usage` with the printed token, and screenshot with headless Chrome in **both** themes (the repo memory: headless Chrome follows OS theme; force with `--force-dark-mode` and default). Attach screenshots to the PR later.
+- [ ] **Step 3:** Any client function crossing complexity 25 gets split before commit (the 2026-08 audit's pattern: extract per-panel builders).
+
+---
+
+### Task 10: CLI — `ak usage score`
+
+**Files:**
+- Modify: `src/commands/usage.mjs` (add `score` subcommand; update `help` text — keep `status`/`refresh` untouched)
+- Test: `tests/kit/usage-cli.test.mjs` (append)
+
+**Interfaces:**
+- Consumes: `buildIndex` + `aggregate` (same modules the dashboard uses — no new computation in the command).
+- Produces: `ak usage score [--window 7|14|30] [--json]` printing: hero five (+deltas), cadence four, rhythm medians/percentiles, mode/provider tables with `not-recorded` rows, reliability rate. `--json` emits the aggregate projection verbatim (totals, rhythm, byMode, byInferenceProvider, previous) — additive, credential-free, offline.
+
+- [ ] **Step 1: Failing test** — follow the file's existing command-invocation pattern; over a fixture root assert the text output contains `AUTONOMY` and a `not-recorded` row, and `--json` parses with `rhythm.latHist.length === 6`.
+- [ ] **Step 2: FAIL** → **Step 3: implement** (rendering only: reuse `heading/info/dim` from `../lib/output.mjs`; window flag validated to {7,14,30}) → **Step 4: PASS**: `node --test tests/kit/usage-cli.test.mjs`
+- [ ] **Step 5: Commit**: `git add src/commands/usage.mjs tests/kit/usage-cli.test.mjs && git commit -m "feat(cli): ak usage score — offline scorecard summary with matrix-a metrics"`
+
+---
+
+### Task 11: Findings detectors
+
+**Files:**
+- Modify: `src/lib/usage-insights.mjs` (two detectors + registry entries at ~584)
+- Test: `tests/kit/usage-insights.test.mjs` (append)
+
+**Interfaces:**
+- Produces: `detectLatencyRegression({ sessions })` → id `latency-regression`, kind `trend`, severity `warn` when the second half-window's bucket-merged p50 exceeds the first half's by ≥25% **and** ≥2s absolute (both halves need ≥30 samples; otherwise no finding). `detectUnrestrictedMode({ sessions, windowCost })` → id `unrestricted-mode`, kind `coach`, severity `info` listing count + cost of sessions with `mode === 'unrestricted'` (zero sessions → no finding; `not-recorded` never counts).
+
+- [ ] **Step 1: Failing tests** — fixture sessions with latHists split across halves (30+ samples each; p50 8s → 12s ⇒ finding fires; 8s → 9s ⇒ no finding) and one `unrestricted` session ⇒ finding with `sessions: 1`.
+- [ ] **Step 2: FAIL** → **Step 3: implement** (follow the file's detector shape exactly — same `{ id, kind, severity, title, body, evidence }` contract as `detectSubagentShare`) → **Step 4: PASS**: `node --test tests/kit/usage-insights.test.mjs`
+- [ ] **Step 5: Commit**: `git add src/lib/usage-insights.mjs tests/kit/usage-insights.test.mjs && git commit -m "feat(usage): latency-regression and unrestricted-mode findings"`
+
+---
+
+### Task 12: Metrics doc — new sections + the stale-claim corrections
+
+**Files:**
+- Modify: `docs/USAGE-SCORECARD-METRICS.md`; `src/lib/pricing.mjs` (comment text only, `UNMODELLED_PRICING_FACTORS` block ~131–150)
+- Test: `tests/kit/doc-citations.test.mjs` (existing — must stay green; it machine-checks every `file:line` citation)
+
+Deliverables:
+1. New sections §15–§19 following the house entry shape (**Displayed as / Formula / Source / Worked example / What this does not model**) for: Rhythm & responsiveness (both histograms, the percentile-from-buckets method, the per-host measurement difference, the explicit "never labeled TTFT" rule); How you run (the full mode-mapping table from Task 1, `not-recorded` semantics, provider provenance gate); Cadence & unit economics (autonomy, touch rate, medians — and why median, with the heavy-tail worked example); Reliability (error-turn sources per host, aborts); Deltas & sparklines (previous-window definition, 2× lookback).
+2. **§13.3 correction**: run a one-off census (scratchpad script, not committed) counting non-null `service_tier` / `inference_geo` / `speed` values across the local corpus; replace the "a transcript does not record which endpoint/tier" rationale with the truth: *recorded per turn since ~CLI version X, observed on N% of turns in the verification corpus; deliberately still unpriced pending semantics verification* — and update the matching `pricing.mjs` comment wording. Pricing **behavior** does not change.
+3. **§8 clarification**: one paragraph distinguishing `byProvider` (legacy host identity, unchanged) from the new `byInferenceProvider` (observed-only, `not-recorded` first-class).
+4. Every citation added uses final line numbers from the frozen code (this is why Wave 4 waits).
+
+- [ ] Steps: draft → `node --test tests/kit/doc-citations.test.mjs` → fix citations → `pnpm run check` (markdown lint) → commit: `git add docs/USAGE-SCORECARD-METRICS.md src/lib/pricing.mjs && git commit -m "docs(usage): matrix-a metric sections; correct stale 13.3 tier/geo claim"`
+
+---
+
+### Task 13: DASHBOARD.md, TRANSCRIPTS.md, ADR-0038
+
+**Files:**
+- Modify: `docs/DASHBOARD.md` (Usage section: new panels, chips, pace tick — current-state voice only, no history); `docs/TRANSCRIPTS.md` (§1.1/§1.2 parser-read tables gain the new fields; §1.3 capability matrix rows for latency/mode/ctx)
+- Create: `docs/adr/0038-consistent-cross-host-session-metrics.md` (status Accepted; records: the mode taxonomy judgment table and why unmapped → not-recorded; bucket-histogram percentiles over raw samples; response-latency semantics and the no-TTFT rule; `byInferenceProvider` provenance gate; schema v11; deferral of Claude tee history retention; links both research artifacts)
+- Modify: `docs/adr/README.md` (index line, following its existing format)
+
+- [ ] Steps: write all three → `pnpm run check` → commit: `git add docs/DASHBOARD.md docs/TRANSCRIPTS.md docs/adr/0038-consistent-cross-host-session-metrics.md docs/adr/README.md && git commit -m "docs: dashboard/transcripts updates + ADR-0038 matrix-a metrics"`
+
+---
+
+### Task 14 (Wave 5): Brutal-honesty QE review + remediation
+
+Run by the lead session, not a lane agent:
+
+- [ ] Invoke the `brutal-honesty-review` skill against `git diff main...feat/scorecard-matrix-a` with reviewers instructed to hunt: fabricated/guessed evidence anywhere `not-recorded` should appear; percentile arithmetic errors; double-counting (the codex cumulative-snapshot and subagent-replay traps); cache-key staleness (SCHEMA_VERSION); complexity-25 breaches; UI theme/a11y regressions (labels present, no color-alone identity, both themes).
+- [ ] In parallel, dispatch `qe-code-reviewer` and `qe-security-reviewer` agents over the same diff; if the AQE MCP is used, `fleet_init` first per machine rules; otherwise native agents suffice.
+- [ ] Optionally run `aqe quality-gate` for the two-gate verdict.
+- [ ] Triage findings into: fix-now (remediation commits, `fix:` subjects, same lanes/files rule) / rejected-with-reason (recorded in the PR body). Re-run the review only on remediated areas.
+
+### Task 15 (Wave 5): Gate, push, PR
+
+- [ ] `pnpm run check` — must be fully green.
+- [ ] Dashboard screenshots (light + dark) captured for the PR.
+- [ ] `git push -u origin feat/scorecard-matrix-a`
+- [ ] `gh pr create` — title `feat(usage): Matrix A consistent cross-host session metrics`; body: summary table of shipped metrics (name → where), the two docs corrections called out explicitly, ADR-0038 link, both artifact links, screenshots, QE review summary (findings found/fixed/rejected), and the standard generated-with footer.
+
+---
+
+## Execution Orchestration (swarm mapping)
+
+Per the machine's ruflo/superpowers house rules: superpowers choreographs (this plan + subagent-driven-development), agents execute, agentic-qe gates. The RuvNet Brain MCP was disconnected when this plan was written, so ruflo usage below follows the machine CLAUDE.md reference rather than freshly-grounded source; if `ruflo memory store` misbehaves, check the `CLAUDE_FLOW_DB_PATH` pin first (known machine issue).
+
+- **Dispatch:** one named agent per lane wave (`coder-parsers`, `coder-aggregate`, `coder-ui`, `coder-cli`, `coder-insights`, `doc-writer`), spawned in a single message with `run_in_background: true`, each prompt = the task text verbatim + Global Constraints + its lane's file-ownership rule. Reviewer gate between waves (subagent-driven-development's two-stage review).
+- **Collision law:** an agent may modify only its lane's files. Cross-lane needs (e.g. UI discovers a missing aggregate field) are messaged to the lead, who queues a follow-up commit in the owning lane — never edited cross-lane.
+- **State:** at each wave boundary the lead stores a checkpoint (`ruflo memory store -k scorecard-matrix-a/wave-N --value "<commits + open issues>" -n patterns`) so a compaction or crash never loses orchestration state.
+- **Worktree note:** lanes share one branch with disjoint files, so a single checkout is sufficient; if parallel agents contend on the working tree, fall back to `superpowers:using-git-worktrees` per lane and merge lane branches into `feat/scorecard-matrix-a` in wave order.

--- a/docs/superpowers/plans/2026-08-28-scorecard-matrix-a.md
+++ b/docs/superpowers/plans/2026-08-28-scorecard-matrix-a.md
@@ -8,7 +8,7 @@
 
 **Tech Stack:** Node ESM (`.mjs`), `node --test` (run via `pnpm test`), no new dependencies, hand-rolled dashboard client (no chart lib).
 
-**Spec:** The two research artifacts — Metric Evidence Matrix (https://claude.ai/code/artifact/1682c1ea-2bbd-4970-8cdd-2cc5e17efcdf) and Scorecard Additions mockup (https://claude.ai/code/artifact/36adf798-625a-4d44-a84b-1dba7093e752). Everything an executor needs is restated inline below; the artifacts are reference, not required reading.
+**Spec:** The two research artifacts — Metric Evidence Matrix (<https://claude.ai/code/artifact/1682c1ea-2bbd-4970-8cdd-2cc5e17efcdf>) and Scorecard Additions mockup (<https://claude.ai/code/artifact/36adf798-625a-4d44-a84b-1dba7093e752>). Everything an executor needs is restated inline below; the artifacts are reference, not required reading.
 
 ## Global Constraints
 
@@ -43,10 +43,12 @@ One file has exactly one lane; a lane's tasks run **serially in order**; differe
 ### Task 1: Mode taxonomy module (`usage-modes.mjs`)
 
 **Files:**
+
 - Create: `src/lib/usage-modes.mjs`
 - Test: `tests/kit/usage-modes.test.mjs`
 
 **Interfaces:**
+
 - Produces: `MODES = ['guarded','auto-edit','plan','unrestricted']`; `normalizeMode({ host, permissionMode, approvalPolicy, sandboxPolicy, opencodeMode }) → { mode: string|null, raw: string|null }`. `mode` is `null` whenever evidence is absent **or unrecognized** (never guessed); `raw` preserves the exact wire value(s) for the Sessions detail strip.
 
 The full mapping table (pinned by tests; recorded in ADR-0038):
@@ -148,6 +150,7 @@ export function normalizeMode({ host, permissionMode, approvalPolicy, sandboxPol
 ### Task 2: Session record v11 — shape, histogram helpers, schema bump
 
 **Files:**
+
 - Modify: `src/lib/usage-parsers.mjs` (blankSession ~line 180; add helpers near `noteSpan`)
 - Modify: `src/lib/usage-index.mjs:92` (`SCHEMA_VERSION` 10 → 11)
 - Test: `tests/kit/usage-index.test.mjs` (append)
@@ -218,10 +221,12 @@ In the record-finishing function (the one that derives `active` from `stamps`, `
 ### Task 3: parseClaude — mode, latency, context pressure
 
 **Files:**
+
 - Modify: `src/lib/usage-parsers.mjs` (`parseClaude`, ~lines 376–401 entry loop; assistant handling ~328–368)
 - Test: `tests/kit/usage-index.test.mjs`
 
 **Interfaces:**
+
 - Consumes: T1 `normalizeMode`, T2 helpers.
 - Produces: Claude sessions carry `mode`/`modeRaw` (last human-turn `permissionMode` seen wins), `latHist`/`latCount` (gap human-prompt → next assistant entry), `ctxLastTokens` (last assistant turn's `input + cacheRead`).
 
@@ -256,10 +261,12 @@ test('parseClaude derives latency, mode, ctx from entries', () => {
 ### Task 4: parseCodex — approval mode, host-measured timing, aborts/errors, ctx window, typed-item tools
 
 **Files:**
+
 - Modify: `src/lib/usage-parsers.mjs` (`parseCodex` ~578–681; `turn_context` handling ~431–437; `event_msg` dispatch)
 - Test: `tests/kit/usage-index-v6.test.mjs` (append — this file owns Codex-detail coverage)
 
 **Interfaces:**
+
 - Consumes: T1, T2.
 - Produces: Codex sessions carry `mode`/`modeRaw` (from `turn_context.approval_policy` + `sandbox_policy`, last wins), `latHist` (from `task_started.started_at` → first agent message, else `task_complete.duration_ms` as the whole-turn fallback sample), `aborts` (count of `turn_aborted`), `exceptions` += `task_complete` events whose `error` is non-null, `ctxWindow` (from `task_started.model_context_window`, last wins), and `rec.tools` counts from `item_completed` items, keyed by the item's own type name — `CommandExecution`, `McpToolCall`, `FileChange`, `CollabAgentToolCall`. Tool names are host vocabularies: never rename Codex activity to Claude tool names; the UI ranks names as-is.
 
@@ -299,10 +306,12 @@ test('parseCodex v11: mode, duration, aborts, ctx window, typed tools', () => {
 ### Task 4b: OpenCode — mode/agent, latency, error, ctx derivation input
 
 **Files:**
+
 - Modify: `src/lib/usage-opencode.mjs` (`processMessageRow` / `recordAssistantMessage`, lines ~194–213)
 - Test: `tests/kit/usage-opencode.test.mjs` (append, using its existing in-memory sqlite fixture helpers)
 
 **Interfaces:**
+
 - Consumes: T1, T2.
 - Produces: OpenCode sessions carry `mode`/`modeRaw` (from message `data.mode`, last wins), `latHist` (user message → next assistant message gap), `exceptions` (messages with a non-null `data.error`), `ctxLastTokens` (last assistant `tokens.input + tokens.cache.read`).
 
@@ -326,10 +335,12 @@ assert.equal(session.ctxLastTokens, 20900);
 ### Task 5: Index carry-through + 2× lookback for deltas
 
 **Files:**
+
 - Modify: `src/lib/usage-index.mjs` (`buildIndex` ~402; the cached-entry projection)
 - Test: `tests/kit/usage-index.test.mjs`
 
 **Interfaces:**
+
 - Produces: cached session entries round-trip the v11 fields (they ride the same record object — verify the cache projection does not strip unknown fields; if it whitelists, extend the whitelist). `buildIndex({ days, lookbackDays })`: when `lookbackDays` (default `days * 2`) is passed by the server, sessions are parsed back to the longer cutoff so a previous-window aggregate has data. Aggregation windows stay governed by `aggregate`'s own `cutoff`.
 
 - [ ] **Step 1: Failing test** — round-trip: build an index over a fixture root twice (second run hits cache) and assert `mode`/`latHist` survive the cached read; assert `buildIndex({ days: 7, lookbackDays: 14 })` includes a session 10 days old.
@@ -341,10 +352,12 @@ assert.equal(session.ctxLastTokens, 20900);
 ### Task 6: Aggregate — buckets, histograms, percentiles, per-day engaged, previous window
 
 **Files:**
+
 - Modify: `src/lib/usage-aggregate.mjs` (`aggregate` ~400, `buildSessionRows` ~304, totals block ~346)
 - Test: `tests/kit/usage-index.test.mjs` (aggregate suites live here)
 
 **Interfaces:**
+
 - Consumes: v11 session fields (T2–T5), `MODES` (T1).
 - Produces on the aggregate result:
 
@@ -402,10 +415,12 @@ test('previous window aggregates the prior equal span only', () => {
 ### Task 7: `/api/usage` payload
 
 **Files:**
+
 - Modify: `src/lib/dashboard-server.mjs` (the `/api/usage` route handler — locate `aggregate(` call)
 - Test: `tests/kit/dashboard-usage-telemetry.test.mjs` (append)
 
 **Interfaces:**
+
 - Produces: the JSON payload adds `previous`, `rhythm`, `byMode`, `byInferenceProvider`, and `byDay[*].engagedSeconds`, passing `previous: true` and `lookbackDays: days * 2` down. Nothing existing is renamed; `byProvider` (legacy host identity) is untouched.
 
 - [ ] **Step 1: Failing test** — extend the existing payload test to assert `payload.rhythm.latHist.length === 6`, `payload.byMode` has only keys from `[...MODES, 'not-recorded']`, and `payload.previous.totals` exists when two windows of fixture data are present.
@@ -417,6 +432,7 @@ test('previous window aggregates the prior equal span only', () => {
 ### Task 8: Client render module `usage-rhythm.mjs` + styles
 
 **Files:**
+
 - Create: `src/lib/dashboard/client/usage-rhythm.mjs`
 - Modify: `src/lib/dashboard/styles/usage.mjs` (append component CSS)
 - Test: `tests/kit/dashboard-usage-telemetry.test.mjs` (string-shape smoke tests — these modules are pure string builders)
@@ -443,11 +459,13 @@ Mark rules (from the mockup): bars 4px top radius; 2px gaps between stacked segm
 ### Task 9: Wire the panels — hero deltas, new rows/panels, session chips, limits pace tick
 
 **Files:**
+
 - Modify: `src/lib/dashboard/client/usage.mjs` (hero `kpi(...)` call sites; panel sequence noted at ~line 338), `src/lib/dashboard/client.mjs` (`renderLimits`/`limRow`), `src/lib/dashboard/client/bootstrap.mjs` only if the new module needs registration (follow how `usage-orchestrators.mjs` is included)
 
 **Interfaces:** Consumes T7 payload fields + T8 renderers, exactly as named above.
 
 Deliverables, all per the mockup (artifact 36adf798…):
+
 1. Hero tiles: append `deltaChip` (cost + cache: `downIsGood`/up-good pt; tokens: `neutral: true`) and `sparklineSvg` over `byDay` series (cost/day, sessions/day, tokens/day, engagedSeconds/day, cache-share/day). Cache tile subtitle renders `saved ≈ $N vs uncached` from `totals.cacheSavedUsd` (T6).
 2. Second KPI row: sessions/active-day + streak, autonomy (`responses/prompts`) + touch rate, cost/session median + P90, cost/engaged-hour — all from `totals`.
 3. Rhythm panel: two `histogram(...)` blocks with median/P90 and p50/p95 markers; the latency card's tooltip carries the measurement note ("codex host-measured · claude/opencode derived from event gaps — not streaming TTFT").
@@ -467,10 +485,12 @@ Deliverables, all per the mockup (artifact 36adf798…):
 ### Task 10: CLI — `ak usage score`
 
 **Files:**
+
 - Modify: `src/commands/usage.mjs` (add `score` subcommand; update `help` text — keep `status`/`refresh` untouched)
 - Test: `tests/kit/usage-cli.test.mjs` (append)
 
 **Interfaces:**
+
 - Consumes: `buildIndex` + `aggregate` (same modules the dashboard uses — no new computation in the command).
 - Produces: `ak usage score [--window 7|14|30] [--json]` printing: hero five (+deltas), cadence four, rhythm medians/percentiles, mode/provider tables with `not-recorded` rows, reliability rate. `--json` emits the aggregate projection verbatim (totals, rhythm, byMode, byInferenceProvider, previous) — additive, credential-free, offline.
 
@@ -483,10 +503,12 @@ Deliverables, all per the mockup (artifact 36adf798…):
 ### Task 11: Findings detectors
 
 **Files:**
+
 - Modify: `src/lib/usage-insights.mjs` (two detectors + registry entries at ~584)
 - Test: `tests/kit/usage-insights.test.mjs` (append)
 
 **Interfaces:**
+
 - Produces: `detectLatencyRegression({ sessions })` → id `latency-regression`, kind `trend`, severity `warn` when the second half-window's bucket-merged p50 exceeds the first half's by ≥25% **and** ≥2s absolute (both halves need ≥30 samples; otherwise no finding). `detectUnrestrictedMode({ sessions, windowCost })` → id `unrestricted-mode`, kind `coach`, severity `info` listing count + cost of sessions with `mode === 'unrestricted'` (zero sessions → no finding; `not-recorded` never counts).
 
 - [ ] **Step 1: Failing tests** — fixture sessions with latHists split across halves (30+ samples each; p50 8s → 12s ⇒ finding fires; 8s → 9s ⇒ no finding) and one `unrestricted` session ⇒ finding with `sessions: 1`.
@@ -498,10 +520,12 @@ Deliverables, all per the mockup (artifact 36adf798…):
 ### Task 12: Metrics doc — new sections + the stale-claim corrections
 
 **Files:**
+
 - Modify: `docs/USAGE-SCORECARD-METRICS.md`; `src/lib/pricing.mjs` (comment text only, `UNMODELLED_PRICING_FACTORS` block ~131–150)
 - Test: `tests/kit/doc-citations.test.mjs` (existing — must stay green; it machine-checks every `file:line` citation)
 
 Deliverables:
+
 1. New sections §15–§19 following the house entry shape (**Displayed as / Formula / Source / Worked example / What this does not model**) for: Rhythm & responsiveness (both histograms, the percentile-from-buckets method, the per-host measurement difference, the explicit "never labeled TTFT" rule); How you run (the full mode-mapping table from Task 1, `not-recorded` semantics, provider provenance gate); Cadence & unit economics (autonomy, touch rate, medians — and why median, with the heavy-tail worked example); Reliability (error-turn sources per host, aborts); Deltas & sparklines (previous-window definition, 2× lookback).
 2. **§13.3 correction**: run a one-off census (scratchpad script, not committed) counting non-null `service_tier` / `inference_geo` / `speed` values across the local corpus; replace the "a transcript does not record which endpoint/tier" rationale with the truth: *recorded per turn since ~CLI version X, observed on N% of turns in the verification corpus; deliberately still unpriced pending semantics verification* — and update the matching `pricing.mjs` comment wording. Pricing **behavior** does not change.
 3. **§8 clarification**: one paragraph distinguishing `byProvider` (legacy host identity, unchanged) from the new `byInferenceProvider` (observed-only, `not-recorded` first-class).
@@ -514,6 +538,7 @@ Deliverables:
 ### Task 13: DASHBOARD.md, TRANSCRIPTS.md, ADR-0038
 
 **Files:**
+
 - Modify: `docs/DASHBOARD.md` (Usage section: new panels, chips, pace tick — current-state voice only, no history); `docs/TRANSCRIPTS.md` (§1.1/§1.2 parser-read tables gain the new fields; §1.3 capability matrix rows for latency/mode/ctx)
 - Create: `docs/adr/0038-consistent-cross-host-session-metrics.md` (status Accepted; records: the mode taxonomy judgment table and why unmapped → not-recorded; bucket-histogram percentiles over raw samples; response-latency semantics and the no-TTFT rule; `byInferenceProvider` provenance gate; schema v11; deferral of Claude tee history retention; links both research artifacts)
 - Modify: `docs/adr/README.md` (index line, following its existing format)

--- a/docs/superpowers/specs/2026-08-29-prompts-view-design.md
+++ b/docs/superpowers/specs/2026-08-29-prompts-view-design.md
@@ -1,0 +1,143 @@
+# Prompts View — Design Spec
+
+Status: draft for maintainer review · 2026-08-29
+Companions: research findings + surfacing analysis (session scratchpad, re-runnable scripts), visual mockup <https://claude.ai/code/artifact/fd08cc85-85dc-4125-9078-622c9135d9bf>, Matrix A ADR (docs/adr/0038).
+
+## 1. Purpose
+
+A new **Usage → Prompts** secondary view (plus three Findings detectors and a CLI companion) that tells the operator what they actually ask across every host, which prompt patterns repeat wastefully, and what to change to gain efficiency — with **coaching that is recalculable, adaptive to the operator's own history, and accountable for its own outcomes**. Nothing in the view is a stored report; everything on the page can be regenerated from the corpus at any moment.
+
+## 2. Evidence contract
+
+### 2.1 Provenance filter (load-bearing)
+
+The 2026-08-29 research measured that **only 27.6% of parser-visible user-role turns were typed by the human** (1,524 of 5,527); the rest is agent-to-agent traffic, harness envelopes, and agentic-kit's own headless spawns. Every metric in this view therefore computes over provenance-filtered prompts only. Provenance classes: `human`, `human-control` (slash records, interrupts, bash-input, image-only), `agent-injected`, `ak-adapter`, `harness`. The classification rules ship in the docs and their residual risk is one-directional by design: an unrecognized machine template counts as human (over-statement, never under-statement).
+
+Prerequisite parser fixes (in flight on PR #186 at spec time): `parseCodex` first-`session_meta`-wins (155/318 subagent rollouts escaped the replay guard) and the codex harness/mirror envelope gate for prompt counting. The view must not build on pre-fix numbers.
+
+### 2.2 Fingerprints, not text (the F1 layer)
+
+On the existing scan path, each `kind === 'prompt'` turn contributes `{ sha256(normalizedText).slice(0,16), tokenCount, provenanceTag, sortedTokenHashes[8B each] }` persisted on the session record (≈220 KB for this machine's corpus). **Prompt text is never persisted in the index and never crosses a wire.** Exact repeats, near-duplicate clustering (token-set Jaccard over token hashes), tap detection, and length stats all compute from fingerprints alone.
+
+### 2.3 Privacy split
+
+- **Dashboard**: aggregates, counts, shares, trends, and pattern names drawn from a **fixed curated vocabulary** (e.g. "Release ritual", "Commit-and-push instruction") — never raw prompt text. Where an exemplar is genuinely needed, the row links to the existing masked `GET /api/session/:id` surface.
+- **CLI (`ak usage prompts`)**: the exemplar-bearing tables (top short prompts, re-ask pairs, cluster exemplars, role-scaffolding list). Opt-in deep pass (`withTurns` re-read, ~4 s on this corpus); output never leaves the terminal; nothing persisted.
+- The research reports themselves stay local for the same reason; they are not published artifacts.
+
+## 3. The view (per the mockup)
+
+Rail placement: `#usage/prompts`, between Findings and Sessions. Window selector applies (7/14/30d) with an **All history** option this view uniquely needs (patterns are lifetime phenomena); every figure carries the window it was computed over.
+
+### 3.1 KPI strip
+
+| KPI | Formula | Does not model |
+|---|---|---|
+| Typed prompts | count(provenance=human) and share of all user-role turns | intent quality; only authorship |
+| Questions : instructions | published rule split (interrogative / imperative / declarative-feedback) | rhetorical questions; the rules are printable |
+| Supervision taps | prompts ≤4 normalized tokens; share of typed; per-host deltas vs trailing baseline | the tap's necessity — some taps are legitimate approvals |
+| Repeated share | prompts inside clusters spanning ≥3 sessions or ≥2 days | whether repetition was deliberate |
+| Headless share | sessions and responses with zero human prompts | value of headless work (it is a reframe, not a criticism) |
+
+Tap cost, when stated, is always the labeled model: `taps × median ctxLastTokens`, order-of-magnitude, mostly cache-priced.
+
+### 3.2 Panels
+
+1. **How you steer** — prompt-type taxonomy (ranked bars; Unclassified first-class and dim). Lexicon fixed in v1, published in docs; user-editable lexicon explicitly rejected for now.
+2. **Host interplay** — monthly tap-share trend per host (the divergence is the headline: measured Claude 16.8→12.5% vs Codex 7.7→15.2%); p90 typed-prompt length per host with the role-scaffolding annotation. Unequal-window caveats render on the panel (Claude history spans 32 days on this machine).
+3. **Repeated patterns** — table: curated pattern name, type chip, n/sessions/days/hosts, suggested-move chip (`skill candidate` / `CLAUDE.md line` / `reporting gap` / `role library`), masked-session link. Clustering is deliberately loose (Jaccard ≈0.6) with the type filter doing precision — **phrasing variance is the signal**: eleven wordings of one request outrank eleven identical ones.
+4. **Coaching** — cards per §5.
+5. **Also in Findings** — the three detectors (§4) render in the Findings tab with the standard card grammar; this panel cross-links.
+
+### 3.3 CLI
+
+`ak usage prompts [--window 7|14|30|all] [--json] [--enrich]` — sections mirroring the panels plus the exemplar tables. `--enrich` runs the delta-inference pass (§6.3). `--json` emits the aggregate projection (fingerprint-derived only — no text).
+
+## 4. Findings detectors (adaptive thresholds)
+
+Three new detectors in the existing `DETECTORS` contract, all computable from fingerprints:
+
+| id | kind/sev | Fires when | Evidence line carries |
+|---|---|---|---|
+| `supervision-tap-share` | trend/warn | current-window tap share > operator's trailing-90d p75 for that host AND ≥20 taps | per-host split; the modelled-cost caveat verbatim |
+| `headless-share` | coach/info | headless response share > 25% (informational reframe; models on detectSubagentShare) | sessions + responses counts |
+| `host-prompt-asymmetry` | coach/info | p90 length ratio between hosts ≥1.5× OR persona-opening prompts ≥10 in window | the ratio; persona count; "no text on the wire" basis |
+
+**No fixed percentages where a baseline can exist**: thresholds compare against the operator's own rolling history (per host), persisted as small aggregates in the index and recomputed each scan. Every fired finding prints the baseline it compared against.
+
+## 5. Coaching cards
+
+Contract:
+
+- A card = finding (evidence + counts) → **Try** (one concrete change) → labeled cost/win basis → optional **Draft →** affordance.
+- **Draft-only, always**: Draft → produces a suggestion (CLAUDE.md line, skill skeleton, role-library entry) the operator edits and applies themselves. Nothing writes to CLAUDE.md, creates a skill, or changes config unprompted.
+- Every card carries `generated-at` + the **evidence hash** of the findings it derives from (§6.2).
+- Initial card set (from the measured baseline): Codex role library (sibling effort, see §8), `/release` skill, commit-and-push instruction, Codex completion-criteria prompting, re-ask delta coaching, unprompted progress reporting.
+
+## 6. Adaptive architecture (the non-static guarantee)
+
+Three layers with different refresh contracts, plus a feedback loop.
+
+### 6.1 Layer 1 — recalculable metrics (deterministic, every scan, free)
+
+All §3 numbers are pure functions of the current corpus, re-derived on the same incremental scan the scorecard uses. No stored reports. New sessions change every figure on the next scan by construction.
+
+### 6.2 Layer 2 — adaptive baselines (statistics, no inference)
+
+Per-host rolling baselines (trailing-window percentiles, EWMA trends) persisted as small aggregates and recomputed each scan. Detector thresholds and "unusual for you" comparisons key on these, so the definition of normal moves with the operator. Fully explainable; every threshold printable; no model calls.
+
+### 6.3 Layer 3 — learned artifacts (inference, delta-only, cached)
+
+Model calls are reserved for two jobs rules cannot do:
+
+1. **Labeling**: naming newly-born clusters and classifying the Unclassified residue — the `--enrich` precedent: cached per fingerprint/cluster id, so inference touches only artifacts created since the last pass. Settled labels are never re-judged.
+2. **Coaching synthesis**: generating/refreshing cards from current findings. Each card stores the evidence hash of its inputs; a rescan that reproduces the hash leaves the cached card standing (with its as-of stamp); a moved hash marks the card **stale — Recompute** rather than silently spending tokens.
+
+**Purity contract:** metrics are functions of the corpus; thresholds are functions of the operator's history; recommendations are functions of current findings plus a learned ranking. Everything is regenerable from scratch; the only persistent learning is the outcome ledger.
+
+### 6.4 The outcome ledger (self-improving loop)
+
+`measure → recommend → adopt/dismiss → measure outcome → recalibrate`, persisted in a kit-owned store beside the index (no prompt text; versioned):
+
+- Recommendation records: `{ id, evidenceHash, status: proposed|adopted|dismissed|expired, generatedAt, outcome }`.
+- **Adoption detection is deterministic first**: a matching skill now exists, a CLAUDE.md line matches the draft, the target cluster's recurrence collapsed.
+- **Outcome checks are measured**: "commit-and-push cluster: 24 → 2 since adoption; tap share on affected host −4 pts" — rendered on the card. Adopted-and-worked raises ranking of similar future recommendations; **dismissed is suppressed and decays (never re-nagged)**; adopted-but-didn't-help is **retired with the refutation shown**.
+- Substrate: kit-local store in v1; ruflo/agentdb pattern memory is a candidate for cross-session substrate to be grounded and evaluated at build time (not asserted here).
+
+### 6.5 Scheduling
+
+- **On-demand default**: layers 1–2 at scan time (free). Layer-3 via the view's Recompute affordance or `ak usage prompts --enrich`.
+- **Scheduled opt-in**: a periodic digest (e.g. weekly) running the delta-inference pass through existing governed machinery (daemon AI workers under the launch budget, or a scheduled routine). Always budget-capped, stamped "scheduled pass · $basis", never default-on. Unattended token spend stays opt-in on this machine by standing policy.
+- Staleness is always visible: evidence-hash drift renders an explicit stale marker (System deep-scan freshness precedent).
+
+## 7. Rejected / non-goals
+
+- **Real-time re-ask nudging** (reading the user's prompt against history mid-session): surveillance-shaped; rejected.
+- **Persisting normalized prompt text in the index** (F3): outside the masking contract; fingerprints + on-demand deep pass cover every need.
+- **Static thresholds** for anything a personal baseline can govern.
+- **Auto-applying any recommendation.**
+- **User-editable lexicon in v1**; the Unclassified share is the honest signal for lexicon work.
+- Exact/0.9-similarity boilerplate detection as a primary signal (measured: finds ≈471 tokens; the real signal is loose-cluster phrasing variance and host asymmetry).
+
+## 8. Sibling effort (out of this spec's scope)
+
+**Codex role library** — the single largest measured win (46 persona prompts, ≈76K tokens, one host) belongs to `ak host`/`ak run` (a managed prompt-fragment directory injected for Codex workers; the Codex analogue of `.claude/agents/`). This spec's coaching card links to it; its design is a separate spec.
+
+Cross-host mirror dedup (exact-twin prompts counted once) remains a recorded follow-up in ADR-0038's deferred list.
+
+## 9. Sequencing (build order)
+
+1. Parser fixes (prerequisite; on PR #186).
+2. F1 fingerprints + provenance tagging on the scan path (schema bump).
+3. Baselines (layer 2) + the three detectors.
+4. The Prompts view panels (dashboard) + `ak usage prompts` CLI.
+5. Coaching cards with evidence hashes + the outcome ledger (deterministic adoption detection first).
+6. Layer-3 enrichment (labeling + coaching synthesis, on-demand) and, last, the opt-in scheduled digest.
+
+## 10. Acceptance criteria (sketch)
+
+- Zero prompt text in any index file or HTTP payload (test-pinned, same tier as the live-snapshot field tests).
+- Every rendered figure reproducible by an exported script over the same corpus; every threshold printable with its baseline.
+- A rescan with unchanged corpus reproduces identical metrics AND identical evidence hashes (determinism pin).
+- Coaching cards regenerate only on hash change; dismissal persistence survives rescans and schema bumps.
+- Detector/aggregate additions carry their metrics-doc sections (formula + what-this-does-not-model) and pass doc-citations.

--- a/src/commands/usage.mjs
+++ b/src/commands/usage.mjs
@@ -1,5 +1,11 @@
-// Explicit provider-account analytics refresh + offline cache status.
+// Explicit provider-account analytics refresh + offline cache status, plus an
+// offline text scorecard (`score`) rendered from the SAME local-transcript
+// aggregate `ak dashboard`'s Usage tab reads — no cost/token/percentile
+// arithmetic is redone here; see the score section below for the boundary.
 import { heading, info, ok, warn, dim } from '../lib/output.mjs';
+import { readIndex } from '../lib/usage-index.mjs';
+import { LAT_BUCKET_EDGES, LEN_BUCKET_EDGES } from '../lib/usage-aggregate.mjs';
+import { MODES } from '../lib/usage-modes.mjs';
 import {
   openRouterActivityFile,
   readOpenRouterActivity,
@@ -9,31 +15,37 @@ import {
 export const options = {
   json: { type: 'boolean', default: false },
   'dry-run': { type: 'boolean', default: false },
+  window: { type: 'string', default: '14' },
 };
 
-export const help = `ak usage — provider account analytics cache
+export const help = `ak usage — provider account analytics cache + offline scorecard summary
 
-The local transcript scorecard remains automatic and offline in \`ak dashboard\`.
-This command manages separately fetched provider-account metadata. Provider
-analytics are never merged into transcript-derived sessions, host totals,
-projects, or task attribution.
+The local transcript scorecard remains automatic and offline in \`ak dashboard\`;
+\`ak usage score\` prints an offline text summary of that same local evidence —
+no network, no credentials. This command otherwise manages separately fetched
+provider-account metadata. Provider analytics are never merged into
+transcript-derived sessions, host totals, projects, or task attribution.
 
 Usage:
   ak usage status
   ak usage refresh openrouter
+  ak usage score [--window 7|14|30] [--json]
 
 Environment:
   OPENROUTER_MANAGEMENT_KEY   required only for refresh; an inference key is
                               intentionally not accepted
 
 Options:
-  --json      emit machine-readable cache status/result
+  --json      emit machine-readable output (cache status/result, or the score projection)
   --dry-run   describe an OpenRouter refresh without network or writes
+  --window N  score only: 7, 14, or 30 days (default 14)
 
 Examples:
-  ak usage status                  inspect the offline cache; no network
-  ak usage refresh openrouter      explicitly fetch the last 30 completed UTC days
-  ak usage status --json           print the normalized credential-free cache`;
+  ak usage status                    inspect the offline cache; no network
+  ak usage refresh openrouter        explicitly fetch the last 30 completed UTC days
+  ak usage status --json             print the normalized credential-free cache
+  ak usage score                     offline scorecard summary, last 14 days
+  ak usage score --window 30 --json  machine-readable scorecard projection`;
 
 function summary(value) {
   if (!value) return null;
@@ -48,10 +60,266 @@ function summary(value) {
   };
 }
 
+// ── score: offline text scorecard over the dashboard's own aggregate ───────
+// `readIndex`/`buildIndex` (usage-index.mjs) already compute everything the
+// dashboard's Usage tab renders; this section is RENDERING ONLY. The one
+// exception is a handful of display-ready ratios the aggregate does not ship
+// as fields (active-day counts, cache-read share) — the browser client
+// derives those the same way, client-side, from the identical payload (see
+// src/lib/dashboard/client/usage.mjs's renderScoreHero/cadenceCells). The
+// formatters below restate that file's fmtUsd/fmtSecs/fmtAtLeast family in
+// Node because that file is a browser bundle read as TEXT into a served page
+// (never node-imported — see its own header comment) and so cannot be
+// imported here.
+
+const SCORE_WINDOWS = [7, 14, 30];
+const LAT_OVERFLOW = LAT_BUCKET_EDGES[LAT_BUCKET_EDGES.length - 1];
+const LEN_OVERFLOW = LEN_BUCKET_EDGES[LEN_BUCKET_EDGES.length - 1];
+const ZERO_BUCKET = { sessions: 0, cost: 0 };
+
+function parseScoreWindow(raw) {
+  const n = Number(raw);
+  return SCORE_WINDOWS.includes(n) ? n : null;
+}
+
+function fmtUsd(n) {
+  const v = Number(n) || 0;
+  if (v >= 1000) return `$${Math.round(v).toLocaleString()}`;
+  if (v >= 10) return `$${v.toFixed(0)}`;
+  return `$${v.toFixed(2)}`;
+}
+
+// A positive figure that rounds away at two decimals is not $0.00 — folding
+// it in there reads as "this cost nothing", a different and false claim from
+// "this cost less than a cent". A true zero is left alone: it is not less
+// than a cent, it is nothing.
+function fmtUsdMin(n) {
+  const v = Number(n) || 0;
+  const txt = fmtUsd(v);
+  return v > 0 && txt === '$0.00' ? '<$0.01' : txt;
+}
+
+function fmtNum(n) { return (Number(n) || 0).toLocaleString(); }
+
+function fmtTok(n) {
+  const v = Number(n) || 0;
+  if (v >= 1e9) return `${(v / 1e9).toFixed(1)}B`;
+  if (v >= 1e6) return `${(v / 1e6).toFixed(1)}M`;
+  if (v >= 1e3) return `${(v / 1e3).toFixed(1)}K`;
+  return String(Math.round(v));
+}
+
+function fmtHours(sec) {
+  const h = (Number(sec) || 0) / 3600;
+  return `${h >= 10 ? Math.round(h) : h.toFixed(1)}h`;
+}
+
+function fmtMins(m) {
+  const v = Number(m) || 0;
+  return v >= 60 ? `${Math.round(v / 60)}h` : `${Math.round(v)}m`;
+}
+
+function fmtRatio(n) {
+  if (n == null || !Number.isFinite(n)) return '—';
+  return Math.abs(n) >= 10 ? String(Math.round(n)) : n.toFixed(1);
+}
+
+// <=60, not <60: the latency histogram's overflow bucket floor IS 60s, and
+// that value has to read "60s" — the edge the reader can see — rather than
+// rolling up to "1m" and renaming the boundary.
+function fmtSecs(sec) {
+  const s = Number(sec) || 0;
+  if (s <= 60) return `${s < 10 ? Math.round(s * 10) / 10 : Math.round(s)}s`;
+  if (s < 5400) return `${Math.round(s / 60)}m`;
+  const h = Math.round(s / 360) / 10;
+  return `${h % 1 === 0 ? String(h) : h.toFixed(1)}h`;
+}
+
+// A value from a histogram's overflow bucket has no upper edge to
+// interpolate towards, so the percentile that landed in it reports that
+// bucket's FLOOR — prefixed "≥" so it reads "at least this". Null is
+// rendered 'no samples', never a bare dash: this is a text report, and
+// "nothing was measured" is a different, more honest claim than a blank.
+function fmtAtLeast(v, lastEdge) {
+  if (v == null || !Number.isFinite(v)) return 'no samples';
+  return `${v >= lastEdge ? '≥' : ''}${fmtSecs(v)}`;
+}
+
+// Signed change vs the previous equal-length window; '' when there is none to
+// compare against (prev null/0 — an unmeasurable baseline claims nothing). A
+// magnitude that rounds away is reported flat rather than claiming a
+// direction the printed number does not support.
+function fmtDelta(curr, prev, { unit = '%' } = {}) {
+  if (prev == null || prev === 0) return '';
+  const c = Number(curr) || 0;
+  const p = Number(prev) || 0;
+  const delta = c - p;
+  const mag = unit === 'pp'
+    ? Math.round(Math.abs(delta) * 10) / 10
+    : Math.round(Math.abs((delta / p) * 100));
+  if (mag === 0) return '  •flat vs prev';
+  const arrow = delta > 0 ? '▲' : '▼';
+  return `  ${arrow}${mag}${unit === 'pp' ? ' pp' : '%'} vs prev`;
+}
+
+function printScoreHero(agg, windowDays) {
+  const t = agg.totals ?? {};
+  const p = agg.previous?.totals ?? null;
+  heading(`ak usage — scorecard (last ${windowDays}d)`);
+  info(`SESSIONS               ${fmtNum(t.sessions)}  `
+    + `${dim(`${fmtNum(t.responses)} assistant turns`)}${fmtDelta(t.sessions, p?.sessions)}`);
+  info(`API-EQUIVALENT         ${fmtUsd(t.cost)}  `
+    + `${dim('list price · not plan billing')}${fmtDelta(t.cost, p?.cost)}`);
+  info(`TOKENS                 ${fmtTok(t.tokens)}  `
+    + `${dim(`${fmtTok(t.output)} out · ${fmtTok(t.cacheRead)} cached`)}${fmtDelta(t.tokens, p?.tokens)}`);
+  info(`ENGAGED TIME           ${fmtHours(t.engagedSeconds)}  `
+    + `${dim(`${fmtMins(t.spanMinutes)} summed · sessions overlap`)}${fmtDelta(t.engagedSeconds, p?.engagedSeconds)}`);
+  const tokens = Number(t.tokens) || 0;
+  const cacheShare = tokens ? (Number(t.cacheRead) / tokens) * 100 : 0;
+  const prevTokens = Number(p?.tokens) || 0;
+  const prevCacheShare = p && prevTokens ? (Number(p.cacheRead) / prevTokens) * 100 : null;
+  const saved = Number(t.cacheSavedUsd) || 0;
+  const savedNote = saved > 0 ? ` · saved ≈ ${fmtUsd(saved)} vs uncached` : '';
+  info(`CACHE READ             ${cacheShare.toFixed(1)}%  `
+    + `${dim(`priced at 0.1× input${savedNote}`)}${fmtDelta(cacheShare, prevCacheShare, { unit: 'pp' })}`);
+}
+
+function printScoreCadence(agg) {
+  const t = agg.totals ?? {};
+  const active = Object.keys(agg.byDay ?? {}).length;
+  heading('cadence');
+  const perDay = active ? (Number(t.sessions) || 0) / active : null;
+  info(`SESSIONS / ACTIVE DAY   ${perDay == null ? '—' : fmtRatio(perDay)}  `
+    + dim(`${fmtNum(active)} active day${active === 1 ? '' : 's'}`));
+  const auto = t.responsesPerPrompt ?? null;
+  const touch = t.humanPromptsPerHour ?? null;
+  const autoNote = auto == null ? 'no prompts you typed in window'
+    : (touch == null ? 'touch rate not recorded' : `${fmtRatio(touch)} prompts / engaged hour`);
+  info(`AUTONOMY                ${auto == null ? '—' : `${fmtRatio(auto)}×`}  ${dim(autoNote)}`);
+  const med = t.costPerSessionMedian ?? null;
+  const p90 = t.costPerSessionP90 ?? null;
+  const costNote = med == null ? 'no priced sessions in window' : `median · P90 ${p90 == null ? '—' : fmtUsdMin(p90)}`;
+  info(`COST / SESSION          ${med == null ? '—' : fmtUsdMin(med)}  ${dim(costNote)}`);
+  const perHour = t.costPerEngagedHour ?? null;
+  info(`COST / ENGAGED HOUR     ${perHour == null ? '—' : fmtUsd(perHour)}  `
+    + dim(perHour == null ? 'no engaged time measured' : 'engaged time, not wall clock'));
+}
+
+function printScoreRhythm(agg) {
+  const r = agg.rhythm ?? {};
+  heading('your rhythm — session length · response latency');
+  info(`SESSION LENGTH          median ${fmtAtLeast(r.lenMedianSeconds, LEN_OVERFLOW)}  `
+    + dim(`P90 ${fmtAtLeast(r.lenP90Seconds, LEN_OVERFLOW)}`));
+  info(`RESPONSE LATENCY        p50 ${fmtAtLeast(r.latP50, LAT_OVERFLOW)}  `
+    + dim(`p95 ${fmtAtLeast(r.latP95, LAT_OVERFLOW)} · n ${fmtNum(r.latCount)}`));
+}
+
+/** Shared renderer for the mode/served-by tables: `keys` decides the row set
+ *  and order, defaulting an absent bucket to zero — so a table always shows
+ *  every row the caller asks for (including 'not-recorded'), never only the
+ *  rows that happened to have data. */
+function printBucketTable(title, map, keys) {
+  heading(title);
+  for (const key of keys) {
+    const b = map[key] ?? ZERO_BUCKET;
+    const n = Number(b.sessions) || 0;
+    info(`${key.padEnd(16)} ${fmtNum(n)} session${n === 1 ? '' : 's'}  ${dim(fmtUsd(b.cost))}`);
+  }
+}
+
+function printScoreModeTable(agg) {
+  printBucketTable('mode — permission posture', agg.byMode ?? {}, [...MODES, 'not-recorded']);
+}
+
+function printScoreProviderTable(agg) {
+  const byProv = agg.byInferenceProvider ?? {};
+  const keys = new Set(Object.keys(byProv));
+  keys.add('not-recorded');
+  const ordered = [...keys].sort((a, b) => (Number(byProv[b]?.cost) || 0) - (Number(byProv[a]?.cost) || 0));
+  printBucketTable('served by — inference provider', byProv, ordered);
+}
+
+function printScoreReliability(agg) {
+  heading('reliability — turns that never landed');
+  const t = agg.totals ?? {};
+  const responses = Number(t.responses) || 0;
+  const exceptions = Number(t.exceptions) || 0;
+  const aborts = Number(t.aborts) || 0;
+  const rate = responses ? (exceptions / responses) * 1000 : null;
+  const line = `EXCEPTIONS / 1K RESPONSES   ${rate == null ? 'no samples' : rate.toFixed(1)}  `
+    + dim(`${fmtNum(exceptions)} of ${fmtNum(responses)} responses`);
+  if (rate == null) info(line);
+  else if (exceptions > 0) warn(line);
+  else ok(line);
+  info(`ABORTED TURNS               ${fmtNum(aborts)}  `
+    + dim('interrupted mid-flight — counted apart from exceptions'));
+}
+
+/** The --json shape: an ADDITIVE, credential-free, offline projection of the
+ *  same aggregate the text report renders from — verbatim fields, no
+ *  reshaping, so a consumer diffing this against the dashboard's /api/usage
+ *  payload sees the identical totals/rhythm/byMode/byInferenceProvider. */
+function scoreProjection(agg, windowDays) {
+  return {
+    window: windowDays,
+    totals: agg.totals,
+    rhythm: agg.rhythm,
+    byMode: agg.byMode,
+    byInferenceProvider: agg.byInferenceProvider,
+    bySource: agg.bySource,
+    previous: agg.previous,
+  };
+}
+
+async function runScore({ flags, deps }) {
+  const windowDays = parseScoreWindow(flags.window);
+  if (windowDays == null) {
+    warn(`ak usage score: --window must be 7, 14, or 30 (got ${JSON.stringify(flags.window)})`);
+    return 2;
+  }
+  const readAgg = deps.readIndex ?? readIndex;
+  let agg;
+  try {
+    // Mirrors dashboard-server.mjs's handleUsage route exactly: lookbackDays
+    // widens what usage-index.mjs reads off disk so records from the window
+    // BEFORE this one survive to be aggregated, and previous:true is what
+    // turns those into agg.previous — this window's own totals/sessions stay
+    // exactly `windowDays` wide either way.
+    agg = await readAgg({ days: windowDays, lookbackDays: windowDays * 2, previous: true });
+  } catch (error) {
+    const message = String(error?.message ?? error);
+    if (flags.json) console.log(JSON.stringify({ window: windowDays, error: message }, null, 2));
+    else warn(message);
+    return 1;
+  }
+  if (flags.json) {
+    console.log(JSON.stringify(scoreProjection(agg, windowDays), null, 2));
+    return 0;
+  }
+  printScoreHero(agg, windowDays);
+  printScoreCadence(agg);
+  printScoreRhythm(agg);
+  printScoreModeTable(agg);
+  printScoreProviderTable(agg);
+  printScoreReliability(agg);
+  return 0;
+}
+
+// Exported ONLY for a direct-import unit test of the <$0.01 boundary
+// (true-zero vs a real sub-cent positive) — see tests/kit/usage-cli.test.mjs.
+// Constructing a SECOND fixture transcript whose priced total is exactly
+// zero is disproportionate: a session prices to exactly $0 only by carrying
+// no usage rows at all, which the aggregate's own cost distribution already
+// excludes (see usage-aggregate.mjs's `_priced`), so there is no fixture
+// shape that reaches the true-zero branch. Not part of this command's CLI
+// contract.
+export const __test = { fmtUsdMin };
+
 /**
  * @param {{ flags: Record<string, any>, positionals: string[],
  *           deps?: { cacheFile?: string, read?: typeof readOpenRouterActivity,
- *                    refresh?: typeof refreshOpenRouterActivity } }} input
+ *                    refresh?: typeof refreshOpenRouterActivity,
+ *                    readIndex?: typeof readIndex } }} input
  */
 export async function run({ flags, positionals, deps = {} }) {
   const action = positionals[0] ?? 'status';
@@ -78,6 +346,10 @@ export async function run({ flags, positionals, deps = {} }) {
       + `${value.byModel.length} model(s) · ${value.byProvider.length} upstream provider(s)`);
     info(dim('account-level only · never merged into local session or host totals'));
     return 0;
+  }
+
+  if (action === 'score') {
+    return runScore({ flags, deps });
   }
 
   if (action === 'refresh' && provider === 'openrouter' && positionals.length === 2) {
@@ -121,6 +393,6 @@ export async function run({ flags, positionals, deps = {} }) {
     }
   }
 
-  warn('usage: ak usage status | ak usage refresh openrouter');
+  warn('usage: ak usage status | ak usage refresh openrouter | ak usage score');
   return 2;
 }

--- a/src/commands/usage.mjs
+++ b/src/commands/usage.mjs
@@ -189,8 +189,12 @@ function printScoreCadence(agg) {
   const active = Object.keys(agg.byDay ?? {}).length;
   heading('cadence');
   const perDay = active ? (Number(t.sessions) || 0) / active : null;
+  // byDay's presence contract is BILLED days, which is why the aggregate keeps
+  // a separate engagedByDay map — the two sets genuinely differ. The browser
+  // judged that surprising enough for a three-line tooltip; a terminal reader
+  // has nothing to hover, so it goes inline.
   info(`SESSIONS / ACTIVE DAY   ${perDay == null ? '—' : fmtRatio(perDay)}  `
-    + dim(`${fmtNum(active)} active day${active === 1 ? '' : 's'}`));
+    + dim(`${fmtNum(active)} day${active === 1 ? '' : 's'} that billed tokens · includes subagent sessions`));
   const auto = t.responsesPerPrompt ?? null;
   const touch = t.humanPromptsPerHour ?? null;
   const autoNote = auto == null ? 'no prompts you typed in window'

--- a/src/commands/usage.mjs
+++ b/src/commands/usage.mjs
@@ -187,7 +187,7 @@ function printScoreHero(agg, windowDays) {
 function printScoreCadence(agg) {
   const t = agg.totals ?? {};
   const active = Object.keys(agg.byDay ?? {}).length;
-  heading('cadence');
+  heading('Cadence');
   const perDay = active ? (Number(t.sessions) || 0) / active : null;
   // byDay's presence contract is BILLED days, which is why the aggregate keeps
   // a separate engagedByDay map — the two sets genuinely differ. The browser
@@ -211,15 +211,15 @@ function printScoreCadence(agg) {
 
 function printScoreRhythm(agg) {
   const r = agg.rhythm ?? {};
-  heading('your rhythm — session length · response latency');
+  heading('Your rhythm — session length · response latency');
   info(`SESSION LENGTH          median ${fmtAtLeast(r.lenMedianSeconds, LEN_OVERFLOW)}  `
     + dim(`P90 ${fmtAtLeast(r.lenP90Seconds, LEN_OVERFLOW)}`));
   info(`RESPONSE LATENCY        p50 ${fmtAtLeast(r.latP50, LAT_OVERFLOW)}  `
     + dim(`p95 ${fmtAtLeast(r.latP95, LAT_OVERFLOW)} · n ${fmtNum(r.latCount)}`));
 }
 
-/** Shared renderer for the mode/served-by tables: `keys` decides the row set
- *  and order, defaulting an absent bucket to zero — so a table always shows
+/** Shared renderer for the posture table: `keys` decides the row set and
+ *  order, defaulting an absent bucket to zero — so a table always shows
  *  every row the caller asks for (including 'not-recorded'), never only the
  *  rows that happened to have data. */
 function printBucketTable(title, map, keys) {
@@ -232,11 +232,11 @@ function printBucketTable(title, map, keys) {
 }
 
 function printScoreModeTable(agg) {
-  printBucketTable('mode — permission posture', agg.byMode ?? {}, [...MODES, 'not-recorded']);
+  printBucketTable('Mode — permission posture', agg.byMode ?? {}, [...MODES, 'not-recorded']);
 }
 
 function printScoreReliability(agg) {
-  heading('reliability — turns that never landed');
+  heading('Reliability — turns that never landed');
   const t = agg.totals ?? {};
   const responses = Number(t.responses) || 0;
   const exceptions = Number(t.exceptions) || 0;

--- a/src/commands/usage.mjs
+++ b/src/commands/usage.mjs
@@ -235,14 +235,6 @@ function printScoreModeTable(agg) {
   printBucketTable('mode — permission posture', agg.byMode ?? {}, [...MODES, 'not-recorded']);
 }
 
-function printScoreProviderTable(agg) {
-  const byProv = agg.byInferenceProvider ?? {};
-  const keys = new Set(Object.keys(byProv));
-  keys.add('not-recorded');
-  const ordered = [...keys].sort((a, b) => (Number(byProv[b]?.cost) || 0) - (Number(byProv[a]?.cost) || 0));
-  printBucketTable('served by — inference provider', byProv, ordered);
-}
-
 function printScoreReliability(agg) {
   heading('reliability — turns that never landed');
   const t = agg.totals ?? {};
@@ -274,14 +266,13 @@ function printScoreReliability(agg) {
 /** The --json shape: an ADDITIVE, credential-free, offline projection of the
  *  same aggregate the text report renders from — verbatim fields, no
  *  reshaping, so a consumer diffing this against the dashboard's /api/usage
- *  payload sees the identical totals/rhythm/byMode/byInferenceProvider. */
+ *  payload sees the identical totals/rhythm/byMode/bySource. */
 function scoreProjection(agg, windowDays) {
   return {
     window: windowDays,
     totals: agg.totals,
     rhythm: agg.rhythm,
     byMode: agg.byMode,
-    byInferenceProvider: agg.byInferenceProvider,
     bySource: agg.bySource,
     previous: agg.previous,
   };
@@ -316,7 +307,6 @@ async function runScore({ flags, deps }) {
   printScoreCadence(agg);
   printScoreRhythm(agg);
   printScoreModeTable(agg);
-  printScoreProviderTable(agg);
   printScoreReliability(agg);
   return 0;
 }

--- a/src/commands/usage.mjs
+++ b/src/commands/usage.mjs
@@ -251,8 +251,20 @@ function printScoreReliability(agg) {
   if (rate == null) info(line);
   else if (exceptions > 0) warn(line);
   else ok(line);
-  info(`ABORTED TURNS               ${fmtNum(aborts)}  `
-    + dim('interrupted mid-flight — counted apart from exceptions'));
+  // Codex-only evidence: turn_aborted is the only interrupt signal any host
+  // writes, so a window with no codex sessions has nothing that COULD have
+  // recorded one. Rendering 0 there would read as "you never interrupted a
+  // turn" — the browser carries the same rule, and a terminal reader has no
+  // tooltip to correct it with.
+  const codex = agg.byHost?.codex ?? null;
+  const codexSessions = Number(codex?.sessions) || 0;
+  const codexResponses = Number(codex?.responses) || 0;
+  const abortNote = codexSessions
+    ? (codexResponses
+      ? `interrupted mid-flight — codex only, ${fmtRatio((aborts / codexResponses) * 1000)} per 1k codex responses`
+      : 'interrupted mid-flight — codex only; no codex responses in window')
+    : 'not recorded — only codex transcripts carry an interrupt signal, and this window has none';
+  info(`ABORTED TURNS               ${codexSessions ? fmtNum(aborts) : '—'}  ${dim(abortNote)}`);
 }
 
 /** The --json shape: an ADDITIVE, credential-free, offline projection of the

--- a/src/lib/dashboard-server.mjs
+++ b/src/lib/dashboard-server.mjs
@@ -545,6 +545,18 @@ function clampInt(raw, fallback, min, max) {
   return Math.min(max, Math.max(min, n));
 }
 
+/** A 500 that discloses nothing about the filesystem. Node's fs errors embed
+ *  the absolute path ("EACCES: permission denied, open
+ *  '/Users/<user>/.claude/projects/<project-slug>/<uuid>.jsonl'"), and project
+ *  slugs are derived from real working directories — so reflecting the raw
+ *  message hands a client the username, the directory layout, and the names of
+ *  projects worked on. The operator still gets the whole error on stderr, where
+ *  it belongs. */
+function serverFault(res, where, e, message) {
+  console.error(`[dashboard] ${where} failed:`, e);
+  sendJson(res, 500, { error: message });
+}
+
 // Observability History's window control — day-count approximations (a
 // calendar "month" is treated as 30 days, matching clampDays' own plain-day
 // semantics rather than adding calendar-aware month math for a browse filter).
@@ -1377,7 +1389,7 @@ export function startDashboard({
           })),
         });
       } catch (e) {
-        sendJson(res, 500, { error: String(e && e.message || e) });
+        serverFault(res, '/api/usage', e, 'usage index unavailable');
       }
       return;
     }
@@ -1393,7 +1405,7 @@ export function startDashboard({
         const { detectLimitInsights } = await import('./usage-insights.mjs');
         sendJson(res, 200, { ...payload, insights: detectLimitInsights(payload, agg) ?? [] });
       } catch (e) {
-        sendJson(res, 500, { error: String(e && e.message || e) });
+        serverFault(res, '/api/limits', e, 'plan limits unavailable');
       }
       return;
     }
@@ -1459,7 +1471,7 @@ export function startDashboard({
         ));
         sendJson(res, 200, { sessions: all.slice(offset, offset + limit), total: all.length, offset, limit });
       } catch (e) {
-        sendJson(res, 500, { error: String(e && e.message || e) });
+        serverFault(res, '/api/sessions', e, 'usage index unavailable');
       }
       return;
     }
@@ -1503,7 +1515,7 @@ export function startDashboard({
         });
       } catch (e) {
         // Includes the fail-closed path: no masker → no transcript, ever.
-        sendJson(res, 500, { error: String(e && e.message || e) });
+        serverFault(res, '/api/session/:id', e, 'session transcript unavailable');
       }
       return;
     }

--- a/src/lib/dashboard-server.mjs
+++ b/src/lib/dashboard-server.mjs
@@ -77,9 +77,14 @@ import {
   maskTurns,
   parseSessionId,
   resolvesInsideRoot,
+  parseNamespacedSessionId,
+  resolvesNamespacedInsideRoot,
 } from './dashboard/session-security.mjs';
 
-export { maskMeta, maskTurns, parseSessionId, resolvesInsideRoot };
+export {
+  maskMeta, maskTurns, parseSessionId, resolvesInsideRoot,
+  parseNamespacedSessionId, resolvesNamespacedInsideRoot,
+};
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const PKG_ROOT = path.resolve(HERE, '..', '..');
@@ -1461,15 +1466,26 @@ export function startDashboard({
 
     async function handleSession(req, res, query, match) {
       // Validate BEFORE touching the index — a rejected id must never reach a
-      // filesystem call, so the 400 happens here and nowhere deeper.
+      // filesystem call, so the 400 happens here and nowhere deeper. Two
+      // shapes are accepted: a plain id (unchanged — parseSessionId/
+      // resolvesInsideRoot, exactly as before), or a namespaced
+      // `<parentId>/<stem>` Claude subagent id (Task 5 round 2), gated by
+      // its own dedicated parse+containment pair rather than loosening
+      // parseSessionId/resolvesInsideRoot — those two also gate the
+      // live-playback/SSE routes, which this fix does not touch.
       const id = parseSessionId(match[1]);
-      if (!id || !TRANSCRIPT_ROOTS.some((r) => resolvesInsideRoot(r, id))) {
+      const plainOk = !!id && TRANSCRIPT_ROOTS.some((r) => resolvesInsideRoot(r, id));
+      const nested = plainOk ? null : parseNamespacedSessionId(match[1]);
+      const nestedOk = !!nested
+        && TRANSCRIPT_ROOTS.some((r) => resolvesNamespacedInsideRoot(r, nested.parentId, nested.stem));
+      if (!plainOk && !nestedOk) {
         sendJson(res, 400, { error: 'invalid session id' });
         return;
       }
+      const effectiveId = plainOk ? id : `${nested.parentId}/${nested.stem}`;
       try {
         const maskFn = typeof usageApi.masker === 'function' ? await usageApi.masker() : usageApi.maskSecrets;
-        const found = await usageApi.readSession(id);
+        const found = await usageApi.readSession(effectiveId);
         // A well-formed id that matches no file is 404, not 200-with-a-null-body.
         // Returning 200 here made every nonexistent session look like an empty
         // one, and turned the route into a mild existence oracle.

--- a/src/lib/dashboard-server.mjs
+++ b/src/lib/dashboard-server.mjs
@@ -1345,8 +1345,15 @@ export function startDashboard({
     // all" control still knows the true count and calls /api/sessions for the rest.
     async function handleUsage(req, res, query) {
       try {
+        const days = clampDays(query.get('days'));
         const [agg, providerAnalytics] = await Promise.all([
-          usageApi.readIndex({ days: clampDays(query.get('days')) }),
+          // lookbackDays widens what usage-index.mjs reads off disk so records
+          // from the window BEFORE this one survive to be aggregated;
+          // previous:true is what actually turns those into agg.previous
+          // (totals + rhythm) — this window's own totals/sessions stay
+          // exactly `days` wide either way (usage-index.mjs's own display-
+          // cutoff guarantee).
+          usageApi.readIndex({ days, lookbackDays: days * 2, previous: true }),
           typeof usageApi.readProviderAnalytics === 'function'
             ? Promise.resolve(usageApi.readProviderAnalytics())
               .catch(() => ({ openrouter: null }))

--- a/src/lib/dashboard/client.mjs
+++ b/src/lib/dashboard/client.mjs
@@ -89,6 +89,22 @@ aboutSrc = inject(aboutSrc, 'var ABOUT = []; // PLACEHOLDER:ABOUT_JS', `var ABOU
 
 const intelligenceSrc = readSplit('intelligence.mjs');
 const pollSrc = readSplit('poll.mjs');
+// usage-rhythm.mjs declares its OWN `esc` on disk, and its comment says why:
+// the tests import it as real ESM, where bootstrap.mjs's `esc` is still the
+// build-time stub. In the concatenated bundle every file shares ONE scope, so
+// shipping that copy would declare `esc` twice — and a later function
+// declaration wins, silently replacing the injected groups.mjs escaper with a
+// hand copy free to drift from it. Strip it here for exactly the reason the
+// cross-file `import` lines are stripped: it exists for the on-disk view only.
+const RHYTHM_ESC = `function esc(s) {
+  return String(s == null ? '' : s).replace(/[&<>"']/g, function (c) {
+    return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c];
+  });
+}`;
+let usageRhythmSrc = readSplit('usage-rhythm.mjs');
+usageRhythmSrc = inject(usageRhythmSrc, RHYTHM_ESC,
+  '// esc: the bundle\'s single injected groups.mjs escaper (client.mjs strips\n'
+  + "// this file's on-disk copy — see RHYTHM_ESC there).");
 const usageSrc = readSplit('usage.mjs');
 const modelLifecycleSrc = readSplit('model-lifecycle.mjs');
 const usageOrchestratorsSrc = readSplit('usage-orchestrators.mjs');
@@ -103,5 +119,5 @@ const bootSrc = readSplit('boot.mjs');
 // sequence) running in the same relative order it always has.
 export const JS = `
 (function(){
-${bootstrapSrc}${overviewSrc}${intelligenceSrc}${pollSrc}${usageSrc}${modelLifecycleSrc}${usageOrchestratorsSrc}${aboutSrc}${systemReadoutSrc}${systemProjectsSrc}${bootSrc}})();
+${bootstrapSrc}${overviewSrc}${intelligenceSrc}${pollSrc}${usageRhythmSrc}${usageSrc}${modelLifecycleSrc}${usageOrchestratorsSrc}${aboutSrc}${systemReadoutSrc}${systemProjectsSrc}${bootSrc}})();
 `;

--- a/src/lib/dashboard/client/usage-rhythm.mjs
+++ b/src/lib/dashboard/client/usage-rhythm.mjs
@@ -38,12 +38,15 @@ export function deltaChip(curr, prev, opts) {
   var downIsGood = !!o.downIsGood, neutral = !!o.neutral, unit = o.unit || '';
   if (prev == null || prev === 0) return '';
   var c = Number(curr) || 0, p = Number(prev) || 0, delta = c - p;
-  var dir = delta > 0 ? 'up' : delta < 0 ? 'down' : 'flat';
+  var magTxt = unit ? fmtDeltaNumber(Math.abs(delta)) : String(Math.round(Math.abs(delta / p * 100)));
+  // A change that ROUNDS AWAY is not a direction this chip can claim. "▲0%"
+  // and "▲0 pp" both draw an arrow for a move the printed number says did not
+  // happen, which reads as a rendering bug at best and as a trend at worst —
+  // so a zero magnitude falls back to the flat mark whatever the raw sign was.
+  var dir = Number(magTxt) === 0 ? 'flat' : (delta > 0 ? 'up' : delta < 0 ? 'down' : 'flat');
   var arrow = dir === 'up' ? '▲' : dir === 'down' ? '▼' : '•';
   var tone = (neutral || dir === 'flat') ? 'flat' : (((dir === 'up') !== downIsGood) ? 'good' : 'bad');
-  var valueTxt = unit
-    ? fmtDeltaNumber(Math.abs(delta)) + esc(unit)
-    : Math.round(Math.abs(delta / p * 100)) + '%';
+  var valueTxt = unit ? magTxt + esc(unit) : magTxt + '%';
   return '<span class="dchip" data-tone="' + tone + '">'
     + '<i class="dchip-arrow" aria-hidden="true">' + arrow + '</i>'
     + '<b class="dchip-val tnum">' + valueTxt + '</b></span>';

--- a/src/lib/dashboard/client/usage-rhythm.mjs
+++ b/src/lib/dashboard/client/usage-rhythm.mjs
@@ -55,20 +55,36 @@ export function deltaChip(curr, prev, opts) {
 // '' when fewer than 2 finite points remain. No axes, no gridlines — a
 // de-emphasis-ink trend line with one accent dot at the most recent point,
 // meant to sit inline next to a KPI rather than stand alone as a chart.
+//
+// A non-finite entry is a GAP, not a dropped point: it keeps its slot on the
+// x axis and the line BREAKS across it, emitting one polyline per run of
+// consecutive finite points. Compacting it away instead would silently
+// squeeze the time axis — three missing days would render as one step — and
+// carrying a neighbour's value forward would state a figure for a day that
+// has none. A visible break says "no measurement here", which is the truth.
 export function sparklineSvg(series, opts) {
   var o = opts || {}, w = o.w || 130, h = o.h || 24;
-  var pts = (Array.isArray(series) ? series : []).filter(Number.isFinite);
+  var raw = Array.isArray(series) ? series : [];
+  var pts = raw.filter(Number.isFinite);
   if (pts.length < 2) return '';
   var pad = 2, innerW = w - pad * 2, innerH = h - pad * 2;
   var min = Math.min.apply(null, pts), max = Math.max.apply(null, pts), span = (max - min) || 1;
-  var coords = pts.map(function (v, i) {
-    return [pad + (i / (pts.length - 1)) * innerW, pad + innerH - ((v - min) / span) * innerH];
+  var span2 = raw.length > 1 ? raw.length - 1 : 1;
+  // One run per unbroken stretch of measured points; a lone point between two
+  // gaps has no segment to draw and is skipped by the length check below.
+  var runs = [], run = [], last = null;
+  raw.forEach(function (v, i) {
+    if (!Number.isFinite(v)) { if (run.length) runs.push(run); run = []; return; }
+    var p = [pad + (i / span2) * innerW, pad + innerH - ((v - min) / span) * innerH];
+    run.push(p); last = p;
   });
-  var last = coords[coords.length - 1];
-  var poly = coords.map(function (p) { return p[0].toFixed(1) + ',' + p[1].toFixed(1); }).join(' ');
+  if (run.length) runs.push(run);
+  var lines = runs.filter(function (r) { return r.length > 1; }).map(function (r) {
+    return '<polyline class="spark-line" fill="none" points="'
+      + esc(r.map(function (p) { return p[0].toFixed(1) + ',' + p[1].toFixed(1); }).join(' ')) + '"/>';
+  }).join('');
   return '<svg class="spark" viewBox="0 0 ' + w + ' ' + h + '" width="' + w + '" height="' + h
-    + '" focusable="false" aria-hidden="true">'
-    + '<polyline class="spark-line" fill="none" points="' + esc(poly) + '"/>'
+    + '" focusable="false" aria-hidden="true">' + lines
     + '<circle class="spark-dot" cx="' + last[0].toFixed(1) + '" cy="' + last[1].toFixed(1) + '" r="2.2"/>'
     + '</svg>';
 }

--- a/src/lib/dashboard/client/usage-rhythm.mjs
+++ b/src/lib/dashboard/client/usage-rhythm.mjs
@@ -73,9 +73,13 @@ export function sparklineSvg(series, opts) {
 // Bars are one sequential hue (accent) — a magnitude series, not a category
 // split, so there is nothing for a second color to distinguish. Markers are
 // emitted BEFORE the bars in DOM order and absolutely overlay the same box
-// (see .hist-markers/.hist-plot in styles/usage.mjs), so a bar always paints
-// over a marker line where they cross; the marker's own label sits above the
-// whole plot instead, so it is never itself covered by a tall bar.
+// (see .hist-markers/.hist-plot in styles/usage.mjs) — but DOM order alone
+// only decides paint order WITHIN one stacking layer. .hist-bars is also
+// given position:relative in that CSS, so it joins .hist-markers' positioned
+// layer instead of losing to it outright; only then does "markers first,
+// bars second" in the markup make the bars paint over the marker lines
+// where they cross. The marker's own label sits above the whole plot
+// instead, so it is never itself covered by a tall bar.
 export function histogram(opts) {
   var o = opts || {};
   var counts = Array.isArray(o.counts) ? o.counts : [];

--- a/src/lib/dashboard/client/usage-rhythm.mjs
+++ b/src/lib/dashboard/client/usage-rhythm.mjs
@@ -70,6 +70,58 @@ export function sparklineSvg(series, opts) {
     + '</svg>';
 }
 
+// The `q`th percentile of a bucketed distribution, in the buckets' own unit —
+// the SAME linear-interpolation rule usage-aggregate.mjs's
+// percentileFromBuckets applies server-side, restated here because this file
+// is read as text into a browser bundle that cannot import a node module. A
+// test pins the two implementations to identical output, so a divergence goes
+// red instead of quietly disagreeing with the server-computed number printed
+// beside it.
+//
+// Two honest edges, both inherited on purpose:
+//   - an empty histogram is null, never 0 — "nothing was measured" and
+//     "measured zero" are different claims;
+//   - the overflow bucket has no upper edge to interpolate towards, so it
+//     reports its FLOOR. Read that as "at least this", which is why every
+//     caller prefixes such a value with "≥" rather than printing it bare.
+export function bucketPercentile(counts, edges, q) {
+  if (!Array.isArray(counts) || !Array.isArray(edges)) return null;
+  var total = counts.reduce(function (a, n) { return a + (Number(n) || 0); }, 0);
+  if (total <= 0) return null;
+  // 2dp, the same rounding the server applies before putting its own
+  // percentiles on the wire — so the two implementations are comparable by
+  // strict equality rather than by an epsilon a test would have to choose.
+  var r2 = function (v) { return Math.round(v * 100) / 100; };
+  var target = total * q, cum = 0;
+  for (var i = 0; i < counts.length; i++) {
+    var n = Number(counts[i]) || 0;
+    if (n <= 0) continue;
+    if (cum + n >= target) {
+      var lo = i === 0 ? 0 : edges[i - 1];
+      if (i >= edges.length) return r2(lo);
+      return r2(lo + (edges[i] - lo) * ((target - cum) / n));
+    }
+    cum += n;
+  }
+  return r2(edges[edges.length - 1]);
+}
+
+// Where a bucketed VALUE sits along the histogram's axis, as 0-100. That axis
+// is BUCKET SLOTS, not values: slot i spans [i/n,(i+1)/n] and the value is
+// placed inside its own slot by the same linear rule that produced it, so a
+// marker drawn here always lands in the bucket its percentile came from.
+// Deliberately ignores the 6px inter-bar gap — a sub-4px offset on a dashed
+// rule that carries its own printed label, against the alternative of teaching
+// this pure function the CSS's box metrics.
+export function bucketPositionPct(edges, value) {
+  if (!Array.isArray(edges) || !edges.length || !Number.isFinite(value)) return null;
+  var slots = edges.length + 1, i = edges.length;
+  for (var e = 0; e < edges.length; e++) { if (value <= edges[e]) { i = e; break; } }
+  var lo = i === 0 ? 0 : edges[i - 1];
+  var frac = i >= edges.length ? 0 : ((edges[i] > lo) ? (value - lo) / (edges[i] - lo) : 0);
+  return Math.max(0, Math.min(100, ((i + frac) / slots) * 100));
+}
+
 // Bars are one sequential hue (accent) — a magnitude series, not a category
 // split, so there is nothing for a second color to distinguish. Markers are
 // emitted BEFORE the bars in DOM order and absolutely overlay the same box

--- a/src/lib/dashboard/client/usage-rhythm.mjs
+++ b/src/lib/dashboard/client/usage-rhythm.mjs
@@ -220,18 +220,25 @@ function donutGradient(aPct) {
 // sibling, not a descendant, of the masked element, so it is never itself
 // clipped. Side labels always carry both the series name and its value —
 // the swatch color is a hint, not the only way to tell A from B.
+//
+// `aValue`/`bValue` are the RAW numbers that set the geometry; `aText`/`bText`
+// are what the legend prints, defaulting to those numbers. The split exists
+// because the two are not interchangeable for money: the arc has to be drawn
+// from 12.3456 while the label has to read "$12.35", and re-deriving one from
+// the other would either round the arc or print an unformatted float.
 export function donut2(opts) {
   var o = opts || {};
   var a = Number(o.aValue) || 0, b = Number(o.bValue) || 0, total = a + b;
   var aPct = total ? (a / total) * 100 : 50;
+  var aText = o.aText == null ? a : o.aText, bText = o.bText == null ? b : o.bText;
   return '<div class="donut2-wrap"><div class="donut2">'
     + '<i class="donut2-ring" style="background:' + donutGradient(aPct) + '"></i>'
     + '<b class="donut2-center">' + esc(o.centerLabel) + '</b></div>'
     + '<div class="donut2-legend">'
     + '<span class="donut2-item"><i style="background:var(--accent)"></i>' + esc(o.aLabel)
-    + ' <b class="tnum">' + esc(a) + '</b></span>'
+    + ' <b class="tnum">' + esc(aText) + '</b></span>'
     + '<span class="donut2-item"><i style="background:var(--purple)"></i>' + esc(o.bLabel)
-    + ' <b class="tnum">' + esc(b) + '</b></span>'
+    + ' <b class="tnum">' + esc(bText) + '</b></span>'
     + '</div></div>';
 }
 

--- a/src/lib/dashboard/client/usage-rhythm.mjs
+++ b/src/lib/dashboard/client/usage-rhythm.mjs
@@ -1,0 +1,195 @@
+// @ts-nocheck — browser bundle source (never node-imported; client.mjs
+// reads it as text). See src/lib/dashboard/client/**'s eslint.config.mjs
+// override comment for why this directory isn't run through the node lib.
+
+// Pure string-building chart primitives for the Usage tab's rhythm/mode
+// panels (Task 9 wires these exports into usage.mjs). No DOM access, no
+// fetch, no module-level state — every function takes plain data in and
+// returns markup out. `esc` is copied from ./groups.mjs's real implementation
+// rather than imported: bootstrap.mjs's own `esc` is only a build-time
+// PLACEHOLDER (see client.mjs's inject()), so importing it here would pull in
+// the stub, not the real escaper.
+function esc(s) {
+  return String(s == null ? '' : s).replace(/[&<>"']/g, function (c) {
+    return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c];
+  });
+}
+
+// Shared pixel plot height for the two bar-style charts below (histogram,
+// stackedDays), computed in PIXELS rather than CSS percent: a percent height
+// needs every ancestor in the chain to declare an explicit height, which the
+// flex layouts here deliberately don't — columns size to content and
+// bottom-align on a shared baseline via align-items:flex-end instead.
+var PLOT_H = 72;
+
+function fmtDeltaNumber(n) {
+  var r = Math.round(n * 10) / 10;
+  return String(Number.isInteger(r) ? Math.round(r) : r);
+}
+
+// '' when there is no previous window to compare against — null/undefined
+// prev, or prev===0 (a zero baseline can't produce a meaningful ratio; this
+// dashboard never invents a claim it can't compute — same "no $ claimed"
+// discipline usage.mjs's insightCard() already applies). Direction is purely
+// mathematical (curr vs prev); `downIsGood` and `neutral` only affect the
+// TONE (good/bad/flat), never which arrow is drawn.
+export function deltaChip(curr, prev, opts) {
+  var o = opts || {};
+  var downIsGood = !!o.downIsGood, neutral = !!o.neutral, unit = o.unit || '';
+  if (prev == null || prev === 0) return '';
+  var c = Number(curr) || 0, p = Number(prev) || 0, delta = c - p;
+  var dir = delta > 0 ? 'up' : delta < 0 ? 'down' : 'flat';
+  var arrow = dir === 'up' ? '▲' : dir === 'down' ? '▼' : '•';
+  var tone = (neutral || dir === 'flat') ? 'flat' : (((dir === 'up') !== downIsGood) ? 'good' : 'bad');
+  var valueTxt = unit
+    ? fmtDeltaNumber(Math.abs(delta)) + esc(unit)
+    : Math.round(Math.abs(delta / p * 100)) + '%';
+  return '<span class="dchip" data-tone="' + tone + '">'
+    + '<i class="dchip-arrow" aria-hidden="true">' + arrow + '</i>'
+    + '<b class="dchip-val tnum">' + valueTxt + '</b></span>';
+}
+
+// '' when fewer than 2 finite points remain. No axes, no gridlines — a
+// de-emphasis-ink trend line with one accent dot at the most recent point,
+// meant to sit inline next to a KPI rather than stand alone as a chart.
+export function sparklineSvg(series, opts) {
+  var o = opts || {}, w = o.w || 130, h = o.h || 24;
+  var pts = (Array.isArray(series) ? series : []).filter(Number.isFinite);
+  if (pts.length < 2) return '';
+  var pad = 2, innerW = w - pad * 2, innerH = h - pad * 2;
+  var min = Math.min.apply(null, pts), max = Math.max.apply(null, pts), span = (max - min) || 1;
+  var coords = pts.map(function (v, i) {
+    return [pad + (i / (pts.length - 1)) * innerW, pad + innerH - ((v - min) / span) * innerH];
+  });
+  var last = coords[coords.length - 1];
+  var poly = coords.map(function (p) { return p[0].toFixed(1) + ',' + p[1].toFixed(1); }).join(' ');
+  return '<svg class="spark" viewBox="0 0 ' + w + ' ' + h + '" width="' + w + '" height="' + h
+    + '" focusable="false" aria-hidden="true">'
+    + '<polyline class="spark-line" fill="none" points="' + esc(poly) + '"/>'
+    + '<circle class="spark-dot" cx="' + last[0].toFixed(1) + '" cy="' + last[1].toFixed(1) + '" r="2.2"/>'
+    + '</svg>';
+}
+
+// Bars are one sequential hue (accent) — a magnitude series, not a category
+// split, so there is nothing for a second color to distinguish. Markers are
+// emitted BEFORE the bars in DOM order and absolutely overlay the same box
+// (see .hist-markers/.hist-plot in styles/usage.mjs), so a bar always paints
+// over a marker line where they cross; the marker's own label sits above the
+// whole plot instead, so it is never itself covered by a tall bar.
+export function histogram(opts) {
+  var o = opts || {};
+  var counts = Array.isArray(o.counts) ? o.counts : [];
+  var labels = Array.isArray(o.labels) ? o.labels : [];
+  var markers = Array.isArray(o.markers) ? o.markers : [];
+  var max = counts.reduce(function (m, v) { return Math.max(m, Number(v) || 0); }, 0);
+  var bars = counts.map(function (v) {
+    var n = Number(v) || 0;
+    var px = max ? Math.max(2, (n / max) * PLOT_H) : 2;
+    return '<div class="hist-bar"><span class="hist-val tnum">' + esc(n) + '</span>'
+      + '<i class="hist-fill" style="height:' + px.toFixed(1) + 'px"></i></div>';
+  }).join('');
+  var labs = labels.map(function (l) { return '<span class="hist-lab">' + esc(l) + '</span>'; }).join('');
+  var marks = markers.map(function (m) {
+    var at = Math.max(0, Math.min(100, Number(m && m.atPct) || 0));
+    return '<span class="hist-marker" style="left:' + at.toFixed(1) + '%">'
+      + '<i class="hist-marker-line"></i><b class="hist-marker-lab">' + esc(m && m.label) + '</b></span>';
+  }).join('');
+  return '<div class="hist"><div class="hist-plot">'
+    + '<div class="hist-markers">' + marks + '</div>'
+    + '<div class="hist-bars">' + bars + '</div>'
+    + '</div><div class="hist-labs">' + labs + '</div></div>';
+}
+
+// 'not-recorded'/'other' are always the de-emphasis token (--ink-dim), never
+// a series color, regardless of what the caller's palette maps them to — the
+// same "the uncategorized bucket is de-emphasis, not a hue" rule
+// renderScoreCategories already applies to Unclassified (var(--ink-dim)
+// instead of var(--accent)) elsewhere in this bundle.
+function segColor(key, palette) {
+  if (key === 'not-recorded' || key === 'other') return 'var(--ink-dim)';
+  return (palette && palette[key]) || 'var(--ink-dim)';
+}
+
+// order is bottom-up; segments render in that same sequence inside a
+// column-reverse flex (2px gap), so the LAST key in order is what actually
+// paints at the top. A day where the nominal top series is zero still needs
+// ITS topmost non-zero segment rounded, not a hard-coded index — topIdx is
+// recomputed per day from whichever segments actually render.
+export function stackedDays(opts) {
+  var o = opts || {};
+  var days = Array.isArray(o.days) ? o.days : [];
+  var order = Array.isArray(o.order) ? o.order : [];
+  var palette = o.palette || {};
+  var totals = days.map(function (d) {
+    var parts = (d && d.parts) || {};
+    return order.reduce(function (sum, key) { return sum + (Number(parts[key]) || 0); }, 0);
+  });
+  var maxTotal = totals.reduce(function (m, v) { return Math.max(m, v); }, 0);
+  var cols = days.map(function (d, i) {
+    var parts = (d && d.parts) || {}, total = totals[i];
+    var barPx = maxTotal ? Math.max(2, (total / maxTotal) * PLOT_H) : 2;
+    var segs = order.map(function (key, idx) { return { key: key, idx: idx, v: Number(parts[key]) || 0 }; })
+      .filter(function (s) { return s.v > 0; });
+    var topIdx = segs.reduce(function (m, s) { return Math.max(m, s.idx); }, -1);
+    var segsHtml = segs.map(function (s) {
+      var share = total ? (s.v / total) * 100 : 0;
+      return '<i class="sday-seg' + (s.idx === topIdx ? ' top' : '') + '" style="height:'
+        + share.toFixed(1) + '%;background:' + esc(segColor(s.key, palette))
+        + '" title="' + esc(s.key + ': ' + s.v) + '"></i>';
+    }).join('');
+    var dayRaw = String((d && d.day) || '');
+    var dayLab = esc(dayRaw.length >= 10 ? dayRaw.slice(8) : dayRaw);
+    return '<div class="sday-col"><div class="sday-bar" style="height:' + barPx.toFixed(1) + 'px">'
+      + segsHtml + '</div><span class="sday-lab">' + dayLab + '</span></div>';
+  }).join('');
+  return '<div class="stackdays">' + cols + '</div>';
+}
+
+// Two-slice conic-gradient ring with a small --line-colored seam at each
+// boundary (never a bare transparent gap, which would read as a rendering
+// bug rather than a deliberate seam).
+function donutGradient(aPct) {
+  var aDeg = (aPct / 100) * 360;
+  var gap = (aPct > 0 && aPct < 100) ? 3 : 0;
+  var aEnd = Math.max(0, aDeg - gap / 2);
+  var bStart = Math.min(360, aDeg + gap / 2);
+  var bEnd = Math.max(bStart, 360 - gap / 2);
+  return 'conic-gradient(var(--accent) 0deg ' + aEnd.toFixed(1) + 'deg,'
+    + 'var(--line) ' + aEnd.toFixed(1) + 'deg ' + bStart.toFixed(1) + 'deg,'
+    + 'var(--purple) ' + bStart.toFixed(1) + 'deg ' + bEnd.toFixed(1) + 'deg,'
+    + 'var(--line) ' + bEnd.toFixed(1) + 'deg 360deg)';
+}
+
+// The hole is masked on the RING element only; the center label is a
+// sibling, not a descendant, of the masked element, so it is never itself
+// clipped. Side labels always carry both the series name and its value —
+// the swatch color is a hint, not the only way to tell A from B.
+export function donut2(opts) {
+  var o = opts || {};
+  var a = Number(o.aValue) || 0, b = Number(o.bValue) || 0, total = a + b;
+  var aPct = total ? (a / total) * 100 : 50;
+  return '<div class="donut2-wrap"><div class="donut2">'
+    + '<i class="donut2-ring" style="background:' + donutGradient(aPct) + '"></i>'
+    + '<b class="donut2-center">' + esc(o.centerLabel) + '</b></div>'
+    + '<div class="donut2-legend">'
+    + '<span class="donut2-item"><i style="background:var(--accent)"></i>' + esc(o.aLabel)
+    + ' <b class="tnum">' + esc(a) + '</b></span>'
+    + '<span class="donut2-item"><i style="background:var(--purple)"></i>' + esc(o.bLabel)
+    + ' <b class="tnum">' + esc(b) + '</b></span>'
+    + '</div></div>';
+}
+
+// share (0-100) drives the track width directly — this never re-derives a
+// share from `value`, which may already be a caller-formatted string (e.g.
+// "$12.40") rather than a raw number this function could sum or compare.
+export function rankedRows(rows) {
+  var list = Array.isArray(rows) ? rows : [];
+  return '<div class="rrows">' + list.map(function (r) {
+    var share = Math.max(0, Math.min(100, Number(r && r.share) || 0));
+    var dim = !!(r && r.dim);
+    return '<div class="rrow"><span class="rrow-label">' + esc(r && r.label) + '</span>'
+      + '<span class="rrow-track"><i class="rrow-fill' + (dim ? ' dim' : '')
+      + '" style="width:' + share.toFixed(1) + '%"></i></span>'
+      + '<span class="rrow-val tnum">' + esc(r && r.value) + '</span></div>';
+  }).join('') + '</div>';
+}

--- a/src/lib/dashboard/client/usage-rhythm.mjs
+++ b/src/lib/dashboard/client/usage-rhythm.mjs
@@ -180,9 +180,18 @@ export function histogram(opts) {
 // same "the uncategorized bucket is de-emphasis, not a hue" rule
 // renderScoreCategories already applies to Unclassified (var(--ink-dim)
 // instead of var(--accent)) elsewhere in this bundle.
+// The return value lands in a CSS declaration, where the dangerous
+// metacharacters are ';', ':' and '}' — none of which esc() (an HTML escaper:
+// & < > " ') touches. So the value is constrained to a CSS colour vocabulary
+// here rather than escaped at the call site: a var() token or a hex literal,
+// anything else de-emphasised. Both callers build palettes from fixed
+// constants today, so this changes no rendered colour; it means a palette
+// that ever becomes data-derived cannot inject a declaration.
+var CSS_COLOR_RE = /^(var\(--[a-z0-9-]+\)|#[0-9a-fA-F]{3,8})$/;
 function segColor(key, palette) {
   if (key === 'not-recorded' || key === 'other') return 'var(--ink-dim)';
-  return (palette && palette[key]) || 'var(--ink-dim)';
+  var c = (palette && Object.prototype.hasOwnProperty.call(palette, key)) ? palette[key] : null;
+  return CSS_COLOR_RE.test(String(c)) ? String(c) : 'var(--ink-dim)';
 }
 
 // order is bottom-up; segments render in that same sequence inside a

--- a/src/lib/dashboard/client/usage.mjs
+++ b/src/lib/dashboard/client/usage.mjs
@@ -996,13 +996,45 @@ import { renderUsage } from './usage-orchestrators.mjs';
     if(isNaN(d))return "";
     return "resets "+d.toLocaleString(undefined,{month:"short",day:"numeric",hour:"2-digit",minute:"2-digit"});
   }
+  // Where this window's own CLOCK is, as a share of its duration — the mark a
+  // straight-line burn would be sitting on right now, which is what turns a
+  // level into "ahead of pace" or "behind". Both halves come from the limits
+  // payload the meter already reads: `resetsAt` (epoch seconds) says when the
+  // window ends, `windowMinutes` how long it runs, so elapsed = duration −
+  // remaining. Nothing is fetched and nothing is assumed about window length.
+  //
+  // null — not a clamp — whenever the arithmetic falls outside [0, duration]:
+  // the snapshot is then older than its own window (it has already reset) or
+  // the browser clock disagrees with the vendor's, and a tick pinned to 0% or
+  // 100% would state a position instead of admitting it cannot compute one.
+  function paceShare(resetSec,windowMinutes){
+    var mins=Number(windowMinutes);
+    if(!resetSec||!isFinite(resetSec)||!isFinite(mins)||mins<=0)return null;
+    var total=mins*60000,elapsed=total-(resetSec*1000-Date.now());
+    if(!isFinite(elapsed)||elapsed<0||elapsed>total)return null;
+    return elapsed/total*100;
+  }
+  function paceTick(resetSec,windowMinutes){
+    var at=paceShare(resetSec,windowMinutes);
+    if(at==null)return "";
+    return '<i class="pace" style="left:'+at.toFixed(1)+'%" title="'
+      +esc(at.toFixed(0)+"% of this window's time has elapsed — a steady burn would sit here")
+      +'"></i>';
+  }
+  // Rendered only when at least one row actually carries a tick, so the key
+  // never explains a mark that is not on screen.
+  var PACE_LEGEND='<div class="legend" style="margin-top:11px"><span class="lg">'
+    +'<i class="pace-key"></i>tick = share of the window&rsquo;s time elapsed &middot; '
+    +"fill past it is ahead of a steady burn</span></div>";
+
   // One utilization row on the shared .mrow grid; fill color says how close to
   // the cap this window is (ok <70, warn ≥70, fail ≥90).
-  function limRow(label,usedPercent,resetSec,sub){
+  function limRow(label,usedPercent,resetSec,sub,windowMinutes){
     var p=Math.max(0,Math.min(100,Number(usedPercent)||0));
     var col=p>=90?"var(--fail)":(p>=70?"var(--warn)":"var(--ok)");
     return '<div class="mrow"><span class="mname">'+esc(label)+"</span>"
-      +'<span class="mbar"><i style="width:'+p.toFixed(1)+"%;background:"+col+'"></i></span>'
+      +'<span class="mbar"><i style="width:'+p.toFixed(1)+"%;background:"+col+'"></i>'
+      +paceTick(resetSec,windowMinutes)+"</span>"
       +'<span class="mval mono">'+p.toFixed(0)+"%</span>"
       +'<span class="msub mono">'+esc(sub||resetTxt(resetSec))+"</span></div>";
   }
@@ -1018,9 +1050,11 @@ import { renderUsage } from './usage-orchestrators.mjs';
       // Claude's tee is push-only: FRESH means a session wrote it in the last
       // 10 minutes; anything older gets the stale badge rather than silence.
       if(cn)cn.textContent="statusline tee · "+limAge(c.fetchedAt)+(limStale(c.fetchedAt,600000)?" · stale":"");
+      var paced=false;
       claudeEl.innerHTML=c.windows.map(function(w){
-        return limRow("claude · "+(w.label||w.id),w.usedPercent,w.resetsAt);
-      }).join("");
+        if(paceShare(w.resetsAt,w.windowMinutes)!=null)paced=true;
+        return limRow("claude · "+(w.label||w.id),w.usedPercent,w.resetsAt,null,w.windowMinutes);
+      }).join("")+(paced?PACE_LEGEND:"");
     }else{
       if(cn)cn.textContent="no data";
       claudeEl.innerHTML='<div class="empty">no Claude limit data yet &mdash; it arrives while a Claude Code session runs '
@@ -1035,15 +1069,17 @@ import { renderUsage } from './usage-orchestrators.mjs';
     var xn=document.getElementById("u-lim-codex-note");
     if(x&&x.lanes&&x.lanes.length){
       if(xn)xn.textContent=(x.planType?("plan "+x.planType+" · "):"")+"app-server · "+limAge(x.fetchedAt);
-      var html="";
+      var html="",paced=false;
       for(var i=0;i<x.lanes.length;i++){
         var lane=x.lanes[i];
         for(var j=0;j<(lane.windows||[]).length;j++){
           var w=lane.windows[j];
-          html+=limRow(lane.name+" · "+(w.label||""),w.usedPercent,w.resetsAt);
+          if(paceShare(w.resetsAt,w.windowMinutes)!=null)paced=true;
+          html+=limRow(lane.name+" · "+(w.label||""),w.usedPercent,w.resetsAt,null,w.windowMinutes);
         }
         if(!(lane.windows||[]).length)html+=limRow(lane.name,0,null,"no window reported");
       }
+      if(paced)html+=PACE_LEGEND;
       var rc=x.resetCredits;
       if(rc&&rc.availableCount>0){
         html+='<div class="legend" style="margin-top:11px"><span class="lg"><i style="background:var(--ok)"></i>'

--- a/src/lib/dashboard/client/usage.mjs
+++ b/src/lib/dashboard/client/usage.mjs
@@ -735,6 +735,137 @@ import { renderUsage } from './usage-orchestrators.mjs';
 
   }
 
+  // ── tool mix and model mix over time ──────────────────────────────────────
+  var TOOL_TOP=8;
+  function toolRows(d){
+    var map=d.byTool||{},list=[],k;
+    for(k in map)list.push({name:k,n:Number(map[k])||0});
+    list.sort(function(a,b){return b.n-a.n;});
+    if(!list.length)return '<div class="empty">no tool calls recorded in window.</div>';
+    var top=list.slice(0,TOOL_TOP),tail=list.slice(TOOL_TOP);
+    var other=tail.reduce(function(s,x){return s+x.n;},0),max=top[0].n;
+    var rows=top.map(function(x){
+      return {label:x.name,value:fmtNum(x.n),share:pct(x.n,max),dim:false};
+    });
+    // The tail is FOLDED, never dropped: those calls happened, and a top-8
+    // list that quietly loses the rest misstates the total every share above
+    // it is read against. Dim, because Other is a residue, not a tool.
+    if(other>0)rows.push({label:"Other ("+tail.length+" tool"+(tail.length===1?"":"s")+")",
+      value:fmtNum(other),share:pct(other,max),dim:true});
+    return rankedRows(rows);
+  }
+
+  // Four series is the most a stacked day column can carry and still be read
+  // apart at this size; the rest fold into one de-emphasised band. Colors are
+  // assigned BY RANK, so the palette is deterministic rather than dependent on
+  // key order, and every band is named in the legend beside the chart.
+  var FAMILY_PALETTE=["var(--accent)","var(--purple)","var(--ok)","var(--warn)"];
+  var FAMILY_TOP=4;
+  function familyTotals(rows){
+    var tot={},i,k;
+    for(i=0;i<rows.length;i++){
+      var parts=(rows[i].v&&rows[i].v.byModelFamily)||{};
+      for(k in parts)tot[k]=(tot[k]||0)+(Number(parts[k])||0);
+    }
+    return tot;
+  }
+  function topFamilies(tot){
+    var list=[],k;
+    // modelFamily()'s own 'other' catch-all never competes for a top slot — it
+    // is the residue bucket, so it belongs in the fold no matter how big it is.
+    for(k in tot)if(k!=="other")list.push({name:k,cost:tot[k]});
+    list.sort(function(a,b){return b.cost-a.cost;});
+    return list.slice(0,FAMILY_TOP).map(function(x){return x.name;});
+  }
+  function foldFamilies(parts,keep){
+    var out={other:0},k;
+    for(k in parts){
+      var v=Number(parts[k])||0;
+      if(keep.indexOf(k)>=0)out[k]=(out[k]||0)+v; else out.other+=v;
+    }
+    return out;
+  }
+  function modelMix(d){
+    var rows=dayRows(d),tot=familyTotals(rows),keep=topFamilies(tot);
+    if(!keep.length&&!(tot.other>0))return '<div class="empty">no model spend in window.</div>';
+    var palette={};
+    keep.forEach(function(name,i){palette[name]=FAMILY_PALETTE[i%FAMILY_PALETTE.length];});
+    var days=rows.map(function(x){
+      return {day:x.day,parts:foldFamilies((x.v&&x.v.byModelFamily)||{},keep)};
+    });
+    var otherTotal=days.reduce(function(s,x){return s+(x.parts.other||0);},0);
+    var legend=keep.map(function(name){
+      return {color:palette[name],label:name,value:fmtUsd(tot[name])};
+    });
+    if(otherTotal>0)legend.push({color:"var(--ink-dim)",label:"other",value:fmtUsd(otherTotal)});
+    // Bottom-up: the fold sits at the base and the biggest family paints on
+    // top, so the legend read top-down is the stack read top-down.
+    return stackedDays({days:days,order:["other"].concat(keep.slice().reverse()),palette:palette})
+      +chartLegend(legend)
+      +'<p class="hr-note">Model ids are folded to a coarse family (<b>opus</b>, <b>gpt-5</b>, …). '
+      +"An id the fold does not recognise lands in <b>other</b> — never a guessed family, and never "
+      +"dropped, because its spend still has to land somewhere.</p>";
+  }
+  function renderScoreMix(d){
+    var pair=ensureBlock("u-toolmix",'<div class="two">'
+      +stripHtml("u-toolmix","tool mix","invocations · top 8, tail folded")
+      +stripHtml("u-modelmix","model mix over time","api-equivalent cost by model family")
+      +"</div>","u-punch");
+    if(!pair)return;
+    pair.innerHTML=toolRows(d)
+      +'<p class="hr-note">Invocations as each host recorded them. A host that does not report tool '
+      +"calls contributes nothing here rather than a zero — telemetry coverage above says which "
+      +"hosts report them at all.</p>";
+    var mix=document.getElementById("u-modelmix");
+    if(mix)mix.innerHTML=modelMix(d);
+  }
+
+  // ── reliability ───────────────────────────────────────────────────────────
+  var REL_TIP="Turns that never resolved to a model — a dropped connection, a rate-limit rejection, "
+    +"an auth failure. They are excluded from the model list (there is no model to attribute them "
+    +"to) and surfaced here instead of vanishing.\nRate is exceptions ÷ responses × 1000.";
+  var ABORT_TIP="Turns the transcript recorded as interrupted — the answer was stopped mid-flight. "
+    +"Counted apart from exceptions: an abort is a choice, not a failure.";
+  var REL_ABSENT="No per-day line: /api/usage's per-day rows carry tokens, cost and sessions, so "
+    +"exceptions exist only as a window total. A daily trend would have to be invented rather than "
+    +"read, so none is drawn.";
+
+  function relRate(t){
+    var r=Number(t&&t.responses)||0;
+    return r?(Number(t.exceptions)||0)/r*1000:null;
+  }
+  // Direction is stated in WORDS and in a glyph as well as in color — a
+  // reader who cannot separate the warn and ok tokens still gets the finding.
+  function relFlag(cur,prev){
+    if(cur==null||prev==null)return "";
+    if(cur>prev)return '<span class="rel-flag" data-sev="warn"><i aria-hidden="true">▲</i>'
+      +"higher than the previous window</span>";
+    if(cur<prev)return '<span class="rel-flag" data-sev="ok"><i aria-hidden="true">▼</i>'
+      +"lower than the previous window</span>";
+    return '<span class="rel-flag" data-sev="flat"><i aria-hidden="true">•</i>'
+      +"unchanged from the previous window</span>";
+  }
+  function relStat(o){
+    return '<div class="rel-stat" title="'+esc(o.tip)+'">'
+      +'<span class="rel-k">'+esc(o.label)+"</span>"
+      +'<span class="rel-v tnum">'+esc(o.value)+"</span>"
+      +'<span class="rel-sub">'+esc(o.sub)+"</span>"+(o.flag||"")+"</div>";
+  }
+  function renderScoreReliability(d){
+    var body=ensureBlock("u-reliability",
+      stripHtml("u-reliability","reliability","turns that never landed"),"u-models");
+    if(!body)return;
+    var t=d.totals||{},p=(d.previous&&d.previous.totals)||null;
+    var cur=relRate(t),exc=Number(t.exceptions)||0,ab=Number(t.aborts)||0,resp=Number(t.responses)||0;
+    body.innerHTML='<div class="rel">'
+      +relStat({label:"exceptions / 1k responses",value:cur==null?"—":cur.toFixed(1),
+        sub:fmtNum(exc)+" of "+fmtNum(resp)+" responses",tip:REL_TIP,
+        flag:relFlag(cur,p?relRate(p):null)})
+      +relStat({label:"aborted turns",value:fmtNum(ab),
+        sub:resp?fmtRatio(ab/resp*1000)+" per 1k responses":"no responses in window",tip:ABORT_TIP})
+      +"</div><p class=\"hr-note\">"+esc(REL_ABSENT)+"</p>";
+  }
+
   function renderScoreModels(d){
     var t=d.totals||{};
     // models + projects
@@ -826,7 +957,9 @@ import { renderUsage } from './usage-orchestrators.mjs';
     renderScoreHosts(d);
     renderScoreTokBar(d);
     renderScorePunchcard(d);
+    renderScoreMix(d);
     renderScoreModels(d);
+    renderScoreReliability(d);
     renderScoreOpenRouter(d);
     renderScoreProjects(d);
     renderScoreCategories(d);

--- a/src/lib/dashboard/client/usage.mjs
+++ b/src/lib/dashboard/client/usage.mjs
@@ -1227,18 +1227,6 @@ import { renderUsage } from './usage-orchestrators.mjs';
   function sessionP50(sx){
     return Array.isArray(sx.latHist)?bucketPercentile(sx.latHist,LAT_EDGES,0.5):null;
   }
-  // A raw spelling carrying "[object Object]" is not a spelling — it is a
-  // failed toString, and printing it would put this dashboard's own
-  // rendering-artifact sentinel inside a tooltip. Rejected as not-recorded,
-  // which is what a stringification failure actually leaves behind. Observed
-  // on every Codex row in a live window: usage-modes.mjs joins Codex's
-  // sandboxPolicy into the raw string and that field is an OBJECT in real
-  // rollouts, so the value never was a spelling. Fixing the join is upstream's
-  // to make; refusing to render the wreckage is this file's.
-  function rawSpelling(v){
-    var s=reportedIdentity(v);
-    return (s&&s.indexOf("[object ")<0)?s:null;
-  }
   // The posture the transcript recorded, and NOTHING when it recorded none: an
   // unobserved or unmapped raw value is not a posture, and a badge that guessed
   // one would read exactly like an observed one. `modeRaw` is the host's own
@@ -1248,7 +1236,7 @@ import { renderUsage } from './usage-orchestrators.mjs';
   function modeBadge(sx){
     var mode=reportedIdentity(sx.mode);
     if(!mode)return "";
-    var raw=rawSpelling(sx.modeRaw);
+    var raw=reportedIdentity(sx.modeRaw);
     return '<span class="s-chip s-mode" data-mode="'+esc(mode)+'" title="'
       +esc("permission posture: "+mode
         +(raw?" · recorded by the host as \""+raw+"\"":" · the host's own spelling was not recorded"))
@@ -1308,7 +1296,7 @@ import { renderUsage } from './usage-orchestrators.mjs';
     // never-omit-a-line rule: a fact that was measured and found absent reads
     // "Not recorded"/"—", not silence, which would teach the reader the field
     // does not exist (ADR-0009 §5).
-    var modeRaw=rawSpelling(sx.modeRaw),modeName=reportedIdentity(sx.mode);
+    var modeRaw=reportedIdentity(sx.modeRaw),modeName=reportedIdentity(sx.mode);
     var posture=modeName
       ? esc(modeName)+" <span class='sd-conf'>("
         +esc(modeRaw?"recorded by the host as \""+modeRaw+"\"":"host spelling not recorded")+")</span>"

--- a/src/lib/dashboard/client/usage.mjs
+++ b/src/lib/dashboard/client/usage.mjs
@@ -511,7 +511,9 @@ import { renderUsage } from './usage-orchestrators.mjs';
   // ── second KPI row: cadence, autonomy, unit economics ─────────────────────
   var TIP_PER_DAY="Sessions ÷ active days.\nAn ACTIVE day is one this window actually billed tokens "
     +"on — that is byDay's own contract, so a day worked but never billed is not counted and breaks "
-    +"the streak.\nStreak counts consecutive active days ending at the most recent one.";
+    +"the streak.\nStreak counts consecutive active days ending at the most recent one.\n"
+    +"Sessions INCLUDES delegated subagent sessions, which the harness dispatches rather than you — "
+    +"the how-you-run panel carries the main/subagent split.";
   var TIP_AUTONOMY="Assistant responses ÷ prompts you typed — how far each prompt travels.\n"
     +"Prompts are MAIN-THREAD only: a subagent's prompts are written by the harness, not by you, so "
     +"counting them would inflate the denominator with work nobody asked for by hand.\nTouch rate is "
@@ -577,10 +579,12 @@ import { renderUsage } from './usage-orchestrators.mjs';
   var LAT_TIP="Wall-clock gap between a prompt and the response that answered it.\n"
     +"codex host-measured · claude/opencode derived from event gaps — not streaming TTFT.\n"
     +"The last bucket has no upper edge, so a percentile landing in it reports that bucket's "
-    +"floor: printed with ≥, read as \"at least this\".";
+    +"floor: printed with ≥, read as \"at least this\".\n"
+    +"INCLUDES delegated subagent responses — the how-you-run panel carries the split.";
   var LEN_TIP="Engaged length of one session — the union of its active sub-intervals, split at "
     +"15-minute silences, not its first-to-last span.\nThe last bucket has no upper edge, so a "
-    +"percentile landing in it is printed with ≥.";
+    +"percentile landing in it is printed with ≥.\n"
+    +"INCLUDES delegated subagent sessions — the how-you-run panel carries the split.";
 
   function histMarker(value,edges,label){
     var at=bucketPositionPct(edges,value);
@@ -763,7 +767,12 @@ import { renderUsage } from './usage-orchestrators.mjs';
     pcHtml+='<div class="pc-axis">';
     for(var ax=0;ax<24;ax++)pcHtml+="<span>"+(ax%3===0?ax:"")+"</span>";
     pcHtml+="</div>";
-    document.getElementById("u-punch").innerHTML=pcMax?pcHtml:'<div class="empty">no responses in window.</div>';
+    var PUNCH_NOTE="Counts responses, not elapsed time, and INCLUDES delegated subagent responses "
+      +"— a long agentic run dispatching subagents fills these cells even when nobody was typing. "
+      +"The how-you-run panel carries the main/subagent split.";
+    document.getElementById("u-punch").innerHTML=pcMax
+      ?pcHtml+'<p class="hr-note">'+esc(PUNCH_NOTE)+"</p>"
+      :'<div class="empty">no responses in window.</div>';
 
   }
 

--- a/src/lib/dashboard/client/usage.mjs
+++ b/src/lib/dashboard/client/usage.mjs
@@ -717,8 +717,13 @@ import { renderUsage } from './usage-orchestrators.mjs';
       var v=prov[name], cost=fld(v,"cost"), sess=fld(v,"sessions"), tok=fld(v,"tokens");
       var idle=!sess&&!cost;
       if(!idle)activeHosts++;
+      // hasOwnProperty, not a bare lookup: `name` comes from byHost's keys,
+      // which the loop above deliberately widens beyond the three known
+      // hosts, so `constructor`/`__proto__` would otherwise reach a
+      // prototype value and land unescaped inside a class attribute.
+      var dot=Object.prototype.hasOwnProperty.call(PDOT_CLASS,name)?PDOT_CLASS[name]:"c";
       return '<div class="pcard'+(idle?" idle":"")+'"><div class="ph"><span class="pdot '
-        +(PDOT_CLASS[name]||"c")+'"></span>'+esc(name)+"</div>"
+        +esc(dot)+'"></span>'+esc(name)+"</div>"
         +'<div class="pv mono">'+esc(fmtUsd(cost))+"</div>"
         +'<div class="pl">'+(idle?"no sessions in window":esc(fmtNum(sess))+" sessions &middot; "+esc(fmtTok(tok))+" tokens")+"</div></div>";
     }).join("");
@@ -1331,8 +1336,14 @@ import { renderUsage } from './usage-orchestrators.mjs';
     var weak=(typeof sx.confidence==="number"&&sx.confidence<0.6)?"0":"1";
     var when=sx.start?new Date(sx.start):null;
     var whenTxt=when&&!isNaN(when)?when.toLocaleString(undefined,{month:"short",day:"numeric",hour:"2-digit",minute:"2-digit"}):"—";
-    // Session ids are validated against [A-Za-z0-9._-]{1,128} by parseSessionId
-    // before they are ever indexed, so they are safe AND unique as DOM ids.
+    // Ids are derived from raw filesystem names (usage-index.mjs listClaude /
+    // listClaudeSubagents), NOT validated at index time — parseSessionId is a
+    // request-path validator that never runs here — and a namespaced subagent
+    // id contains '/', which the charset once claimed for them does not.
+    // POSIX filenames permit '"', '<' and '>', so esc() is LOAD-BEARING, not
+    // belt-and-braces: every render of sx.id must keep it, or a project
+    // directory named with a quote breaks out of these attributes and, under
+    // this page's script-src 'unsafe-inline', executes.
     var sid=esc(sx.id);
     var wt=sx.worktree!=null?'<span class="s-wt" title="git worktree — the repo is the project">⑂'+esc(sx.worktree)+"</span>":"";
     return '<div class="srow" data-id="'+sid+'" title="open transcript">'

--- a/src/lib/dashboard/client/usage.mjs
+++ b/src/lib/dashboard/client/usage.mjs
@@ -4,7 +4,7 @@
 import { VIEWS, authHeaders, esc, setTab, syncHash } from './bootstrap.mjs';
 import { ago } from './intelligence.mjs';
 import { renderModelFacets, renderModelInventory, renderModelLifecycle } from './model-lifecycle.mjs';
-import { deltaChip, sparklineSvg } from './usage-rhythm.mjs';
+import { bucketPositionPct, deltaChip, donut2, histogram, rankedRows, sparklineSvg, stackedDays } from './usage-rhythm.mjs';
 import { renderUsage } from './usage-orchestrators.mjs';
 
   // ══ Usage tab ══════════════════════════════════════════════════════════════
@@ -363,6 +363,26 @@ import { renderUsage } from './usage-orchestrators.mjs';
     anchor.parentNode.insertBefore(node,anchor.nextSibling);
     return document.getElementById(probeId);
   }
+  // The same heading grammar the served markup uses, so an inserted panel is
+  // indistinguishable from a static one. `note` is escaped: every caller
+  // passes a literal caption, and a panel's live figures belong in its body
+  // (rewritten each render) rather than in a header this builds once.
+  function stripHtml(bodyId,heading,note){
+    return '<section class="strip"><div class="sh"><h2>'+esc(heading)+"</h2>"
+      +'<span class="n mono">'+esc(note)+"</span></div>"
+      +'<div id="'+esc(bodyId)+'"></div></section>';
+  }
+  // A legend the chart primitives do not draw for themselves. Reuses the
+  // scorecard's own .legend/.lg grammar so an external legend is the same
+  // object here as it is under the token bar. The label is always spelled out
+  // beside the swatch — the hue is a hint, never the only way to read a series.
+  function chartLegend(items){
+    return '<div class="legend">'+items.map(function(it){
+      return '<span class="lg"><i style="background:'+esc(it.color)+'"></i>'+esc(it.label)
+        +' <b class="tnum">'+esc(it.value)+"</b></span>";
+    }).join("")+"</div>";
+  }
+
   // byDay ascending. Shared by the day-bar strip and every per-day series
   // below, so they cannot disagree about which days are in the window.
   function dayRows(d){
@@ -384,6 +404,24 @@ import { renderUsage } from './usage-orchestrators.mjs';
   function fmtRatio(n){
     if(n==null||!isFinite(n))return "—";
     return Math.abs(n)>=10?String(Math.round(n)):n.toFixed(1);
+  }
+  // Durations that span four orders of magnitude (a 1.4s reply, a 3h session)
+  // in one compact token. A whole number of hours prints as "2h", not "2.0h":
+  // the extra digit claims a precision a bucket floor does not have.
+  function fmtSecs(sec){
+    sec=Number(sec)||0;
+    if(sec<60)return (sec<10?Math.round(sec*10)/10:Math.round(sec))+"s";
+    if(sec<5400)return Math.round(sec/60)+"m";
+    var h=Math.round(sec/360)/10;
+    return (h%1===0?String(h):h.toFixed(1))+"h";
+  }
+  // A value from a histogram's OVERFLOW bucket has no upper edge to
+  // interpolate towards, so the percentile reports that bucket's FLOOR.
+  // Printing it bare would state a figure the counts cannot support, so it is
+  // prefixed and reads "at least this". `lastEdge` is that floor.
+  function fmtAtLeast(v,lastEdge,fmt){
+    if(v==null||!isFinite(v))return "—";
+    return (v>=lastEdge?"≥":"")+fmt(v);
   }
   // renderScore was one CC-41 function writing ~10 independent scorecard
   // regions (hero KPIs, cost-per-day bars, host cards, token bar/legend,
@@ -497,6 +535,126 @@ import { renderUsage } from './usage-orchestrators.mjs';
     if(!body)return;
     var days=dayRows(d).map(function(x){return x.day;});
     body.innerHTML=cadenceCells(d.totals||{},days.length,activeStreak(days));
+  }
+
+  // ── rhythm: how long sessions run, how long replies take ──────────────────
+  // The edges are restated from usage-aggregate.mjs's exported
+  // LAT_BUCKET_EDGES/LEN_BUCKET_EDGES: the payload ships the COUNTS, never the
+  // edges they were binned on, and this file is read as text into a browser
+  // bundle that cannot import that module. A test pins the copies equal, so a
+  // change to either goes red instead of silently re-labelling every bucket.
+  var LAT_EDGES=[2,5,10,30,60];
+  var LAT_LABELS=["≤2s","≤5s","≤10s","≤30s","≤60s","＞60s"];
+  var LEN_EDGES=[300,900,2700,7200];
+  var LEN_LABELS=["≤5m","≤15m","≤45m","≤2h","＞2h"];
+  var LAT_TIP="Wall-clock gap between a prompt and the response that answered it.\n"
+    +"codex host-measured · claude/opencode derived from event gaps — not streaming TTFT.\n"
+    +"The last bucket has no upper edge, so a percentile landing in it reports that bucket's "
+    +"floor: printed with ≥, read as \"at least this\".";
+  var LEN_TIP="Engaged length of one session — the union of its active sub-intervals, split at "
+    +"15-minute silences, not its first-to-last span.\nThe last bucket has no upper edge, so a "
+    +"percentile landing in it is printed with ≥.";
+
+  function histMarker(value,edges,label){
+    var at=bucketPositionPct(edges,value);
+    return at==null?null:{atPct:at,label:label};
+  }
+  function histCard(o){
+    var counts=Array.isArray(o.counts)?o.counts:[];
+    var total=counts.reduce(function(a,n){return a+(Number(n)||0);},0);
+    return '<div class="rcard" title="'+esc(o.tip)+'">'
+      +'<div class="rcard-h"><span class="rcard-t">'+esc(o.title)+"</span>"
+      +'<span class="rcard-n mono">'+esc(total?o.note:"not measured")+"</span></div>"
+      +(total?histogram({counts:counts,labels:o.labels,
+        markers:(o.markers||[]).filter(Boolean)})
+        :'<div class="empty">'+esc(o.emptyText)+"</div>")+"</div>";
+  }
+  function lengthCard(r){
+    var med=r.lenMedianSeconds,p90=r.lenP90Seconds;
+    var medTxt=fmtAtLeast(med,7200,fmtSecs),p90Txt=fmtAtLeast(p90,7200,fmtSecs);
+    return histCard({title:"session length",counts:r.lenHist,labels:LEN_LABELS,
+      markers:[histMarker(med,LEN_EDGES,"median "+medTxt),histMarker(p90,LEN_EDGES,"P90 "+p90Txt)],
+      note:"median "+medTxt+" · P90 "+p90Txt,tip:LEN_TIP,
+      emptyText:"no session lengths in window."});
+  }
+  function latencyCard(r){
+    var p50=r.latP50,p95=r.latP95,n=Number(r.latCount)||0;
+    var p50Txt=fmtAtLeast(p50,60,fmtSecs),p95Txt=fmtAtLeast(p95,60,fmtSecs);
+    return histCard({title:"response latency",counts:r.latHist,labels:LAT_LABELS,
+      markers:[histMarker(p50,LAT_EDGES,"p50 "+p50Txt),histMarker(p95,LAT_EDGES,"p95 "+p95Txt)],
+      note:"p50 "+p50Txt+" · p95 "+p95Txt+" · n "+fmtNum(n),tip:LAT_TIP,
+      emptyText:"no response latency measured in window."});
+  }
+  function renderScoreRhythm(d){
+    var body=ensureBlock("u-rhythm",
+      stripHtml("u-rhythm","your rhythm","session length · response latency"),"u-daybars");
+    if(!body)return;
+    var r=d.rhythm||{};
+    body.innerHTML='<div class="rhythm-grid">'+lengthCard(r)+latencyCard(r)+"</div>";
+  }
+
+  // ── how you run: posture, who drove, who served ───────────────────────────
+  // ADR-0038's closed posture vocabulary, ordered least to most permissive so
+  // the stack reads bottom-up as "how much rope was given", with the
+  // unobserved bucket at the base. Every color is a token AND is named in the
+  // legend beside the chart — the hue is a hint, never the only way to read it.
+  // 'not-recorded' is forced to the de-emphasis ink by the primitive itself,
+  // so it deliberately has no palette entry here.
+  var MODE_ORDER=["not-recorded","plan","guarded","auto-edit","unrestricted"];
+  var MODE_COLOR={plan:"var(--purple)",guarded:"var(--ok)","auto-edit":"var(--accent)",
+    unrestricted:"var(--fail)"};
+
+  function modeChart(d){
+    var byMode=d.byMode||{};
+    var present=MODE_ORDER.filter(function(k){
+      return Object.prototype.hasOwnProperty.call(byMode,k);
+    });
+    if(!present.length)return '<div class="hr-t">posture, by day</div>'
+      +'<div class="empty">no permission posture recorded in window.</div>';
+    var days=dayRows(d).map(function(x){return {day:x.day,parts:(x.v&&x.v.byMode)||{}};});
+    // Legend order is the stack read TOP-down, which is the reverse of the
+    // bottom-up paint order — so the entry your eye reaches first names the
+    // band your eye reaches first.
+    var legend=present.slice().reverse().map(function(k){
+      return {color:k==="not-recorded"?"var(--ink-dim)":(MODE_COLOR[k]||"var(--ink-dim)"),
+        label:k,value:fmtUsd(fld(byMode[k],"cost"))};
+    });
+    return '<div class="hr-t">posture, by day</div>'
+      +stackedDays({days:days,order:present,palette:MODE_COLOR})
+      +chartLegend(legend)
+      +'<p class="hr-note">Api-equivalent cost, stacked by the permission posture the transcript '
+      +'recorded. <b>not-recorded</b> is spend from a session that carried no posture evidence — '
+      +"held apart rather than folded into a real posture.</p>";
+  }
+  function sourceDonut(d){
+    var src=d.bySource||{};
+    var main=fld(src.main,"cost"),sub=fld(src.subagent,"cost"),total=main+sub;
+    return '<div class="hr-block"><div class="hr-t">main vs subagent</div>'
+      +(total?donut2({aValue:main,bValue:sub,aText:fmtUsd(main),bText:fmtUsd(sub),
+        aLabel:"main thread",bLabel:"subagent",centerLabel:Math.round(main/total*100)+"%"})
+        :'<div class="empty">no priced work in window.</div>')
+      +'<p class="hr-note">Share of api-equivalent cost; the ring reads main-thread. Subagent work '
+      +"is Claude's sidechain flag or Codex's ledger-backed thread source — either way, not a "
+      +"session a human was driving.</p></div>";
+  }
+  function providerRows(d){
+    var list=entries(d.byInferenceProvider);
+    var max=list.length?list[0].cost:0;
+    return '<div class="hr-block"><div class="hr-t">inference provider</div>'
+      +(list.length?rankedRows(list.map(function(x){
+        return {label:x.name==="not-recorded"?"Not recorded":identityName(x.name),
+          value:fmtUsd(x.cost),share:pct(x.cost,max),dim:x.name==="not-recorded"};
+      })):'<div class="empty">no provider evidence in window.</div>')
+      +'<p class="hr-note">A transcript host does not prove which vendor served the tokens, so '
+      +"spend whose provenance was never observed keys to <b>Not recorded</b> instead of being "
+      +"attributed to an assumption.</p></div>";
+  }
+  function renderScoreHowRun(d){
+    var body=ensureBlock("u-howrun",
+      stripHtml("u-howrun","how you run","permission posture · who drove · who served"),"u-rhythm");
+    if(!body)return;
+    body.innerHTML='<div class="howrun"><div class="hr-block hr-chart">'+modeChart(d)+"</div>"
+      +'<div class="hr-side">'+sourceDonut(d)+providerRows(d)+"</div></div>";
   }
 
   function renderScoreDayBars(d){
@@ -660,6 +818,11 @@ import { renderUsage } from './usage-orchestrators.mjs';
     renderScoreHero(d);
     renderScoreCadence(d);
     renderScoreDayBars(d);
+    // Order is load-bearing here and nowhere else in this list: how-you-run
+    // anchors its container to the rhythm strip, which renderScoreRhythm has
+    // to have inserted first.
+    renderScoreRhythm(d);
+    renderScoreHowRun(d);
     renderScoreHosts(d);
     renderScoreTokBar(d);
     renderScorePunchcard(d);

--- a/src/lib/dashboard/client/usage.mjs
+++ b/src/lib/dashboard/client/usage.mjs
@@ -91,7 +91,7 @@ import { renderUsage } from './usage-orchestrators.mjs';
       var grp=SOURCE_HEALTH_GROUPS[g],present=[];
       for(var p=0; p<grp.parts.length; p++){
         var part=grp.parts[p],item=health[part.key];
-        if(item) present.push({status:String(item.status||"not-read"),reason:item.reason,diagnostics:item.diagnostics,capabilities:item.capabilities,sub:part.sub});
+        if(item) present.push({status:String(item.status||"not-read"),reason:item.reason,diagnostics:item.diagnostics,sub:part.sub});
       }
       if(!present.length)continue;
       var lead=present.slice().sort(function(a,b){
@@ -103,8 +103,6 @@ import { renderUsage } from './usage-orchestrators.mjs';
         if(q&&q.files) d+=" · "+fmtNum(q.responses)+" responses / "+fmtNum(q.files)+" files";
         if(q&&q.warnings&&q.warnings.length) d+=" · "+q.warnings.join(", ");
         if(q&&q.common) d+=" · "+fmtNum(q.common.unitsParsed)+"/"+fmtNum(q.common.unitsSeen)+" parsed · "+fmtNum(q.common.prompts)+" prompts / "+fmtNum(q.common.responses)+" responses";
-        var caps=pt.capabilities;
-        if(caps) d+=" · tools "+String(caps.toolCalls||"unavailable");
         return pt.sub?pt.sub+": "+d:d;
       }).join(" · ");
       pills.push('<span class="source-pill" data-status="'+esc(lead.status)+'">'

--- a/src/lib/dashboard/client/usage.mjs
+++ b/src/lib/dashboard/client/usage.mjs
@@ -18,6 +18,16 @@ import { renderUsage } from './usage-orchestrators.mjs';
     if(n>=10)return "$"+n.toFixed(0);
     return "$"+n.toFixed(2);
   }
+  // A POSITIVE figure that rounds away at two decimals is not $0.00 — printing
+  // it that way beside a caption about excluding $0-by-construction sessions
+  // reads as "the median session was free", which is a different claim from
+  // "the median session cost less than a cent". The threshold is derived from
+  // fmtUsd's own output rather than restating its rounding rule, so the two
+  // cannot disagree. A true zero is left alone: it is not less than a cent.
+  function fmtUsdMin(n){
+    var v=Number(n)||0,txt=fmtUsd(v);
+    return (v>0&&txt==="$0.00")?"<$0.01":txt;
+  }
   export function fmtNum(n){return (Number(n)||0).toLocaleString();}
   export function fmtTok(n){
     n=Number(n)||0;
@@ -452,8 +462,12 @@ import { renderUsage } from './usage-orchestrators.mjs';
   }
   var CACHE_TIP="Share of this window's tokens that were cache reads. Higher is cheaper, so a rise "
     +"is the good direction.\nsaved ≈ prices the same cache-read tokens as fresh input and takes the "
-    +"gap, at each day's own rate.\nNo trend line: /api/usage's per-day rows carry tokens, cost and "
-    +"sessions — cache reads are not broken out per day, so a daily share cannot be computed here.";
+    +"gap, at each day's own rate.\nThe trend is that share recomputed per day. A day that billed no "
+    +"tokens has no share to compute, so the line breaks across it rather than carrying a neighbour's "
+    +"value forward.";
+  // Engaged time is the ONE hero trend drawn from a different day set. Said on
+  // the tile, because the tiles otherwise look directly comparable and are not.
+  var ENGAGED_TREND_NOTE="\ntrend covers days you worked; the other tiles' trends cover billed days.";
 
   function renderScoreHero(d){
     var t=d.totals||{},p=(d.previous&&d.previous.totals)||{};
@@ -474,13 +488,22 @@ import { renderUsage } from './usage-orchestrators.mjs';
         esc(fmtMins(t.spanMinutes))+" summed"
         +'<span class="d-note">sessions overlap</span>'
         +kpiFoot(deltaChip(t.engagedSeconds,p.engagedSeconds,{}),
-          sparklineSvg(mapRows(d.engagedByDay).map(function(x){return Number(x.v)||0;}),{})),"",ladder(t))
+          sparklineSvg(mapRows(d.engagedByDay).map(function(x){return Number(x.v)||0;}),{})),
+        "",ladder(t)+ENGAGED_TREND_NOTE)
       // Cache share is up-good, unlike the cost tile beside it: cache reads
       // bill at 0.1× input, so a bigger share of them is a cheaper window.
       // The delta is in percentage POINTS — a percent-of-a-percent would be
       // read as a share change and is not what moved.
+      // A day that billed no tokens has no share to compute. It keeps its slot
+      // in the series as a null, which sparklineSvg draws as a BREAK — never a
+      // carried-forward value, which would state a figure for a day that has
+      // none, and never a dropped point, which would squeeze the time axis.
       +kpi("cache read",cacheShare.toFixed(1)+"%",cacheSubtitle(t)
-        +kpiFoot(deltaChip(cacheShare,prevCacheShare,{unit:" pp"}),""),"warnv",CACHE_TIP);
+        +kpiFoot(deltaChip(cacheShare,prevCacheShare,{unit:" pp"}),
+          spark(function(x){
+            var tok=fld(x.v,"tokens");
+            return tok?pct(fld(x.v,"cacheRead"),tok):null;
+          })),"warnv",CACHE_TIP);
     document.getElementById("u-asof").textContent=d.pricesAsOf?("rates as of "+d.pricesAsOf):"";
 
   }
@@ -496,7 +519,8 @@ import { renderUsage } from './usage-orchestrators.mjs';
   var TIP_PER_SESSION="Median api-equivalent cost of one session, and the 90th percentile of the same "
     +"set.\nSessions with NO token evidence at all are excluded: they are structurally $0 (a Codex "
     +"subagent rollout whose tokens were stripped as a double-count, say), not cheap, and folding "
-    +"them in would drag the median toward zero for a reason that is not about spend.";
+    +"them in would drag the median toward zero for a reason that is not about spend.\n<$0.01 means "
+    +"a real, positive figure smaller than a cent — not zero.";
   var TIP_PER_HOUR="Api-equivalent cost ÷ engaged hours.\nEngaged time unions active sub-intervals "
     +"split at 15-minute silences — not wall clock, and not the sum of session spans, which "
     +"double-counts overlap.\n— when no engaged time was measured.";
@@ -526,10 +550,10 @@ import { renderUsage } from './usage-orchestrators.mjs';
         auto==null?"no prompts you typed in window"
           :(touch==null?"touch rate not recorded"
             :esc(fmtRatio(touch))+" prompts / engaged hour"),"",TIP_AUTONOMY)
-      +kpi("cost / session",med==null?"—":fmtUsd(med),
+      +kpi("cost / session",med==null?"—":fmtUsdMin(med),
         med==null?"no priced sessions in window"
           :"median &middot; excludes $0-by-construction"
-            +'<span class="d-note">P90 '+esc(p90==null?"—":fmtUsd(p90))+"</span>","",TIP_PER_SESSION)
+            +'<span class="d-note">P90 '+esc(p90==null?"—":fmtUsdMin(p90))+"</span>","",TIP_PER_SESSION)
       +kpi("cost / engaged hour",perHour==null?"—":fmtUsd(perHour),
         perHour==null?"no engaged time measured":"engaged time, not wall clock","",TIP_PER_HOUR);
   }
@@ -829,9 +853,13 @@ import { renderUsage } from './usage-orchestrators.mjs';
     +"to) and surfaced here instead of vanishing.\nRate is exceptions ÷ responses × 1000.";
   var ABORT_TIP="Turns the transcript recorded as interrupted — the answer was stopped mid-flight. "
     +"Counted apart from exceptions: an abort is a choice, not a failure.";
-  var REL_ABSENT="No per-day line: /api/usage's per-day rows carry tokens, cost and sessions, so "
-    +"exceptions exist only as a window total. A daily trend would have to be invented rather than "
-    +"read, so none is drawn.";
+  // The per-day series rides the SAME first-billed-day attribution the session
+  // count uses, which is not the moment a turn dropped: a session that spans
+  // midnight lands all of its exceptions on one day. Said on the panel, because
+  // a reader will otherwise take a peak as "something broke that afternoon".
+  var REL_TREND_NOTE="Attributed to the day each session first billed — not the moment a turn "
+    +"dropped, so a session spanning midnight lands all of its exceptions on one day. A session that "
+    +"never billed has no day to attribute to and appears in neither this line nor the counts above.";
 
   function relRate(t){
     var r=Number(t&&t.responses)||0;
@@ -854,6 +882,30 @@ import { renderUsage } from './usage-orchestrators.mjs';
       +'<span class="rel-v tnum">'+esc(o.value)+"</span>"
       +'<span class="rel-sub">'+esc(o.sub)+"</span>"+(o.flag||"")+"</div>";
   }
+  // The single worst day, named. "Worst" is a fact the counts already carry —
+  // no threshold is invented to decide what counts as a spike, because any
+  // constant this file picked would be a judgement the data never made.
+  function relWorstDay(rows){
+    var worst=null;
+    for(var i=0;i<rows.length;i++){
+      var n=fld(rows[i].v,"exceptions");
+      if(n>0&&(!worst||n>worst.n))worst={day:rows[i].day,n:n};
+    }
+    return worst;
+  }
+  function relTrend(d){
+    var rows=dayRows(d),series=rows.map(function(x){return fld(x.v,"exceptions");});
+    var total=series.reduce(function(a,n){return a+n;},0);
+    if(!total)return '<div class="rel-trend"><div class="hr-t">exceptions by day</div>'
+      +'<div class="empty">no exceptions on any day in this window.</div></div>';
+    var worst=relWorstDay(rows);
+    // Icon, words and color together — the day is named in text, so the flag
+    // survives a reader who cannot separate the status tokens.
+    var flag=worst?'<span class="rel-flag" data-sev="warn"><i aria-hidden="true">▲</i>worst day '
+      +esc(worst.day.slice(5))+" &middot; "+esc(fmtNum(worst.n))+" of "+esc(fmtNum(total))+"</span>":"";
+    return '<div class="rel-trend"><div class="hr-t">exceptions by day</div>'
+      +sparklineSvg(series,{w:640,h:44})+flag+"</div>";
+  }
   function renderScoreReliability(d){
     var body=ensureBlock("u-reliability",
       stripHtml("u-reliability","reliability","turns that never landed"),"u-models");
@@ -866,7 +918,7 @@ import { renderUsage } from './usage-orchestrators.mjs';
         flag:relFlag(cur,p?relRate(p):null)})
       +relStat({label:"aborted turns",value:fmtNum(ab),
         sub:resp?fmtRatio(ab/resp*1000)+" per 1k responses":"no responses in window",tip:ABORT_TIP})
-      +"</div><p class=\"hr-note\">"+esc(REL_ABSENT)+"</p>";
+      +"</div>"+relTrend(d)+'<p class="hr-note">'+esc(REL_TREND_NOTE)+"</p>";
   }
 
   function renderScoreModels(d){
@@ -1175,6 +1227,18 @@ import { renderUsage } from './usage-orchestrators.mjs';
   function sessionP50(sx){
     return Array.isArray(sx.latHist)?bucketPercentile(sx.latHist,LAT_EDGES,0.5):null;
   }
+  // A raw spelling carrying "[object Object]" is not a spelling — it is a
+  // failed toString, and printing it would put this dashboard's own
+  // rendering-artifact sentinel inside a tooltip. Rejected as not-recorded,
+  // which is what a stringification failure actually leaves behind. Observed
+  // on every Codex row in a live window: usage-modes.mjs joins Codex's
+  // sandboxPolicy into the raw string and that field is an OBJECT in real
+  // rollouts, so the value never was a spelling. Fixing the join is upstream's
+  // to make; refusing to render the wreckage is this file's.
+  function rawSpelling(v){
+    var s=reportedIdentity(v);
+    return (s&&s.indexOf("[object ")<0)?s:null;
+  }
   // The posture the transcript recorded, and NOTHING when it recorded none: an
   // unobserved or unmapped raw value is not a posture, and a badge that guessed
   // one would read exactly like an observed one. `modeRaw` is the host's own
@@ -1184,7 +1248,7 @@ import { renderUsage } from './usage-orchestrators.mjs';
   function modeBadge(sx){
     var mode=reportedIdentity(sx.mode);
     if(!mode)return "";
-    var raw=reportedIdentity(sx.modeRaw);
+    var raw=rawSpelling(sx.modeRaw);
     return '<span class="s-chip s-mode" data-mode="'+esc(mode)+'" title="'
       +esc("permission posture: "+mode
         +(raw?" · recorded by the host as \""+raw+"\"":" · the host's own spelling was not recorded"))
@@ -1244,7 +1308,7 @@ import { renderUsage } from './usage-orchestrators.mjs';
     // never-omit-a-line rule: a fact that was measured and found absent reads
     // "Not recorded"/"—", not silence, which would teach the reader the field
     // does not exist (ADR-0009 §5).
-    var modeRaw=reportedIdentity(sx.modeRaw),modeName=reportedIdentity(sx.mode);
+    var modeRaw=rawSpelling(sx.modeRaw),modeName=reportedIdentity(sx.mode);
     var posture=modeName
       ? esc(modeName)+" <span class='sd-conf'>("
         +esc(modeRaw?"recorded by the host as \""+modeRaw+"\"":"host spelling not recorded")+")</span>"

--- a/src/lib/dashboard/client/usage.mjs
+++ b/src/lib/dashboard/client/usage.mjs
@@ -4,7 +4,7 @@
 import { VIEWS, authHeaders, esc, setTab, syncHash } from './bootstrap.mjs';
 import { ago } from './intelligence.mjs';
 import { renderModelFacets, renderModelInventory, renderModelLifecycle } from './model-lifecycle.mjs';
-import { bucketPositionPct, deltaChip, donut2, histogram, rankedRows, sparklineSvg, stackedDays } from './usage-rhythm.mjs';
+import { bucketPercentile, bucketPositionPct, deltaChip, donut2, histogram, rankedRows, sparklineSvg, stackedDays } from './usage-rhythm.mjs';
 import { renderUsage } from './usage-orchestrators.mjs';
 
   // ══ Usage tab ══════════════════════════════════════════════════════════════
@@ -1124,6 +1124,57 @@ import { renderUsage } from './usage-orchestrators.mjs';
   function reportedIdentity(v){v=String(v==null?"":v).trim();return v&&!/^unknown$/i.test(v)?v:null;}
   function identityName(v){var raw=reportedIdentity(v);if(!raw)return"Not recorded";return{claude:"Claude Code",codex:"Codex",opencode:"OpenCode",anthropic:"Anthropic",openai:"OpenAI",openrouter:"OpenRouter",bedrock:"AWS Bedrock",vertex:"Google Vertex AI",foundry:"Microsoft Foundry",gateway:"Custom gateway",ollama:"Ollama",lmstudio:"LM Studio"}[raw.toLowerCase()]||raw;}
 
+  // ── per-session chips ─────────────────────────────────────────────────────
+  // Evidence the row already carries, shown only where the transcript
+  // established it. An ABSENT chip is itself the signal that the fact was
+  // never recorded — a chip that appeared with a guessed value would be
+  // indistinguishable from one that was measured.
+  var LAT_CHIP_TIP="This session's median response latency, interpolated from its own latency "
+    +"histogram — the same bucket math the window's rhythm panel uses.\ncodex host-measured · "
+    +"claude/opencode derived from event gaps — not streaming TTFT.\nA value in the last bucket "
+    +"has no upper edge and is printed with ≥.";
+  function sessionP50(sx){
+    return Array.isArray(sx.latHist)?bucketPercentile(sx.latHist,LAT_EDGES,0.5):null;
+  }
+  // The posture the transcript recorded, and NOTHING when it recorded none: an
+  // unobserved or unmapped raw value is not a posture, and a badge that guessed
+  // one would read exactly like an observed one. `modeRaw` is the host's own
+  // spelling and rides in the tooltip when the payload carries it — the
+  // aggregate does not project that field today, so the tooltip says the raw
+  // form was not recorded rather than inventing one.
+  function modeBadge(sx){
+    var mode=reportedIdentity(sx.mode);
+    if(!mode)return "";
+    var raw=reportedIdentity(sx.modeRaw);
+    return '<span class="s-chip s-mode" data-mode="'+esc(mode)+'" title="'
+      +esc("permission posture: "+mode
+        +(raw?" · recorded by the host as \""+raw+"\"":" · the host's own spelling was not recorded"))
+      +'">'+esc(mode)+"</span>";
+  }
+  // Context fill, and only when BOTH halves were observed: the last turn's
+  // context tokens AND that model's window. Codex records a window; claude and
+  // opencode do not, and this page carries no published-window table to fall
+  // back on — so the chip is omitted rather than divided by a guessed
+  // denominator, which would be a fabricated percentage.
+  function ctxChip(sx){
+    var used=Number(sx.ctxLastTokens),win=Number(sx.ctxWindow);
+    if(!isFinite(used)||!isFinite(win)||used<=0||win<=0)return "";
+    return '<span class="s-chip" title="'
+      +esc("context at the last turn: "+fmtTok(used)+" of "+fmtTok(win)
+        +" tokens — both recorded by the transcript")
+      +'">ctx '+esc(Math.min(100,used/win*100).toFixed(0))+"%</span>";
+  }
+  function sessionChips(sx){
+    var out="",len=Number(sx.lenSeconds)||0,p50=sessionP50(sx);
+    if(len>0)out+='<span class="s-chip" title="'
+      +esc("engaged length — this session's active sub-intervals unioned, split at 15-minute "
+        +"silences; not its first-to-last span, which the duration column shows")
+      +'">'+esc(fmtSecs(len))+"</span>";
+    if(p50!=null)out+='<span class="s-chip" title="'+esc(LAT_CHIP_TIP)+'">p50 '
+      +esc(fmtAtLeast(p50,60,fmtSecs))+"</span>";
+    return out+modeBadge(sx)+ctxChip(sx);
+  }
+
   /* The ten fields that shipped on the wire and rendered nowhere. Everything
      here comes from the row the browser already holds — no route, no fetch. */
   function sdetail(sx){
@@ -1149,7 +1200,22 @@ import { renderUsage } from './usage-orchestrators.mjs';
     var flags="skill "+dash(sx.skill)+" · plugin "+dash(sx.plugin)
       +" · sidechain "+(sx.sidechain==null?"—":(sx.sidechain?"yes":"no"))
       +" · worktree "+dash(sx.worktree);
-    var rows=[["execution host",esc(identityName(sx.host))],["inference provider",esc(provider)+" <span class='sd-conf'>("+esc(providerContext)+")</span>"],["models",esc(models)],["basis",esc(basis)+conf],["tokens",esc(toks)],
+    // Posture and rhythm are the row's own v11 evidence, spelled out here
+    // where the chips only had room for a badge. Both follow this strip's
+    // never-omit-a-line rule: a fact that was measured and found absent reads
+    // "Not recorded"/"—", not silence, which would teach the reader the field
+    // does not exist (ADR-0009 §5).
+    var modeRaw=reportedIdentity(sx.modeRaw),modeName=reportedIdentity(sx.mode);
+    var posture=modeName
+      ? esc(modeName)+" <span class='sd-conf'>("
+        +esc(modeRaw?"recorded by the host as \""+modeRaw+"\"":"host spelling not recorded")+")</span>"
+      : "Not recorded <span class='sd-conf'>(no posture evidence in this transcript)</span>";
+    var p50=sessionP50(sx);
+    var rhythm="engaged "+((Number(sx.lenSeconds)||0)>0?fmtSecs(sx.lenSeconds):"—")
+      +" · p50 "+(p50==null?"—":fmtAtLeast(p50,60,fmtSecs))
+      +" · latency samples "+fmtNum(Number(sx.latCount)||0)
+      +" · aborts "+fmtNum(Number(sx.aborts)||0);
+    var rows=[["execution host",esc(identityName(sx.host))],["inference provider",esc(provider)+" <span class='sd-conf'>("+esc(providerContext)+")</span>"],["models",esc(models)],["posture",posture],["rhythm",esc(rhythm)],["basis",esc(basis)+conf],["tokens",esc(toks)],
       ["tools",esc(tools)],["flags",esc(flags)]];
     return '<div class="sdetail" id="sd-'+esc(sx.id)+'" hidden>'
       +rows.map(function(r){
@@ -1184,6 +1250,7 @@ import { renderUsage } from './usage-orchestrators.mjs';
       +'<span class="s-host s-'+esc(host)+'" title="'+esc(identityTip)+'" aria-label="Execution host: '+esc(identityName(host))+'">'+esc(identityName(host))+"</span>"
       +'<span class="s-title">'+esc(sx.title||"(untitled)")+wt+"</span>"
       +'<span class="cat'+(uncl?" uncl":"")+'" data-w="'+weak+'">'+esc(cat)+"</span>"
+      +'<span class="s-chips">'+sessionChips(sx)+"</span>"
       +'<span class="s-when mono">'+esc(whenTxt)+"</span>"
       +'<span class="s-dur mono">'+esc(fmtMins(sx.minutes))+"</span>"
       +'<span class="s-turns mono">'+esc((sx.prompts||0)+"/"+(sx.responses||0))+"</span>"

--- a/src/lib/dashboard/client/usage.mjs
+++ b/src/lib/dashboard/client/usage.mjs
@@ -410,7 +410,10 @@ import { renderUsage } from './usage-orchestrators.mjs';
   // the extra digit claims a precision a bucket floor does not have.
   function fmtSecs(sec){
     sec=Number(sec)||0;
-    if(sec<60)return (sec<10?Math.round(sec*10)/10:Math.round(sec))+"s";
+    // <=60, not <60: the latency histogram's overflow bucket floor IS 60s, and
+    // that value has to read "60s" so "≥60s" names the bucket edge the reader
+    // can see on the axis. Rolling it up to "1m" renamed the boundary.
+    if(sec<=60)return (sec<10?Math.round(sec*10)/10:Math.round(sec))+"s";
     if(sec<5400)return Math.round(sec/60)+"m";
     var h=Math.round(sec/360)/10;
     return (h%1===0?String(h):h.toFixed(1))+"h";
@@ -544,9 +547,9 @@ import { renderUsage } from './usage-orchestrators.mjs';
   // bundle that cannot import that module. A test pins the copies equal, so a
   // change to either goes red instead of silently re-labelling every bucket.
   var LAT_EDGES=[2,5,10,30,60];
-  var LAT_LABELS=["≤2s","≤5s","≤10s","≤30s","≤60s","＞60s"];
+  var LAT_LABELS=["≤2s","≤5s","≤10s","≤30s","≤60s",">60s"];
   var LEN_EDGES=[300,900,2700,7200];
-  var LEN_LABELS=["≤5m","≤15m","≤45m","≤2h","＞2h"];
+  var LEN_LABELS=["≤5m","≤15m","≤45m","≤2h",">2h"];
   var LAT_TIP="Wall-clock gap between a prompt and the response that answered it.\n"
     +"codex host-measured · claude/opencode derived from event gaps — not streaming TTFT.\n"
     +"The last bucket has no upper edge, so a percentile landing in it reports that bucket's "

--- a/src/lib/dashboard/client/usage.mjs
+++ b/src/lib/dashboard/client/usage.mjs
@@ -1057,7 +1057,7 @@ import { renderUsage } from './usage-orchestrators.mjs';
   function limRow(label,usedPercent,resetSec,sub,windowMinutes){
     var p=Math.max(0,Math.min(100,Number(usedPercent)||0));
     var col=p>=90?"var(--fail)":(p>=70?"var(--warn)":"var(--ok)");
-    return '<div class="mrow"><span class="mname">'+esc(label)+"</span>"
+    return '<div class="mrow"><span class="mname" title="'+esc(label)+'">'+esc(label)+"</span>"
       +'<span class="mbar"><i style="width:'+p.toFixed(1)+"%;background:"+col+'"></i>'
       +paceTick(resetSec,windowMinutes)+"</span>"
       +'<span class="mval mono">'+p.toFixed(0)+"%</span>"

--- a/src/lib/dashboard/client/usage.mjs
+++ b/src/lib/dashboard/client/usage.mjs
@@ -301,49 +301,6 @@ import { renderUsage } from './usage-orchestrators.mjs';
       +"open unions whole session spans; summed double-counts overlap.";
   }
 
-  // Host-neutral telemetry is deliberately separate from the scorecard's
-  // measured totals. A missing common envelope means an older API response,
-  // not zero observations; the UI says so rather than backfilling a claim.
-  var TELEMETRY_HOSTS=[
-    {key:"claude",label:"Claude"},
-    {key:"codex",label:"Codex transcript"},
-    {key:"opencode",label:"OpenCode"}
-  ];
-  var TELEMETRY_CATEGORIES=[
-    ["prompts","prompts"],["responses","responses"],["toolCalls","tools"],
-    ["commandExecutions","commands"],["fileChanges","file changes"],
-    ["mcpCalls","MCP"],["collaboration","collaboration"]
-  ];
-  function renderTelemetryCoverage(health){
-    var el=document.getElementById("u-telemetry-grid");
-    if(!el)return;
-    health=health||{};
-    el.innerHTML=TELEMETRY_HOSTS.map(function(host){
-      var source=health[host.key]||{},status=String(source.status||"not-read");
-      var common=source.diagnostics&&source.diagnostics.common;
-      var counts;
-      if(!common){
-        counts="coverage not reported by this API";
-      }else if(status==="ok"){
-        counts=fmtNum(common.unitsParsed)+"/"+fmtNum(common.unitsSeen)+" parsed · "+fmtNum(common.prompts)+" prompts · "+fmtNum(common.responses)+" responses";
-      }else if(common.unitsSeen>0){
-        counts=fmtNum(common.unitsParsed)+"/"+fmtNum(common.unitsSeen)+" parsed · "+fmtNum(common.prompts)+" prompts · "+fmtNum(common.responses)+" responses · partial coverage";
-      }else{
-        counts="coverage unavailable"+(source.reason?" · "+String(source.reason):"");
-      }
-      if(common&&common.warnings&&common.warnings.length) counts+=" · "+common.warnings.join(", ");
-      var capabilities=source.capabilities||{};
-      var caps=TELEMETRY_CATEGORIES.map(function(item){
-        var state=String(capabilities[item[0]]||"unavailable");
-        return '<span class="tc-cap" data-state="'+esc(state)+'" title="'+esc(item[1]+" capability: "+state)+'">'+esc(item[1])+" "+esc(state)+"</span>";
-      }).join("");
-      return '<article class="telemetry-card" data-status="'+esc(status)+'">'
-        +'<div class="tc-head"><span>'+esc(host.label)+"</span><span class=\"tc-status\">"+esc(status)+"</span></div>"
-        +'<div class="tc-counts">'+esc(counts)+"</div>"
-        +'<div class="tc-caps">'+caps+"</div></article>";
-    }).join("");
-  }
-
   // ── panels grafted onto the served scorecard markup ───────────────────────
   // page.mjs renders the scorecard's containers. The panels below arrived
   // after that markup shipped and build their own container instead of growing
@@ -701,8 +658,6 @@ import { renderUsage } from './usage-orchestrators.mjs';
       return '<div class="daybar" title="'+esc(tip)+'"><div class="db-fill" style="height:'+h.toFixed(1)+'%"></div>'
         +'<span class="db-lab">'+esc(x.day.slice(8))+"</span></div>";
     }).join(""):'<div class="empty">no days in window.</div>';
-    renderTelemetryCoverage(d.sourceHealth);
-
   }
 
   function renderScoreHosts(d){
@@ -854,9 +809,10 @@ import { renderUsage } from './usage-orchestrators.mjs';
       +"</div>","u-punch");
     if(!pair)return;
     pair.innerHTML=toolRows(d)
-      +'<p class="hr-note">Invocations as each host recorded them. A host that does not report tool '
-      +"calls contributes nothing here rather than a zero — telemetry coverage above says which "
-      +"hosts report them at all.</p>";
+      +'<p class="hr-note">Invocations as each host recorded them, under each host\'s own tool '
+      +"names — nothing is renamed to make two hosts line up. A host that records no tool calls "
+      +"contributes nothing here rather than a zero, so these totals are not a cross-host "
+      +"comparison of how much tooling each one did.</p>";
     var mix=document.getElementById("u-modelmix");
     if(mix)mix.innerHTML=modelMix(d);
   }

--- a/src/lib/dashboard/client/usage.mjs
+++ b/src/lib/dashboard/client/usage.mjs
@@ -625,24 +625,12 @@ import { renderUsage } from './usage-orchestrators.mjs';
       +"is Claude's sidechain flag or Codex's ledger-backed thread source — either way, not a "
       +"session a human was driving.</p></div>";
   }
-  function providerRows(d){
-    var list=entries(d.byInferenceProvider);
-    var max=list.length?list[0].cost:0;
-    return '<div class="hr-block"><div class="hr-t">inference provider</div>'
-      +(list.length?rankedRows(list.map(function(x){
-        return {label:x.name==="not-recorded"?"Not recorded":identityName(x.name),
-          value:fmtUsd(x.cost),share:pct(x.cost,max),dim:x.name==="not-recorded"};
-      })):'<div class="empty">no provider evidence in window.</div>')
-      +'<p class="hr-note">A transcript host does not prove which vendor served the tokens, so '
-      +"spend whose provenance was never observed keys to <b>Not recorded</b> instead of being "
-      +"attributed to an assumption.</p></div>";
-  }
   function renderScoreHowRun(d){
     var body=ensureBlock("u-howrun",
-      stripHtml("u-howrun","how you run","permission posture · who drove · who served"),"u-rhythm");
+      stripHtml("u-howrun","how you run","permission posture · who drove"),"u-rhythm");
     if(!body)return;
     body.innerHTML='<div class="howrun"><div class="hr-block hr-chart">'+modeChart(d)+"</div>"
-      +'<div class="hr-side">'+sourceDonut(d)+providerRows(d)+"</div></div>";
+      +'<div class="hr-side">'+sourceDonut(d)+"</div></div>";
   }
 
   function renderScoreDayBars(d){

--- a/src/lib/dashboard/client/usage.mjs
+++ b/src/lib/dashboard/client/usage.mjs
@@ -4,6 +4,7 @@
 import { VIEWS, authHeaders, esc, setTab, syncHash } from './bootstrap.mjs';
 import { ago } from './intelligence.mjs';
 import { renderModelFacets, renderModelInventory, renderModelLifecycle } from './model-lifecycle.mjs';
+import { deltaChip, sparklineSvg } from './usage-rhythm.mjs';
 import { renderUsage } from './usage-orchestrators.mjs';
 
   // ══ Usage tab ══════════════════════════════════════════════════════════════
@@ -333,31 +334,174 @@ import { renderUsage } from './usage-orchestrators.mjs';
     }).join("");
   }
 
+  // ── panels grafted onto the served scorecard markup ───────────────────────
+  // page.mjs renders the scorecard's containers. The panels below arrived
+  // after that markup shipped and build their own container instead of growing
+  // the served template with ids it has no other reason to know about. Every
+  // one is IDEMPOTENT: renderScore runs on each poll, so a second call finds
+  // the container the first call built rather than stacking a duplicate.
+  //
+  // scoreBlock walks up to the direct child of #v-score that owns `id`, which
+  // is the granularity the scorecard's own layout uses (a .strip, a .two pair,
+  // the .hero grid) — so an inserted panel lands between whole sections, never
+  // inside one.
+  function scoreBlock(id){
+    var el=document.getElementById(id),view=document.getElementById("v-score");
+    if(!el||!view)return null;
+    while(el&&el.parentNode&&el.parentNode!==view)el=el.parentNode;
+    return (el&&el.parentNode===view)?el:null;
+  }
+  function ensureBlock(probeId,html,afterId){
+    var existing=document.getElementById(probeId);
+    if(existing)return existing;
+    var anchor=scoreBlock(afterId);
+    if(!anchor)return null;
+    var host=document.createElement("div");
+    host.innerHTML=html;
+    var node=host.firstElementChild;
+    if(!node)return null;
+    anchor.parentNode.insertBefore(node,anchor.nextSibling);
+    return document.getElementById(probeId);
+  }
+  // byDay ascending. Shared by the day-bar strip and every per-day series
+  // below, so they cannot disagree about which days are in the window.
+  function dayRows(d){
+    var out=[],k;
+    for(k in (d.byDay||{}))out.push({day:k,v:d.byDay[k]});
+    out.sort(function(a,b){return a.day<b.day?-1:1;});
+    return out;
+  }
+  // engagedByDay is a SIBLING map with its own key set, not a byDay field:
+  // byDay's presence contract is billed days only, and a day worked but never
+  // billed still has engaged time. Sorting it separately keeps that day in the
+  // trend instead of dropping it to match a different question's day set.
+  function mapRows(map){
+    var out=[],k;
+    for(k in (map||{}))out.push({day:k,v:map[k]});
+    out.sort(function(a,b){return a.day<b.day?-1:1;});
+    return out;
+  }
+  function fmtRatio(n){
+    if(n==null||!isFinite(n))return "—";
+    return Math.abs(n)>=10?String(Math.round(n)):n.toFixed(1);
+  }
   // renderScore was one CC-41 function writing ~10 independent scorecard
   // regions (hero KPIs, cost-per-day bars, host cards, token bar/legend,
   // punchcard, models, OpenRouter, projects, categories) in sequence. Split
   // by region; each keeps its original logic verbatim, so the rendered DOM
   // and its ordering are unchanged.
+
+  // A hero tile's footer: the change against the previous equal-length window,
+  // and a per-day trend for the same figure. Both self-suppress when the data
+  // cannot support them (deltaChip is '' with no previous window, sparklineSvg
+  // is '' below two points), so a tile with neither renders exactly as it did
+  // before this row existed.
+  function kpiFoot(chip,spark){
+    return (chip||spark)?'<div class="kpi-foot">'+chip+spark+"</div>":"";
+  }
+  // The cache tile's own dollar claim. cacheSavedUsd is computed server-side
+  // as a DIFFERENCE — the same tokens priced as fresh input minus priced as
+  // cache reads, at the rate in effect on the day they were spent — so it
+  // cannot drift out of step with the pricing table the way a hardcoded
+  // discount factor would. Rendered only when there is a figure to render.
+  function cacheSubtitle(t){
+    var saved=Number(t.cacheSavedUsd)||0;
+    return "priced at 0.1&times; input"
+      +(saved>0?'<span class="d-note">saved &asymp; '+esc(fmtUsd(saved))+" vs uncached</span>":"");
+  }
+  var CACHE_TIP="Share of this window's tokens that were cache reads. Higher is cheaper, so a rise "
+    +"is the good direction.\nsaved ≈ prices the same cache-read tokens as fresh input and takes the "
+    +"gap, at each day's own rate.\nNo trend line: /api/usage's per-day rows carry tokens, cost and "
+    +"sessions — cache reads are not broken out per day, so a daily share cannot be computed here.";
+
   function renderScoreHero(d){
-    var t=d.totals||{};
-    var cacheShare=pct(t.cacheRead,t.tokens);
+    var t=d.totals||{},p=(d.previous&&d.previous.totals)||{};
+    var rows=dayRows(d);
+    var cacheShare=pct(t.cacheRead,t.tokens),prevCacheShare=pct(p.cacheRead,p.tokens);
+    function spark(pick){return sparklineSvg(rows.map(pick),{});}
     document.getElementById("u-hero").innerHTML=
-      kpi("sessions",fmtNum(t.sessions),esc(fmtNum(t.responses))+" assistant turns","")
-      +kpi("api-equivalent",fmtUsd(t.cost),"list price &middot; not plan billing","accent")
-      +kpi("tokens",fmtTok(t.tokens),esc(fmtTok(t.output))+" out &middot; "+esc(fmtTok(t.cacheRead))+" cached","")
+      kpi("sessions",fmtNum(t.sessions),esc(fmtNum(t.responses))+" assistant turns"
+        +kpiFoot(deltaChip(t.sessions,p.sessions,{}),
+          spark(function(x){return fld(x.v,"sessions");})),"")
+      +kpi("api-equivalent",fmtUsd(t.cost),"list price &middot; not plan billing"
+        +kpiFoot(deltaChip(t.cost,p.cost,{downIsGood:true}),
+          spark(function(x){return fld(x.v,"cost");})),"accent")
+      +kpi("tokens",fmtTok(t.tokens),esc(fmtTok(t.output))+" out &middot; "+esc(fmtTok(t.cacheRead))+" cached"
+        +kpiFoot(deltaChip(t.tokens,p.tokens,{neutral:true}),
+          spark(function(x){return fld(x.v,"tokens");})),"")
       +kpi("engaged time",fmtHours(t.engagedSeconds),
         esc(fmtMins(t.spanMinutes))+" summed"
-        +'<span class="d-note">sessions overlap</span>',"",ladder(t))
-      +kpi("cache read",cacheShare.toFixed(1)+"%","priced at 0.1&times; input","warnv");
+        +'<span class="d-note">sessions overlap</span>'
+        +kpiFoot(deltaChip(t.engagedSeconds,p.engagedSeconds,{}),
+          sparklineSvg(mapRows(d.engagedByDay).map(function(x){return Number(x.v)||0;}),{})),"",ladder(t))
+      // Cache share is up-good, unlike the cost tile beside it: cache reads
+      // bill at 0.1× input, so a bigger share of them is a cheaper window.
+      // The delta is in percentage POINTS — a percent-of-a-percent would be
+      // read as a share change and is not what moved.
+      +kpi("cache read",cacheShare.toFixed(1)+"%",cacheSubtitle(t)
+        +kpiFoot(deltaChip(cacheShare,prevCacheShare,{unit:" pp"}),""),"warnv",CACHE_TIP);
     document.getElementById("u-asof").textContent=d.pricesAsOf?("rates as of "+d.pricesAsOf):"";
 
   }
 
+  // ── second KPI row: cadence, autonomy, unit economics ─────────────────────
+  var TIP_PER_DAY="Sessions ÷ active days.\nAn ACTIVE day is one this window actually billed tokens "
+    +"on — that is byDay's own contract, so a day worked but never billed is not counted and breaks "
+    +"the streak.\nStreak counts consecutive active days ending at the most recent one.";
+  var TIP_AUTONOMY="Assistant responses ÷ prompts you typed — how far each prompt travels.\n"
+    +"Prompts are MAIN-THREAD only: a subagent's prompts are written by the harness, not by you, so "
+    +"counting them would inflate the denominator with work nobody asked for by hand.\nTouch rate is "
+    +"those same prompts per engaged hour.";
+  var TIP_PER_SESSION="Median api-equivalent cost of one session, and the 90th percentile of the same "
+    +"set.\nSessions with NO token evidence at all are excluded: they are structurally $0 (a Codex "
+    +"subagent rollout whose tokens were stripped as a double-count, say), not cheap, and folding "
+    +"them in would drag the median toward zero for a reason that is not about spend.";
+  var TIP_PER_HOUR="Api-equivalent cost ÷ engaged hours.\nEngaged time unions active sub-intervals "
+    +"split at 15-minute silences — not wall clock, and not the sum of session spans, which "
+    +"double-counts overlap.\n— when no engaged time was measured.";
+
+  function dayBefore(day){
+    var t=Date.parse(String(day)+"T00:00:00Z");
+    if(!isFinite(t))return null;
+    return new Date(t-86400000).toISOString().slice(0,10);
+  }
+  function activeStreak(days){
+    if(!days.length)return 0;
+    var n=1;
+    for(var i=days.length-1;i>0;i--){
+      if(dayBefore(days[i])!==days[i-1])break;
+      n++;
+    }
+    return n;
+  }
+  function cadenceCells(t,active,streak){
+    var perDay=active?(Number(t.sessions)||0)/active:null;
+    var auto=t.responsesPerPrompt,touch=t.humanPromptsPerHour;
+    var med=t.costPerSessionMedian,p90=t.costPerSessionP90,perHour=t.costPerEngagedHour;
+    return kpi("sessions / active day",fmtRatio(perDay),
+      esc(fmtNum(active))+" active day"+(active===1?"":"s")
+      +'<span class="d-note">streak '+esc(String(streak))+" day"+(streak===1?"":"s")+"</span>","",TIP_PER_DAY)
+      +kpi("autonomy",auto==null?"—":fmtRatio(auto)+"×",
+        auto==null?"no prompts you typed in window"
+          :(touch==null?"touch rate not recorded"
+            :esc(fmtRatio(touch))+" prompts / engaged hour"),"",TIP_AUTONOMY)
+      +kpi("cost / session",med==null?"—":fmtUsd(med),
+        med==null?"no priced sessions in window"
+          :"median &middot; excludes $0-by-construction"
+            +'<span class="d-note">P90 '+esc(p90==null?"—":fmtUsd(p90))+"</span>","",TIP_PER_SESSION)
+      +kpi("cost / engaged hour",perHour==null?"—":fmtUsd(perHour),
+        perHour==null?"no engaged time measured":"engaged time, not wall clock","",TIP_PER_HOUR);
+  }
+  function renderScoreCadence(d){
+    var body=ensureBlock("u-cadence",'<div class="hero hero-2" id="u-cadence"></div>',"u-hero");
+    if(!body)return;
+    var days=dayRows(d).map(function(x){return x.day;});
+    body.innerHTML=cadenceCells(d.totals||{},days.length,activeStreak(days));
+  }
+
   function renderScoreDayBars(d){
     // cost per day
-    var days=[],k;
-    for(k in (d.byDay||{}))days.push({day:k,v:d.byDay[k]});
-    days.sort(function(a,b){return a.day<b.day?-1:1;});
+    var days=dayRows(d);
     var maxDay=0;
     for(var i=0;i<days.length;i++)maxDay=Math.max(maxDay,fld(days[i].v,"cost"));
     document.getElementById("u-days-note").textContent="api-equivalent · "+usageDays+"-day window";
@@ -514,6 +658,7 @@ import { renderUsage } from './usage-orchestrators.mjs';
 
   export function renderScore(d){
     renderScoreHero(d);
+    renderScoreCadence(d);
     renderScoreDayBars(d);
     renderScoreHosts(d);
     renderScoreTokBar(d);

--- a/src/lib/dashboard/client/usage.mjs
+++ b/src/lib/dashboard/client/usage.mjs
@@ -857,7 +857,11 @@ import { renderUsage } from './usage-orchestrators.mjs';
     +"an auth failure. They are excluded from the model list (there is no model to attribute them "
     +"to) and surfaced here instead of vanishing.\nRate is exceptions ÷ responses × 1000.";
   var ABORT_TIP="Turns the transcript recorded as interrupted — the answer was stopped mid-flight. "
-    +"Counted apart from exceptions: an abort is a choice, not a failure.";
+    +"Counted apart from exceptions: an abort is a choice, not a failure.\n"
+    +"CODEX ONLY. Only codex rollouts carry an interrupt signal (turn_aborted); claude and "
+    +"opencode transcripts record nothing when you stop a turn. So the count and its rate are "
+    +"over codex responses alone, and a window with no codex sessions shows — (not 0), because "
+    +"nothing in it could have recorded an interrupt.";
   // The per-day series rides the SAME first-billed-day attribution the session
   // count uses, which is not the moment a turn dropped: a session that spans
   // midnight lands all of its exceptions on one day. Said on the panel, because
@@ -917,12 +921,22 @@ import { renderUsage } from './usage-orchestrators.mjs';
     if(!body)return;
     var t=d.totals||{},p=(d.previous&&d.previous.totals)||null;
     var cur=relRate(t),exc=Number(t.exceptions)||0,ab=Number(t.aborts)||0,resp=Number(t.responses)||0;
+    // aborts is CODEX-ONLY evidence: turn_aborted is the only interrupt signal
+    // any host writes, so a claude-or-opencode window renders "—", not a 0 that
+    // reads as "you never interrupted a turn". The rate's denominator is codex
+    // responses for the same reason — dividing codex aborts by every host's
+    // responses dilutes it by an arbitrary amount that depends on host mix.
+    var cx=(d.byHost&&d.byHost.codex)||null;
+    var cxSess=Number(cx&&cx.sessions)||0,cxResp=Number(cx&&cx.responses)||0;
     body.innerHTML='<div class="rel">'
       +relStat({label:"exceptions / 1k responses",value:cur==null?"—":cur.toFixed(1),
         sub:fmtNum(exc)+" of "+fmtNum(resp)+" responses",tip:REL_TIP,
         flag:relFlag(cur,p?relRate(p):null)})
-      +relStat({label:"aborted turns",value:fmtNum(ab),
-        sub:resp?fmtRatio(ab/resp*1000)+" per 1k responses":"no responses in window",tip:ABORT_TIP})
+      +relStat({label:"aborted turns",value:cxSess?fmtNum(ab):"—",
+        sub:cxSess
+          ?(cxResp?fmtRatio(ab/cxResp*1000)+" per 1k codex responses":"no codex responses in window")
+          :"no codex sessions — no other host records interrupts",
+        tip:ABORT_TIP})
       +"</div>"+relTrend(d)+'<p class="hr-note">'+esc(REL_TREND_NOTE)+"</p>";
   }
 
@@ -1235,9 +1249,9 @@ import { renderUsage } from './usage-orchestrators.mjs';
   // The posture the transcript recorded, and NOTHING when it recorded none: an
   // unobserved or unmapped raw value is not a posture, and a badge that guessed
   // one would read exactly like an observed one. `modeRaw` is the host's own
-  // spelling and rides in the tooltip when the payload carries it — the
-  // aggregate does not project that field today, so the tooltip says the raw
-  // form was not recorded rather than inventing one.
+  // spelling, projected onto the session row by v11Projection, and rides in
+  // this badge's tooltip; the row's detail strip is where an unmapped raw
+  // value is surfaced, since there is no classified name to put on a badge.
   function modeBadge(sx){
     var mode=reportedIdentity(sx.mode);
     if(!mode)return "";
@@ -1271,6 +1285,21 @@ import { renderUsage } from './usage-orchestrators.mjs';
     return out+modeBadge(sx)+ctxChip(sx);
   }
 
+  // THREE states, not two. A transcript that recorded a posture the taxonomy
+  // does not map still recorded a posture: printing "no posture evidence in
+  // this transcript" over a modeRaw sitting on the same row is a fabrication
+  // in the opposite direction from the usual one — denying data that exists.
+  // The host's own spelling is shown instead, labelled unrecognized so it is
+  // never mistaken for a classified posture.
+  function postureLine(sx){
+    var modeRaw=reportedIdentity(sx.modeRaw),modeName=reportedIdentity(sx.mode);
+    if(modeName)return esc(modeName)+" <span class='sd-conf'>("
+      +esc(modeRaw?"recorded by the host as \""+modeRaw+"\"":"host spelling not recorded")+")</span>";
+    return modeRaw
+      ? "Unrecognized <span class='sd-conf'>(host recorded \""+esc(modeRaw)+"\" — not in this taxonomy)</span>"
+      : "Not recorded <span class='sd-conf'>(no posture evidence in this transcript)</span>";
+  }
+
   /* The ten fields that shipped on the wire and rendered nowhere. Everything
      here comes from the row the browser already holds — no route, no fetch. */
   function sdetail(sx){
@@ -1301,16 +1330,15 @@ import { renderUsage } from './usage-orchestrators.mjs';
     // never-omit-a-line rule: a fact that was measured and found absent reads
     // "Not recorded"/"—", not silence, which would teach the reader the field
     // does not exist (ADR-0009 §5).
-    var modeRaw=reportedIdentity(sx.modeRaw),modeName=reportedIdentity(sx.mode);
-    var posture=modeName
-      ? esc(modeName)+" <span class='sd-conf'>("
-        +esc(modeRaw?"recorded by the host as \""+modeRaw+"\"":"host spelling not recorded")+")</span>"
-      : "Not recorded <span class='sd-conf'>(no posture evidence in this transcript)</span>";
+    var posture=postureLine(sx);
     var p50=sessionP50(sx);
     var rhythm="engaged "+((Number(sx.lenSeconds)||0)>0?fmtSecs(sx.lenSeconds):"—")
       +" · p50 "+(p50==null?"—":fmtAtLeast(p50,60,fmtSecs))
       +" · latency samples "+fmtNum(Number(sx.latCount)||0)
-      +" · aborts "+fmtNum(Number(sx.aborts)||0);
+      // Same capability rule as the reliability panel, applied per row: only a
+      // codex transcript can record an interrupt, so a claude/opencode row
+      // reads "not recorded" rather than a measured-looking 0.
+      +" · aborts "+(sx.host==="codex"?fmtNum(Number(sx.aborts)||0):"not recorded for this host");
     var rows=[["execution host",esc(identityName(sx.host))],["inference provider",esc(provider)+" <span class='sd-conf'>("+esc(providerContext)+")</span>"],["models",esc(models)],["posture",posture],["rhythm",esc(rhythm)],["basis",esc(basis)+conf],["tokens",esc(toks)],
       ["tools",esc(tools)],["flags",esc(flags)]];
     return '<div class="sdetail" id="sd-'+esc(sx.id)+'" hidden>'

--- a/src/lib/dashboard/client/usage.mjs
+++ b/src/lib/dashboard/client/usage.mjs
@@ -575,7 +575,7 @@ import { renderUsage } from './usage-orchestrators.mjs';
   }
   function renderScoreRhythm(d){
     var body=ensureBlock("u-rhythm",
-      stripHtml("u-rhythm","your rhythm","session length · response latency"),"u-daybars");
+      stripHtml("u-rhythm","Your rhythm","session length · response latency"),"u-daybars");
     if(!body)return;
     var r=d.rhythm||{};
     body.innerHTML='<div class="rhythm-grid">'+lengthCard(r)+latencyCard(r)+"</div>";
@@ -627,7 +627,7 @@ import { renderUsage } from './usage-orchestrators.mjs';
   }
   function renderScoreHowRun(d){
     var body=ensureBlock("u-howrun",
-      stripHtml("u-howrun","how you run","permission posture · who drove"),"u-rhythm");
+      stripHtml("u-howrun","How you run","permission posture · who drove"),"u-rhythm");
     if(!body)return;
     body.innerHTML='<div class="howrun"><div class="hr-block hr-chart">'+modeChart(d)+"</div>"
       +'<div class="hr-side">'+sourceDonut(d)+"</div></div>";
@@ -792,8 +792,8 @@ import { renderUsage } from './usage-orchestrators.mjs';
   }
   function renderScoreMix(d){
     var pair=ensureBlock("u-toolmix",'<div class="two">'
-      +stripHtml("u-toolmix","tool mix","invocations · top 8, tail folded")
-      +stripHtml("u-modelmix","model mix over time","api-equivalent cost by model family")
+      +stripHtml("u-toolmix","Tool mix","invocations · top 8, tail folded")
+      +stripHtml("u-modelmix","Model mix over time","api-equivalent cost by model family")
       +"</div>","u-punch");
     if(!pair)return;
     pair.innerHTML=toolRows(d)
@@ -870,7 +870,7 @@ import { renderUsage } from './usage-orchestrators.mjs';
   }
   function renderScoreReliability(d){
     var body=ensureBlock("u-reliability",
-      stripHtml("u-reliability","reliability","turns that never landed"),"u-models");
+      stripHtml("u-reliability","Reliability","turns that never landed"),"u-models");
     if(!body)return;
     var t=d.totals||{},p=(d.previous&&d.previous.totals)||null;
     var cur=relRate(t),exc=Number(t.exceptions)||0,ab=Number(t.aborts)||0,resp=Number(t.responses)||0;

--- a/src/lib/dashboard/page.mjs
+++ b/src/lib/dashboard/page.mjs
@@ -434,10 +434,6 @@ export function renderPage({ name, version }) {
         <div class="sh"><h2>cost per day</h2><span class="n mono" id="u-days-note"></span></div>
         <div class="days" id="u-daybars"></div>
       </section>
-      <section class="strip">
-        <div class="sh"><h2>telemetry coverage</h2><span class="n mono" id="u-telemetry-note">capabilities &middot; observed locally</span></div>
-        <div class="telemetry-grid" id="u-telemetry-grid"></div>
-      </section>
       <div class="two">
         <section class="strip">
           <div class="sh"><h2>by host</h2><span class="n mono" id="u-hosts-note"></span></div>

--- a/src/lib/dashboard/page.mjs
+++ b/src/lib/dashboard/page.mjs
@@ -431,28 +431,28 @@ export function renderPage({ name, version }) {
         Cache reads bill at 0.1&times; input and cache writes at 1.25&times;; ignoring that would overstate
         a window by roughly <b>10&times;</b>. <span class="mono" id="u-asof"></span></span></div>
       <section class="strip">
-        <div class="sh"><h2>cost per day</h2><span class="n mono" id="u-days-note"></span></div>
+        <div class="sh"><h2>Cost per day</h2><span class="n mono" id="u-days-note"></span></div>
         <div class="days" id="u-daybars"></div>
       </section>
       <div class="two">
         <section class="strip">
-          <div class="sh"><h2>by host</h2><span class="n mono" id="u-hosts-note"></span></div>
+          <div class="sh"><h2>By host</h2><span class="n mono" id="u-hosts-note"></span></div>
           <div class="psplit" id="u-hosts"></div>
           <div class="tokbar" id="u-tokbar"></div>
           <div class="legend" id="u-toklegend"></div>
         </section>
         <section class="strip">
-          <div class="sh"><h2>when you work</h2><span class="n mono">responses &middot; local time</span></div>
+          <div class="sh"><h2>When you work</h2><span class="n mono">responses &middot; local time</span></div>
           <div id="u-punch"></div>
         </section>
       </div>
       <div class="two">
         <section class="strip">
-          <div class="sh"><h2>models in play</h2><span class="n mono">observed in transcripts &middot; by api-equivalent cost<span class="n-sub" id="u-models-note"></span></span></div>
+          <div class="sh"><h2>Models in play</h2><span class="n mono">observed in transcripts &middot; by api-equivalent cost<span class="n-sub" id="u-models-note"></span></span></div>
           <div id="u-models"></div>
         </section>
         <section class="strip">
-          <div class="sh"><h2>projects</h2><span class="n mono" id="u-projects-note"></span></div>
+          <div class="sh"><h2>Projects</h2><span class="n mono" id="u-projects-note"></span></div>
           <div id="u-projects"></div>
         </section>
       </div>
@@ -460,7 +460,7 @@ export function renderPage({ name, version }) {
         <div class="sh">
           <button class="strip-toggle" type="button" aria-expanded="false" aria-controls="u-openrouter-body">
             <span class="chev" aria-hidden="true">&rsaquo;</span>
-            <h2>provider account analytics</h2>
+            <h2>Provider account analytics</h2>
           </button>
           <span class="n mono" id="u-openrouter-note">offline cache &middot; separate from transcript totals</span></div>
         <div class="strip-body" id="u-openrouter-body" hidden>
@@ -468,7 +468,7 @@ export function renderPage({ name, version }) {
         </div>
       </section>
       <section class="strip">
-        <div class="sh"><h2>what you worked on</h2>
+        <div class="sh"><h2>What you worked on</h2>
           <span class="n mono">classified from titles, skills &amp; tool mix &middot; click to filter</span></div>
         <div id="u-cats"></div>
         <div class="legend" style="margin-top:11px">
@@ -485,11 +485,11 @@ export function renderPage({ name, version }) {
         <b>codex app-server</b> using codex&rsquo;s own login. This panel reads no vendor credential.</span></div>
       <div class="two">
         <section class="strip">
-          <div class="sh"><h2>claude plan limits</h2><span class="n mono" id="u-lim-claude-note"></span></div>
+          <div class="sh"><h2>Claude plan limits</h2><span class="n mono" id="u-lim-claude-note"></span></div>
           <div class="lim" id="u-lim-claude"></div>
         </section>
         <section class="strip">
-          <div class="sh"><h2>codex plan limits</h2><span class="n mono" id="u-lim-codex-note"></span></div>
+          <div class="sh"><h2>Codex plan limits</h2><span class="n mono" id="u-lim-codex-note"></span></div>
           <div class="lim" id="u-lim-codex"></div>
         </section>
       </div>
@@ -574,10 +574,10 @@ export function renderPage({ name, version }) {
         </div>
       </details>
       <div class="two">
-        <section class="strip" aria-labelledby="mli-history-title"><div class="sh"><h2 id="mli-history-title">change history</h2><span class="n mono" id="mli-history-note"></span></div><div id="mli-history"></div></section>
-        <section class="strip"><div class="sh"><h2>consumers</h2><span class="n mono">configured / reported evidence</span></div><div id="mli-consumers"></div></section>
+        <section class="strip" aria-labelledby="mli-history-title"><div class="sh"><h2 id="mli-history-title">Change history</h2><span class="n mono" id="mli-history-note"></span></div><div id="mli-history"></div></section>
+        <section class="strip"><div class="sh"><h2>Consumers</h2><span class="n mono">configured / reported evidence</span></div><div id="mli-consumers"></div></section>
       </div>
-      <section class="strip"><div class="sh"><h2>swap impact</h2><span class="n mono">read-only canonical-policy preview</span></div><div id="mli-impact"></div></section>
+      <section class="strip"><div class="sh"><h2>Swap impact</h2><span class="n mono">read-only canonical-policy preview</span></div><div id="mli-impact"></div></section>
       <div class="foot">swap analysis is available with <b>ak models plan</b> &middot; the dashboard never changes a route</div>
       <dialog class="mli-detail-dialog" id="mli-detail" aria-labelledby="mli-detail-title"><div class="mli-detail-head"><h2 id="mli-detail-title">Model details</h2><button type="button" id="mli-detail-close" aria-label="Close model details">Close</button></div><div id="mli-detail-body"></div></dialog>
     </section>

--- a/src/lib/dashboard/session-security.mjs
+++ b/src/lib/dashboard/session-security.mjs
@@ -7,12 +7,17 @@ export const TRANSCRIPT_ROOTS = [
   path.join(os.homedir(), '.codex', 'sessions'),
 ];
 
+/** The plain (top-level session) id charset — shared by parseSessionId and
+ *  parseNamespacedSessionId's parent segment, so a namespaced id's parent
+ *  half can never be more permissive than a plain id already is. */
+const PLAIN_ID_RE = /^[A-Za-z0-9._-]{1,128}$/;
+
 /** Decode and validate an opaque session identifier. */
 export function parseSessionId(raw) {
   let id;
   try { id = decodeURIComponent(String(raw ?? '')); } catch { return null; }
   if (id !== String(raw ?? '') && /%[0-9a-f]{2}/i.test(id)) return null;
-  if (!/^[A-Za-z0-9._-]{1,128}$/.test(id)) return null;
+  if (!PLAIN_ID_RE.test(id)) return null;
   if (id === '.' || id === '..') return null;
   return id;
 }
@@ -24,6 +29,55 @@ export function resolvesInsideRoot(root, id) {
   return resolved !== base
     && resolved.startsWith(base + path.sep)
     && path.dirname(resolved) === base;
+}
+
+/** A nested Claude subagent transcript's own filename stem (no `.jsonl`):
+ *  Claude Code writes every one as `agent-<hex>`, or `agent-<name>-<hex>`
+ *  when the Task tool call carried a name (the Agent tool's own `name`
+ *  parameter, charset [A-Za-z0-9_-]). A survey of this machine's real
+ *  corpus (404 files, Task 5 round 2) found most stems carry a name — a
+ *  hex-only pattern would leave most subagent sessions still unopenable.
+ *  '/', '.', and '\' are simply not in this charset, so no separate
+ *  traversal check is needed for this segment beyond the charset itself. */
+const SUBAGENT_STEM_RE = /^agent-[A-Za-z0-9_-]{1,100}$/;
+
+/** Decode and validate a namespaced Claude subagent session id: EXACTLY
+ *  `<parentId>/<stem>`, one slash. Returns `{ parentId, stem }` on a match,
+ *  `null` otherwise — the same fail-closed contract as parseSessionId.
+ *
+ *  Kept as its own function rather than folded into parseSessionId (which
+ *  would risk loosening it) because parseSessionId/resolvesInsideRoot ALSO
+ *  gate the live-playback/SSE routes (handlePlayback, handleTranscriptEvents
+ *  in dashboard-server.mjs), which resolve ids through an entirely
+ *  different, independently-guarded code path
+ *  (live/transcript-streams.mjs's own VALID_ID + locate()) that this fix has
+ *  no reason to touch or re-verify — the smallest correct surface is a new,
+ *  additive function used only by the one route this round is about. */
+export function parseNamespacedSessionId(raw) {
+  let id;
+  try { id = decodeURIComponent(String(raw ?? '')); } catch { return null; }
+  if (id !== String(raw ?? '') && /%[0-9a-f]{2}/i.test(id)) return null;
+  const parts = id.split('/');
+  if (parts.length !== 2) return null; // exactly one slash, two segments
+  const [parentId, stem] = parts;
+  if (!PLAIN_ID_RE.test(parentId) || parentId === '.' || parentId === '..') return null;
+  if (!SUBAGENT_STEM_RE.test(stem)) return null;
+  return { parentId, stem };
+}
+
+/** Require a namespaced id's two segments to resolve to a subagent
+ *  transcript exactly two levels below a direct child of a transcript root:
+ *  `<root>/<parentId>/subagents/<stem>.jsonl`. The parent segment is pinned
+ *  by reusing resolvesInsideRoot UNCHANGED — "resolves inside the project
+ *  dir exactly as plain ids do" — the child segment then extends that by
+ *  two fixed, already-validated components. Belt and braces alongside
+ *  parseNamespacedSessionId's charset checks, not a substitute for them:
+ *  this only ever receives segments that already passed that parse. */
+export function resolvesNamespacedInsideRoot(root, parentId, stem) {
+  if (!resolvesInsideRoot(root, parentId)) return false;
+  const parentDir = path.join(path.resolve(root), parentId);
+  const resolved = path.resolve(parentDir, 'subagents', `${stem}.jsonl`);
+  return resolved.startsWith(parentDir + path.sep) && path.dirname(resolved) === path.join(parentDir, 'subagents');
 }
 
 /** Copy and mask every string field in each transcript turn. */

--- a/src/lib/dashboard/styles/usage.mjs
+++ b/src/lib/dashboard/styles/usage.mjs
@@ -655,6 +655,17 @@ export const USAGE_CSS = `
    inside it. The fill already carries its own radius, so nothing else changes.
    The tick overrides .mbar i's block/height/background by carrying a class
    (0,2,1 beats 0,1,1). */
+/* A pool label — "GPT-5.3-Codex-Spark · weekly" — needs ~183px, where the
+   shared magnitude grid gives 137px and ellipsises the rest. Two rows both
+   truncating to something plausible is how one pool reported under two lanes
+   went unnoticed, so the limits label column is widened to fit: measured
+   1000-1600px, the full string fits with no row overflow. The cap is a MAX,
+   not a min — each .mrow is its own grid, so a content-sized track would let
+   every row start its meter at a different x and the panel would stop reading
+   as a stack of comparable bars. A fixed cap that yields under pressure keeps
+   them aligned; below ~950px the ellipsis returns and limRow's title carries
+   the full text. */
+.lim .mrow{grid-template-columns:minmax(0,190px) minmax(60px,0.9fr) 54px minmax(88px,auto)}
 .lim .mbar{position:relative; overflow:visible}
 .lim .mbar i.pace{
   position:absolute; top:-3px; bottom:-3px; left:0; width:2px; height:auto;

--- a/src/lib/dashboard/styles/usage.mjs
+++ b/src/lib/dashboard/styles/usage.mjs
@@ -356,7 +356,7 @@ export const USAGE_CSS = `
    which is silent: the row still renders, it just renders the wrong data under
    each heading. */
 .srow{
-  display:grid; grid-template-columns:18px 82px minmax(150px,2.1fr) minmax(90px,1fr) minmax(84px,.9fr) 106px 46px 60px 62px 68px 20px;
+  display:grid; grid-template-columns:18px 82px minmax(150px,2fr) minmax(80px,.55fr) minmax(155px,1.35fr) 106px 46px 60px 62px 68px 20px;
   gap:10px; align-items:center; padding:9px 13px; background:var(--panel); font-size:12.5px; cursor:pointer;
 }
 .srow:hover{background:var(--panel-2)}
@@ -369,7 +369,13 @@ export const USAGE_CSS = `
    make room for its annotations. Each chip renders only when the transcript
    established that fact, so an absent chip is the signal that it was never
    recorded; the cell overflows hidden rather than wrapping, which would give
-   this row a second line and halve the list's density. */
+   this row a second line and halve the list's density.
+   The track is sized (155px floor) from the widest chip set measured across a
+   real 100-row corpus, which was 170px — so the common row does not truncate
+   at all. The rarer wider set still has to degrade somehow, and .s-mode is the
+   one chip that shrinks: the numbers beside it are short and must stay whole,
+   while a posture ellipsised to "unrestric…" is the same treatment .cat and
+   .s-title already get in this table, with the full value in its tooltip. */
 .s-chips{display:flex; gap:4px; overflow:hidden; min-width:0}
 .s-chip{
   font-family:var(--mono); font-size:9.5px; color:var(--ink-dim); white-space:nowrap; flex:none;
@@ -377,7 +383,7 @@ export const USAGE_CSS = `
 }
 /* The posture chip always spells the posture out, so its tint is a second
    channel and never the only one carrying "this session had a wide mandate". */
-.s-chip.s-mode{color:var(--ink-2)}
+.s-chip.s-mode{color:var(--ink-2); flex:0 1 auto; min-width:0; overflow:hidden; text-overflow:ellipsis}
 .s-chip.s-mode[data-mode="plan"]{color:var(--purple); border-color:color-mix(in srgb,var(--purple) 32%,transparent)}
 .s-chip.s-mode[data-mode="unrestricted"]{color:var(--warn); border-color:color-mix(in srgb,var(--warn) 32%,transparent)}
 .s-proj,.s-when,.s-dur,.s-turns,.s-tok{color:var(--ink-2); font-size:11.5px}

--- a/src/lib/dashboard/styles/usage.mjs
+++ b/src/lib/dashboard/styles/usage.mjs
@@ -356,7 +356,7 @@ export const USAGE_CSS = `
    which is silent: the row still renders, it just renders the wrong data under
    each heading. */
 .srow{
-  display:grid; grid-template-columns:18px 82px minmax(150px,2.1fr) minmax(90px,1fr) 106px 46px 60px 62px 68px 20px;
+  display:grid; grid-template-columns:18px 82px minmax(150px,2.1fr) minmax(90px,1fr) minmax(84px,.9fr) 106px 46px 60px 62px 68px 20px;
   gap:10px; align-items:center; padding:9px 13px; background:var(--panel); font-size:12.5px; cursor:pointer;
 }
 .srow:hover{background:var(--panel-2)}
@@ -364,6 +364,22 @@ export const USAGE_CSS = `
 .s-claude{color:var(--warn); background:color-mix(in srgb,var(--warn) 12%,transparent); border-color:color-mix(in srgb,var(--warn) 30%,transparent)}
 .s-codex{color:var(--accent); background:var(--accent-soft); border-color:color-mix(in srgb,var(--accent) 35%,transparent)}
 .s-title{overflow:hidden; text-overflow:ellipsis; white-space:nowrap}
+/* Per-session evidence chips, in their OWN column rather than crowded into
+   .s-title — the title is the row's identifier and must not be truncated to
+   make room for its annotations. Each chip renders only when the transcript
+   established that fact, so an absent chip is the signal that it was never
+   recorded; the cell overflows hidden rather than wrapping, which would give
+   this row a second line and halve the list's density. */
+.s-chips{display:flex; gap:4px; overflow:hidden; min-width:0}
+.s-chip{
+  font-family:var(--mono); font-size:9.5px; color:var(--ink-dim); white-space:nowrap; flex:none;
+  border:1px solid var(--line); border-radius:100px; padding:1px 6px; background:var(--panel-2);
+}
+/* The posture chip always spells the posture out, so its tint is a second
+   channel and never the only one carrying "this session had a wide mandate". */
+.s-chip.s-mode{color:var(--ink-2)}
+.s-chip.s-mode[data-mode="plan"]{color:var(--purple); border-color:color-mix(in srgb,var(--purple) 32%,transparent)}
+.s-chip.s-mode[data-mode="unrestricted"]{color:var(--warn); border-color:color-mix(in srgb,var(--warn) 32%,transparent)}
 .s-proj,.s-when,.s-dur,.s-turns,.s-tok{color:var(--ink-2); font-size:11.5px}
 .s-cost{text-align:right; color:var(--ink); font-size:12px}
 .s-tx{background:transparent; border:0; color:var(--ink-dim); font-size:14px; cursor:pointer; padding:0; border-radius:5px}
@@ -483,9 +499,13 @@ export const USAGE_CSS = `
      in the 20px glyph column and were clipped, and the transcript glyph wrapped
      onto a line of its own. Five columns for five cells is what makes the
      arithmetic close. The category is still reachable — it is on the project
-     header chips and on the Scorecard's category rows. */
+     header chips and on the Scorecard's category rows.
+     .s-chips joins the hidden set for the same arithmetic reason: it is an
+     ELEVENTH desktop column, and leaving it visible here would put six cells
+     into five tracks. Nothing it carries is lost — the row's detail strip
+     spells posture and rhythm out in full. */
   .srow{grid-template-columns:18px 58px 1fr 68px 20px}
-  .srow .s-proj,.srow .s-when,.srow .s-dur,.srow .s-turns,.srow .s-tok,.srow .cat{display:none}
+  .srow .s-proj,.srow .s-when,.srow .s-dur,.srow .s-turns,.srow .s-tok,.srow .cat,.srow .s-chips{display:none}
   .phead{grid-template-columns:16px 1fr 58px 66px}
   .phead .pchips,.phead .p-h,.phead .p-tok{display:none}
 }

--- a/src/lib/dashboard/styles/usage.mjs
+++ b/src/lib/dashboard/styles/usage.mjs
@@ -599,4 +599,19 @@ export const USAGE_CSS = `
 .hr-note b{color:var(--ink-2); font-weight:600}
 @media(max-width:820px){ .howrun{grid-template-columns:1fr} }
 
+/* reliability strip — a failure rate is a claim about the whole window, so it
+   is stated as a figure with its own denominator beside it, not as a gauge. */
+.rel{display:grid; gap:12px; grid-template-columns:repeat(auto-fit,minmax(240px,1fr))}
+.rel-stat{min-width:0; border:1px solid var(--line); border-radius:var(--r-sm); background:var(--panel-2); padding:12px 14px}
+.rel-k{display:block; font-size:10px; font-weight:600; letter-spacing:.07em; text-transform:uppercase; color:var(--ink-dim)}
+.rel-v{display:block; font-size:23px; font-weight:700; letter-spacing:-.02em; color:var(--ink); margin-top:5px}
+.rel-sub{display:block; font-size:11px; color:var(--ink-2); margin-top:4px}
+/* Direction is carried by the glyph and the wording as well as the color: a
+   reader who cannot separate --warn from --ok still gets the whole finding. */
+.rel-flag{display:inline-flex; align-items:center; gap:5px; margin-top:9px; font-size:11px; font-weight:600}
+.rel-flag i{font-style:normal}
+.rel-flag[data-sev="warn"]{color:var(--warn)}
+.rel-flag[data-sev="ok"]{color:var(--ok)}
+.rel-flag[data-sev="flat"]{color:var(--ink-dim)}
+
 `;

--- a/src/lib/dashboard/styles/usage.mjs
+++ b/src/lib/dashboard/styles/usage.mjs
@@ -573,4 +573,30 @@ export const USAGE_CSS = `
 .rrow-fill.dim{background:var(--ink-dim)}
 .rrow-val{font-size:12px; color:var(--ink); text-align:right}
 
+/* rhythm panel — two histogram cards side by side */
+.rhythm-grid{display:grid; gap:16px; grid-template-columns:repeat(auto-fit,minmax(280px,1fr))}
+.rcard{min-width:0; border:1px solid var(--line); border-radius:var(--r-sm); background:var(--panel-2); padding:12px 14px 13px}
+.rcard-h{display:flex; align-items:baseline; justify-content:space-between; gap:10px; margin-bottom:8px}
+.rcard-t{font-size:12px; font-weight:600; color:var(--ink)}
+.rcard-n{font-size:10.5px; color:var(--ink-dim)}
+/* A marker's label is drawn ABOVE the plot box (top:-14px) so a tall bar can
+   never cover it — which means the card has to reserve that strip, or the
+   label is clipped by the card instead. Two markers close together would
+   collide on one line, so the second sits a row higher; the reserved strip is
+   tall enough for both. */
+.rcard .hist{padding-top:30px}
+.rcard .hist-marker+.hist-marker .hist-marker-lab{top:-27px}
+
+/* how-you-run panel — the by-day posture chart beside the two small readouts */
+.howrun{display:grid; gap:18px; grid-template-columns:minmax(0,1.35fr) minmax(0,1fr)}
+.hr-block{min-width:0}
+.hr-side{display:flex; flex-direction:column; gap:16px; min-width:0}
+.hr-t{font-size:11px; font-weight:600; letter-spacing:.06em; text-transform:uppercase; color:var(--ink-dim); margin-bottom:10px}
+/* Every chart in this panel carries a sentence saying what its buckets mean
+   and what the de-emphasised bucket is holding — the charts split spend by
+   things ("posture", "provider") whose absence is itself a finding. */
+.hr-note{margin:10px 0 0; font-size:11px; line-height:1.5; color:var(--ink-dim)}
+.hr-note b{color:var(--ink-2); font-weight:600}
+@media(max-width:820px){ .howrun{grid-template-columns:1fr} }
+
 `;

--- a/src/lib/dashboard/styles/usage.mjs
+++ b/src/lib/dashboard/styles/usage.mjs
@@ -128,12 +128,21 @@ export const USAGE_CSS = `
 .kpi.accent .v{color:var(--accent)}
 .kpi.warnv .v{color:var(--warn)}
 /* The tile footer carries the change against the previous equal-length window
-   and the per-day trend for the same figure. space-between rather than a gap:
-   the sparkline anchors to the tile's right edge, so the trend lines across a
-   row of tiles share a baseline and can be compared at a glance. Both halves
+   and the per-day trend for the same figure. space-between rather than a gap,
+   so the chip stays left and the sparkline anchors to the tile's right edge
+   instead of drifting with the chip's width. Each line is scaled to its OWN
+   min/max and the tiles do not all cover the same day set (Engaged time is
+   drawn from days worked, the rest from days billed), so these are shape
+   readings one tile at a time — not a row to compare across. Both halves
    self-suppress when their data is absent, and the row is omitted entirely
    when neither renders — so a tile never grows an empty band. */
 .kpi-foot{display:flex; align-items:center; justify-content:space-between; gap:10px; margin-top:9px; min-height:24px}
+/* The chip is the reading; the line is the shape. So the chip never shrinks or
+   wraps — a unit-suffixed delta ("0 pp") broke across two lines once the cache
+   tile gained a trend to share the row with — and the sparkline gives up width
+   instead, scaling inside its own viewBox. */
+.kpi-foot .dchip{flex:none; white-space:nowrap}
+.kpi-foot .spark{flex:0 1 auto; min-width:0; max-width:100%}
 /* The second KPI row is a continuation of the hero, not a new section: same
    grid, pulled up so the two read as one block, and quieter numbers because
    these are derived rates rather than the measured totals above them. */
@@ -639,6 +648,14 @@ export const USAGE_CSS = `
 .rel-flag[data-sev="warn"]{color:var(--warn)}
 .rel-flag[data-sev="ok"]{color:var(--ok)}
 .rel-flag[data-sev="flat"]{color:var(--ink-dim)}
+/* The per-day exceptions line sits below the two stat cards at full strip
+   width, not inside the .rel grid — a third auto-fit cell would have squeezed
+   it to a third of the row, which is not enough horizontal room for one point
+   per day to read as a shape. max-width keeps it from stretching thin on a
+   wide window; the line never scales, so its stroke stays 1.6px everywhere. */
+.rel-trend{margin-top:14px}
+.rel-trend .spark{display:block; max-width:100%}
+.rel-trend .rel-flag{margin-top:2px}
 
 /* limits pace tick — where the window's own clock is, so a meter reads as
    "ahead of pace" or "behind" rather than only as a level. Scoped to .lim so

--- a/src/lib/dashboard/styles/usage.mjs
+++ b/src/lib/dashboard/styles/usage.mjs
@@ -477,4 +477,83 @@ export const USAGE_CSS = `
   .phead .pchips,.phead .p-h,.phead .p-tok{display:none}
 }
 
+/* rhythm/mode chart primitives (usage-rhythm.mjs) — a small, self-contained
+   component family for the rhythm/mode panels: delta chips, sparklines, a
+   latency histogram, a stacked-by-day bar, a two-slice donut, and ranked
+   rows. Every numeric figure here carries .tnum (tabular-nums) explicitly,
+   same spirit as .mono elsewhere in this file — inherited font-variant-numeric
+   from body is not something a reader can see in the markup, so state it. */
+.tnum{font-variant-numeric:tabular-nums}
+
+/* delta chip */
+.dchip{display:inline-flex; align-items:center; gap:4px; font-size:12px; font-weight:600}
+.dchip-arrow{font-style:normal}
+.dchip[data-tone="good"]{color:var(--ok)}
+.dchip[data-tone="bad"]{color:var(--fail)}
+.dchip[data-tone="flat"]{color:var(--ink-dim)}
+
+/* sparkline */
+.spark{overflow:visible; vertical-align:middle}
+.spark-line{fill:none; stroke:var(--ink-dim); stroke-width:1.6}
+.spark-dot{fill:var(--accent)}
+
+/* histogram — sequential single hue; markers render BEFORE bars in DOM
+   order so a bar always paints over a marker line where they cross; the
+   marker's own label sits above the plot box instead, so it is never itself
+   covered. */
+.hist-plot{position:relative}
+.hist-markers{position:absolute; inset:0; pointer-events:none}
+.hist-marker{position:absolute; top:0; bottom:0}
+.hist-marker-line{position:absolute; top:0; bottom:0; border-left:1px dashed var(--ink-dim)}
+.hist-marker-lab{position:absolute; top:-14px; left:3px; font-style:normal; font-size:9px; font-weight:600; color:var(--ink-dim); white-space:nowrap}
+.hist-bars{display:flex; align-items:flex-end; gap:6px}
+.hist-bar{flex:1; min-width:0; display:flex; flex-direction:column; align-items:center; justify-content:flex-end}
+.hist-val{font-size:9.5px; color:var(--ink-2); margin-bottom:3px}
+.hist-fill{display:block; width:100%; border-radius:4px 4px 0 0; background:var(--accent)}
+.hist-labs{display:flex; gap:6px; margin-top:6px}
+.hist-lab{flex:1; min-width:0; text-align:center; font-size:9.5px; color:var(--ink-dim); overflow:hidden; text-overflow:ellipsis; white-space:nowrap}
+
+/* stacked days — order is bottom-up; segments render in a column-reverse
+   flex with a 2px gap, so the LAST key in order paints at the top of the
+   stack. not-recorded/other are forced to --ink-dim in JS (never a series
+   color), same "the uncategorized bucket is de-emphasis, not a hue" rule
+   renderScoreCategories already applies to Unclassified above. */
+.stackdays{display:flex; align-items:flex-end; gap:6px}
+.sday-col{flex:1; min-width:0; display:flex; flex-direction:column; align-items:center}
+.sday-bar{width:100%; display:flex; flex-direction:column-reverse; gap:2px}
+.sday-seg{display:block; width:100%}
+.sday-seg.top{border-radius:4px 4px 0 0}
+.sday-lab{margin-top:6px; font-family:var(--mono); font-size:9.5px; color:var(--ink-dim)}
+
+/* two-slice donut — a mask on the RING punches the hole; the center label is
+   a sibling, not a descendant, of the masked element, so it is never itself
+   clipped. Seams between slices are --line, not bare transparent, so a small
+   gap reads as a deliberate seam rather than a rendering gap. */
+.donut2-wrap{display:flex; align-items:center; gap:16px}
+.donut2{position:relative; width:88px; height:88px; flex:none}
+.donut2-ring{
+  display:block; width:100%; height:100%; border-radius:50%;
+  -webkit-mask:radial-gradient(farthest-side,transparent 61%,#000 62%);
+  mask:radial-gradient(farthest-side,transparent 61%,#000 62%);
+}
+.donut2-center{
+  position:absolute; inset:0; display:grid; place-items:center;
+  font-style:normal; font-size:13px; font-weight:700; color:var(--ink); text-align:center;
+}
+.donut2-legend{display:flex; flex-direction:column; gap:8px}
+.donut2-item{display:flex; align-items:center; gap:6px; font-size:12.5px; color:var(--ink-2)}
+.donut2-item i{width:8px; height:8px; border-radius:2px; display:inline-block; flex:none}
+.donut2-item b{color:var(--ink); font-weight:600}
+
+/* ranked rows — the same label/track/value grammar as .mrow above, kept as
+   its own small component so this file's chart primitives can evolve
+   independently of the scorecard's magnitude rows. */
+.rrows{display:flex; flex-direction:column; gap:7px}
+.rrow{display:grid; grid-template-columns:minmax(90px,1.2fr) 2fr auto; gap:10px; align-items:center}
+.rrow-label{font-size:12px; color:var(--ink); overflow:hidden; text-overflow:ellipsis; white-space:nowrap}
+.rrow-track{height:7px; border-radius:4px; background:var(--panel-2); overflow:hidden}
+.rrow-fill{display:block; height:100%; border-radius:4px; background:var(--accent)}
+.rrow-fill.dim{background:var(--ink-dim)}
+.rrow-val{font-size:12px; color:var(--ink); text-align:right}
+
 `;

--- a/src/lib/dashboard/styles/usage.mjs
+++ b/src/lib/dashboard/styles/usage.mjs
@@ -634,4 +634,19 @@ export const USAGE_CSS = `
 .rel-flag[data-sev="ok"]{color:var(--ok)}
 .rel-flag[data-sev="flat"]{color:var(--ink-dim)}
 
+/* limits pace tick — where the window's own clock is, so a meter reads as
+   "ahead of pace" or "behind" rather than only as a level. Scoped to .lim so
+   the same .mbar the scorecard's magnitude rows use is untouched: the track
+   joins the positioned layer only here, and only here does it stop clipping,
+   which lets the tick stand 3px proud of a 7px bar instead of being lost
+   inside it. The fill already carries its own radius, so nothing else changes.
+   The tick overrides .mbar i's block/height/background by carrying a class
+   (0,2,1 beats 0,1,1). */
+.lim .mbar{position:relative; overflow:visible}
+.lim .mbar i.pace{
+  position:absolute; top:-3px; bottom:-3px; left:0; width:2px; height:auto;
+  border-radius:1px; background:var(--ink-2); transform:translateX(-1px);
+}
+.lim .legend .pace-key{width:2px; height:11px; border-radius:1px; background:var(--ink-2)}
+
 `;

--- a/src/lib/dashboard/styles/usage.mjs
+++ b/src/lib/dashboard/styles/usage.mjs
@@ -609,14 +609,17 @@ export const USAGE_CSS = `
 .rcard .hist{padding-top:30px}
 .rcard .hist-marker+.hist-marker .hist-marker-lab{top:-27px}
 
-/* how-you-run panel — the by-day posture chart beside the two small readouts */
-.howrun{display:grid; gap:18px; grid-template-columns:minmax(0,1.35fr) minmax(0,1fr)}
+/* how-you-run panel — the by-day posture chart beside the delegation donut.
+   The side column holds one 88px ring and its legend, so the stack takes the
+   larger share: a wider day chart is more days legible, where extra width in
+   the side column would only be padding around a fixed-size ring. */
+.howrun{display:grid; gap:18px; grid-template-columns:minmax(0,2fr) minmax(0,1fr)}
 .hr-block{min-width:0}
 .hr-side{display:flex; flex-direction:column; gap:16px; min-width:0}
 .hr-t{font-size:11px; font-weight:600; letter-spacing:.06em; text-transform:uppercase; color:var(--ink-dim); margin-bottom:10px}
 /* Every chart in this panel carries a sentence saying what its buckets mean
    and what the de-emphasised bucket is holding — the charts split spend by
-   things ("posture", "provider") whose absence is itself a finding. */
+   things (posture, who drove) whose absence is itself a finding. */
 .hr-note{margin:10px 0 0; font-size:11px; line-height:1.5; color:var(--ink-dim)}
 .hr-note b{color:var(--ink-2); font-weight:600}
 @media(max-width:820px){ .howrun{grid-template-columns:1fr} }

--- a/src/lib/dashboard/styles/usage.mjs
+++ b/src/lib/dashboard/styles/usage.mjs
@@ -497,16 +497,20 @@ export const USAGE_CSS = `
 .spark-line{fill:none; stroke:var(--ink-dim); stroke-width:1.6}
 .spark-dot{fill:var(--accent)}
 
-/* histogram — sequential single hue; markers render BEFORE bars in DOM
-   order so a bar always paints over a marker line where they cross; the
-   marker's own label sits above the plot box instead, so it is never itself
-   covered. */
+/* histogram — sequential single hue; a positioned element always paints
+   above a non-positioned one regardless of DOM order (DOM order only breaks
+   ties WITHIN the same paint layer), so .hist-bars must ALSO be positioned —
+   not just come after .hist-markers in the markup — for it to paint over the
+   dashed marker lines. With both positioned (z-index:auto), DOM order then
+   correctly decides between them: markers first, bars second, so bars win.
+   The marker's own label sits above the plot box instead, so it is never
+   itself covered by a bar. */
 .hist-plot{position:relative}
 .hist-markers{position:absolute; inset:0; pointer-events:none}
 .hist-marker{position:absolute; top:0; bottom:0}
 .hist-marker-line{position:absolute; top:0; bottom:0; border-left:1px dashed var(--ink-dim)}
 .hist-marker-lab{position:absolute; top:-14px; left:3px; font-style:normal; font-size:9px; font-weight:600; color:var(--ink-dim); white-space:nowrap}
-.hist-bars{display:flex; align-items:flex-end; gap:6px}
+.hist-bars{position:relative; display:flex; align-items:flex-end; gap:6px}
 .hist-bar{flex:1; min-width:0; display:flex; flex-direction:column; align-items:center; justify-content:flex-end}
 .hist-val{font-size:9.5px; color:var(--ink-2); margin-bottom:3px}
 .hist-fill{display:block; width:100%; border-radius:4px 4px 0 0; background:var(--accent)}

--- a/src/lib/dashboard/styles/usage.mjs
+++ b/src/lib/dashboard/styles/usage.mjs
@@ -200,19 +200,6 @@ export const USAGE_CSS = `
   transition:filter .15s ease;
 }
 .daybar:hover .db-fill{filter:brightness(1.35)}
-.telemetry-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(190px,1fr));gap:8px}
-.telemetry-card{min-width:0;padding:10px 12px;border:1px solid var(--line);border-radius:var(--r-sm);background:var(--panel-2)}
-.telemetry-card .tc-head{display:flex;align-items:center;justify-content:space-between;gap:8px;color:var(--ink);font-size:12px;font-weight:650}
-.telemetry-card .tc-status{font-size:9px;font-weight:650;text-transform:uppercase;letter-spacing:.06em;color:var(--ink-dim)}
-.telemetry-card[data-status="ok"] .tc-status{color:var(--ok)}
-.telemetry-card[data-status="degraded"] .tc-status{color:var(--warn)}
-.telemetry-card[data-status="absent"] .tc-status,.telemetry-card[data-status="not-read"] .tc-status{color:var(--ink-dim)}
-.telemetry-card .tc-counts{margin-top:5px;color:var(--ink-2);font-size:10px;line-height:1.45}
-.telemetry-card .tc-caps{display:flex;flex-wrap:wrap;gap:4px;margin-top:8px}
-.telemetry-card .tc-cap{padding:3px 5px;border:1px solid var(--line);border-radius:5px;color:var(--ink-dim);font:9px/1.1 ui-monospace,monospace}
-.telemetry-card .tc-cap[data-state="supported"]{border-color:color-mix(in srgb,var(--ok) 42%,var(--line));color:var(--ok)}
-.telemetry-card .tc-cap[data-state="unsupported"]{color:var(--ink-dim)}
-.telemetry-card .tc-cap[data-state="unavailable"]{border-color:color-mix(in srgb,var(--warn) 42%,var(--line));color:var(--warn)}
 .db-lab{font-family:var(--mono); font-size:9.5px; color:var(--ink-dim); margin-top:6px}
 
 /* punchcard */

--- a/src/lib/dashboard/styles/usage.mjs
+++ b/src/lib/dashboard/styles/usage.mjs
@@ -127,6 +127,19 @@ export const USAGE_CSS = `
 .kpi .d-note{display:block; color:var(--ink-dim); font-size:11px; margin-top:2px}
 .kpi.accent .v{color:var(--accent)}
 .kpi.warnv .v{color:var(--warn)}
+/* The tile footer carries the change against the previous equal-length window
+   and the per-day trend for the same figure. space-between rather than a gap:
+   the sparkline anchors to the tile's right edge, so the trend lines across a
+   row of tiles share a baseline and can be compared at a glance. Both halves
+   self-suppress when their data is absent, and the row is omitted entirely
+   when neither renders — so a tile never grows an empty band. */
+.kpi-foot{display:flex; align-items:center; justify-content:space-between; gap:10px; margin-top:9px; min-height:24px}
+/* The second KPI row is a continuation of the hero, not a new section: same
+   grid, pulled up so the two read as one block, and quieter numbers because
+   these are derived rates rather than the measured totals above them. */
+.hero-2{margin-top:-4px}
+.hero-2 .kpi{background:var(--panel-2); box-shadow:none}
+.hero-2 .kpi .v{font-size:22px}
 .note{
   display:flex; gap:9px; padding:10px 14px; margin-bottom:16px; border-radius:var(--r-sm);
   background:var(--accent-soft); color:var(--ink-2); font-size:12.5px; align-items:baseline;

--- a/src/lib/pricing.mjs
+++ b/src/lib/pricing.mjs
@@ -130,8 +130,12 @@ export const PRICES = {
  *
  * - **Regional-processing uplift.** OpenAI charges +10% on data-residency
  *   endpoints for models released on/after 2026-03-05. Codex CLI does not use
- *   those endpoints by default, and a transcript does not record which endpoint
- *   served it, so we cannot detect it.
+ *   those endpoints by default, and a rollout names no endpoint, so we cannot
+ *   detect it. Anthropic's equivalent is the 1.1x `inference_geo` uplift on
+ *   "us"-pinned inference; Claude transcripts DO carry `usage.inference_geo`
+ *   per assistant turn, but the only value observed locally is the literal
+ *   "not_available" — the key is recorded, the region is not, so there is
+ *   nothing to price on.
  * - **Large-prompt surcharge.** A 2x input / 1.5x output surcharge above ~272K
  *   input tokens has been reported for the GPT-5.6 line but is NOT restated on
  *   the current pricing page; it is left unmodelled rather than encoded on one
@@ -139,8 +143,16 @@ export const PRICES = {
  * - **`*-pro` models list no cached-input rate** (caching appears unsupported).
  *   Their transcripts therefore report zero cached tokens, so the 0.1x branch
  *   is simply never exercised for them.
- * - **Service tiers.** Batch / Flex / Priority multipliers are not applied; the
- *   transcripts do not record the tier a request used.
+ * - **Service tiers.** Batch / Flex / Priority multipliers are not applied.
+ *   Not for want of a field: Claude turns carry `usage.service_tier` and
+ *   `usage.speed`, and newer Codex rollouts carry a
+ *   `thread_settings.service_tier`. Semantics is the blocker: each corpus holds
+ *   exactly ONE value ("standard" / "standard" / "default"), so no mapping
+ *   from a recorded string to a published multiplier can be checked against
+ *   evidence — only asserted. The Codex field is configured INTENT, not a
+ *   record of the tier that served a request. And which billing SURFACE ran
+ *   (plain Messages API, Batch, Managed Agents) is recorded nowhere at all.
+ *   See docs/USAGE-SCORECARD-METRICS.md §13.3 for the key-presence census.
  */
 export const UNMODELLED_PRICING_FACTORS = Object.freeze([
   'regional-processing-uplift', 'large-prompt-surcharge', 'service-tiers',

--- a/src/lib/quota.mjs
+++ b/src/lib/quota.mjs
@@ -105,10 +105,42 @@ export function readClaudeLimits({ file = claudeLimitsFile() } = {}) {
 
 // ── Codex (app-server) ──────────────────────────────────────────────────────
 
+/** The legacy lane id, from before app-server named its model pools. */
+const GENERIC_CODEX_LANE = 'codex';
+
+/**
+ * app-server reports one pool under BOTH its named lane and the legacy generic
+ * `codex` lane — the same window twice. Left alone, the panel draws two
+ * identical meters and the limit detectors count one pool as two.
+ *
+ * Two windows are the same pool only when duration, reset instant, AND
+ * utilization all match exactly. A difference in any of them means two real
+ * pools and both stay: a percentage guard is what keeps this from folding a
+ * genuinely distinct pool that happens to share a reset clock. Duration and
+ * reset must both be RECORDED — deduping on two absent values would be
+ * dropping a window for want of evidence rather than because of it.
+ *
+ * The named lane wins: "GPT-5.3-Codex-Spark · weekly" says which pool it is
+ * and "codex · weekly" does not. Older builds ship only the generic lane,
+ * which has nothing to dedupe against and comes back untouched.
+ */
+function dedupeGenericLane(lanes) {
+  const generic = lanes.find((l) => l.id === GENERIC_CODEX_LANE);
+  if (!generic || lanes.length < 2) return lanes;
+  const named = lanes.filter((l) => l !== generic).flatMap((l) => l.windows);
+  generic.windows = generic.windows.filter((w) => !(
+    w.windowMinutes !== null && w.resetsAt !== null
+    && named.some((n) => n.windowMinutes === w.windowMinutes
+      && n.resetsAt === w.resetsAt && n.usedPercent === w.usedPercent)
+  ));
+  return generic.windows.length ? lanes : lanes.filter((l) => l !== generic);
+}
+
 /**
  * Normalize a GetAccountRateLimitsResponse. Lanes come from
  * `rateLimitsByLimitId` (per-model pools, e.g. `codex` + `codex_bengalfox`)
- * with the legacy single-bucket `rateLimits` as fallback. Pure.
+ * with the legacy single-bucket `rateLimits` as fallback, and a pool reported
+ * under both a named and the generic lane is kept once. Pure.
  */
 export function normalizeCodexLimits(resp, { fetchedAt = null } = {}) {
   if (!resp || typeof resp !== 'object') return null;
@@ -139,6 +171,7 @@ export function normalizeCodexLimits(resp, { fetchedAt = null } = {}) {
     });
   }
   if (!lanes.length) return null;
+  const deduped = dedupeGenericLane(lanes);
   const rc = resp.rateLimitResetCredits;
   const resetCredits = rc && typeof rc === 'object' && Number.isFinite(Number(rc.availableCount))
     ? {
@@ -156,8 +189,8 @@ export function normalizeCodexLimits(resp, { fetchedAt = null } = {}) {
     provider: 'codex',
     source: 'app-server',
     fetchedAt,
-    planType: lanes.find((l) => l.planType)?.planType ?? null,
-    lanes,
+    planType: deduped.find((l) => l.planType)?.planType ?? null,
+    lanes: deduped,
     resetCredits,
   };
 }

--- a/src/lib/usage-aggregate.mjs
+++ b/src/lib/usage-aggregate.mjs
@@ -856,7 +856,11 @@ export function aggregate(records, { days, now, cutoff, deps, previous = false }
  *   - a session the ledger says is a subagent has its token usage STRIPPED,
  *     mirroring the parse-time exclusion: its rollout replays the parent's
  *     entire token history, so keeping the tokens double-counts the parent
- *     (ccusage/ccusage#950). The record itself stays visible/auditable.
+ *     (ccusage/ccusage#950). `reasoningOutput` goes with them — it is read
+ *     off the SAME cumulative token_count snapshot (finalizeCodexUsage) and
+ *     carries the same inflation, and leaving it made the session detail
+ *     render a replayed "reasoning 412K (in out)" beside an output total the
+ *     strip had just zeroed. The record itself stays visible/auditable.
  * Exported for test.
  */
 export function applyCodexLedger(records, ledger) {
@@ -866,9 +870,10 @@ export function applyCodexLedger(records, ledger) {
     const t = ledger.threads.get(rec.id);
     const fromEdges = ledger.parents instanceof Map && ledger.parents.has(rec.id) ? 'subagent' : null;
     const source = rec.threadSource ?? t?.threadSource ?? fromEdges;
-    if (source === rec.threadSource && (source !== 'subagent' || !rec.usage.length)) return rec;
+    const stripped = !rec.usage.length && !rec.reasoningOutput;
+    if (source === rec.threadSource && (source !== 'subagent' || stripped)) return rec;
     const out = { ...rec, threadSource: source };
-    if (source === 'subagent' && out.usage.length) out.usage = [];
+    if (source === 'subagent') { out.usage = []; out.reasoningOutput = 0; }
     return out;
   });
 }

--- a/src/lib/usage-aggregate.mjs
+++ b/src/lib/usage-aggregate.mjs
@@ -312,7 +312,7 @@ function sealBuckets(...maps) {
 function dayBucket(byDay, day) {
   if (!byDay[day]) {
     byDay[day] = {
-      tokens: 0, cost: 0, sessions: 0, sessionsActive: 0,
+      tokens: 0, cost: 0, cacheRead: 0, sessions: 0, sessionsActive: 0, exceptions: 0,
       byMode: Object.create(null), byModelFamily: Object.create(null),
     };
   }
@@ -376,6 +376,9 @@ function foldSessionUsageRow(row, rec, deps, acc, byDay, byModel, activeDays) {
   const rowTokens = row.input + row.output + row.cacheRead + row.cacheWrite;
   const d = dayBucket(byDay, row.day);
   d.tokens += rowTokens;
+  // Kept alongside `tokens` so the day's cache share is readable without
+  // re-deriving it from the session rows.
+  d.cacheRead += row.cacheRead;
   d.cost = round(d.cost + rowCost);
   // Cost by posture and by model family, per day: the two stacked series the
   // day chart draws. Both live here rather than in the session pass because
@@ -406,6 +409,31 @@ function foldSessionUsageRows(rec, deps, byDay, byModel, rates) {
   }
   for (const day of activeDays) byDay[day].sessionsActive++;
   return { ...acc, firstDay };
+}
+
+/**
+ * The v11 posture, rhythm and context-window facts a session recorded (ADR-0038)
+ * — every one a straight null-safe copy off the record. Carried on the row
+ * rather than folded away because each is a per-session fact the transcript
+ * actually observed, and the window's histograms have to be traceable back to
+ * the sessions that built them. `mode`/`modeRaw`/`latHist`/`ctx*` stay
+ * honest-absent (null) when nothing observed them; a zero there would read as a
+ * measurement. `modeRaw` rides beside the normalized `mode` because the
+ * taxonomy is a judgment call, and a reader checking it needs the evidence it
+ * was made from. Split out of buildSessionRow to keep that projection under the
+ * repo's complexity ceiling.
+ */
+function v11Projection(rec) {
+  return {
+    mode: rec.mode ?? null,
+    modeRaw: rec.modeRaw ?? null,
+    latHist: Array.isArray(rec.latHist) ? rec.latHist.slice() : null,
+    latCount: rec.latCount ?? 0,
+    lenSeconds: rec.lenSeconds ?? 0,
+    ctxWindow: rec.ctxWindow ?? null,
+    ctxLastTokens: rec.ctxLastTokens ?? null,
+    aborts: rec.aborts ?? 0,
+  };
 }
 
 /** One aggregate session row from a parsed record, its folded usage sums,
@@ -439,16 +467,7 @@ function buildSessionRow(rec, usage, verdict) {
     // records (the schema bump re-derives those).
     reasoningOutput: rec.reasoningOutput ?? 0,
     rateLimits: rec.rateLimits ?? null,
-    // v11 posture and rhythm (ADR-0038). Carried on the row, not folded away,
-    // because every one of them is a per-session fact the transcript actually
-    // recorded — and the window's histograms have to be traceable back to the
-    // sessions that built them. `mode` and `latHist` stay honest-absent (null)
-    // when nothing observed them.
-    mode: rec.mode ?? null,
-    latHist: Array.isArray(rec.latHist) ? rec.latHist.slice() : null,
-    latCount: rec.latCount ?? 0,
-    lenSeconds: rec.lenSeconds ?? 0,
-    aborts: rec.aborts ?? 0,
+    ...v11Projection(rec),
     _span: [rec.start ?? rec.end, rec.end],
     // Did this session carry ANY token evidence? A session with no usage rows
     // costs $0 structurally — nothing was measured — rather than because the
@@ -575,7 +594,14 @@ function foldSessionTotals(sessions, byDay, byModel) {
     addTo(bucket(byProject, s.project), s);
     addTo(bucket(byCategory, s.category), s);
     foldSessionByModel(byModel, s);
-    if (s._day && byDay[s._day]) byDay[s._day].sessions++;
+    // Exceptions ride the SAME first-billed-day attribution as the session
+    // count, so the reliability trend and the session trend are drawn from one
+    // convention. A session that never billed has no day to attribute to and
+    // contributes to neither — the same silence, not a different one.
+    if (s._day && byDay[s._day]) {
+      byDay[s._day].sessions++;
+      byDay[s._day].exceptions += s.exceptions;
+    }
     for (const [k, n] of Object.entries(s._punchcard)) punchcard[k] = (punchcard[k] ?? 0) + n;
     for (const [k, n] of Object.entries(s.tools)) byTool[k] = (byTool[k] ?? 0) + n;
     foldSessionIntoTree(tree, s);

--- a/src/lib/usage-aggregate.mjs
+++ b/src/lib/usage-aggregate.mjs
@@ -337,10 +337,13 @@ function addCost(map, key, v) {
  * from the same table, at the same date, as the cost sitting beside it — a
  * savings number quoted at today's rate for August's tokens would be a
  * different claim than the one the panel makes everywhere else. Memoised per
- * (model, provider, day) because a window has few of those and many rows.
+ * (model, provider, day) because a window has few of those and many rows; the
+ * key joins on \x1f (ASCII unit separator), which cannot occur in a model id,
+ * provider or day — and unlike NUL does not make grep read this file as
+ * binary and silently report no matches.
  */
 function cacheSavingPerMillion(model, provider, day, deps, rates) {
-  const key = `${model} ${provider} ${day}`;
+  const key = `${model}\x1f${provider}\x1f${day}`;
   if (rates.has(key)) return rates.get(key);
   const base = { model, provider, day, input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
   const asInput = deps.costOf({ ...base, input: 1e6 }) || 0;

--- a/src/lib/usage-aggregate.mjs
+++ b/src/lib/usage-aggregate.mjs
@@ -528,17 +528,6 @@ function foldSessionIntoTree(tree, s) {
   node.rows.push(s);
 }
 
-/** The bucket key for a session's INFERENCE provider — and only when that
- *  identity was actually observed. A transcript host (`claude`, `codex`) does
- *  not prove which vendor served the tokens, so an unobserved provenance keys
- *  to `'not-recorded'` even when a provider string is present: that string is
- *  an assumption, and spend is not bucketed under assumptions. The ungated
- *  `byProvider` map still exists beside this one for callers that want the
- *  string as-recorded. */
-function providerKey(s) {
-  return s.providerProvenance === 'observed' && s.provider ? s.provider : 'not-recorded';
-}
-
 /** Subagent work is either Claude's sidechain flag or Codex's ledger-backed
  *  thread source; both mean "not a session a human was driving". */
 function sourceKey(s) {
@@ -558,7 +547,7 @@ function foldSessionTotals(sessions, byDay, byModel) {
     cacheSavedUsd: 0, spanMinutes: 0, spanUnionSeconds: 0, engagedSeconds: 0,
   };
   const byHost = Object.create(null), byProvider = Object.create(null);
-  const byMode = Object.create(null), byInferenceProvider = Object.create(null);
+  const byMode = Object.create(null);
   const bySource = Object.create(null), byTool = Object.create(null);
   const byProject = Object.create(null);
   const byCategory = Object.create(null), punchcard = Object.create(null);
@@ -589,7 +578,6 @@ function foldSessionTotals(sessions, byDay, byModel) {
     // 'not-recorded' is a first-class key, not a display fallback: a transcript
     // that carried no mode evidence must not be folded into a real posture.
     addTo(bucket(byMode, s.mode ?? 'not-recorded'), s);
-    addTo(bucket(byInferenceProvider, providerKey(s)), s);
     addTo(bucket(bySource, source), s);
     addTo(bucket(byProject, s.project), s);
     addTo(bucket(byCategory, s.category), s);
@@ -608,7 +596,7 @@ function foldSessionTotals(sessions, byDay, byModel) {
   }
 
   return {
-    totals, byHost, byProvider, byMode, byInferenceProvider, bySource, byTool,
+    totals, byHost, byProvider, byMode, bySource, byTool,
     byProject, byCategory, punchcard, tree, spanMs, pricedCosts,
   };
 }
@@ -816,11 +804,11 @@ export function aggregate(records, { days, now, cutoff, deps, previous = false }
   sessions.sort((a, b) => b.cost - a.cost || Date.parse(b.start) - Date.parse(a.start));
 
   const folded = foldSessionTotals(sessions, byDay, byModel);
-  const { totals, byHost, byProvider, byMode, byInferenceProvider, bySource, byTool,
+  const { totals, byHost, byProvider, byMode, bySource, byTool,
     byProject, byCategory, punchcard, tree } = folded;
 
   sealBuckets(byHost, byProvider, byProject, byCategory, byModel,
-    byMode, byInferenceProvider, bySource);
+    byMode, bySource);
   finishTotals(totals, sessions, folded);
   const engagedByDay = buildEngagedByDay(sessions);
   const rhythm = buildRhythm(sessions);
@@ -836,7 +824,7 @@ export function aggregate(records, { days, now, cutoff, deps, previous = false }
     windowDays: days,
     pricesAsOf: deps.pricesAsOf ?? null,
     totals, byDay, engagedByDay, byModel, byHost, byProvider,
-    byMode, byInferenceProvider, bySource, byTool,
+    byMode, bySource, byTool,
     byProject, byCategory,
     punchcard, projectTree, sessions, codexRateLimits, rhythm,
     previous: previous ? previousWindow(records, { days, now, deps, rates }) : null,

--- a/src/lib/usage-aggregate.mjs
+++ b/src/lib/usage-aggregate.mjs
@@ -219,7 +219,7 @@ export function percentileFromBuckets(counts, edges, q) {
     }
     cum += n;
   }
-  return round(edges[edges.length - 1], 2);
+  return round(edges[edges.length - 1], 2);   // unreachable but for float drift in `target`
 }
 
 /** Family names that appear INSIDE an Anthropic model id. Matched by
@@ -304,14 +304,15 @@ function sealBuckets(...maps) {
   }
 }
 
-/** One day's row, created on first touch. Shared by the usage-row fold and the
- *  engaged-time fold below so both agree on the shape: a day reached by only
- *  one of them still carries every field, zeroed, instead of a ragged row the
- *  UI has to guess at. */
+/** One day's row, created on first touch. `byDay`'s presence contract is
+ *  BILLED DAYS ONLY: a key exists exactly when tokens landed on that day, which
+ *  is what the insight detectors count active days from. Engaged time therefore
+ *  lives in its own sibling map (see buildEngagedByDay) rather than here, where
+ *  a day worked but never billed would have had to invent a zero-token row. */
 function dayBucket(byDay, day) {
   if (!byDay[day]) {
     byDay[day] = {
-      tokens: 0, cost: 0, sessions: 0, sessionsActive: 0, engagedSeconds: 0,
+      tokens: 0, cost: 0, sessions: 0, sessionsActive: 0,
       byMode: Object.create(null), byModelFamily: Object.create(null),
     };
   }
@@ -325,24 +326,35 @@ function addCost(map, key, v) {
 }
 
 /**
- * What the prompt cache actually saved on one usage row. Cache reads meter at a
- * TENTH of the input rate (pricing.mjs CACHE_READ_MULTIPLIER), so the avoided
- * spend is the other 0.9 of what those tokens would have cost as fresh input.
+ * What the prompt cache saved per 1M cache-read tokens, asked of the injected
+ * pricer as a DIFFERENCE rather than derived from a discount factor: price 1M
+ * tokens as fresh input, price the same 1M as cache reads, and the gap is the
+ * spend that was avoided. Nothing here knows what the cache multiplier is, so
+ * this figure cannot drift out of step with pricing.mjs the way a hardcoded
+ * "0.9 of the input rate" would the day that multiplier changes.
  *
- * The rate is asked OF THE INJECTED PRICER rather than looked up separately: a
- * 1M input-token probe at this row's own model/provider/day returns exactly
- * that day's input rate, because cost is linear in each token class. That keeps
- * this figure priced from the same table, at the same date, as the cost sitting
- * beside it — a savings number quoted at today's rate for August's tokens would
- * be a different claim than the one the panel makes everywhere else.
+ * Both probes carry the row's own model/provider/DAY, so the saving is priced
+ * from the same table, at the same date, as the cost sitting beside it — a
+ * savings number quoted at today's rate for August's tokens would be a
+ * different claim than the one the panel makes everywhere else. Memoised per
+ * (model, provider, day) because a window has few of those and many rows.
  */
-function cacheSavedFor(row, rec, deps) {
+function cacheSavingPerMillion(model, provider, day, deps, rates) {
+  const key = `${model} ${provider} ${day}`;
+  if (rates.has(key)) return rates.get(key);
+  const base = { model, provider, day, input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
+  const asInput = deps.costOf({ ...base, input: 1e6 }) || 0;
+  const asCacheRead = deps.costOf({ ...base, cacheRead: 1e6 }) || 0;
+  const saved = asInput - asCacheRead;
+  rates.set(key, saved);
+  return saved;
+}
+
+/** What the prompt cache actually saved on one usage row: the per-million gap
+ *  above, scaled to the tokens this row actually read from cache. */
+function cacheSavedFor(row, rec, deps, rates) {
   if (!(row.cacheRead > 0)) return 0;
-  const rateIn = deps.costOf({
-    model: row.model, provider: rec.provider, day: row.day,
-    input: 1e6, output: 0, cacheRead: 0, cacheWrite: 0,
-  }) || 0;
-  return (0.9 * row.cacheRead * rateIn) / 1e6;
+  return (cacheSavingPerMillion(row.model, rec.provider, row.day, deps, rates) * row.cacheRead) / 1e6;
 }
 
 /** Price one usage row (observed opencode cost wins over the pricing table —
@@ -357,7 +369,6 @@ function foldSessionUsageRow(row, rec, deps, acc, byDay, byModel, activeDays) {
   acc.input += row.input; acc.output += row.output;
   acc.cacheRead += row.cacheRead; acc.cacheWrite += row.cacheWrite;
   acc.cost += rowCost;
-  acc.cacheSaved += cacheSavedFor(row, rec, deps);
 
   const rowTokens = row.input + row.output + row.cacheRead + row.cacheWrite;
   const d = dayBucket(byDay, row.day);
@@ -381,12 +392,13 @@ function foldSessionUsageRow(row, rec, deps, acc, byDay, byModel, activeDays) {
  *  this session's tokens FIRST landed on — always a key of byDay, which keeps
  *  sum(byDay.sessions) === totals.sessions (a session's start day is not
  *  usable: it can open at 23:58 and only bill after midnight). */
-function foldSessionUsageRows(rec, deps, byDay, byModel) {
+function foldSessionUsageRows(rec, deps, byDay, byModel, rates) {
   const acc = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, cacheSaved: 0 };
   let firstDay = null;
   const activeDays = new Set();
   for (const row of rec.usage) {
     if (firstDay === null || row.day < firstDay) firstDay = row.day;
+    acc.cacheSaved += cacheSavedFor(row, rec, deps, rates);
     foldSessionUsageRow(row, rec, deps, acc, byDay, byModel, activeDays);
   }
   for (const day of activeDays) byDay[day].sessionsActive++;
@@ -435,6 +447,13 @@ function buildSessionRow(rec, usage, verdict) {
     lenSeconds: rec.lenSeconds ?? 0,
     aborts: rec.aborts ?? 0,
     _span: [rec.start ?? rec.end, rec.end],
+    // Did this session carry ANY token evidence? A session with no usage rows
+    // costs $0 structurally — nothing was measured — rather than because the
+    // work was cheap. Codex subagent rollouts are the common case: their tokens
+    // are stripped as a double-count (applyCodexLedger), leaving a real session
+    // with an empty ledger. The cost distribution excludes them; see
+    // finishTotals.
+    _priced: (rec.usage?.length ?? 0) > 0,
     // Pre-v2 cache entries have no `active`; fall back to the whole span so a
     // stale record degrades to the old figure instead of vanishing.
     _active: Array.isArray(rec.active) && rec.active.length ? rec.active : [[rec.start ?? rec.end, rec.end]],
@@ -449,13 +468,13 @@ function buildSessionRow(rec, usage, verdict) {
  *  cutoff", which is what the current window wants. Exclusive on purpose: a
  *  session ending exactly at the cutoff belongs to the current window, and
  *  must not also be counted in the one before it. */
-function buildSessionRows(records, { cutoff, endMs = null, deps, byDay, byModel }) {
+function buildSessionRows(records, { cutoff, endMs = null, deps, byDay, byModel, rates }) {
   const sessions = [];
   for (const rec of records) {
     if (!rec || !rec.responses) continue;                 // no assistant turn → not a session
     if (rec.end === null || rec.end < cutoff) continue;    // outside the window
     if (endMs != null && rec.end >= endMs) continue;       // ... or after the window asked for
-    const usage = foldSessionUsageRows(rec, deps, byDay, byModel);
+    const usage = foldSessionUsageRows(rec, deps, byDay, byModel, rates);
     const verdict = deps.classify({
       title: rec.title, skill: rec.skill, plugin: rec.plugin,
       tools: rec.tools, prompts: rec.prompts, responses: rec.responses,
@@ -511,7 +530,8 @@ function sourceKey(s) {
  *  session/minutes/confidence fields. */
 function foldSessionTotals(sessions, byDay, byModel) {
   const totals = {
-    sessions: sessions.length, prompts: 0, responses: 0, exceptions: 0, aborts: 0,
+    sessions: sessions.length, prompts: 0, humanPrompts: 0, responses: 0,
+    exceptions: 0, aborts: 0,
     input: 0, output: 0, cacheRead: 0, cacheWrite: 0, tokens: 0, cost: 0,
     cacheSavedUsd: 0, spanMinutes: 0, spanUnionSeconds: 0, engagedSeconds: 0,
   };
@@ -521,20 +541,25 @@ function foldSessionTotals(sessions, byDay, byModel) {
   const byProject = Object.create(null);
   const byCategory = Object.create(null), punchcard = Object.create(null);
   const tree = new Map();
-  const costs = [];
+  const pricedCosts = [];
   let spanMs = 0;
   // Both source rows always exist: "no subagent sessions" is a fact worth
   // rendering as a zero, not a row the UI silently drops.
   bucket(bySource, 'main'); bucket(bySource, 'subagent');
 
   for (const s of sessions) {
+    const source = sourceKey(s);
     totals.prompts += s.prompts; totals.responses += s.responses;
+    // Only a MAIN-thread prompt is a human typing. A subagent's prompts are
+    // written by the harness, so counting them would inflate every
+    // per-prompt denominator with work nobody asked for by hand.
+    if (source === 'main') totals.humanPrompts += s.prompts;
     totals.exceptions += s.exceptions; totals.aborts += Number(s.aborts) || 0;
     totals.input += s.input; totals.output += s.output;
     totals.cacheRead += s.cacheRead; totals.cacheWrite += s.cacheWrite;
     totals.tokens += s.tokens; totals.cost += s.cost;
     totals.cacheSavedUsd += Number(s.cacheSavedUsd) || 0;
-    costs.push(s.cost);
+    if (s._priced) pricedCosts.push(s.cost);
     spanMs += s._span[1] - s._span[0];
 
     addTo(bucket(byHost, s.host ?? 'unknown'), s);
@@ -543,7 +568,7 @@ function foldSessionTotals(sessions, byDay, byModel) {
     // that carried no mode evidence must not be folded into a real posture.
     addTo(bucket(byMode, s.mode ?? 'not-recorded'), s);
     addTo(bucket(byInferenceProvider, providerKey(s)), s);
-    addTo(bucket(bySource, sourceKey(s)), s);
+    addTo(bucket(bySource, source), s);
     addTo(bucket(byProject, s.project), s);
     addTo(bucket(byCategory, s.category), s);
     foldSessionByModel(byModel, s);
@@ -555,7 +580,7 @@ function foldSessionTotals(sessions, byDay, byModel) {
 
   return {
     totals, byHost, byProvider, byMode, byInferenceProvider, bySource, byTool,
-    byProject, byCategory, punchcard, tree, spanMs, costs,
+    byProject, byCategory, punchcard, tree, spanMs, pricedCosts,
   };
 }
 
@@ -567,6 +592,16 @@ function median(values) {
   const v = values.slice().sort((a, b) => a - b);
   const mid = v.length >> 1;
   return round(v.length % 2 ? v[mid] : (v[mid - 1] + v[mid]) / 2);
+}
+
+/** Nearest-rank `q`th percentile of a numeric list, `null` when empty. Exact
+ *  values (unlike percentileFromBuckets, which only has counts to work from),
+ *  so no interpolation is needed or honest here. */
+function percentile(values, q) {
+  if (!values.length) return null;
+  const v = values.slice().sort((a, b) => a - b);
+  const i = Math.min(v.length - 1, Math.max(0, Math.ceil(q * v.length) - 1));
+  return round(v[i]);
 }
 
 /**
@@ -583,8 +618,18 @@ function median(values) {
  *
  * A rate whose denominator is zero is `null`, never 0: no engaged time means
  * the rate was never measured, which is not the claim "zero per hour" makes.
+ *
+ * Two denominators are narrower than they look, deliberately:
+ *   - both per-prompt figures divide by HUMAN prompts (main-thread only). A
+ *     subagent's prompts are written by the harness, so counting them would
+ *     report a person as typing work they never typed;
+ *   - the cost median and P90 are taken over PRICED sessions only. A session
+ *     with no usage rows is $0 structurally — no tokens were ever recorded for
+ *     it (a stripped Codex subagent, or a session that never billed) — and
+ *     letting those into the distribution reports "the typical session cost
+ *     nothing" when the truth is "we did not measure the typical session".
  */
-function finishTotals(totals, sessions, { spanMs, costs }) {
+function finishTotals(totals, sessions, { spanMs, pricedCosts }) {
   totals.cost = round(totals.cost);
   totals.cacheSavedUsd = round(totals.cacheSavedUsd);
   totals.spanMinutes = Math.round((spanMs / 60_000) * 10) / 10;
@@ -592,10 +637,12 @@ function finishTotals(totals, sessions, { spanMs, costs }) {
   totals.engagedSeconds = mergeIntervals(sessions.flatMap((s) => s._active));
 
   const hours = totals.engagedSeconds / 3600;
-  totals.humanPromptsPerHour = hours ? round(totals.prompts / hours) : null;
-  totals.responsesPerPrompt = totals.prompts ? round(totals.responses / totals.prompts) : null;
+  totals.humanPromptsPerHour = hours ? round(totals.humanPrompts / hours) : null;
+  totals.responsesPerPrompt = totals.humanPrompts
+    ? round(totals.responses / totals.humanPrompts) : null;
   totals.costPerEngagedHour = hours ? round(totals.cost / hours) : null;
-  totals.costPerSessionMedian = median(costs);
+  totals.costPerSessionMedian = median(pricedCosts);
+  totals.costPerSessionP90 = percentile(pricedCosts, 0.9);
 }
 
 /** The window's response-latency and session-length distributions. Latency
@@ -647,37 +694,50 @@ function splitAtLocalMidnight(start, end, out) {
   }
 }
 
-/** Per-day engaged seconds: the UNION of that day's active intervals, so two
- *  sessions worked in parallel spend the minute once — the rule
- *  totals.engagedSeconds follows, applied a day at a time. */
-function foldEngagedByDay(sessions, byDay) {
+/**
+ * Engaged seconds per LOCAL day: the UNION of that day's active intervals, so
+ * two sessions worked in parallel spend the minute once — the rule
+ * totals.engagedSeconds follows, applied a day at a time. Summing this map
+ * therefore reproduces totals.engagedSeconds exactly.
+ *
+ * A SIBLING of byDay, not a field on it: engaged time is keyed by the days work
+ * happened on, byDay by the days tokens BILLED on, and those sets genuinely
+ * differ (a session that runs past midnight, a day spent reading). Folding one
+ * into the other would have meant either inventing zero-token byDay rows or
+ * dropping real worked time.
+ */
+function buildEngagedByDay(sessions) {
   const perDay = Object.create(null);
   for (const s of sessions) {
     for (const [a, b] of s._active) splitAtLocalMidnight(a, b, perDay);
   }
-  for (const day of Object.keys(perDay)) {
-    dayBucket(byDay, day).engagedSeconds = mergeIntervals(perDay[day]);
-  }
+  const out = Object.create(null);
+  for (const day of Object.keys(perDay)) out[day] = mergeIntervals(perDay[day]);
+  return out;
 }
 
 const DAY_MS = 86_400_000;
 
 /**
- * Totals + rhythm for the equal-length window immediately BEFORE `cutoff` —
- * the baseline any "vs. previous period" delta is measured against.
+ * Totals + rhythm for the equal-length window immediately before the DISPLAYED
+ * one — the baseline any "vs. previous period" delta is measured against.
  * Deliberately a projection rather than a second whole Aggregate: nothing
  * downstream compares project trees or punchcards across windows, and shipping
  * the full shape twice would double the payload for fields nobody reads.
  *
- * Records older than `cutoff` only reach this module when the index was built
- * with a lookback (`buildIndex({ lookbackDays })`), so an un-widened corpus
- * yields a visibly ZEROED previous window rather than a wrong one.
+ * Both bounds come from `now` and `days` — the window the UI is SHOWING — and
+ * never from `cutoff`. The caller widens `cutoff` (via `buildIndex`'s
+ * `lookbackDays`) precisely so records older than the displayed window survive
+ * to be aggregated here; deriving the comparison from that widened bound would
+ * make the baseline silently stretch to whatever lookback the caller happened
+ * to ask for, and a delta against an unknown-length window is not a delta.
  */
-function previousWindow(records, { days, cutoff, deps }) {
+function previousWindow(records, { days, now, deps, rates }) {
+  const windowStart = now - days * DAY_MS;
   const byDay = Object.create(null);
   const byModel = Object.create(null);
   const sessions = buildSessionRows(records, {
-    cutoff: cutoff - days * DAY_MS, endMs: cutoff, deps, byDay, byModel,
+    cutoff: windowStart - days * DAY_MS, endMs: windowStart, deps, byDay, byModel, rates,
   });
   const folded = foldSessionTotals(sessions, byDay, byModel);
   finishTotals(folded.totals, sessions, folded);
@@ -707,9 +767,10 @@ function buildCodexRateLimits(sessions) {
 }
 
 /** Turn cached per-file records into the Aggregate the UI and detectors read.
- *  `previous: true` additionally projects the equal-length window before
- *  `cutoff` (see previousWindow); left off, `agg.previous` is `null` — "not
- *  requested", which a zeroed totals object would misreport as "measured
+ *  `previous: true` additionally projects the equal-length window before the
+ *  DISPLAYED one — `[now − 2·days, now − days)`, derived from `now`/`days` and
+ *  not from `cutoff` (see previousWindow). Left off, `agg.previous` is `null` —
+ *  "not requested", which a zeroed totals object would misreport as "measured
  *  nothing". */
 export function aggregate(records, { days, now, cutoff, deps, previous = false }) {
   // Null-prototype: these are keyed by transcript-derived strings (day, model id,
@@ -717,8 +778,12 @@ export function aggregate(records, { days, now, cutoff, deps, previous = false }
   // ordinary bucket, not a prototype write that silently discards the data.
   const byDay = Object.create(null);
   const byModel = Object.create(null);
+  // One pricing-probe memo for the whole run, shared with the previous window:
+  // both price the same models on the same days, and the rates cannot move
+  // between them.
+  const rates = new Map();
 
-  const sessions = buildSessionRows(records, { cutoff, deps, byDay, byModel });
+  const sessions = buildSessionRows(records, { cutoff, deps, byDay, byModel, rates });
   sessions.sort((a, b) => b.cost - a.cost || Date.parse(b.start) - Date.parse(a.start));
 
   const folded = foldSessionTotals(sessions, byDay, byModel);
@@ -728,22 +793,24 @@ export function aggregate(records, { days, now, cutoff, deps, previous = false }
   sealBuckets(byHost, byProvider, byProject, byCategory, byModel,
     byMode, byInferenceProvider, bySource);
   finishTotals(totals, sessions, folded);
-  foldEngagedByDay(sessions, byDay);
+  const engagedByDay = buildEngagedByDay(sessions);
   const rhythm = buildRhythm(sessions);
 
   const projectTree = buildProjectTree(tree);
-  for (const s of sessions) { delete s._span; delete s._active; delete s._punchcard; delete s._day; }
+  for (const s of sessions) {
+    delete s._span; delete s._active; delete s._punchcard; delete s._day; delete s._priced;
+  }
   const codexRateLimits = buildCodexRateLimits(sessions);
 
   const agg = {
     generatedAt: new Date(now).toISOString(),
     windowDays: days,
     pricesAsOf: deps.pricesAsOf ?? null,
-    totals, byDay, byModel, byHost, byProvider,
+    totals, byDay, engagedByDay, byModel, byHost, byProvider,
     byMode, byInferenceProvider, bySource, byTool,
     byProject, byCategory,
     punchcard, projectTree, sessions, codexRateLimits, rhythm,
-    previous: previous ? previousWindow(records, { days, cutoff, deps }) : null,
+    previous: previous ? previousWindow(records, { days, now, deps, rates }) : null,
     insights: [],
   };
   agg.insights = deps.detectInsights(agg) ?? [];

--- a/src/lib/usage-aggregate.mjs
+++ b/src/lib/usage-aggregate.mjs
@@ -159,6 +159,90 @@ export function normalizeSessionIdentity(record = {}) {
 
 const round = (n, p = 6) => Math.round(n * 10 ** p) / 10 ** p;
 
+/** Local calendar day, `YYYY-MM-DD`. Local because "what did I spend today" is
+ *  a question about the user's clock, not UTC's. Restated from
+ *  usage-parsers.mjs (which keys its usage rows on the same convention)
+ *  because THAT module imports from THIS one — see the header note on the
+ *  one-way dependency. */
+function localDay(ms) {
+  const d = new Date(ms);
+  const p = (n) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}`;
+}
+
+// ── histograms & percentiles ────────────────────────────────────────────────
+
+/** Response-latency histogram edges, in seconds; the 6th bucket (index 5)
+ *  catches everything over 60s. */
+export const LAT_BUCKET_EDGES = [2, 5, 10, 30, 60];
+/** Session-length histogram edges, in seconds; the 5th bucket (index 4)
+ *  catches everything over 2h. */
+export const LEN_BUCKET_EDGES = [300, 900, 2700, 7200];
+// These are the SAME edges usage-parsers.mjs fills each session's `latHist` on,
+// restated here for the one-way-import reason above. A test pins the two copies
+// equal, so a change to either goes red rather than silently re-labelling every
+// bucket in the panel.
+
+/** First bucket `i` whose edge `v` does not exceed, else the overflow bucket. */
+function bucketIndex(edges, v) {
+  for (let i = 0; i < edges.length; i++) if (v <= edges[i]) return i;
+  return edges.length;
+}
+
+/**
+ * The `q`th percentile of a bucketed distribution, in the buckets' own unit.
+ * Interpolates LINEARLY inside the bucket the percentile lands in: the samples'
+ * exact values are gone, and a uniform spread across the bucket is the only
+ * assumption the counts still support.
+ *
+ * Two deliberately honest edges:
+ *   - an empty histogram is `null`, never 0 — "nothing was measured" and
+ *     "measured zero" are different claims, and only one of them is true here;
+ *   - the overflow bucket has no upper edge to interpolate towards, so it
+ *     reports its FLOOR. That understates by an unknown amount rather than
+ *     inventing a ceiling; read it as "at least this".
+ * Pure — exported for test.
+ */
+export function percentileFromBuckets(counts, edges, q) {
+  if (!Array.isArray(counts) || !Array.isArray(edges)) return null;
+  const total = counts.reduce((a, n) => a + (Number(n) || 0), 0);
+  if (total <= 0) return null;
+  const target = total * q;
+  let cum = 0;
+  for (let i = 0; i < counts.length; i++) {
+    const n = Number(counts[i]) || 0;
+    if (n <= 0) continue;
+    if (cum + n >= target) {
+      const lo = i === 0 ? 0 : edges[i - 1];
+      if (i >= edges.length) return round(lo, 2);
+      return round(lo + (edges[i] - lo) * ((target - cum) / n), 2);
+    }
+    cum += n;
+  }
+  return round(edges[edges.length - 1], 2);
+}
+
+/** Family names that appear INSIDE an Anthropic model id. Matched by
+ *  containment rather than position because the id shape has moved over time
+ *  (`claude-3-5-sonnet-…` puts the family last, `claude-opus-5-…` puts it
+ *  second) and both spellings still show up in real transcripts. */
+const CLAUDE_FAMILIES = ['opus', 'sonnet', 'haiku', 'fable', 'mythos'];
+
+/**
+ * Fold a model id to the coarse family a stacked chart can carry — `opus`,
+ * `sonnet`, `gpt-5`, … An id this fold does not recognise is `'other'`: never a
+ * guessed family, and never dropped, because its spend still has to land
+ * somewhere. Pure — exported for test.
+ */
+export function modelFamily(id) {
+  const s = typeof id === 'string' ? id.toLowerCase() : '';
+  if (!s) return 'other';
+  const tail = s.slice(s.lastIndexOf('/') + 1);   // openrouter/anthropic/claude-… → claude-…
+  for (const f of CLAUDE_FAMILIES) if (tail.includes(f)) return f;
+  const gpt = /gpt-(\d+)/.exec(tail);
+  return gpt ? `gpt-${gpt[1]}` : 'other';
+}
+
 /** Sum a record's per-model usage rows into one API-equivalent cost. Rows with
  *  an observed transcript cost (opencode) use it — same preference as aggregate. */
 function sessionCost(rec, deps) {
@@ -220,6 +304,47 @@ function sealBuckets(...maps) {
   }
 }
 
+/** One day's row, created on first touch. Shared by the usage-row fold and the
+ *  engaged-time fold below so both agree on the shape: a day reached by only
+ *  one of them still carries every field, zeroed, instead of a ragged row the
+ *  UI has to guess at. */
+function dayBucket(byDay, day) {
+  if (!byDay[day]) {
+    byDay[day] = {
+      tokens: 0, cost: 0, sessions: 0, sessionsActive: 0, engagedSeconds: 0,
+      byMode: Object.create(null), byModelFamily: Object.create(null),
+    };
+  }
+  return byDay[day];
+}
+
+/** Accumulate one cost into a keyed cost map, rounding as it goes (the same
+ *  treatment byDay.cost gets, so the parts still add up to the whole). */
+function addCost(map, key, v) {
+  map[key] = round((map[key] ?? 0) + v);
+}
+
+/**
+ * What the prompt cache actually saved on one usage row. Cache reads meter at a
+ * TENTH of the input rate (pricing.mjs CACHE_READ_MULTIPLIER), so the avoided
+ * spend is the other 0.9 of what those tokens would have cost as fresh input.
+ *
+ * The rate is asked OF THE INJECTED PRICER rather than looked up separately: a
+ * 1M input-token probe at this row's own model/provider/day returns exactly
+ * that day's input rate, because cost is linear in each token class. That keeps
+ * this figure priced from the same table, at the same date, as the cost sitting
+ * beside it — a savings number quoted at today's rate for August's tokens would
+ * be a different claim than the one the panel makes everywhere else.
+ */
+function cacheSavedFor(row, rec, deps) {
+  if (!(row.cacheRead > 0)) return 0;
+  const rateIn = deps.costOf({
+    model: row.model, provider: rec.provider, day: row.day,
+    input: 1e6, output: 0, cacheRead: 0, cacheWrite: 0,
+  }) || 0;
+  return (0.9 * row.cacheRead * rateIn) / 1e6;
+}
+
 /** Price one usage row (observed opencode cost wins over the pricing table —
  *  `day` prices it at the rate in effect WHEN THOSE TOKENS WERE SPENT, not
  *  today's) and fold it into a session's running sums plus the shared
@@ -232,11 +357,17 @@ function foldSessionUsageRow(row, rec, deps, acc, byDay, byModel, activeDays) {
   acc.input += row.input; acc.output += row.output;
   acc.cacheRead += row.cacheRead; acc.cacheWrite += row.cacheWrite;
   acc.cost += rowCost;
+  acc.cacheSaved += cacheSavedFor(row, rec, deps);
 
   const rowTokens = row.input + row.output + row.cacheRead + row.cacheWrite;
-  if (!byDay[row.day]) byDay[row.day] = { tokens: 0, cost: 0, sessions: 0, sessionsActive: 0 };
-  byDay[row.day].tokens += rowTokens;
-  byDay[row.day].cost = round(byDay[row.day].cost + rowCost);
+  const d = dayBucket(byDay, row.day);
+  d.tokens += rowTokens;
+  d.cost = round(d.cost + rowCost);
+  // Cost by posture and by model family, per day: the two stacked series the
+  // day chart draws. Both live here rather than in the session pass because
+  // only a usage ROW knows which day its dollars landed on.
+  addCost(d.byMode, rec.mode ?? 'not-recorded', rowCost);
+  addCost(d.byModelFamily, modelFamily(row.model), rowCost);
   activeDays.add(row.day);
 
   const m = bucket(byModel, row.model);
@@ -251,7 +382,7 @@ function foldSessionUsageRow(row, rec, deps, acc, byDay, byModel, activeDays) {
  *  sum(byDay.sessions) === totals.sessions (a session's start day is not
  *  usable: it can open at 23:58 and only bill after midnight). */
 function foldSessionUsageRows(rec, deps, byDay, byModel) {
-  const acc = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0 };
+  const acc = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, cacheSaved: 0 };
   let firstDay = null;
   const activeDays = new Set();
   for (const row of rec.usage) {
@@ -265,7 +396,7 @@ function foldSessionUsageRows(rec, deps, byDay, byModel) {
 /** One aggregate session row from a parsed record, its folded usage sums,
  *  and its classifier verdict. */
 function buildSessionRow(rec, usage, verdict) {
-  const { input, output, cacheRead, cacheWrite, cost, firstDay } = usage;
+  const { input, output, cacheRead, cacheWrite, cost, cacheSaved, firstDay } = usage;
   return {
     id: rec.id, host: rec.host ?? rec.provider,
     provider: rec.inferenceProvider ?? null,
@@ -281,6 +412,9 @@ function buildSessionRow(rec, usage, verdict) {
     input, output, cacheRead, cacheWrite,
     tokens: input + output + cacheRead + cacheWrite,
     cost: round(cost),
+    // What the cache avoided for THIS session, so the window total is
+    // auditable a row at a time rather than only in aggregate.
+    cacheSavedUsd: round(cacheSaved),
     tools: { ...rec.tools },
     category: verdict.category ?? 'Unclassified',
     confidence: verdict.confidence ?? 0,
@@ -290,6 +424,16 @@ function buildSessionRow(rec, usage, verdict) {
     // records (the schema bump re-derives those).
     reasoningOutput: rec.reasoningOutput ?? 0,
     rateLimits: rec.rateLimits ?? null,
+    // v11 posture and rhythm (ADR-0038). Carried on the row, not folded away,
+    // because every one of them is a per-session fact the transcript actually
+    // recorded — and the window's histograms have to be traceable back to the
+    // sessions that built them. `mode` and `latHist` stay honest-absent (null)
+    // when nothing observed them.
+    mode: rec.mode ?? null,
+    latHist: Array.isArray(rec.latHist) ? rec.latHist.slice() : null,
+    latCount: rec.latCount ?? 0,
+    lenSeconds: rec.lenSeconds ?? 0,
+    aborts: rec.aborts ?? 0,
     _span: [rec.start ?? rec.end, rec.end],
     // Pre-v2 cache entries have no `active`; fall back to the whole span so a
     // stale record degrades to the old figure instead of vanishing.
@@ -300,12 +444,17 @@ function buildSessionRow(rec, usage, verdict) {
 }
 
 /** Records → aggregate session rows, folding usage into the shared byDay/
- *  byModel buckets as a side effect. */
-function buildSessionRows(records, { cutoff, deps, byDay, byModel }) {
+ *  byModel buckets as a side effect. `endMs` is the EXCLUSIVE upper bound the
+ *  previous-window pass needs; leaving it unset means "everything since
+ *  cutoff", which is what the current window wants. Exclusive on purpose: a
+ *  session ending exactly at the cutoff belongs to the current window, and
+ *  must not also be counted in the one before it. */
+function buildSessionRows(records, { cutoff, endMs = null, deps, byDay, byModel }) {
   const sessions = [];
   for (const rec of records) {
     if (!rec || !rec.responses) continue;                 // no assistant turn → not a session
     if (rec.end === null || rec.end < cutoff) continue;    // outside the window
+    if (endMs != null && rec.end >= endMs) continue;       // ... or after the window asked for
     const usage = foldSessionUsageRows(rec, deps, byDay, byModel);
     const verdict = deps.classify({
       title: rec.title, skill: rec.skill, plugin: rec.plugin,
@@ -338,40 +487,201 @@ function foldSessionIntoTree(tree, s) {
   node.rows.push(s);
 }
 
+/** The bucket key for a session's INFERENCE provider — and only when that
+ *  identity was actually observed. A transcript host (`claude`, `codex`) does
+ *  not prove which vendor served the tokens, so an unobserved provenance keys
+ *  to `'not-recorded'` even when a provider string is present: that string is
+ *  an assumption, and spend is not bucketed under assumptions. The ungated
+ *  `byProvider` map still exists beside this one for callers that want the
+ *  string as-recorded. */
+function providerKey(s) {
+  return s.providerProvenance === 'observed' && s.provider ? s.provider : 'not-recorded';
+}
+
+/** Subagent work is either Claude's sidechain flag or Codex's ledger-backed
+ *  thread source; both mean "not a session a human was driving". */
+function sourceKey(s) {
+  return s.sidechain || s.threadSource === 'subagent' ? 'subagent' : 'main';
+}
+
 /** Second pass over the (now sorted) session rows: totals, the by-host/
- *  provider/project/category/model buckets, the punchcard, and the project
- *  tree. `byModel` is the SAME object buildSessionRows already populated
- *  from usage rows — this pass adds its session/minutes/confidence fields. */
+ *  provider/mode/source/project/category/model buckets, the tool tally, the
+ *  punchcard, and the project tree. `byModel` is the SAME object
+ *  buildSessionRows already populated from usage rows — this pass adds its
+ *  session/minutes/confidence fields. */
 function foldSessionTotals(sessions, byDay, byModel) {
   const totals = {
-    sessions: sessions.length, responses: 0, exceptions: 0, input: 0, output: 0,
-    cacheRead: 0, cacheWrite: 0, tokens: 0, cost: 0,
-    spanMinutes: 0, spanUnionSeconds: 0, engagedSeconds: 0,
+    sessions: sessions.length, prompts: 0, responses: 0, exceptions: 0, aborts: 0,
+    input: 0, output: 0, cacheRead: 0, cacheWrite: 0, tokens: 0, cost: 0,
+    cacheSavedUsd: 0, spanMinutes: 0, spanUnionSeconds: 0, engagedSeconds: 0,
   };
   const byHost = Object.create(null), byProvider = Object.create(null);
+  const byMode = Object.create(null), byInferenceProvider = Object.create(null);
+  const bySource = Object.create(null), byTool = Object.create(null);
   const byProject = Object.create(null);
   const byCategory = Object.create(null), punchcard = Object.create(null);
   const tree = new Map();
+  const costs = [];
   let spanMs = 0;
+  // Both source rows always exist: "no subagent sessions" is a fact worth
+  // rendering as a zero, not a row the UI silently drops.
+  bucket(bySource, 'main'); bucket(bySource, 'subagent');
 
   for (const s of sessions) {
-    totals.responses += s.responses; totals.exceptions += s.exceptions;
+    totals.prompts += s.prompts; totals.responses += s.responses;
+    totals.exceptions += s.exceptions; totals.aborts += Number(s.aborts) || 0;
     totals.input += s.input; totals.output += s.output;
     totals.cacheRead += s.cacheRead; totals.cacheWrite += s.cacheWrite;
     totals.tokens += s.tokens; totals.cost += s.cost;
+    totals.cacheSavedUsd += Number(s.cacheSavedUsd) || 0;
+    costs.push(s.cost);
     spanMs += s._span[1] - s._span[0];
 
     addTo(bucket(byHost, s.host ?? 'unknown'), s);
     addTo(bucket(byProvider, s.provider ?? 'unknown'), s);
+    // 'not-recorded' is a first-class key, not a display fallback: a transcript
+    // that carried no mode evidence must not be folded into a real posture.
+    addTo(bucket(byMode, s.mode ?? 'not-recorded'), s);
+    addTo(bucket(byInferenceProvider, providerKey(s)), s);
+    addTo(bucket(bySource, sourceKey(s)), s);
     addTo(bucket(byProject, s.project), s);
     addTo(bucket(byCategory, s.category), s);
     foldSessionByModel(byModel, s);
     if (s._day && byDay[s._day]) byDay[s._day].sessions++;
     for (const [k, n] of Object.entries(s._punchcard)) punchcard[k] = (punchcard[k] ?? 0) + n;
+    for (const [k, n] of Object.entries(s.tools)) byTool[k] = (byTool[k] ?? 0) + n;
     foldSessionIntoTree(tree, s);
   }
 
-  return { totals, byHost, byProvider, byProject, byCategory, punchcard, tree, spanMs };
+  return {
+    totals, byHost, byProvider, byMode, byInferenceProvider, bySource, byTool,
+    byProject, byCategory, punchcard, tree, spanMs, costs,
+  };
+}
+
+/** Exact median of a numeric list — the mean of the two middles on an even
+ *  count — and `null` when there is nothing to take a median of. Sorts a copy:
+ *  the caller's array is the order sessions were folded in. */
+function median(values) {
+  if (!values.length) return null;
+  const v = values.slice().sort((a, b) => a - b);
+  const mid = v.length >> 1;
+  return round(v.length % 2 ? v[mid] : (v[mid - 1] + v[mid]) / 2);
+}
+
+/**
+ * The derived half of `totals`: the three time tiers, then the rates and the
+ * median that only mean anything once every session has been folded. Split out
+ * so the previous-window projection derives them the SAME way instead of a
+ * second, drifting way.
+ *
+ * The three tiers, each honest about a different thing:
+ *   engagedSeconds   — union of ACTIVE intervals: time actually worked
+ *   spanUnionSeconds — union of whole spans: wall-clock with a session open
+ *   spanMinutes      — sum of spans: the double-counting figure, kept as the
+ *                      clearly-labelled secondary the ADR asks the UI to show
+ *
+ * A rate whose denominator is zero is `null`, never 0: no engaged time means
+ * the rate was never measured, which is not the claim "zero per hour" makes.
+ */
+function finishTotals(totals, sessions, { spanMs, costs }) {
+  totals.cost = round(totals.cost);
+  totals.cacheSavedUsd = round(totals.cacheSavedUsd);
+  totals.spanMinutes = Math.round((spanMs / 60_000) * 10) / 10;
+  totals.spanUnionSeconds = mergeIntervals(sessions.map((s) => s._span));
+  totals.engagedSeconds = mergeIntervals(sessions.flatMap((s) => s._active));
+
+  const hours = totals.engagedSeconds / 3600;
+  totals.humanPromptsPerHour = hours ? round(totals.prompts / hours) : null;
+  totals.responsesPerPrompt = totals.prompts ? round(totals.responses / totals.prompts) : null;
+  totals.costPerEngagedHour = hours ? round(totals.cost / hours) : null;
+  totals.costPerSessionMedian = median(costs);
+}
+
+/** The window's response-latency and session-length distributions. Latency
+ *  histograms are merged slot-wise from the ones the parsers recorded — a
+ *  session that never observed a latency carries `null` and contributes
+ *  nothing, because absent is not a row of zeroes — while lengths are bucketed
+ *  here from each session's own engaged seconds. */
+function buildRhythm(sessions) {
+  const latHist = new Array(LAT_BUCKET_EDGES.length + 1).fill(0);
+  const lenHist = new Array(LEN_BUCKET_EDGES.length + 1).fill(0);
+  let latCount = 0;
+  for (const s of sessions) {
+    if (Array.isArray(s.latHist)) {
+      for (let i = 0; i < latHist.length; i++) latHist[i] += Number(s.latHist[i]) || 0;
+      latCount += Number(s.latCount) || 0;
+    }
+    lenHist[bucketIndex(LEN_BUCKET_EDGES, Number(s.lenSeconds) || 0)]++;
+  }
+  return {
+    latHist,
+    latCount,
+    latP50: percentileFromBuckets(latHist, LAT_BUCKET_EDGES, 0.5),
+    latP95: percentileFromBuckets(latHist, LAT_BUCKET_EDGES, 0.95),
+    lenHist,
+    lenMedianSeconds: percentileFromBuckets(lenHist, LEN_BUCKET_EDGES, 0.5),
+    lenP90Seconds: percentileFromBuckets(lenHist, LEN_BUCKET_EDGES, 0.9),
+  };
+}
+
+/** Start of the LOCAL day after `ms`. Derived through Date rather than by
+ *  adding 24h so a DST transition lands on the real midnight. */
+function nextLocalMidnight(ms) {
+  const d = new Date(ms);
+  d.setHours(24, 0, 0, 0);
+  return d.getTime();
+}
+
+/** Cut one active interval at every local midnight it crosses and file each
+ *  piece under the day it was actually worked, so a session running past
+ *  midnight gives the next day its real minutes instead of handing all of them
+ *  to the day it started on. Mutates `out`. */
+function splitAtLocalMidnight(start, end, out) {
+  let s = start;
+  while (s < end) {
+    const next = nextLocalMidnight(s);
+    const e = next > s ? Math.min(end, next) : end;   // never fail to advance
+    (out[localDay(s)] ??= []).push([s, e]);
+    s = e;
+  }
+}
+
+/** Per-day engaged seconds: the UNION of that day's active intervals, so two
+ *  sessions worked in parallel spend the minute once — the rule
+ *  totals.engagedSeconds follows, applied a day at a time. */
+function foldEngagedByDay(sessions, byDay) {
+  const perDay = Object.create(null);
+  for (const s of sessions) {
+    for (const [a, b] of s._active) splitAtLocalMidnight(a, b, perDay);
+  }
+  for (const day of Object.keys(perDay)) {
+    dayBucket(byDay, day).engagedSeconds = mergeIntervals(perDay[day]);
+  }
+}
+
+const DAY_MS = 86_400_000;
+
+/**
+ * Totals + rhythm for the equal-length window immediately BEFORE `cutoff` —
+ * the baseline any "vs. previous period" delta is measured against.
+ * Deliberately a projection rather than a second whole Aggregate: nothing
+ * downstream compares project trees or punchcards across windows, and shipping
+ * the full shape twice would double the payload for fields nobody reads.
+ *
+ * Records older than `cutoff` only reach this module when the index was built
+ * with a lookback (`buildIndex({ lookbackDays })`), so an un-widened corpus
+ * yields a visibly ZEROED previous window rather than a wrong one.
+ */
+function previousWindow(records, { days, cutoff, deps }) {
+  const byDay = Object.create(null);
+  const byModel = Object.create(null);
+  const sessions = buildSessionRows(records, {
+    cutoff: cutoff - days * DAY_MS, endMs: cutoff, deps, byDay, byModel,
+  });
+  const folded = foldSessionTotals(sessions, byDay, byModel);
+  finishTotals(folded.totals, sessions, folded);
+  return { totals: folded.totals, rhythm: buildRhythm(sessions) };
 }
 
 function buildProjectTree(tree) {
@@ -396,31 +706,30 @@ function buildCodexRateLimits(sessions) {
     .sort((x, y) => x.at - y.at);
 }
 
-/** Turn cached per-file records into the Aggregate the UI and detectors read. */
-export function aggregate(records, { days, now, cutoff, deps }) {
+/** Turn cached per-file records into the Aggregate the UI and detectors read.
+ *  `previous: true` additionally projects the equal-length window before
+ *  `cutoff` (see previousWindow); left off, `agg.previous` is `null` — "not
+ *  requested", which a zeroed totals object would misreport as "measured
+ *  nothing". */
+export function aggregate(records, { days, now, cutoff, deps, previous = false }) {
   // Null-prototype: these are keyed by transcript-derived strings (day, model id,
-  // provider, project, category), so `__proto__` as a key must be an ordinary
-  // bucket, not a prototype write that silently discards the data.
+  // provider, project, category, tool name), so `__proto__` as a key must be an
+  // ordinary bucket, not a prototype write that silently discards the data.
   const byDay = Object.create(null);
   const byModel = Object.create(null);
 
   const sessions = buildSessionRows(records, { cutoff, deps, byDay, byModel });
   sessions.sort((a, b) => b.cost - a.cost || Date.parse(b.start) - Date.parse(a.start));
 
-  const { totals, byHost, byProvider, byProject, byCategory, punchcard, tree, spanMs } =
-    foldSessionTotals(sessions, byDay, byModel);
+  const folded = foldSessionTotals(sessions, byDay, byModel);
+  const { totals, byHost, byProvider, byMode, byInferenceProvider, bySource, byTool,
+    byProject, byCategory, punchcard, tree } = folded;
 
-  totals.cost = round(totals.cost);
-  // Three tiers, each honest about a different thing:
-  //   engagedSeconds   — union of ACTIVE intervals: time actually worked
-  //   spanUnionSeconds — union of whole spans: wall-clock with a session open
-  //   spanMinutes      — sum of spans: the double-counting figure, kept as the
-  //                      clearly-labelled secondary the ADR asks the UI to show
-  sealBuckets(byHost, byProvider, byProject, byCategory, byModel);
-
-  totals.spanMinutes = Math.round((spanMs / 60_000) * 10) / 10;
-  totals.spanUnionSeconds = mergeIntervals(sessions.map((s) => s._span));
-  totals.engagedSeconds = mergeIntervals(sessions.flatMap((s) => s._active));
+  sealBuckets(byHost, byProvider, byProject, byCategory, byModel,
+    byMode, byInferenceProvider, bySource);
+  finishTotals(totals, sessions, folded);
+  foldEngagedByDay(sessions, byDay);
+  const rhythm = buildRhythm(sessions);
 
   const projectTree = buildProjectTree(tree);
   for (const s of sessions) { delete s._span; delete s._active; delete s._punchcard; delete s._day; }
@@ -431,8 +740,11 @@ export function aggregate(records, { days, now, cutoff, deps }) {
     windowDays: days,
     pricesAsOf: deps.pricesAsOf ?? null,
     totals, byDay, byModel, byHost, byProvider,
+    byMode, byInferenceProvider, bySource, byTool,
     byProject, byCategory,
-    punchcard, projectTree, sessions, codexRateLimits, insights: [],
+    punchcard, projectTree, sessions, codexRateLimits, rhythm,
+    previous: previous ? previousWindow(records, { days, cutoff, deps }) : null,
+    insights: [],
   };
   agg.insights = deps.detectInsights(agg) ?? [];
   return agg;

--- a/src/lib/usage-index.mjs
+++ b/src/lib/usage-index.mjs
@@ -95,8 +95,14 @@ export { MAX_TURN_CHARS, mergeIntervals, maskSecrets, normalizeSessionIdentity, 
  *       `ctxLastTokens` (model context-window detail), and `aborts`
  *       (codex's explicit user-abort count). A v10-cached record carries
  *       none of these, so every session must be re-derived or the new
- *       fields silently read as undefined. */
-export const SCHEMA_VERSION = 11;
+ *       fields silently read as undefined.
+ *  v12: Codex writes `sandbox_policy` as an object keyed `.type`, so v11
+ *       records persisted `modeRaw: "never/[object Object]"` and a null
+ *       `mode` for every Codex session — the taxonomy's plan/auto-edit/
+ *       unrestricted arms could not fire at all. The parser now extracts
+ *       `.type`, so every Codex record must be re-derived rather than left
+ *       carrying the failed stringification and its missing posture. */
+export const SCHEMA_VERSION = 12;
 
 const DAY_MS = 86_400_000;
 // One day of slack past dashboard-server.mjs's 365-day clampDays ceiling —

--- a/src/lib/usage-index.mjs
+++ b/src/lib/usage-index.mjs
@@ -44,7 +44,7 @@ import {
 } from './usage-opencode.mjs';
 import {
   addTelemetryDiagnostics, emptyTelemetryDiagnostics, finalizeTelemetryDiagnostics,
-  MAX_TELEMETRY_UNKNOWN_KINDS, recordTelemetryUnit, telemetryCapabilities,
+  MAX_TELEMETRY_UNKNOWN_KINDS, recordTelemetryUnit,
 } from './usage-telemetry.mjs';
 import { parseClaude, parseCodex } from './usage-parsers.mjs';
 import { maskSecrets, applyCodexLedger, aggregate, sessionPayload } from './usage-aggregate.mjs';
@@ -234,14 +234,13 @@ function finalizeCodexHealth(root, diagnostics) {
   return { ...root, status, reason, diagnostics };
 }
 
-/** Attach the additive host-neutral telemetry contract to source health.
+/** Attach the additive host-neutral telemetry counters to source health.
  * Existing status/reason and Codex diagnostic keys remain where consumers
- * already find them; `diagnostics.common` and `capabilities` are the new
- * cross-host surface. */
-function attachTelemetryHealth(host, health, common, diagnostics = health.diagnostics) {
+ * already find them; `diagnostics.common` is the cross-host surface. It
+ * reports what was read — never a per-host claim about what could be read. */
+function attachTelemetryHealth(health, common, diagnostics = health.diagnostics) {
   return {
     ...health,
-    capabilities: telemetryCapabilities(host, health.status),
     diagnostics: {
       ...(diagnostics ?? {}),
       common: finalizeTelemetryDiagnostics(common),
@@ -762,9 +761,9 @@ async function scan(o = {}) {
     warnings: codexSourceHealth.diagnostics.warnings,
   });
   result.sourceHealth = {
-    claude: attachTelemetryHealth('claude', claudeHealth, commonDiagnostics.claude),
-    codex: attachTelemetryHealth('codex', codexSourceHealth, commonDiagnostics.codex),
-    opencode: attachTelemetryHealth('opencode', opencodeHealth, commonDiagnostics.opencode),
+    claude: attachTelemetryHealth(claudeHealth, commonDiagnostics.claude),
+    codex: attachTelemetryHealth(codexSourceHealth, commonDiagnostics.codex),
+    opencode: attachTelemetryHealth(opencodeHealth, commonDiagnostics.opencode),
     codexLedger: codexLedgerHealth,
   };
   return result;

--- a/src/lib/usage-index.mjs
+++ b/src/lib/usage-index.mjs
@@ -374,11 +374,16 @@ let _memo = null;
  *  case still changes the key instead of colliding with every other scan. */
 function scanKey(o = {}) {
   const roots = Object.entries(o.roots || {}).sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
-  // lookbackDays changes the RESULT (it widens what scan() parses/returns —
-  // see scan() below) exactly like days/force/roots/cachePath already do, so
-  // it must be folded into the single-flight/memo identity too: two calls
-  // differing only by lookbackDays must never coalesce into one answer.
-  return JSON.stringify([Number(o.days) || 14, Number(o.lookbackDays) || 0, !!o.force, roots, o.cachePath || '']);
+  // lookbackDays and previous both change the RESULT — lookbackDays widens
+  // what scan() parses/returns, previous turns on aggregate's previous-window
+  // projection (agg.previous) — exactly like days/force/roots/cachePath
+  // already do, so both must be folded into the single-flight/memo identity
+  // too: two calls differing only by one of these must never coalesce into
+  // one answer (a {previous:true} caller must never be served a memoized
+  // {previous:false} answer, or vice versa).
+  return JSON.stringify([
+    Number(o.days) || 14, Number(o.lookbackDays) || 0, !!o.previous, !!o.force, roots, o.cachePath || '',
+  ]);
 }
 
 /** Drop process-level state (single-flight promises, read memo, lazy deps). */

--- a/src/lib/usage-index.mjs
+++ b/src/lib/usage-index.mjs
@@ -374,7 +374,11 @@ let _memo = null;
  *  case still changes the key instead of colliding with every other scan. */
 function scanKey(o = {}) {
   const roots = Object.entries(o.roots || {}).sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
-  return JSON.stringify([Number(o.days) || 14, !!o.force, roots, o.cachePath || '']);
+  // lookbackDays changes the RESULT (it widens what scan() parses/returns —
+  // see scan() below) exactly like days/force/roots/cachePath already do, so
+  // it must be folded into the single-flight/memo identity too: two calls
+  // differing only by lookbackDays must never coalesce into one answer.
+  return JSON.stringify([Number(o.days) || 14, Number(o.lookbackDays) || 0, !!o.force, roots, o.cachePath || '']);
 }
 
 /** Drop process-level state (single-flight promises, read memo, lazy deps). */
@@ -388,6 +392,14 @@ function notify(onProgress, payload) {
 /**
  * @typedef {object} IndexOptions
  * @property {number} [days]        window size in days (default 14)
+ * @property {number} [lookbackDays] widen the discovery/parse cutoff (and the
+ *           cutoff `aggregate` filters `sessions` against) to this many days
+ *           back instead of `days` — a caller computing a delta between two
+ *           `days`-sized windows can pass e.g. `lookbackDays: days * 2` and
+ *           get both windows' sessions back from one scan; `windowDays` in
+ *           the result still reports `days` — splitting the wider `sessions`
+ *           list back into windows is the caller's job. Undefined (default)
+ *           behaves exactly as `days` alone: no widening.
  * @property {boolean} [force]      ignore cached per-file entries
  * @property {Function} [onProgress] called with { scanned, total, phase }
  * @property {{claude?: string, codex?: string, opencode?: string}} [roots] override transcript roots (tests; opencode = the SQLite store path)
@@ -564,12 +576,20 @@ function resolveCodexLedger(o, rawRoots) {
 /** @param {IndexOptions} [o] */
 async function scan(o = {}) {
   const {
-    days = 14, force = false, onProgress, roots, cachePath, now = Date.now(), deps: injected,
+    days = 14, lookbackDays, force = false, onProgress, roots, cachePath, now = Date.now(), deps: injected,
   } = o;
   const deps = await loadDeps(injected);
   const r = { ...defaultRoots(), ...(roots ?? {}) };
   const cacheFile = cachePath ?? defaultCachePath();
-  const cutoff = now - days * DAY_MS;
+  // Widened when the caller passes lookbackDays (a server computing a delta
+  // between two `days`-sized windows, e.g.) — every discovery/parse use below
+  // (candidates, opencode listing, carry-forward, and the cutoff `aggregate`
+  // filters `sessions` against) shares this ONE value, so widening it here is
+  // the entire effect. `windowDays` in the returned aggregate still reports
+  // `days` unchanged; bucketing the wider `sessions` list back into windows
+  // is the caller's job. Unset, `lookbackDays ?? days` is exactly `days` —
+  // today's behavior, unchanged.
+  const cutoff = now - (lookbackDays ?? days) * DAY_MS;
 
   // Primary transcript roots: read once at root level (cheap — not the
   // recursive per-file walk listClaude/listCodex still do below).

--- a/src/lib/usage-index.mjs
+++ b/src/lib/usage-index.mjs
@@ -108,6 +108,19 @@ const KEEP_MS = 366 * DAY_MS;
  *  unavailable rather than risking the panel's process. */
 const MAX_SESSION_BYTES = 64 * 1024 * 1024;
 const VALID_ID = /^[A-Za-z0-9._-]{1,128}$/;
+/** A nested Claude subagent transcript's id: EXACTLY `<parentId>/<stem>`,
+ *  one slash. The parent segment reuses VALID_ID's own charset (capture
+ *  group 1) — a namespaced id's parent half can never be more permissive
+ *  than a plain id already is. The child segment (group 2) matches the REAL
+ *  on-disk shape Claude Code writes every subagent transcript with:
+ *  `agent-<hex>` when the Task tool call carried no name, or
+ *  `agent-<name>-<hex>` when it did (the name is the Agent tool's own
+ *  `name` parameter, charset [A-Za-z0-9_-]). Surveyed on this machine's real
+ *  corpus (404 files, 2026-08-28): most stems carry a name — a hex-only
+ *  pattern would leave most subagent sessions still unopenable, defeating
+ *  the point of this fix. Neither capture group's charset contains '/', '.',
+ *  or '\', so this is a strict allowlist, not merely "not a plain id". */
+const VALID_SUBAGENT_ID = /^([A-Za-z0-9._-]{1,128})\/(agent-[A-Za-z0-9_-]{1,100})$/;
 
 // ── file discovery ──────────────────────────────────────────────────────────
 
@@ -746,9 +759,44 @@ function invalidId(id) {
   return err;
 }
 
+/** The project directory name for a resolved claude FILE — one level up for
+ *  a plain `<project>/<id>.jsonl`, three levels up for a nested subagent
+ *  transcript `<project>/<parentId>/subagents/<stem>.jsonl` (the extra
+ *  `subagents` and `<parentId>` levels a namespaced id resolves through).
+ *  Shared by locate()'s cache-hit path and its own nested-id fallback scan
+ *  below, so both agree on what "the project" means for the same file
+ *  shape — a cache-hit that instead reported the literal `subagents`
+ *  directory as the project would only ever surface when a transcript
+ *  carries no `cwd` at all (parseClaude's fallback path), but it would still
+ *  be wrong, so this file shape is resolved to the real project everywhere
+ *  a dirName is derived from a FILE, not just on the fresh-parse path. */
+function claudeDirNameFor(file) {
+  const parentDir = path.dirname(file);
+  return path.basename(parentDir) === 'subagents'
+    ? path.basename(path.dirname(path.dirname(parentDir)))
+    : path.basename(parentDir);
+}
+
+/** locate()'s namespaced-id branch, pulled out to keep locate() itself under
+ *  the project's complexity ceiling — the same reason listClaudeSubagents was
+ *  split out of listClaude on the discovery side. Resolves ONLY to a nested
+ *  Claude subagent transcript, constructing the candidate path from the two
+ *  VALIDATED capture groups `locate` already extracted — never by joining raw
+ *  request input. Returns `null` (not "fall through") on a miss: a namespaced
+ *  id is never a plain id too, so there is nothing else for locate to try. */
+function locateSubagent(parentId, stem, claudeRoot, id) {
+  for (const d of readDirSafe(claudeRoot)) {
+    if (!d.isDirectory()) continue;
+    const file = path.join(claudeRoot, d.name, parentId, 'subagents', `${stem}.jsonl`);
+    if (statSafe(file)) return { file, provider: 'claude', id, dirName: d.name };
+  }
+  return null;
+}
+
 /** Resolve an id to exactly one transcript file. Consults the index cache
  *  first; otherwise matches on FILE NAMES only — never opens a transcript it is
- *  not going to return. */
+ *  not going to return. A namespaced id (VALID_SUBAGENT_ID) resolves via
+ *  locateSubagent only — see there. */
 function locate(id, r, cacheFile) {
   const cache = readCache(cacheFile);
   const hitFile = idIndexFor(cache).get(id);
@@ -761,9 +809,12 @@ function locate(id, r, cacheFile) {
     // instead of silently rewriting the provider to claude.
     const provider = e?.session?.provider;
     if ((provider === 'claude' || provider === 'codex') && e.session.id === id && statSafe(hitFile)) {
-      return { file: hitFile, provider, id, dirName: provider === 'claude' ? path.basename(path.dirname(hitFile)) : null };
+      return { file: hitFile, provider, id, dirName: provider === 'claude' ? claudeDirNameFor(hitFile) : null };
     }
   }
+
+  const nested = VALID_SUBAGENT_ID.exec(id);
+  if (nested) return locateSubagent(nested[1], nested[2], r.claude, id);
 
   for (const d of readDirSafe(r.claude)) {
     if (!d.isDirectory()) continue;
@@ -791,14 +842,16 @@ function locate(id, r, cacheFile) {
 /**
  * Read ONE session by id — never a corpus scan. Returns `{ meta, turns }` with
  * every text body run through `maskSecrets`, or `null` when no such session.
- * Throws `ERR_INVALID_SESSION_ID` for an id that fails the id grammar (the
- * path-traversal guard), before any filesystem access.
+ * Throws `ERR_INVALID_SESSION_ID` for an id that fails EITHER id grammar — a
+ * plain id (VALID_ID) or a namespaced Claude subagent id (VALID_SUBAGENT_ID,
+ * `<parentId>/<stem>`) — before any filesystem access. Both are the same
+ * path-traversal guard; the namespaced grammar is just as strict, not looser.
  *
  * @param {string} id
  * @param {IndexOptions} [o]
  */
 export async function readSession(id, o = {}) {
-  if (typeof id !== 'string' || !VALID_ID.test(id)) throw invalidId(id);
+  if (typeof id !== 'string' || (!VALID_ID.test(id) && !VALID_SUBAGENT_ID.test(id))) throw invalidId(id);
   const r = { ...defaultRoots(), ...(o.roots ?? {}) };
 
   // opencode sessions live in the SQLite store, not a JSONL file — resolve

--- a/src/lib/usage-index.mjs
+++ b/src/lib/usage-index.mjs
@@ -392,14 +392,21 @@ function notify(onProgress, payload) {
 /**
  * @typedef {object} IndexOptions
  * @property {number} [days]        window size in days (default 14)
- * @property {number} [lookbackDays] widen the discovery/parse cutoff (and the
- *           cutoff `aggregate` filters `sessions` against) to this many days
- *           back instead of `days` — a caller computing a delta between two
- *           `days`-sized windows can pass e.g. `lookbackDays: days * 2` and
- *           get both windows' sessions back from one scan; `windowDays` in
- *           the result still reports `days` — splitting the wider `sessions`
- *           list back into windows is the caller's job. Undefined (default)
- *           behaves exactly as `days` alone: no widening.
+ * @property {number} [lookbackDays] widen the discovery/parse/cache cutoff to
+ *           this many days back instead of `days`, so records older than the
+ *           DISPLAYED window are still read off disk and handed to
+ *           `aggregate`. The `aggregate` call itself always filters the
+ *           CURRENT window's `sessions`/`totals` at the display cutoff
+ *           (`now - days * DAY_MS`), never the widened one — a caller must
+ *           pair this with `previous: true` (below) to actually get the
+ *           older records back out, via `previous.totals`/`previous.rhythm`,
+ *           rather than by hand-splitting a widened `sessions[]`. Undefined
+ *           (default) behaves exactly as `days` alone: no widening.
+ * @property {boolean} [previous]   also have `aggregate` project the
+ *           equal-length window immediately before the displayed one (see
+ *           usage-aggregate.mjs's `previousWindow`); needs `lookbackDays` set
+ *           wide enough for those older records to have been read at all.
+ *           Forwarded to `aggregate`'s own `previous` option unchanged.
  * @property {boolean} [force]      ignore cached per-file entries
  * @property {Function} [onProgress] called with { scanned, total, phase }
  * @property {{claude?: string, codex?: string, opencode?: string}} [roots] override transcript roots (tests; opencode = the SQLite store path)
@@ -577,17 +584,19 @@ function resolveCodexLedger(o, rawRoots) {
 async function scan(o = {}) {
   const {
     days = 14, lookbackDays, force = false, onProgress, roots, cachePath, now = Date.now(), deps: injected,
+    previous = false,
   } = o;
   const deps = await loadDeps(injected);
   const r = { ...defaultRoots(), ...(roots ?? {}) };
   const cacheFile = cachePath ?? defaultCachePath();
-  // Widened when the caller passes lookbackDays (a server computing a delta
-  // between two `days`-sized windows, e.g.) — every discovery/parse use below
-  // (candidates, opencode listing, carry-forward, and the cutoff `aggregate`
-  // filters `sessions` against) shares this ONE value, so widening it here is
-  // the entire effect. `windowDays` in the returned aggregate still reports
-  // `days` unchanged; bucketing the wider `sessions` list back into windows
-  // is the caller's job. Unset, `lookbackDays ?? days` is exactly `days` —
+  // Widened when the caller passes lookbackDays (a server wanting a
+  // `previous`-window projection, e.g.) — every DISCOVERY/parse use below
+  // (candidates, opencode listing, carry-forward) shares this ONE value, so
+  // widening it here is the entire discovery-side effect. It does NOT reach
+  // `aggregate`'s own cutoff below — see displayCutoff — so the CURRENT
+  // window's `sessions`/`totals` never silently widen with it; only
+  // `aggregate`'s `previous` projection (when requested) reads the extra
+  // records this pulls in. Unset, `lookbackDays ?? days` is exactly `days` —
   // today's behavior, unchanged.
   const cutoff = now - (lookbackDays ?? days) * DAY_MS;
 
@@ -642,7 +651,16 @@ async function scan(o = {}) {
   // arrives later (or gets repaired) corrects old sessions without a cache
   // invalidation.
   const { ledger, health: codexLedgerHealth } = resolveCodexLedger(o, roots);
-  const result = aggregate(applyCodexLedger(records, ledger), { days, now, cutoff, deps });
+  // DISPLAY cutoff, deliberately distinct from the (possibly lookback-
+  // widened) discovery `cutoff` above: `records` may span further back than
+  // `days` so `previous` below has something to project from, but the
+  // CURRENT window's own sessions/totals must stay exactly `days` wide, or a
+  // `previous: true` caller would find its "current" totals silently
+  // absorbing what should have been the previous window (the bug this fixes).
+  const displayCutoff = now - days * DAY_MS;
+  const result = aggregate(applyCodexLedger(records, ledger), {
+    days, now, cutoff: displayCutoff, deps, previous,
+  });
   const codexSourceHealth = finalizeCodexHealth(codexHealth, codexDiagnostics);
   addTelemetryDiagnostics(commonDiagnostics.codex, {
     warnings: codexSourceHealth.diagnostics.warnings,

--- a/src/lib/usage-index.mjs
+++ b/src/lib/usage-index.mjs
@@ -101,8 +101,23 @@ export { MAX_TURN_CHARS, mergeIntervals, maskSecrets, normalizeSessionIdentity, 
  *       `mode` for every Codex session — the taxonomy's plan/auto-edit/
  *       unrestricted arms could not fire at all. The parser now extracts
  *       `.type`, so every Codex record must be re-derived rather than left
- *       carrying the failed stringification and its missing posture. */
-export const SCHEMA_VERSION = 12;
+ *       carrying the failed stringification and its missing posture.
+ *  v13: two parseCodex defects corrected together, both inflating persisted
+ *       counts/identities. (a) `session_meta` was last-wins; a subagent
+ *       rollout replays its parent thread's history, including the parent's
+ *       OWN session_meta line, so a later meta relabeled `threadSource`
+ *       subagent→user and re-keyed `id` to the parent's — letting up to 155
+ *       of 318 observed subagent rollouts escape the finalizeCodexUsage
+ *       guard and double-bill the parent. The FIRST session_meta now wins
+ *       for identity (id/threadSource/cwd). (b) every `user_message`/
+ *       `UserMessage` counted toward `prompts` regardless of origin; Codex
+ *       carried no equivalent of the harness/mirror gate v5 already applies
+ *       to Claude, so harness output and mirrored cross-host envelopes
+ *       (task notifications, command stdout, teammate-message/cross-session
+ *       deliveries) inflated Codex prompt counts. A v12-cached Codex record
+ *       carries the old (possibly relabeled, possibly inflated) figures and
+ *       must be re-derived rather than trusted as-is. */
+export const SCHEMA_VERSION = 13;
 
 const DAY_MS = 86_400_000;
 // One day of slack past dashboard-server.mjs's 365-day clampDays ceiling —

--- a/src/lib/usage-index.mjs
+++ b/src/lib/usage-index.mjs
@@ -864,7 +864,11 @@ export async function readSession(id, o = {}) {
     if (parsed) {
       const rec = parsed.session;
       rec.title = maskSecrets(rec.title);
-      return sessionPayload(rec, parsed.turns);
+      // deps is not optional here: an opencode row whose messages carried no
+      // `cost` field keeps costObserved null by design, and sessionCost then
+      // falls back to the pricer. Omitting it threw on exactly the data state
+      // the null is there to represent.
+      return sessionPayload(rec, parsed.turns, await loadDeps(o.deps));
     }
   }
 

--- a/src/lib/usage-index.mjs
+++ b/src/lib/usage-index.mjs
@@ -209,7 +209,40 @@ function defaultRoots() {
   };
 }
 
-/** Claude transcripts: exactly one level of project directories. */
+/** `<projectDir>/<sessionId>/subagents/*.jsonl` — a session's own subagent
+ *  (sidechain) transcripts, real cost-bearing Claude work that otherwise
+ *  never enters the index: parseClaude already prices these bytes and marks
+ *  them `sidechain` from their own entries (isSidechain), so discovery was
+ *  the entire gap. Bounded to exactly this one nested shape — not a generic
+ *  recursive walk — so a directory entry that ISN'T a session-id dir with a
+ *  subagents child (e.g. Claude Code's own `memory` dir) just contributes
+ *  nothing, harmlessly.
+ *
+ *  The id is namespaced `<sessionId>/<stem>`: Claude Code names every
+ *  subagent file `agent-<hash>.jsonl`, and that stem is NOT guaranteed
+ *  unique across two different parent sessions, so an unnamespaced id could
+ *  silently collide two unrelated subagent records into one.
+ *
+ *  An unreadable (or absent — most sessions have none) subagents dir
+ *  degrades silently via readDirSafe, exactly like every other per-directory
+ *  read in this file: one bad nested entry must not abort the whole scan,
+ *  and this draws no new health signal — same convention, not a new one. */
+function listClaudeSubagents(projectDir, sessionId, projectDirName) {
+  const out = [];
+  const subDir = path.join(projectDir, sessionId, 'subagents');
+  for (const f of readDirSafe(subDir)) {
+    if (f.isFile() && f.name.endsWith('.jsonl')) {
+      out.push({
+        file: path.join(subDir, f.name), provider: 'claude', dirName: projectDirName,
+        id: `${sessionId}/${f.name.slice(0, -6)}`,
+      });
+    }
+  }
+  return out;
+}
+
+/** Claude transcripts: one level of project directories, plus each session's
+ *  own nested subagents/ (see listClaudeSubagents). */
 function listClaude(root) {
   const out = [];
   for (const d of readDirSafe(root)) {
@@ -218,6 +251,8 @@ function listClaude(root) {
     for (const f of readDirSafe(dir)) {
       if (f.isFile() && f.name.endsWith('.jsonl')) {
         out.push({ file: path.join(dir, f.name), provider: 'claude', dirName: d.name, id: f.name.slice(0, -6) });
+      } else if (f.isDirectory()) {
+        out.push(...listClaudeSubagents(dir, f.name, d.name));
       }
     }
   }

--- a/src/lib/usage-index.mjs
+++ b/src/lib/usage-index.mjs
@@ -124,9 +124,37 @@ const VALID_ID = /^[A-Za-z0-9._-]{1,128}$/;
  *  `name` parameter, charset [A-Za-z0-9_-]). Surveyed on this machine's real
  *  corpus (404 files, 2026-08-28): most stems carry a name — a hex-only
  *  pattern would leave most subagent sessions still unopenable, defeating
- *  the point of this fix. Neither capture group's charset contains '/', '.',
- *  or '\', so this is a strict allowlist, not merely "not a plain id". */
+ *  the point of this fix.
+ *
+ *  This regex is NOT the whole grammar: '.' IS in the parent charset, so
+ *  `.` and `..` match it. Use matchSubagentId(), never this constant
+ *  directly. */
 const VALID_SUBAGENT_ID = /^([A-Za-z0-9._-]{1,128})\/(agent-[A-Za-z0-9_-]{1,100})$/;
+
+/** The namespaced-id grammar, complete: VALID_SUBAGENT_ID's charsets PLUS
+ *  the dot-segment rejection, so this is character-for-character the rule
+ *  session-security.mjs's parseNamespacedSessionId applies at the HTTP tier
+ *  (PLAIN_ID_RE + `parentId === '.' || parentId === '..'` + SUBAGENT_STEM_RE).
+ *  The two tiers are kept as separate functions on purpose — the route's also
+ *  owns percent-decoding, which a library caller passing an already-decoded
+ *  id must not get — but they now accept exactly the same id set.
+ *
+ *  The dot check is what the charset cannot do and what matters most here:
+ *  the parent is the only place in this module where caller-shaped text
+ *  becomes a path SEGMENT rather than a filename stem, and path.join
+ *  collapses `..`. `readSession('../agent-x')` used to probe
+ *  `<claudeRoot>/subagents/agent-x.jsonl` — still inside the transcript root,
+ *  so the realpath containment check below could not catch it: containment
+ *  answers "did we leave the root?", not "did we leave the shape?".
+ *
+ *  @returns {{ parentId: string, stem: string }|null} */
+function matchSubagentId(id) {
+  const m = typeof id === 'string' ? VALID_SUBAGENT_ID.exec(id) : null;
+  if (!m) return null;
+  const [, parentId, stem] = m;
+  if (parentId === '.' || parentId === '..') return null;
+  return { parentId, stem };
+}
 
 // ── file discovery ──────────────────────────────────────────────────────────
 
@@ -250,12 +278,21 @@ function listClaudeSubagents(projectDir, sessionId, projectDirName) {
   const out = [];
   const subDir = path.join(projectDir, sessionId, 'subagents');
   for (const f of readDirSafe(subDir)) {
-    if (f.isFile() && f.name.endsWith('.jsonl')) {
-      out.push({
-        file: path.join(subDir, f.name), provider: 'claude', dirName: projectDirName,
-        id: `${sessionId}/${f.name.slice(0, -6)}`,
-      });
-    }
+    if (!f.isFile() || !f.name.endsWith('.jsonl')) continue;
+    const id = `${sessionId}/${f.name.slice(0, -6)}`;
+    // Discovery and resolution share ONE grammar. Without this, any other
+    // file appearing in a subagents/ dir (a summary, an index, a renamed
+    // stem) — or a parent dir name outside the plain-id charset — became a
+    // session row that answers 400 when clicked: a row disclosing title,
+    // project, tokens, cost and timing for a transcript the id grammar has
+    // decided is not addressable. Surveyed 2026-08-28: 411 files, 0 rejected,
+    // so this drops nothing today; it keeps the two sides from disagreeing
+    // when the on-disk shape next changes, at the point of discovery rather
+    // than as a 400 far from its cause.
+    if (!matchSubagentId(id)) continue;
+    out.push({
+      file: path.join(subDir, f.name), provider: 'claude', dirName: projectDirName, id,
+    });
   }
   return out;
 }
@@ -819,8 +856,8 @@ function locate(id, r, cacheFile) {
     }
   }
 
-  const nested = VALID_SUBAGENT_ID.exec(id);
-  if (nested) return locateSubagent(nested[1], nested[2], r.claude, id);
+  const nested = matchSubagentId(id);
+  if (nested) return locateSubagent(nested.parentId, nested.stem, r.claude, id);
 
   for (const d of readDirSafe(r.claude)) {
     if (!d.isDirectory()) continue;
@@ -849,15 +886,28 @@ function locate(id, r, cacheFile) {
  * Read ONE session by id — never a corpus scan. Returns `{ meta, turns }` with
  * every text body run through `maskSecrets`, or `null` when no such session.
  * Throws `ERR_INVALID_SESSION_ID` for an id that fails EITHER id grammar — a
- * plain id (VALID_ID) or a namespaced Claude subagent id (VALID_SUBAGENT_ID,
- * `<parentId>/<stem>`) — before any filesystem access. Both are the same
- * path-traversal guard; the namespaced grammar is just as strict, not looser.
+ * plain id (VALID_ID) or a namespaced Claude subagent id (matchSubagentId,
+ * `<parentId>/<stem>`) — before any filesystem access.
+ *
+ * The namespaced grammar accepts exactly the id set session-security.mjs's
+ * parseNamespacedSessionId accepts at the HTTP tier, dot-segment rejection
+ * included — so this guard is sound on its own and a caller reaching
+ * readSession from outside the route (a CLI, an MCP tool) inherits the same
+ * protection. That parity is enforced by matchSubagentId, not by these two
+ * grammars being kept in step by hand: the parity claim that used to stand
+ * here was false, because '.' is inside the parent charset.
+ *
+ * The plain grammar is deliberately NOT identical to parseSessionId's: it
+ * has no '.'/'..' exclusion, because a plain id is only ever used as a
+ * filename STEM (`${id}.jsonl`), where '..' yields the literal '...jsonl'.
+ * Only the namespaced parent becomes a path segment, which is why only it
+ * needs the check.
  *
  * @param {string} id
  * @param {IndexOptions} [o]
  */
 export async function readSession(id, o = {}) {
-  if (typeof id !== 'string' || (!VALID_ID.test(id) && !VALID_SUBAGENT_ID.test(id))) throw invalidId(id);
+  if (typeof id !== 'string' || (!VALID_ID.test(id) && !matchSubagentId(id))) throw invalidId(id);
   const r = { ...defaultRoots(), ...(o.roots ?? {}) };
 
   // opencode sessions live in the SQLite store, not a JSONL file — resolve

--- a/src/lib/usage-index.mjs
+++ b/src/lib/usage-index.mjs
@@ -780,12 +780,21 @@ async function scan(o = {}) {
 export async function readIndex(o = {}) {
   const { days = 14, maxAgeMs = 15_000, now = Date.now() } = o;
   // code-quality Finding 7: this used to hand-roll a SECOND "what counts as
-  // the same question" key that omitted `force` (and `deps`) — the exact
-  // mistake buildIndex's _inflight keying (scanKey, above) was written to
-  // prevent one layer up. readIndex({ force: true }) within maxAgeMs of a
-  // normal read would silently return the stale memoized aggregate and never
-  // reach buildIndex. Reusing scanKey means there is exactly one definition
-  // of "same question" for both the single-flight map and this memo.
+  // the same question" key that omitted `force` — the exact mistake
+  // buildIndex's _inflight keying (scanKey, above) was written to prevent one
+  // layer up. readIndex({ force: true }) within maxAgeMs of a normal read
+  // would silently return the stale memoized aggregate and never reach
+  // buildIndex. Reusing scanKey means there is exactly one definition of
+  // "same question" for both the single-flight map and this memo.
+  //
+  // scanKey deliberately does NOT fold in `deps` or `codexState`, and this
+  // comment says so rather than implying otherwise: both hold live objects
+  // (functions, Maps) that do not serialize, so keying on them would mean
+  // minting identity tokens through a WeakMap. Two calls differing ONLY by an
+  // injected pricer or ledger would therefore coalesce — a latent trap, not a
+  // live bug: production never injects `deps`, and tests sandbox `roots` and
+  // `cachePath` per test so their keys already differ. Ruled parked with that
+  // reason rather than left implied.
   const key = scanKey({ ...o, days });
   if (_memo && _memo.key === key && now - _memo.at < maxAgeMs) return _memo.agg;
   const agg = await buildIndex({ ...o, days });

--- a/src/lib/usage-index.mjs
+++ b/src/lib/usage-index.mjs
@@ -88,8 +88,15 @@ export { MAX_TURN_CHARS, mergeIntervals, maskSecrets, normalizeSessionIdentity, 
  *      re-derived or the placeholder keeps showing as a real "model in play".
  *  v10: Codex rollout messages can arrive in the `item_completed` envelope;
  *       v9-cached records parsed from those files have token rows but zero
- *       prompts/responses, so every Codex record must be re-derived. */
-export const SCHEMA_VERSION = 10;
+ *       prompts/responses, so every Codex record must be re-derived.
+ *  v11: session records grow `mode`/`modeRaw` (cross-host permission
+ *       posture), `latHist`/`latCount` (response-latency histogram),
+ *       `lenSeconds` (this session's own engaged seconds), `ctxWindow`/
+ *       `ctxLastTokens` (model context-window detail), and `aborts`
+ *       (codex's explicit user-abort count). A v10-cached record carries
+ *       none of these, so every session must be re-derived or the new
+ *       fields silently read as undefined. */
+export const SCHEMA_VERSION = 11;
 
 const DAY_MS = 86_400_000;
 // One day of slack past dashboard-server.mjs's 365-day clampDays ceiling —

--- a/src/lib/usage-insights.mjs
+++ b/src/lib/usage-insights.mjs
@@ -19,6 +19,11 @@
 //      A diagnostic panel that nudges toward the newest model by default is an
 //      advertisement, not a diagnostic.
 
+// Bucket-percentile math is shared with the window-level rhythm this same
+// histogram data feeds (usage-aggregate.mjs's buildRhythm) — reused here, not
+// reimplemented, so the two never drift on what "p50" means.
+import { percentileFromBuckets, LAT_BUCKET_EDGES } from './usage-aggregate.mjs';
+
 // ── Pricing structure (multipliers, not rates) ───────────────────────────────
 // `pricing.mjs` owns the per-model $ rates. What we need here is only the SHAPE
 // of the formula, so a token mix can be converted into billable "units" and the
@@ -109,6 +114,17 @@ export const THRESHOLDS = {
   // the high mark while the other host has a lane under the low mark.
   arbitrageHighPercent: 75,
   arbitrageLowPercent: 25,
+
+  // latency-regression: each half of the window needs this many latency
+  // samples before a p50 means anything, and the second half's bucket-merged
+  // p50 must clear BOTH a relative and an absolute floor over the first's.
+  latencyRegressionMinSamples: 30,
+  latencyRegressionMinRelative: 0.25,
+  latencyRegressionMinSeconds: 2,
+
+  // unrestricted-mode: an approval-posture nudge, not a spend-share one — it
+  // fires on any recorded use, so the only floor is "at least one".
+  unrestrictedMinSessions: 1,
 };
 
 // ── Grounding for `model-routing` (ADR-0009 §6) ──────────────────────────────
@@ -222,7 +238,7 @@ function withDefaults(insight) {
   return { command: null, impact: null, ...insight };
 }
 
-// ── The 13 detectInsights heuristics ─────────────────────────────────────────
+// ── The 15 detectInsights heuristics ─────────────────────────────────────────
 // Each detector is independent, sharing only the `ctx` prelude detectInsights
 // computes once (a/totals/sessions/windowCost/sessionCount). `detect(ctx)`
 // returns zero or one insight, wrapped in an array so DETECTORS.flatMap below
@@ -579,6 +595,97 @@ function detectLongSessionShare({ sessions, windowCost }) {
   })];
 }
 
+// Latest end time a session's own data supports: start (parsed) plus its
+// measured duration. Sessions carry no `end` field by the time they reach
+// this module — usage-aggregate.mjs strips the working `_span` once the
+// window totals are folded — so this reconstructs it instead of adding a
+// clock read anywhere near this file.
+function sessionEndMs(s) {
+  const startMs = Date.parse(s.start);
+  return Number.isFinite(startMs) ? startMs + num(s.minutes) * 60_000 : NaN;
+}
+
+// Slot-wise sum of a group of sessions' latHist arrays — the same fold
+// buildRhythm does for the whole window, scoped to half of it here. A
+// session that never observed a latency (`latHist` absent) contributes
+// nothing, the same honest-absent handling buildRhythm uses.
+function mergeLatHist(rows) {
+  const hist = new Array(LAT_BUCKET_EDGES.length + 1).fill(0);
+  let samples = 0;
+  for (const s of rows) {
+    if (!Array.isArray(s.latHist)) continue;
+    for (let i = 0; i < hist.length; i++) hist[i] += num(s.latHist[i]);
+    samples += num(s.latCount);
+  }
+  return { hist, samples };
+}
+
+// 14 ── latency-regression. Splits the window's OWN sessions into an earlier
+// and later half by end time (never a live clock) and compares their
+// bucket-merged p50s. A relative AND an absolute floor must clear together,
+// so neither a big swing on a fast baseline nor a small percentage on an
+// already-slow one reads as a regression on its own — and each half needs
+// enough samples for a p50 to mean anything. No finding when the data does
+// not support one; this detector never reports "latency looks fine".
+function detectLatencyRegression({ sessions }) {
+  const ordered = sessions
+    .map((s) => ({ s, end: sessionEndMs(s) }))
+    .filter((r) => Number.isFinite(r.end))
+    .sort((x, y) => x.end - y.end)
+    .map((r) => r.s);
+  const half = Math.floor(ordered.length / 2);
+  if (half < 1) return [];
+  const first = mergeLatHist(ordered.slice(0, half));
+  const second = mergeLatHist(ordered.slice(-half));
+  if (first.samples < THRESHOLDS.latencyRegressionMinSamples
+    || second.samples < THRESHOLDS.latencyRegressionMinSamples) return [];
+  const p50First = percentileFromBuckets(first.hist, LAT_BUCKET_EDGES, 0.5);
+  const p50Second = percentileFromBuckets(second.hist, LAT_BUCKET_EDGES, 0.5);
+  if (p50First === null || p50Second === null || p50First <= 0) return [];
+  const deltaAbs = p50Second - p50First;
+  const deltaShare = deltaAbs / p50First;
+  if (deltaShare < THRESHOLDS.latencyRegressionMinRelative
+    || deltaAbs < THRESHOLDS.latencyRegressionMinSeconds) return [];
+  return [withDefaults({
+    id: 'latency-regression', kind: 'trend', severity: 'warn',
+    title: 'Response latency is trending up',
+    finding: `The second half of this window's sessions had a ${p50Second}s median response `
+      + `time, up from ${p50First}s in the first half — a ${pct(deltaShare)} increase.`,
+    evidence: `${count(first.samples)} latency samples in the earlier half, `
+      + `${count(second.samples)} in the later half.`,
+    action: 'Confirm this is not a provider-side or network slowdown before assuming a local '
+      + 'change is responsible.',
+  })];
+}
+
+// 15 ── unrestricted-mode. Sessions the harness itself recorded running in
+// its most permissive approval posture (Claude's bypassPermissions, Codex's
+// never-approve + full-access sandbox — see usage-modes.mjs). An approval-
+// posture nudge, not a spend-share one: rule 2 floors dollar thresholds
+// against the window, but there is no dollar floor to apply here, so this
+// fires on any recorded use. `not-recorded` — a transcript that never
+// observed a posture — is a different, honest-absent value and never counts.
+function detectUnrestrictedMode({ sessions, windowCost }) {
+  const unrestricted = sessions.filter((s) => s.mode === 'unrestricted');
+  if (unrestricted.length < THRESHOLDS.unrestrictedMinSessions) return [];
+  const spend = sumBy(unrestricted, 'cost');
+  const projects = new Set(unrestricted.map((s) => s.project)).size;
+  const n = unrestricted.length;
+  return [withDefaults({
+    id: 'unrestricted-mode', kind: 'coach', severity: 'info',
+    title: `${count(n)} session${n === 1 ? '' : 's'} ran in unrestricted mode`,
+    finding: `${count(n)} session${n === 1 ? '' : 's'} across ${count(projects)} `
+      + `project${projects === 1 ? '' : 's'} recorded the harness's unrestricted approval `
+      + `posture, costing ${usd(spend)}${windowCost > 0 ? ` of this window's ${usd(windowCost)}` : ''}. `
+      + 'See the Sessions view to review which ones.',
+    evidence: 'Based only on the approval posture each session itself recorded (`mode`); a '
+      + 'session that never reported a posture is not counted here, so this is a floor, not a '
+      + 'full census.',
+    action: 'Confirm unrestricted sessions were intentional — reserve that posture for scoped, '
+      + 'trusted work rather than as a default.',
+  })];
+}
+
 /** @type {Array<{id: string, detect: (ctx: object) => Insight[]}>} */
 const DETECTORS = [
   { id: 'context-tax', detect: detectContextTax },
@@ -594,6 +701,8 @@ const DETECTORS = [
   { id: 'parallel-sessions', detect: detectParallelSessions },
   { id: 'subagent-share', detect: detectSubagentShare },
   { id: 'long-session-share', detect: detectLongSessionShare },
+  { id: 'latency-regression', detect: detectLatencyRegression },
+  { id: 'unrestricted-mode', detect: detectUnrestrictedMode },
 ];
 
 /** Exposed only for direct per-detector unit tests; not part of the public API. */

--- a/src/lib/usage-insights.mjs
+++ b/src/lib/usage-insights.mjs
@@ -680,7 +680,8 @@ function detectUnrestrictedMode({ sessions, windowCost }) {
       + 'See the Sessions view to review which ones.',
     evidence: 'Based only on the approval posture each session itself recorded (`mode`); a '
       + 'session that never reported a posture is not counted here, so this is a floor, not a '
-      + 'full census.',
+      + 'full census. Cost is each session\'s post-ledger figure — a Codex subagent replay is '
+      + '$0 by design, so this can undercount.',
     action: 'Confirm unrestricted sessions were intentional — reserve that posture for scoped, '
       + 'trusted work rather than as a default.',
   })];

--- a/src/lib/usage-modes.mjs
+++ b/src/lib/usage-modes.mjs
@@ -10,6 +10,8 @@ function codexMode(approval, sandbox) {
   if (sandbox === 'read-only') return 'plan';
   if (approval === 'never' && sandbox === 'danger-full-access') return 'unrestricted';
   if (approval === 'never' && sandbox === 'workspace-write') return 'auto-edit';
+  // Approval evidence alone is sufficient for 'guarded' — human-in-the-loop is the posture;
+  // sandbox evidence is not required (ADR-0038 ruling).
   if (['on-request', 'on-failure', 'untrusted'].includes(approval)) return 'guarded';
   return null;
 }

--- a/src/lib/usage-modes.mjs
+++ b/src/lib/usage-modes.mjs
@@ -16,6 +16,10 @@ function codexMode(approval, sandbox) {
   return null;
 }
 
+/**
+ * @param {{ host?: string, permissionMode?: string, approvalPolicy?: string, sandboxPolicy?: string, opencodeMode?: string }} [opts]
+ * @returns {{ mode: string|null, raw: string|null }}
+ */
 export function normalizeMode({ host, permissionMode, approvalPolicy, sandboxPolicy, opencodeMode } = {}) {
   if (host === 'claude' && typeof permissionMode === 'string') {
     return { mode: CC[permissionMode] ?? null, raw: permissionMode };

--- a/src/lib/usage-modes.mjs
+++ b/src/lib/usage-modes.mjs
@@ -1,0 +1,29 @@
+// usage-modes.mjs — the cross-host permission-posture taxonomy (ADR-0038).
+// One closed vocabulary; every mapping is a recorded judgment call pinned by
+// tests. An unmapped raw value is null (not recorded), NEVER a guess.
+export const MODES = ['guarded', 'auto-edit', 'plan', 'unrestricted'];
+
+const CC = { default: 'guarded', acceptEdits: 'auto-edit', auto: 'auto-edit', dontAsk: 'auto-edit', plan: 'plan', bypassPermissions: 'unrestricted' };
+const OC = { build: 'auto-edit', plan: 'plan' };
+
+function codexMode(approval, sandbox) {
+  if (sandbox === 'read-only') return 'plan';
+  if (approval === 'never' && sandbox === 'danger-full-access') return 'unrestricted';
+  if (approval === 'never' && sandbox === 'workspace-write') return 'auto-edit';
+  if (['on-request', 'on-failure', 'untrusted'].includes(approval)) return 'guarded';
+  return null;
+}
+
+export function normalizeMode({ host, permissionMode, approvalPolicy, sandboxPolicy, opencodeMode } = {}) {
+  if (host === 'claude' && typeof permissionMode === 'string') {
+    return { mode: CC[permissionMode] ?? null, raw: permissionMode };
+  }
+  if (host === 'codex' && (approvalPolicy || sandboxPolicy)) {
+    const raw = [approvalPolicy, sandboxPolicy].filter(Boolean).join('/');
+    return { mode: codexMode(approvalPolicy, sandboxPolicy), raw };
+  }
+  if (host === 'opencode' && typeof opencodeMode === 'string') {
+    return { mode: OC[opencodeMode] ?? null, raw: opencodeMode };
+  }
+  return { mode: null, raw: null };
+}

--- a/src/lib/usage-opencode.mjs
+++ b/src/lib/usage-opencode.mjs
@@ -29,7 +29,8 @@ import { withDb } from './sqlite.mjs';
 // definitions in usage-parsers.mjs. usage-index.mjs imports FROM this module
 // (defaultOpencodeDbPath, parseSession, …), but that is no longer a cycle:
 // this module depends only on usage-parsers.mjs, not on usage-index.mjs.
-import { addUsage, blankSession } from './usage-parsers.mjs';
+import { addUsage, blankSession, noteLatencySample } from './usage-parsers.mjs';
+import { normalizeMode } from './usage-modes.mjs';
 
 /** The live opencode store. Overridable via roots in tests. */
 export function defaultOpencodeDbPath() {
@@ -76,6 +77,12 @@ function activeIntervals(stamps) {
 
 const num = (v) => (Number.isFinite(Number(v)) ? Number(v) : 0);
 const parseJson = (raw) => { try { return JSON.parse(raw); } catch { return null; } };
+
+/** A prompt-to-response gap longer than this is an idle resume, not a real
+ *  wait for a reply — excluded from latency sampling (mirrors usage-parsers'
+ *  own MAX_LATENCY_SAMPLE_SECONDS, private there, so redeclared here rather
+ *  than exported cross-module for a single constant). */
+const MAX_LATENCY_SAMPLE_SECONDS = 3600;
 
 /** Incremental candidates: sessions whose latest message lands at/after
  *  cutoffMs. `mtimeMs` (latest message time) + `size` (message count) are the
@@ -149,6 +156,9 @@ function noteStamp(rec, at) {
 
 function recordUserMessage(rec, turns, { rowId, at, withTurns, partsByMessage }) {
   rec.prompts++;
+  // Opens the prompt→assistant-message latency window; closed by the next
+  // recordAssistantMessage (mirrors parseClaude/parseCodex's latState).
+  rec.pendingPromptMs = at;
   if (!withTurns) return;
   const text = messagePartsText(partsByMessage, rowId, ['text']);
   turns.push({ role: 'user', at: new Date(at).toISOString(), text, prompt: true, kind: 'prompt' });
@@ -179,6 +189,10 @@ function recordAssistantUsage(rec, data, at) {
   usageRow.costObserved ??= null;
   if (Number.isFinite(Number(data.cost))) usageRow.costObserved = (usageRow.costObserved ?? 0) + Number(data.cost);
   rec.reasoningOutput += num(t.reasoning);
+  // Context pressure for THIS turn — overwritten every message so the field
+  // always reflects the LAST completion, not a running total (mirrors
+  // parseClaude's ctxLastTokens).
+  rec.ctxLastTokens = num(t.input) + num(cache.read);
   return model;
 }
 
@@ -194,6 +208,25 @@ function recordAssistantTurn(rec, turns, { rowId, at, model, partsByMessage }) {
 function recordAssistantMessage(rec, turns, { data, rowId, at, withTurns, partsByMessage }) {
   rec.responses++;
   if (at) { const pk = punchKey(at); rec.punchcard[pk] = (rec.punchcard[pk] ?? 0) + 1; }
+  if (data.error != null) {
+    // A provider/auth/network failure: no real completion behind it, so —
+    // like parseClaude's isApiError placeholder — it never claims a model,
+    // usage, ctx window, or mode. It IS an exception, but never a latency
+    // SAMPLE (an unanswered prompt is not a measured response time); the
+    // pending prompt is still consumed here (unlike parseClaude, which
+    // leaves it open for the next real completion) so a later, unrelated
+    // assistant message is never mis-sampled against a stale prompt.
+    rec.exceptions++;
+    rec.pendingPromptMs = null;
+    return;
+  }
+  if (rec.pendingPromptMs !== null && rec.pendingPromptMs !== undefined) {
+    const gapSeconds = (at - rec.pendingPromptMs) / 1000;
+    if (gapSeconds <= MAX_LATENCY_SAMPLE_SECONDS) noteLatencySample(rec, gapSeconds);
+    rec.pendingPromptMs = null;
+  }
+  const m = normalizeMode({ host: 'opencode', opencodeMode: data.mode });
+  if (m.raw) { rec.mode = m.mode; rec.modeRaw = m.raw; }
   const model = recordAssistantUsage(rec, data, at);
   if (withTurns) recordAssistantTurn(rec, turns, { rowId, at, model, partsByMessage });
 }
@@ -236,6 +269,10 @@ function initSessionRecord(srow) {
   rec.sidechain = !!srow.parent_id;
   rec.threadSource = srow.parent_id ? 'subagent' : null;
   if (worktree) rec.worktree = worktree;
+  // Transient parse-time state (the open prompt→assistant latency window,
+  // see recordUserMessage/recordAssistantMessage) — deleted before return in
+  // parseSession, never part of the returned session shape.
+  rec.pendingPromptMs = null;
   return rec;
 }
 
@@ -267,6 +304,7 @@ export function parseSession({ dbFile, id, withTurns = false }) {
     rec.active = activeIntervals(rec.stamps);
     rec.lenSeconds = Math.round(rec.active.reduce((n, [a, b]) => n + (b - a), 0) / 1000);
     delete rec.stamps;
+    delete rec.pendingPromptMs;
     return { session: rec, turns };
   });
   return result.ok ? result.value : null;

--- a/src/lib/usage-opencode.mjs
+++ b/src/lib/usage-opencode.mjs
@@ -189,10 +189,15 @@ function recordAssistantUsage(rec, data, at) {
   usageRow.costObserved ??= null;
   if (Number.isFinite(Number(data.cost))) usageRow.costObserved = (usageRow.costObserved ?? 0) + Number(data.cost);
   rec.reasoningOutput += num(t.reasoning);
-  // Context pressure for THIS turn — overwritten every message so the field
-  // always reflects the LAST completion, not a running total (mirrors
-  // parseClaude's ctxLastTokens).
-  rec.ctxLastTokens = num(t.input) + num(cache.read);
+  // Context pressure for THIS turn, evidence-gated: only a row that actually
+  // carries a tokens object can claim one — a token-less row (error or not)
+  // must never overwrite a real prior value with a fabricated 0 (mirrors
+  // parseClaude, which only ever reaches this line for a real usage entry).
+  // Overwritten every qualifying message so the field reflects the LAST
+  // completion, not a running total.
+  if (data.tokens !== null && typeof data.tokens === 'object') {
+    rec.ctxLastTokens = num(t.input) + num(cache.read);
+  }
   return model;
 }
 
@@ -208,19 +213,18 @@ function recordAssistantTurn(rec, turns, { rowId, at, model, partsByMessage }) {
 function recordAssistantMessage(rec, turns, { data, rowId, at, withTurns, partsByMessage }) {
   rec.responses++;
   if (at) { const pk = punchKey(at); rec.punchcard[pk] = (rec.punchcard[pk] ?? 0) + 1; }
+  // A provider/auth/network failure is a REAL logged row here — unlike
+  // parseClaude's synthetic all-zero placeholder, it still carries whatever
+  // mode/model/usage/cost evidence it has, and that evidence is kept. Only
+  // two effects are error-specific: it counts as an exception, and it can
+  // never BE a latency sample (an unanswered prompt is not a measured
+  // response time) — though the pending prompt is still consumed here so a
+  // later, unrelated assistant message is never mis-sampled against a stale
+  // prompt.
   if (data.error != null) {
-    // A provider/auth/network failure: no real completion behind it, so —
-    // like parseClaude's isApiError placeholder — it never claims a model,
-    // usage, ctx window, or mode. It IS an exception, but never a latency
-    // SAMPLE (an unanswered prompt is not a measured response time); the
-    // pending prompt is still consumed here (unlike parseClaude, which
-    // leaves it open for the next real completion) so a later, unrelated
-    // assistant message is never mis-sampled against a stale prompt.
     rec.exceptions++;
     rec.pendingPromptMs = null;
-    return;
-  }
-  if (rec.pendingPromptMs !== null && rec.pendingPromptMs !== undefined) {
+  } else if (rec.pendingPromptMs !== null && rec.pendingPromptMs !== undefined) {
     const gapSeconds = (at - rec.pendingPromptMs) / 1000;
     if (gapSeconds <= MAX_LATENCY_SAMPLE_SECONDS) noteLatencySample(rec, gapSeconds);
     rec.pendingPromptMs = null;

--- a/src/lib/usage-opencode.mjs
+++ b/src/lib/usage-opencode.mjs
@@ -265,6 +265,7 @@ export function parseSession({ dbFile, id, withTurns = false }) {
 
     if (!rec.title) rec.title = '(untitled)';
     rec.active = activeIntervals(rec.stamps);
+    rec.lenSeconds = Math.round(rec.active.reduce((n, [a, b]) => n + (b - a), 0) / 1000);
     delete rec.stamps;
     return { session: rec, turns };
   });

--- a/src/lib/usage-parsers.mjs
+++ b/src/lib/usage-parsers.mjs
@@ -618,19 +618,49 @@ function handleCodexTaskComplete(rec, latState, payload) {
   if (payload.error != null) rec.exceptions++;
 }
 
-/** `event_msg` → a `user_message`/`item_completed` user turn. Codex rollouts
- *  record only real prompts as user_message events — tool output travels in
- *  other event types that are not surfaced as turns — so every normalized
- *  Codex user turn is kind 'prompt' by construction. */
+/** Codex-side counterpart to Claude's `isHumanPrompt`/`HARNESS_OUTPUT_RE`
+ *  gate (schema v5). Codex has no discipline of its own: harness output
+ *  (task notifications, command stdout/stderr) and MIRRORED Claude-host
+ *  envelopes — a teammate delivery or a cross-session message replayed into
+ *  a Codex rollout rather than typed there — can both arrive as
+ *  `user_message`/`UserMessage` events. Reuses HARNESS_OUTPUT_RE verbatim
+ *  (Claude's own envelope markers reproduce byte-for-byte inside a mirrored
+ *  rollout) plus the two clear machine markers usage-research's provenance
+ *  rules validated for cross-host delivery: a `<teammate-message` wrapper
+ *  and the literal "Another Claude session sent a message:" prefix
+ *  cross-session delivery uses. Deliberately narrow — exact-twin cross-host
+ *  dedup by flush timestamp is a recorded follow-up, not attempted here —
+ *  so when unsure this counts a message as human; over-counting is the safe
+ *  direction, same one-directional risk stance the research took. */
+const CODEX_MACHINE_ENVELOPE_RE = /^\s*(?:<teammate-message|Another Claude session sent a message:)/;
+
+function isCodexHumanMessage(text) {
+  return !HARNESS_OUTPUT_RE.test(text) && !CODEX_MACHINE_ENVELOPE_RE.test(text);
+}
+
+/** `event_msg` → a `user_message`/`item_completed` user turn. Every such
+ *  event still gets a turn row (kept visible for audit, exactly as
+ *  parseClaude keeps a harness-origin "user" entry's turn row) — but only a
+ *  genuinely human one (isCodexHumanMessage) counts toward `rec.prompts`,
+ *  sets the session title, or opens the prompt→agent-message latency
+ *  window. `stats.prompts` stays a raw per-event-shape diagnostic,
+ *  deliberately ungated: it answers "how many user_message-shaped events did
+ *  this file carry", which is a different, still-useful question from "how
+ *  many were human". */
 function handleCodexUserMessage(rec, turns, stats, titleState, latState, decoded, ms, withTurns) {
-  rec.prompts++;
   stats.prompts++;
   const text = decoded.text;
-  if (!titleState.firstPrompt) titleState.firstPrompt = text;
-  // Opens the prompt→agent-message latency window; closed by the first
-  // following handleCodexAssistantMessage (mirrors Claude's latState, Task 3).
-  latState.pendingPromptMs = ms;
-  if (withTurns && text) turns.push({ role: 'user', at: new Date(ms).toISOString(), text, prompt: true, kind: 'prompt' });
+  const human = isCodexHumanMessage(text);
+  if (human) {
+    rec.prompts++;
+    if (!titleState.firstPrompt) titleState.firstPrompt = text;
+    // Opens the prompt→agent-message latency window; closed by the first
+    // following handleCodexAssistantMessage (mirrors Claude's latState, Task 3).
+    latState.pendingPromptMs = ms;
+  }
+  if (withTurns && text) {
+    turns.push({ role: 'user', at: new Date(ms).toISOString(), text, prompt: human, kind: human ? 'prompt' : 'context' });
+  }
 }
 
 function handleCodexAssistantMessage(rec, turns, stats, latState, decoded, ms, withTurns) {

--- a/src/lib/usage-parsers.mjs
+++ b/src/lib/usage-parsers.mjs
@@ -420,8 +420,13 @@ function recordClaudeAssistantTurn(rec, turns, latState, ms, decoded, withTurns)
   // Context pressure: the tokens actually IN the model's window for this
   // turn (fresh input plus what got served from cache) — overwritten every
   // turn so the field always reflects the LAST completion, not a running
-  // total across the session.
-  rec.ctxLastTokens = decoded.usage.input + decoded.usage.cacheRead;
+  // total across the session. Evidence-gated, exactly as the opencode parser
+  // is: decodeClaudeRecord normalizes an ABSENT message.usage to all-zeros,
+  // so writing unconditionally let a token-less entry overwrite real context
+  // pressure with a fabricated 0. A completion with neither fresh input nor a
+  // cache read carried no context evidence to record.
+  const ctxTokens = decoded.usage.input + decoded.usage.cacheRead;
+  if (ctxTokens > 0) rec.ctxLastTokens = ctxTokens;
 
   const tools = collectClaudeToolNames(rec, decoded.toolUses);
   if (withTurns) {
@@ -670,9 +675,17 @@ function handleCodexEventMsg(rec, turns, stats, titleState, usageState, latState
   if (decoded.generation === 'legacy') stats.legacyEvents++;
   else if (decoded.generation === 'item') stats.itemCompletedEvents++;
   if (decoded.unknownItemType) {
-    recordCodexUnknownType(stats, decoded.unknownItemType);
+    // A type this parser tallies is a type it UNDERSTANDS. Recording it as an
+    // unknown kind too made the four tool items simultaneously "tools" in the
+    // scorecard and "unknown kinds" in sourceHealth — raising the
+    // unknown-item-types warning for a shape nothing failed to handle, and
+    // consuming slots in the 32-kind cap that exist to surface genuinely new
+    // shapes. (The field is named unknownItemType because the DECODER, which
+    // has no tool vocabulary, does not normalize these to messages.)
     if (CODEX_TOOL_ITEM_TYPES.has(decoded.unknownItemType)) {
       rec.tools[decoded.unknownItemType] = (rec.tools[decoded.unknownItemType] ?? 0) + 1;
+    } else {
+      recordCodexUnknownType(stats, decoded.unknownItemType);
     }
   }
   if (decoded.type !== 'message') return;

--- a/src/lib/usage-parsers.mjs
+++ b/src/lib/usage-parsers.mjs
@@ -13,6 +13,7 @@ import { repoRoot } from './paths.mjs';
 import { MAX_TELEMETRY_UNKNOWN_KINDS } from './usage-telemetry.mjs';
 import { decodeClaudeRecord, decodeCodexRecord } from './telemetry-records.mjs';
 import { toMs, maskSecrets } from './usage-aggregate.mjs';
+import { normalizeMode } from './usage-modes.mjs';
 
 /** Silence longer than this ends a stretch of engagement. A session is split
  *  into active sub-intervals at gaps ABOVE this bound (exactly this much is not
@@ -226,6 +227,12 @@ export function noteLatencySample(rec, seconds) {
   rec.latCount++;
 }
 
+/** A prompt-to-response gap longer than this is an idle resume (the person
+ *  walked away and came back), not a real wait for a reply — so it is
+ *  excluded from latency sampling entirely, rather than merely landing in
+ *  noteLatencySample's own overflow bucket alongside genuinely slow turns. */
+const MAX_LATENCY_SAMPLE_SECONDS = 3600;
+
 function noteSpan(rec, ms) {
   if (!Number.isFinite(ms)) return;
   if (rec.start === null || ms < rec.start) rec.start = ms;
@@ -335,13 +342,19 @@ function userTurnKind(entry) {
 /** A `user`-role Claude entry: span/prompt-count bookkeeping, plus its turn
  *  row when withTurns. `titleState.firstPrompt` is set from the first HUMAN
  *  prompt whose text is non-empty (mutated in place: later entries only fill
- *  it in while it is still empty). */
-function recordClaudeUserTurn(rec, turns, titleState, e, ms, decoded, withTurns) {
+ *  it in while it is still empty). A human prompt also opens the latency
+ *  window (`latState.pendingMs`, closed by the next real assistant turn) and
+ *  is the only place `permissionMode` is read — a tool-result or harness-
+ *  injected "user" entry never carries the human's own posture. */
+function recordClaudeUserTurn(rec, turns, titleState, latState, e, ms, decoded, withTurns) {
   noteSpan(rec, ms);
   const human = isHumanPrompt(e);
   if (human) {
     rec.prompts++;
     if (!titleState.firstPrompt) titleState.firstPrompt = decoded.text;
+    latState.pendingMs = ms;
+    const m = normalizeMode({ host: 'claude', permissionMode: e.permissionMode });
+    if (m.raw) { rec.mode = m.mode; rec.modeRaw = m.raw; }
   }
   if (withTurns && decoded.text) {
     turns.push({ role: 'user', at: new Date(ms).toISOString(), text: decoded.text, prompt: human, kind: userTurnKind(e) });
@@ -363,8 +376,8 @@ function collectClaudeToolNames(rec, toolUses) {
 
 /** An `assistant`-role Claude entry (caller has already confirmed `e.message`
  *  exists): span/response-count bookkeeping, the API-error placeholder path,
- *  and otherwise model/usage/tool accounting plus its turn row. */
-function recordClaudeAssistantTurn(rec, turns, ms, decoded, withTurns) {
+ *  and otherwise latency/model/usage/tool accounting plus its turn row. */
+function recordClaudeAssistantTurn(rec, turns, latState, ms, decoded, withTurns) {
   noteSpan(rec, ms);
   rec.responses++;
   const at = Number.isFinite(ms) ? ms : (rec.start ?? Date.now());
@@ -380,7 +393,9 @@ function recordClaudeAssistantTurn(rec, turns, ms, decoded, withTurns) {
   // it stays visible rather than silently vanishing. isApiErrorMessage isn't
   // reliably set on every build that emits this placeholder, so the literal
   // model marker is checked directly too — it's the one part of the shape
-  // that's never varied in observed transcripts.
+  // that's never varied in observed transcripts. A dropped request is also
+  // never a latency SAMPLE — `latState.pendingMs` is deliberately left set so
+  // the FIRST real completion that eventually follows is what gets timed.
   if (decoded.isApiError) {
     rec.exceptions++;
     if (withTurns) {
@@ -392,10 +407,21 @@ function recordClaudeAssistantTurn(rec, turns, ms, decoded, withTurns) {
     return;
   }
 
+  if (latState.pendingMs !== null) {
+    const gapSeconds = (ms - latState.pendingMs) / 1000;
+    if (gapSeconds <= MAX_LATENCY_SAMPLE_SECONDS) noteLatencySample(rec, gapSeconds);
+    latState.pendingMs = null;
+  }
+
   const model = typeof decoded.model === 'string' ? decoded.model : 'unknown';
   if (!rec.models.includes(model)) rec.models.push(model);
 
   addUsage(rec, localDay(at), model, { ...decoded.usage, responses: 1 });
+  // Context pressure: the tokens actually IN the model's window for this
+  // turn (fresh input plus what got served from cache) — overwritten every
+  // turn so the field always reflects the LAST completion, not a running
+  // total across the session.
+  rec.ctxLastTokens = decoded.usage.input + decoded.usage.cacheRead;
 
   const tools = collectClaudeToolNames(rec, decoded.toolUses);
   if (withTurns) {
@@ -415,6 +441,9 @@ export function parseClaude(raw, { id, dirName, withTurns = false }) {
   const rec = blankSession(id, 'claude');
   const turns = [];
   const titleState = { firstPrompt: '', aiTitle: '' };
+  // Open by the most recent human prompt, closed by the first real assistant
+  // turn that follows it — see recordClaudeUserTurn/recordClaudeAssistantTurn.
+  const latState = { pendingMs: null };
 
   for (const e of jsonLines(raw)) {
     const ms = toMs(e.timestamp);
@@ -426,12 +455,12 @@ export function parseClaude(raw, { id, dirName, withTurns = false }) {
     if (rec.project === 'unknown' && typeof e.cwd === 'string') applyProject(rec, projectLabel(e.cwd, dirName, repoRootOf(e.cwd)));
 
     if (decoded.role === 'user') {
-      recordClaudeUserTurn(rec, turns, titleState, e, ms, decoded, withTurns);
+      recordClaudeUserTurn(rec, turns, titleState, latState, e, ms, decoded, withTurns);
       continue;
     }
 
     if (decoded.role !== 'assistant' || !e.message) continue;
-    recordClaudeAssistantTurn(rec, turns, ms, decoded, withTurns);
+    recordClaudeAssistantTurn(rec, turns, latState, ms, decoded, withTurns);
   }
 
   rec.title = maskSecrets(titleState.aiTitle || clip(titleState.firstPrompt)) || '(untitled)';

--- a/src/lib/usage-parsers.mjs
+++ b/src/lib/usage-parsers.mjs
@@ -566,11 +566,16 @@ function handleCodexTaskStarted(rec, latState, payload) {
  *  duration for the turn, used as a latency sample ONLY when no prompt→
  *  agent-message gap already covered this turn (`latState.turnStartedAt` is
  *  cleared the moment such a gap fires — see handleCodexAssistantMessage —
- *  so a turn is never double-sampled). A non-null `error` counts as an
+ *  so a turn is never double-sampled). MAX_LATENCY_SAMPLE_SECONDS applies here
+ *  exactly as it does to the other two sampling paths: duration_ms is turn
+ *  wall-clock and includes time blocked on an approval prompt, so a turn left
+ *  awaiting approval overnight arrives as a multi-hour "response" that the
+ *  prompt-gap path would have discarded. A non-null `error` counts as an
  *  exception regardless of whether the fallback sample fires. */
 function handleCodexTaskComplete(rec, latState, payload) {
   const duration = Number(payload.duration_ms);
-  if (latState.turnStartedAt !== null && Number.isFinite(duration)) {
+  if (latState.turnStartedAt !== null && Number.isFinite(duration)
+    && duration / 1000 <= MAX_LATENCY_SAMPLE_SECONDS) {
     noteLatencySample(rec, duration / 1000);
   }
   latState.turnStartedAt = null;

--- a/src/lib/usage-parsers.mjs
+++ b/src/lib/usage-parsers.mjs
@@ -187,7 +187,43 @@ export function blankSession(id, provider) {
     // rate-limit snapshot the rollout carried. Claude sessions keep the zero
     // and the null — absent, not unknown.
     reasoningOutput: 0, rateLimits: null,
+    // v11: cross-host permission posture (usage-modes.normalizeMode), a
+    // response-latency histogram, THIS session's own engaged seconds, model
+    // context-window detail, and codex's explicit-abort count. Every field
+    // here defaults honest-absent (null/0) until a parser observes evidence
+    // for it — never a guess.
+    mode: null, modeRaw: null,
+    latHist: null, latCount: 0,
+    lenSeconds: 0,
+    ctxWindow: null, ctxLastTokens: null,
+    aborts: 0,
   };
+}
+
+/** Response-latency histogram edges, in seconds; the 6th bucket (index 5)
+ *  catches everything over 60s. */
+export const LAT_BUCKET_EDGES = [2, 5, 10, 30, 60];
+/** Session-length histogram edges, in seconds; the 5th bucket (index 4)
+ *  catches everything over 2h. */
+export const LEN_BUCKET_EDGES = [300, 900, 2700, 7200];
+
+/** First bucket `i` whose edge `v` does not exceed, else the overflow bucket
+ *  (`edges.length`). Shared by every histogram built from these edges, so a
+ *  bucket boundary is defined in exactly one place. */
+export function bucketIndex(edges, v) {
+  for (let i = 0; i < edges.length; i++) if (v <= edges[i]) return i;
+  return edges.length;
+}
+
+/** Record one response-latency sample onto `rec.latHist`, allocating the
+ *  histogram lazily so a session that never observes a latency (older
+ *  transcripts, a source that carries no turn timing) keeps `latHist` null —
+ *  absent, not a fabricated all-zero histogram. */
+export function noteLatencySample(rec, seconds) {
+  if (!Number.isFinite(seconds) || seconds < 0) return;
+  rec.latHist ??= new Array(LAT_BUCKET_EDGES.length + 1).fill(0);
+  rec.latHist[bucketIndex(LAT_BUCKET_EDGES, seconds)]++;
+  rec.latCount++;
 }
 
 function noteSpan(rec, ms) {
@@ -217,10 +253,12 @@ function activeIntervals(stamps) {
   return out;
 }
 
-/** Finish a parsed record: derive active intervals, drop the raw timestamps
- *  (thousands per session, and never needed again once collapsed). */
+/** Finish a parsed record: derive active intervals and this session's own
+ *  engaged seconds from them, then drop the raw timestamps (thousands per
+ *  session, and never needed again once collapsed). */
 function seal(rec) {
   rec.active = activeIntervals(rec.stamps);
+  rec.lenSeconds = Math.round(rec.active.reduce((n, [a, b]) => n + (b - a), 0) / 1000);
   delete rec.stamps;
   return rec;
 }

--- a/src/lib/usage-parsers.mjs
+++ b/src/lib/usage-parsers.mjs
@@ -641,7 +641,17 @@ function handleCodexEventMsg(rec, turns, stats, titleState, usageState, latState
   if (decoded.type === 'tokenCount') { handleCodexTokenCount(rec, stats, usageState, decoded, ms); return; }
   if (payload.type === 'task_started') { handleCodexTaskStarted(rec, latState, payload); return; }
   if (payload.type === 'task_complete') { handleCodexTaskComplete(rec, latState, payload); return; }
-  if (payload.type === 'turn_aborted') { rec.aborts++; return; }
+  if (payload.type === 'turn_aborted') {
+    rec.aborts++;
+    // An interrupted turn leaves no valid latency evidence behind it: a
+    // pending prompt was never answered, so it must never be mistaken for
+    // one a LATER, unrelated agent_message answered; and the turn-started
+    // gate must not misfire a task_complete fallback for a turn that never
+    // completed.
+    latState.pendingPromptMs = null;
+    latState.turnStartedAt = null;
+    return;
+  }
   if (decoded.generation === 'legacy') stats.legacyEvents++;
   else if (decoded.generation === 'item') stats.itemCompletedEvents++;
   if (decoded.unknownItemType) {

--- a/src/lib/usage-parsers.mjs
+++ b/src/lib/usage-parsers.mjs
@@ -495,13 +495,17 @@ function handleCodexMeta(rec, decoded) {
   }
 }
 
-function handleCodexTurnContext(rec, decoded) {
+function handleCodexTurnContext(rec, decoded, payload) {
   if (typeof decoded.model === 'string' && !rec.models.includes(decoded.model)) rec.models.push(decoded.model);
   if (decoded.provider) {
     rec.inferenceProvider = decoded.provider;
     rec.providerProvenance = 'observed';
   }
   if (rec.project === 'unknown' && typeof decoded.cwd === 'string') applyProject(rec, projectLabel(decoded.cwd, null, repoRootOf(decoded.cwd)));
+  // v11: cross-host permission posture — last turn_context with evidence
+  // wins, since a session may renegotiate approval/sandbox policy mid-run.
+  const m = normalizeMode({ host: 'codex', approvalPolicy: payload.approval_policy, sandboxPolicy: payload.sandbox_policy });
+  if (m.raw) { rec.mode = m.mode; rec.modeRaw = m.raw; }
 }
 
 /** Normalize one token_count event's rate-limit windows (primary/secondary),
@@ -546,24 +550,62 @@ function handleCodexTokenCount(rec, stats, usageState, decoded, ms) {
   if (rl) applyCodexRateLimit(rec, rl, ms);
 }
 
+/** `event_msg` → `task_started`: the model's context window in effect for
+ *  this turn (last wins — a session may renegotiate mid-run) and the turn's
+ *  start time, remembered so `task_complete` can tell whether a prompt→
+ *  agent-message gap already sampled this turn before falling back to its
+ *  own host-measured duration (see handleCodexTaskComplete). */
+function handleCodexTaskStarted(rec, latState, payload) {
+  const w = Number(payload.model_context_window);
+  if (Number.isFinite(w)) rec.ctxWindow = w;
+  const startedMs = toMs(payload.started_at);
+  latState.turnStartedAt = Number.isFinite(startedMs) ? startedMs : null;
+}
+
+/** `event_msg` → `task_complete`: Codex's own host-measured wall-clock
+ *  duration for the turn, used as a latency sample ONLY when no prompt→
+ *  agent-message gap already covered this turn (`latState.turnStartedAt` is
+ *  cleared the moment such a gap fires — see handleCodexAssistantMessage —
+ *  so a turn is never double-sampled). A non-null `error` counts as an
+ *  exception regardless of whether the fallback sample fires. */
+function handleCodexTaskComplete(rec, latState, payload) {
+  const duration = Number(payload.duration_ms);
+  if (latState.turnStartedAt !== null && Number.isFinite(duration)) {
+    noteLatencySample(rec, duration / 1000);
+  }
+  latState.turnStartedAt = null;
+  if (payload.error != null) rec.exceptions++;
+}
+
 /** `event_msg` → a `user_message`/`item_completed` user turn. Codex rollouts
  *  record only real prompts as user_message events — tool output travels in
  *  other event types that are not surfaced as turns — so every normalized
  *  Codex user turn is kind 'prompt' by construction. */
-function handleCodexUserMessage(rec, turns, stats, titleState, decoded, ms, withTurns) {
+function handleCodexUserMessage(rec, turns, stats, titleState, latState, decoded, ms, withTurns) {
   rec.prompts++;
   stats.prompts++;
   const text = decoded.text;
   if (!titleState.firstPrompt) titleState.firstPrompt = text;
+  // Opens the prompt→agent-message latency window; closed by the first
+  // following handleCodexAssistantMessage (mirrors Claude's latState, Task 3).
+  latState.pendingPromptMs = ms;
   if (withTurns && text) turns.push({ role: 'user', at: new Date(ms).toISOString(), text, prompt: true, kind: 'prompt' });
 }
 
-function handleCodexAssistantMessage(rec, turns, stats, decoded, ms, withTurns) {
+function handleCodexAssistantMessage(rec, turns, stats, latState, decoded, ms, withTurns) {
   rec.responses++;
   stats.responses++;
   const at = Number.isFinite(ms) ? ms : (rec.start ?? Date.now());
   const pk = punchKey(at);
   rec.punchcard[pk] = (rec.punchcard[pk] ?? 0) + 1;
+  if (latState.pendingPromptMs !== null) {
+    const gapSeconds = (ms - latState.pendingPromptMs) / 1000;
+    if (gapSeconds <= MAX_LATENCY_SAMPLE_SECONDS) noteLatencySample(rec, gapSeconds);
+    latState.pendingPromptMs = null;
+    // This turn now has a prompt-gap sample — task_complete's duration_ms
+    // fallback must not also fire for it (see handleCodexTaskComplete).
+    latState.turnStartedAt = null;
+  }
   if (withTurns) {
     turns.push({
       role: 'assistant', at: new Date(at).toISOString(),
@@ -575,33 +617,60 @@ function handleCodexAssistantMessage(rec, turns, stats, decoded, ms, withTurns) 
 
 /** `event_msg` → a decoded `message` (user or assistant), after generation/
  *  unknown-type bookkeeping already ran in handleCodexEventMsg. */
-function handleCodexEventMessage(rec, turns, stats, titleState, decoded, ms, withTurns) {
+function handleCodexEventMessage(rec, turns, stats, titleState, latState, decoded, ms, withTurns) {
   if (decoded.role === 'user') {
-    handleCodexUserMessage(rec, turns, stats, titleState, decoded, ms, withTurns);
+    handleCodexUserMessage(rec, turns, stats, titleState, latState, decoded, ms, withTurns);
     return;
   }
-  handleCodexAssistantMessage(rec, turns, stats, decoded, ms, withTurns);
+  handleCodexAssistantMessage(rec, turns, stats, latState, decoded, ms, withTurns);
 }
 
-/** One `event_msg` record: token_count, a message, or lifecycle/unknown
- *  (generation/unknown-item-type diagnostics apply to every non-token_count
- *  shape, so they run before the message/non-message split). */
-function handleCodexEventMsg(rec, turns, stats, titleState, usageState, decoded, ms, withTurns) {
+/** The four Codex `item_completed` item types this parser tallies into
+ *  `rec.tools`, keyed by the item's OWN type name — never renamed to Claude
+ *  tool names. Codex's tool vocabulary is host-specific and the UI ranks
+ *  names as-is. Every other item type (including UserMessage/AgentMessage,
+ *  already handled as messages) is left to the unknownItemType diagnostic
+ *  only, not tallied as a tool. */
+const CODEX_TOOL_ITEM_TYPES = new Set(['CommandExecution', 'McpToolCall', 'FileChange', 'CollabAgentToolCall']);
+
+/** One `event_msg` record: token_count, a lifecycle event (task_started/
+ *  task_complete/turn_aborted), a message, or unknown (generation/unknown-
+ *  item-type diagnostics apply to every non-token_count/non-lifecycle shape,
+ *  so they run before the message/non-message split). */
+function handleCodexEventMsg(rec, turns, stats, titleState, usageState, latState, decoded, payload, ms, withTurns) {
   if (decoded.type === 'tokenCount') { handleCodexTokenCount(rec, stats, usageState, decoded, ms); return; }
+  if (payload.type === 'task_started') { handleCodexTaskStarted(rec, latState, payload); return; }
+  if (payload.type === 'task_complete') { handleCodexTaskComplete(rec, latState, payload); return; }
+  if (payload.type === 'turn_aborted') { rec.aborts++; return; }
   if (decoded.generation === 'legacy') stats.legacyEvents++;
   else if (decoded.generation === 'item') stats.itemCompletedEvents++;
-  if (decoded.unknownItemType) recordCodexUnknownType(stats, decoded.unknownItemType);
+  if (decoded.unknownItemType) {
+    recordCodexUnknownType(stats, decoded.unknownItemType);
+    if (CODEX_TOOL_ITEM_TYPES.has(decoded.unknownItemType)) {
+      rec.tools[decoded.unknownItemType] = (rec.tools[decoded.unknownItemType] ?? 0) + 1;
+    }
+  }
   if (decoded.type !== 'message') return;
-  handleCodexEventMessage(rec, turns, stats, titleState, decoded, ms, withTurns);
+  handleCodexEventMessage(rec, turns, stats, titleState, latState, decoded, ms, withTurns);
+}
+
+/** Raw payload of one rollout line, defensively defaulted — mirrors
+ *  decodeCodexRecord's own guard. Read directly here (rather than threading
+ *  new fields through telemetry-records.mjs's decode) for the same reason
+ *  recordClaudeUserTurn reads `e.permissionMode` straight off the raw Claude
+ *  entry: a field only one caller needs, not a shape every consumer of the
+ *  decoded record should carry. */
+function rawPayload(e) {
+  return e?.payload && typeof e.payload === 'object' ? e.payload : {};
 }
 
 /** One line of a Codex rollout, dispatched on its decoded type. */
-function processCodexLine(rec, turns, stats, titleState, usageState, e, ms, withTurns) {
+function processCodexLine(rec, turns, stats, titleState, usageState, latState, e, ms, withTurns) {
   const decoded = decodeCodexRecord(e);
   if (decoded.type === 'meta') { handleCodexMeta(rec, decoded); return; }
-  if (decoded.type === 'turnContext') { handleCodexTurnContext(rec, decoded); return; }
+  if (decoded.type === 'turnContext') { handleCodexTurnContext(rec, decoded, rawPayload(e)); return; }
   if (e.type !== 'event_msg') return;
-  handleCodexEventMsg(rec, turns, stats, titleState, usageState, decoded, ms, withTurns);
+  handleCodexEventMsg(rec, turns, stats, titleState, usageState, latState, decoded, rawPayload(e), ms, withTurns);
 }
 
 /** The session-total usage row, derived from the LAST token_count event seen
@@ -648,11 +717,16 @@ export function parseCodex(raw, { id, withTurns = false }) {
   const stats = codexParseStats();
   const usageState = { lastUsage: null, lastUsageAt: null };
   const titleState = { firstPrompt: '' };
+  // Opened by task_started (turn start remembered), closed either by a
+  // prompt→agent-message gap sample or by task_complete's own duration_ms
+  // fallback — see handleCodexTaskStarted/handleCodexAssistantMessage/
+  // handleCodexTaskComplete.
+  const latState = { pendingPromptMs: null, turnStartedAt: null };
 
   for (const e of jsonLines(raw)) {
     const ms = toMs(e.timestamp);
     noteSpan(rec, ms);
-    processCodexLine(rec, turns, stats, titleState, usageState, e, ms, withTurns);
+    processCodexLine(rec, turns, stats, titleState, usageState, latState, e, ms, withTurns);
   }
 
   finalizeCodexUsage(rec, usageState);

--- a/src/lib/usage-parsers.mjs
+++ b/src/lib/usage-parsers.mjs
@@ -490,10 +490,31 @@ function recordCodexUnknownType(stats, type) {
   }
 }
 
-function handleCodexMeta(rec, decoded) {
-  if (typeof decoded.sessionId === 'string' && decoded.sessionId) rec.id = decoded.sessionId;
-  if (typeof decoded.cwd === 'string') applyProject(rec, projectLabel(decoded.cwd, null, repoRootOf(decoded.cwd)));
-  if (typeof decoded.threadSource === 'string') rec.threadSource = decoded.threadSource;
+/** `session_meta` → the session's stable identity: which file this is, and
+ *  whether it is a genuine user thread or a subagent's delegated one. The
+ *  FIRST meta wins for identity fields (id, threadSource, cwd/project) — a
+ *  subagent rollout replays its PARENT thread's entire prior history before
+ *  its own new turns (see parseCodex's own doc comment), including the
+ *  parent's OWN session_meta line further down the file. Letting a later
+ *  meta win relabeled 155 of 318 observed subagent rollouts back to 'user'
+ *  and re-keyed their id to the parent's, which let their (parent-
+ *  duplicating) cumulative token totals escape finalizeCodexUsage's subagent
+ *  guard entirely — exactly the ccusage#950 double-count mechanism that
+ *  guard exists to prevent. `cwd`/project latches first for the same reason,
+ *  matching handleCodexTurnContext's own treatment of the identical field
+ *  (only a fallback while project is still 'unknown' — never an overwrite of
+ *  an already-resolved one). `provider` stays last-wins, deliberately not
+ *  gated here: handleCodexTurnContext already treats the identical field as
+ *  progressive (fires on every turn_context, latest observed value wins), so
+ *  gating it only in the meta path would be inconsistent with that AND
+ *  ineffective — a later turn_context would still overwrite it regardless. */
+function handleCodexMeta(rec, metaState, decoded) {
+  if (!metaState.seen) {
+    metaState.seen = true;
+    if (typeof decoded.sessionId === 'string' && decoded.sessionId) rec.id = decoded.sessionId;
+    if (typeof decoded.cwd === 'string') applyProject(rec, projectLabel(decoded.cwd, null, repoRootOf(decoded.cwd)));
+    if (typeof decoded.threadSource === 'string') rec.threadSource = decoded.threadSource;
+  }
   if (decoded.provider) {
     rec.inferenceProvider = decoded.provider;
     rec.providerProvenance = 'observed';
@@ -703,9 +724,9 @@ function rawPayload(e) {
 }
 
 /** One line of a Codex rollout, dispatched on its decoded type. */
-function processCodexLine(rec, turns, stats, titleState, usageState, latState, e, ms, withTurns) {
+function processCodexLine(rec, turns, stats, titleState, usageState, latState, metaState, e, ms, withTurns) {
   const decoded = decodeCodexRecord(e);
-  if (decoded.type === 'meta') { handleCodexMeta(rec, decoded); return; }
+  if (decoded.type === 'meta') { handleCodexMeta(rec, metaState, decoded); return; }
   if (decoded.type === 'turnContext') { handleCodexTurnContext(rec, decoded, rawPayload(e)); return; }
   if (e.type !== 'event_msg') return;
   handleCodexEventMsg(rec, turns, stats, titleState, usageState, latState, decoded, rawPayload(e), ms, withTurns);
@@ -760,11 +781,15 @@ export function parseCodex(raw, { id, withTurns = false }) {
   // fallback — see handleCodexTaskStarted/handleCodexAssistantMessage/
   // handleCodexTaskComplete.
   const latState = { pendingPromptMs: null, turnStartedAt: null };
+  // Latches TRUE on the first session_meta line this parse observes — see
+  // handleCodexMeta's own doc comment for why identity fields must not
+  // follow a later (possibly replayed-parent) meta.
+  const metaState = { seen: false };
 
   for (const e of jsonLines(raw)) {
     const ms = toMs(e.timestamp);
     noteSpan(rec, ms);
-    processCodexLine(rec, turns, stats, titleState, usageState, latState, e, ms, withTurns);
+    processCodexLine(rec, turns, stats, titleState, usageState, latState, metaState, e, ms, withTurns);
   }
 
   finalizeCodexUsage(rec, usageState);

--- a/src/lib/usage-parsers.mjs
+++ b/src/lib/usage-parsers.mjs
@@ -492,29 +492,40 @@ function recordCodexUnknownType(stats, type) {
 
 /** `session_meta` → the session's stable identity: which file this is, and
  *  whether it is a genuine user thread or a subagent's delegated one. The
- *  FIRST meta wins for identity fields (id, threadSource, cwd/project) — a
+ *  FIRST session_meta line wins for ALL of it — `id`, `threadSource`,
+ *  `cwd`/project, AND `inferenceProvider`/`providerProvenance` — because a
  *  subagent rollout replays its PARENT thread's entire prior history before
  *  its own new turns (see parseCodex's own doc comment), including the
- *  parent's OWN session_meta line further down the file. Letting a later
- *  meta win relabeled 155 of 318 observed subagent rollouts back to 'user'
- *  and re-keyed their id to the parent's, which let their (parent-
- *  duplicating) cumulative token totals escape finalizeCodexUsage's subagent
- *  guard entirely — exactly the ccusage#950 double-count mechanism that
- *  guard exists to prevent. `cwd`/project latches first for the same reason,
- *  matching handleCodexTurnContext's own treatment of the identical field
- *  (only a fallback while project is still 'unknown' — never an overwrite of
- *  an already-resolved one). `provider` stays last-wins, deliberately not
- *  gated here: handleCodexTurnContext already treats the identical field as
- *  progressive (fires on every turn_context, latest observed value wins), so
- *  gating it only in the meta path would be inconsistent with that AND
- *  ineffective — a later turn_context would still overwrite it regardless. */
+ *  parent's OWN session_meta line further down the file, and a replayed
+ *  parent line is not an observation about THIS record, for provider any
+ *  more than for identity. Letting a later meta win relabeled 155 of 318
+ *  observed subagent rollouts back to 'user' and re-keyed their id to the
+ *  parent's, which let their (parent-duplicating) cumulative token totals
+ *  escape finalizeCodexUsage's subagent guard entirely — exactly the
+ *  ccusage#950 double-count mechanism that guard exists to prevent.
+ *  `inferenceProvider`/`providerProvenance` join this SAME latch for the
+ *  same reason, even though the identical field read off `turn_context`
+ *  stays independently progressive (`handleCodexTurnContext`, last observed
+ *  value wins on every turn_context line) — that is a separate, unrelated
+ *  design choice this latch does not touch or depend on.
+ *
+ *  The gate is META-LEVEL (`!metaState.seen`), not per-field: if the first
+ *  meta omits a field, no LATER meta backfills it either. Each field has its
+ *  own fallback for exactly that case, and none of them is another
+ *  session_meta line: `threadSource` defaults to `null` and falls back to
+ *  the codex ledger at aggregation time (`rec.threadSource ?? ledger ??
+ *  fromEdges`, usage-aggregate.mjs); `id` falls back to the caller's
+ *  filename-derived id, already correct for the file (blankSession's
+ *  constructor argument, usage-index.mjs); `cwd`/project falls back to
+ *  `handleCodexTurnContext`'s own `rec.project === 'unknown'` check — a
+ *  DIFFERENT gate that coincides with this one in the common case but is
+ *  not "the same rule" as this latch. */
 function handleCodexMeta(rec, metaState, decoded) {
-  if (!metaState.seen) {
-    metaState.seen = true;
-    if (typeof decoded.sessionId === 'string' && decoded.sessionId) rec.id = decoded.sessionId;
-    if (typeof decoded.cwd === 'string') applyProject(rec, projectLabel(decoded.cwd, null, repoRootOf(decoded.cwd)));
-    if (typeof decoded.threadSource === 'string') rec.threadSource = decoded.threadSource;
-  }
+  if (metaState.seen) return;
+  metaState.seen = true;
+  if (typeof decoded.sessionId === 'string' && decoded.sessionId) rec.id = decoded.sessionId;
+  if (typeof decoded.cwd === 'string') applyProject(rec, projectLabel(decoded.cwd, null, repoRootOf(decoded.cwd)));
+  if (typeof decoded.threadSource === 'string') rec.threadSource = decoded.threadSource;
   if (decoded.provider) {
     rec.inferenceProvider = decoded.provider;
     rec.providerProvenance = 'observed';

--- a/src/lib/usage-parsers.mjs
+++ b/src/lib/usage-parsers.mjs
@@ -504,7 +504,17 @@ function handleCodexTurnContext(rec, decoded, payload) {
   if (rec.project === 'unknown' && typeof decoded.cwd === 'string') applyProject(rec, projectLabel(decoded.cwd, null, repoRootOf(decoded.cwd)));
   // v11: cross-host permission posture — last turn_context with evidence
   // wins, since a session may renegotiate approval/sandbox policy mid-run.
-  const m = normalizeMode({ host: 'codex', approvalPolicy: payload.approval_policy, sandboxPolicy: payload.sandbox_policy });
+  // Codex writes sandbox_policy as an OBJECT keyed `.type`
+  // ({"type":"danger-full-access"}, or workspace-write with sibling fields);
+  // the string form the taxonomy is written against does not occur in current
+  // rollouts. Extract before normalizing — passing the object through matched
+  // no rule and stringified to "[object Object]" in modeRaw. An object with no
+  // `.type` yields undefined, which normalizeMode treats as absent sandbox
+  // evidence rather than a guess.
+  const sandbox = (payload.sandbox_policy && typeof payload.sandbox_policy === 'object')
+    ? payload.sandbox_policy.type
+    : payload.sandbox_policy;
+  const m = normalizeMode({ host: 'codex', approvalPolicy: payload.approval_policy, sandboxPolicy: sandbox });
   if (m.raw) { rec.mode = m.mode; rec.modeRaw = m.raw; }
 }
 

--- a/src/lib/usage-telemetry.mjs
+++ b/src/lib/usage-telemetry.mjs
@@ -1,49 +1,12 @@
-// usage-telemetry.mjs — the host-neutral evidence contract for the usage
-// scorecard. This module describes what a source can report; it does not
-// reinterpret host wire events as a different kind of activity.
-//
-// The first implementation deliberately stops at prompts, responses, and
-// parser coverage. Claude and OpenCode can expose normalized tool calls, but
-// Codex's current rollout item families do not map one-to-one to that existing
-// contract. Activity categories therefore remain explicit capabilities rather
-// than being filled with host-specific guesses.
-
-export const TELEMETRY_CAPABILITY_STATES = Object.freeze([
-  'supported', 'unsupported', 'unavailable',
-]);
-
-/** Categories whose meanings are shared across transcript hosts. */
-export const TELEMETRY_CATEGORIES = Object.freeze([
-  'prompts', 'responses', 'toolCalls', 'commandExecutions',
-  'fileChanges', 'mcpCalls', 'collaboration',
-]);
+// usage-telemetry.mjs — the host-neutral diagnostics envelope for the usage
+// scorecard. Everything here is COUNTED: units discovered, units parsed, and
+// the prompt/response evidence those units carried. Nothing here interprets a
+// host's wire events as a different kind of activity, and nothing declares
+// what a parser could report in principle — an unclaimed activity category
+// contributes no counter rather than a matrix entry saying it is unclaimed.
 
 /** Keep future wire-kind growth from becoming an unbounded diagnostics payload. */
 export const MAX_TELEMETRY_UNKNOWN_KINDS = 32;
-
-/**
- * Static capability matrix. `supported` means the source format carries
- * enough evidence for this category under the current parser contract;
- * `unsupported` means the category is intentionally not claimed. Runtime
- * source health can turn a supported category into `unavailable`.
- */
-export const HOST_TELEMETRY_CAPABILITIES = Object.freeze({
-  claude: Object.freeze({
-    prompts: 'supported', responses: 'supported', toolCalls: 'supported',
-    commandExecutions: 'unsupported', fileChanges: 'unsupported',
-    mcpCalls: 'unsupported', collaboration: 'unsupported',
-  }),
-  codex: Object.freeze({
-    prompts: 'supported', responses: 'supported', toolCalls: 'unsupported',
-    commandExecutions: 'unsupported', fileChanges: 'unsupported',
-    mcpCalls: 'unsupported', collaboration: 'unsupported',
-  }),
-  opencode: Object.freeze({
-    prompts: 'supported', responses: 'supported', toolCalls: 'supported',
-    commandExecutions: 'unsupported', fileChanges: 'unsupported',
-    mcpCalls: 'unsupported', collaboration: 'unsupported',
-  }),
-});
 
 /** Empty host-neutral parser diagnostics. */
 export function emptyTelemetryDiagnostics() {
@@ -123,18 +86,4 @@ export function finalizeTelemetryDiagnostics(value) {
   }
   out.unknownKindOverflow += Math.max(0, Number(value.unknownKindOverflow) || 0);
   return out;
-}
-
-/**
- * Resolve the runtime capability state for one host/source. A source that is
- * absent, unreadable, or partially degraded cannot claim a measured zero for
- * a category the parser supports; it is `unavailable` instead.
- */
-export function telemetryCapabilities(host, sourceStatus = 'unavailable') {
-  const base = HOST_TELEMETRY_CAPABILITIES[host];
-  if (!base) return Object.fromEntries(TELEMETRY_CATEGORIES.map((key) => [key, 'unavailable']));
-  return Object.fromEntries(TELEMETRY_CATEGORIES.map((key) => [
-    key,
-    base[key] === 'supported' && sourceStatus !== 'ok' ? 'unavailable' : base[key],
-  ]));
 }

--- a/tests/dashboard.test.cjs
+++ b/tests/dashboard.test.cjs
@@ -1247,7 +1247,7 @@ async function main() {
       contains(r.body, 'data-status="');
       contains(r.body, 'OpenCode');
       contains(r.body, 'SOURCE_HEALTH_GROUPS'); // Codex + its thread ledger render as one grouped chip
-      contains(r.body, 'provider account analytics');
+      contains(r.body, 'Provider account analytics');
       contains(r.body, 'never merged into transcript totals');
       contains(r.body, 'OpenRouter credits');
       contains(r.body, 'BYOK estimate');

--- a/tests/dashboard.test.cjs
+++ b/tests/dashboard.test.cjs
@@ -427,7 +427,10 @@ async function main() {
   // testable without a 1.3 GB transcript corpus on disk, and the traversal tests
   // need a spy that PROVES no file read was attempted.
   // ══════════════════════════════════════════════════════════════════════════
-  const { parseSessionId, resolvesInsideRoot, maskTurns } = await import('file://' + MOD);
+  const {
+    parseSessionId, resolvesInsideRoot, maskTurns,
+    parseNamespacedSessionId, resolvesNamespacedInsideRoot,
+  } = await import('file://' + MOD);
 
   // ── the guard, as pure functions (no server, no I/O) ──
   await test('parseSessionId accepts a plain session id and decodes percent-encoding', async () => {
@@ -456,6 +459,41 @@ async function main() {
     assert(resolvesInsideRoot(root, '../abc') === false, 'a parent hop escapes the root');
     assert(resolvesInsideRoot(root, path.join('sub', 'abc')) === false, 'a nested path is not a bare id');
     assert(resolvesInsideRoot(root, path.resolve(path.sep, 'etc', 'passwd')) === false, 'an absolute path escapes the root');
+  });
+
+  // ── namespaced subagent session ids (Task 5 round 2) ──
+  await test('parseNamespacedSessionId accepts <parentId>/<stem>, decodes percent-encoding, and parses named subagents', async () => {
+    const r = parseNamespacedSessionId('fc8c05e0-c311-456e-a226-6dac4279199b/agent-a2fc4593254cc01b9');
+    assert(r && r.parentId === 'fc8c05e0-c311-456e-a226-6dac4279199b' && r.stem === 'agent-a2fc4593254cc01b9',
+      'a well-formed namespaced id must parse into its two segments');
+    const encoded = parseNamespacedSessionId('%66oo/agent-1');
+    assert(encoded && encoded.parentId === 'foo', 'percent-encoding is decoded BEFORE validation, never after');
+    // Most real subagent stems on this machine's corpus carry a Task-tool
+    // name, not just a bare hex tail — a hex-only pattern would leave most
+    // subagent sessions still unopenable.
+    const named = parseNamespacedSessionId('foo/agent-acourt-brutal_honesty-fb47a0cb49087a58');
+    assert(named && named.stem === 'agent-acourt-brutal_honesty-fb47a0cb49087a58', 'a named subagent stem must parse');
+  });
+
+  await test('parseNamespacedSessionId rejects traversal, backslash, extra slashes, absolutes, and a non-agent-* child', async () => {
+    const bad = [
+      '../etc/agent-1', '..%2fagent-1', 'foo/..', 'foo/../agent-1',
+      'foo\\bar/agent-1', 'foo/agent-1\\..\\..\\etc', 'a/b/agent-1', 'a//agent-1',
+      '/agent-1', 'foo/', '/foo/agent-1', 'C:%5CWindows/agent-1',
+      'foo/notanagent', 'foo/Agent-1', 'foo/agent-', 'foo/agent',
+      'foo/agent-1/extra', '', 'foo', 'agent-1', '..',
+    ];
+    for (const b of bad) {
+      assert(parseNamespacedSessionId(b) === null,
+        'must reject ' + JSON.stringify(b) + ', got ' + JSON.stringify(parseNamespacedSessionId(b)));
+    }
+  });
+
+  await test('resolvesNamespacedInsideRoot pins both segments to the transcript root, exactly as plain ids do', async () => {
+    const root = path.join(os.tmpdir(), 'ak-usage-root');
+    assert(resolvesNamespacedInsideRoot(root, 'abc', 'agent-1') === true, 'a well-formed pair resolves inside the root');
+    assert(resolvesNamespacedInsideRoot(root, '../abc', 'agent-1') === false, 'a parent-hop parent segment escapes the root');
+    assert(resolvesNamespacedInsideRoot(root, path.join('sub', 'abc'), 'agent-1') === false, 'a nested parent segment is not a bare id');
   });
 
   await test('maskTurns runs every turn body through the masker (and fails closed without one)', async () => {
@@ -661,6 +699,39 @@ async function main() {
       }
       assert(spy.calls.readSession.length === before,
         'readSession must NOT be called for any hostile id — got ' + (spy.calls.readSession.length - before) + ' call(s)');
+    });
+
+    // ── namespaced subagent session ids reach readSession end-to-end (Task 5 round 2) ──
+    await test('GET /api/session/:parentId/:stem → a namespaced subagent id reaches readSession end-to-end', async () => {
+      const before = spy.calls.readSession.length;
+      const r = await get(usageSrv.url + 'api/session/parent-uuid/agent-a2fc4593254cc01b9', usageSrv.token);
+      assert(r.status === 200, 'expected 200, got ' + r.status);
+      const j = JSON.parse(r.body);
+      assert(j.meta && j.meta.id === 'parent-uuid/agent-a2fc4593254cc01b9', 'meta must carry the namespaced id');
+      assert(spy.calls.readSession.length === before + 1
+        && spy.calls.readSession[spy.calls.readSession.length - 1] === 'parent-uuid/agent-a2fc4593254cc01b9',
+        'readSession must be called with the full namespaced id, unmangled');
+    });
+
+    await test('GET /api/session/:id traversal via a namespaced-shaped id → 400 and readSession is never reached', async () => {
+      const before = spy.calls.readSession.length;
+      const hostile = [
+        '/api/session/parent/../../../etc/passwd',
+        '/api/session/parent%2f..%2f..%2fetc%2fpasswd',
+        '/api/session/' + encodeURIComponent(path.resolve(path.sep, 'etc', 'passwd')) + '/agent-1',
+        '/api/session/parent/agent-1/extra',
+        '/api/session/parent/notanagent',
+        '/api/session/parent/Agent-1',
+        '/api/session/' + 'x'.repeat(129) + '/agent-1',
+      ];
+      for (const p of hostile) {
+        const r = await getRaw(usageSrv.port, p, usageSrv.token);
+        assert(r.status === 400, 'expected 400 for ' + p + ', got ' + r.status);
+        assert(!/root:|passwd/i.test(r.body), 'a rejected request must not echo file content: ' + p);
+      }
+      assert(spy.calls.readSession.length === before,
+        'readSession must NOT be called for any hostile namespaced-shaped id — got '
+        + (spy.calls.readSession.length - before) + ' call(s)');
     });
   } finally {
     await usageSrv.close();
@@ -1978,7 +2049,7 @@ async function main() {
   // is the suite where it matters most — the traversal-guard and credential-
   // leak tests live here and were the reviewer's cited example of a block
   // that could silently vanish with the old harness never noticing.
-  const EXPECTED = 77;
+  const EXPECTED = 82;
   if (passed + failed !== EXPECTED) {
     console.error(`\nPLAN MISMATCH: expected ${EXPECTED} tests, ran ${passed + failed}`);
     process.exit(1);

--- a/tests/dashboard.test.cjs
+++ b/tests/dashboard.test.cjs
@@ -856,7 +856,13 @@ async function main() {
       try {
         const r = await get(broken.url + 'api/limits', broken.token);
         assert(r.status === 500, 'expected 500, got ' + r.status);
-        contains(r.body, 'quota backend down');
+        // The body is a STABLE, non-reflective string. Node's fs errors embed
+        // the absolute path, and project slugs come from real working
+        // directories, so reflecting e.message hands the client the username,
+        // the directory layout, and project names. The operator gets the real
+        // error on stderr instead.
+        contains(r.body, 'plan limits unavailable');
+        assert(!r.body.includes('quota backend down'), 'the raw exception message must not be reflected');
       } finally { await broken.close(); }
     });
   } finally {

--- a/tests/dashboard.test.cjs
+++ b/tests/dashboard.test.cjs
@@ -542,7 +542,6 @@ async function main() {
       codex: { status: 'ok', reason: null },
       opencode: {
         status: 'degraded', reason: 'busy',
-        capabilities: { prompts: 'unavailable', toolCalls: 'unavailable' },
         diagnostics: { common: {
           unitsSeen: 0, unitsParsed: 0, unitsWithUsage: 0,
           unitsWithPrompts: 0, unitsWithResponses: 0,
@@ -645,8 +644,6 @@ async function main() {
       assert(Array.isArray(j.insights) && j.insights.length === 1, 'insights must survive');
       assert(j.sourceHealth.opencode.status === 'degraded' && j.sourceHealth.opencode.reason === 'busy',
         'source-health evidence must survive the dashboard route');
-      assert(j.sourceHealth.opencode.capabilities.toolCalls === 'unavailable',
-        'capability states must survive the dashboard route');
       assert(j.sourceHealth.opencode.diagnostics.common.warnings[0] === 'corrupt',
         'common telemetry diagnostics must survive the dashboard route');
       assert(spy.calls.readIndex.some((o) => o && o.days === 7), 'days must reach readIndex, got ' + JSON.stringify(spy.calls.readIndex));

--- a/tests/kit/codex-state.test.mjs
+++ b/tests/kit/codex-state.test.mjs
@@ -114,6 +114,32 @@ test('applyCodexLedger backfills thread_source and STRIPS a subagent’s usage',
   assert.deepEqual(out.usage, []); // replayed parent history must not double-bill
 });
 
+// reasoningOutput comes from the SAME replayed cumulative snapshot as the
+// tokens (finalizeCodexUsage reads both off the last token_count), so leaving
+// it behind kept 100% of the double-count in one field and rendered it beside
+// the zeroed totals as "in 0 · out 0 · … · reasoning 412K (in out)" — a
+// subset annotation pointing at an output total the same correction just
+// zeroed. Reachable only on the ledger path: parse-time detection returns
+// before reasoningOutput is ever set.
+test('applyCodexLedger strips reasoningOutput along with the replayed tokens', () => {
+  const [out] = applyCodexLedger(
+    [rec({ reasoningOutput: 412_000 })],
+    ledgerOf({ 'child-1': { threadSource: 'subagent' } }),
+  );
+  assert.deepEqual(out.usage, []);
+  assert.equal(out.reasoningOutput, 0, 'same replayed snapshot, same double-count');
+});
+
+test('applyCodexLedger strips a subagent whose ONLY replayed figure is reasoningOutput', () => {
+  // The early return must not let a record through just because usage is
+  // already empty while reasoningOutput still carries the inflation.
+  const [out] = applyCodexLedger(
+    [rec({ threadSource: 'subagent', usage: [], reasoningOutput: 412_000 })],
+    ledgerOf({ 'child-1': { threadSource: 'subagent' } }),
+  );
+  assert.equal(out.reasoningOutput, 0);
+});
+
 test('applyCodexLedger marks a spawn-edge child subagent even without a thread row', () => {
   const [out] = applyCodexLedger([rec()], ledgerOf({}, [['child-1', 'parent-1']]));
   assert.equal(out.threadSource, 'subagent');

--- a/tests/kit/dashboard-usage-telemetry.test.mjs
+++ b/tests/kit/dashboard-usage-telemetry.test.mjs
@@ -348,6 +348,26 @@ test('the cadence row is built once, after the hero, from totals the payload alr
   assert.match(JS, /a day worked but never billed is not counted/, 'the streak says what breaks it');
 });
 
+test('deltaChip refuses to draw a direction for a change that rounds away', () => {
+  // "▲0%" and "▲0 pp" both put an arrow on a move the printed number says did
+  // not happen. Real data hit this: cache share moved 0.04pp between windows.
+  const tiny = deltaChip(96.84, 96.80, { unit: ' pp' });
+  assert.match(tiny, /data-tone="flat"/);
+  assert.match(tiny, /•/);
+  assert.doesNotMatch(tiny, /▲|▼/);
+  assert.match(deltaChip(1004, 1000, {}), /data-tone="flat"/, 'a 0.4% move rounds to 0% and is flat too');
+  // A change that survives rounding still gets its arrow and its tone.
+  assert.match(deltaChip(584, 540, {}), /▲/);
+  assert.match(deltaChip(50, 100, { downIsGood: true }), /data-tone="good"/);
+});
+
+test('60 seconds reads as 60s, so the overflow prefix names the bucket edge on the axis', () => {
+  // fmtSecs rolled 60 up to "1m", which made the ruled "≥60s" render "≥1m" —
+  // a percentile labelled with a boundary that appears nowhere on the axis.
+  assert.match(JS, /if\(sec<=60\)return/);
+  assert.match(JS, /var LAT_LABELS=\["≤2s","≤5s","≤10s","≤30s","≤60s",">60s"\]/);
+});
+
 test('donut2 draws the arc from the raw value while the legend prints the caller-formatted text', () => {
   const html = donut2({
     aValue: 12.3456, bValue: 4.1, aText: '$12.35', bText: '$4.10',
@@ -366,8 +386,8 @@ test('the rhythm panel labels buckets on the same edges the server binned them w
   // this pin exists to make loud.
   assert.match(JS, new RegExp(`var LAT_EDGES=\\[${LAT_BUCKET_EDGES.join(',')}\\]`));
   assert.match(JS, new RegExp(`var LEN_EDGES=\\[${LEN_BUCKET_EDGES.join(',')}\\]`));
-  assert.match(JS, /var LAT_LABELS=\["≤2s","≤5s","≤10s","≤30s","≤60s","＞60s"\]/);
-  assert.match(JS, /var LEN_LABELS=\["≤5m","≤15m","≤45m","≤2h","＞2h"\]/);
+  assert.match(JS, /var LAT_LABELS=\["≤2s","≤5s","≤10s","≤30s","≤60s",">60s"\]/);
+  assert.match(JS, /var LEN_LABELS=\["≤5m","≤15m","≤45m","≤2h",">2h"\]/);
 });
 
 test('an overflow-bucket percentile is printed with a ≥ prefix, never as a bare figure', () => {

--- a/tests/kit/dashboard-usage-telemetry.test.mjs
+++ b/tests/kit/dashboard-usage-telemetry.test.mjs
@@ -456,13 +456,63 @@ test('reliability states a rate with its denominator, and flags direction in wor
   assert.match(CSS, /\.rel-flag\[data-sev="warn"\]\{color:var\(--warn\)\}/);
 });
 
-test('reliability says why there is no per-day line rather than drawing an invented one', () => {
-  // byDay rows carry tokens/cost/sessions only — exceptions exist as a window
-  // total, so a daily trend cannot be read from this payload.
-  assert.match(JS, /No per-day line/);
-  assert.match(JS, /A daily trend would have to be invented rather than /);
-  assert.match(JS, /exceptions exist only as a window total/);
-  assert.doesNotMatch(JS, /sparklineSvg\([^)]*exception/i, 'no exceptions series is charted');
+test('reliability draws the per-day line and names its worst day without inventing a threshold', () => {
+  // byDay carries exceptions as of the upstream v11 projection, so the line is
+  // read rather than invented. "Worst" is a fact the counts already carry — no
+  // constant decides what counts as a spike, because any constant this file
+  // picked would be a judgement the data never made.
+  assert.match(JS, /function relTrend\(d\)/);
+  assert.match(JS, /rows\.map\(function\(x\)\{return fld\(x\.v,"exceptions"\);\}\)/);
+  assert.match(JS, /sparklineSvg\(series,\{w:640,h:44\}\)/);
+  assert.match(JS, /function relWorstDay\(rows\)/);
+  assert.match(JS, /no exceptions on any day in this window/, 'an all-zero window draws no line');
+  // Icon + words + color, and the day is named in text.
+  assert.match(JS, /rel-flag" data-sev="warn"><i aria-hidden="true">▲<\/i>worst day /);
+  // The attribution caveat is the point: a peak is not "the day it broke".
+  assert.match(JS, /Attributed to the day each session first billed/);
+  assert.match(JS, /spanning midnight lands all of its exceptions on one day/);
+});
+
+test('sparklineSvg breaks across a gap rather than dropping the point or carrying one forward', () => {
+  // Dropping would squeeze the time axis (three missing days rendering as one
+  // step); carrying forward would state a figure for a day that has none.
+  assert.equal((sparklineSvg([1, 2, 3]).match(/<polyline/g) || []).length, 1);
+  assert.equal((sparklineSvg([1, 2, null, 4, 5]).match(/<polyline/g) || []).length, 2, 'one run each side of the gap');
+  assert.equal((sparklineSvg([1, 2, null, 4, null, 6, 7]).match(/<polyline/g) || []).length, 2, 'the lone point between two gaps has no segment');
+  assert.match(sparklineSvg([1, 2, 3, null]), /circle/, 'the dot marks the last MEASURED point');
+  // The gap keeps its slot: with 3 slots the run ends at the same x it would
+  // have had with no gap at all.
+  const gapped = /points="([^"]+)"/.exec(sparklineSvg([1, 2, null, 4]));
+  assert.ok(gapped, 'a 4-point series with one gap still draws its leading run');
+  // Unchanged for callers that pass only finite points.
+  assert.equal(sparklineSvg([1]), '');
+  assert.equal(sparklineSvg([1, NaN]), '');
+});
+
+test('the cache tile trends its share per day, nulling a day that billed no tokens', () => {
+  assert.match(JS, /var tok=fld\(x\.v,"tokens"\);\s*return tok\?pct\(fld\(x\.v,"cacheRead"\),tok\):null;/);
+  assert.match(JS, /the line breaks across it rather than carrying a neighbour's/);
+});
+
+test('the engaged tile says its trend covers a different day set than the others', () => {
+  // engagedByDay is keyed on days WORKED; every other hero trend is keyed on
+  // days BILLED. The tiles look directly comparable and are not.
+  assert.match(JS, /trend covers days you worked; the other tiles' trends cover billed days/);
+  assert.match(JS, /ladder\(t\)\+ENGAGED_TREND_NOTE/);
+  // And the .kpi-foot comment no longer claims the row shares a baseline. (The
+  // phrase is scoped tightly: styles/system.mjs has its own, unrelated "compared
+  // at a glance" about a different layout.)
+  assert.doesNotMatch(CSS, /trend lines across a row of tiles share a baseline/);
+  assert.match(CSS, /not a row to compare across/);
+});
+
+test('a positive figure under a cent reads <$0.01; a true zero does not', () => {
+  // "$0.00 median" beside "excludes $0-by-construction" reads as "the median
+  // session was free", which is a different claim from "under a cent".
+  assert.match(JS, /function fmtUsdMin\(n\)\{\s*var v=Number\(n\)\|\|0,txt=fmtUsd\(v\);\s*return \(v>0&&txt==="\$0\.00"\)\?"<\$0\.01":txt;/);
+  assert.match(JS, /med==null\?"—":fmtUsdMin\(med\)/);
+  assert.match(JS, /fmtUsdMin\(p90\)/);
+  assert.match(JS, /means \\na real, positive figure smaller than a cent|a real, positive figure smaller than a cent/);
 });
 
 test('session chips render only what the transcript established, and nothing else', () => {
@@ -480,6 +530,35 @@ test('the mode badge is absent when no posture was observed, never a guessed one
   assert.match(JS, /recorded by the host as/, 'modeRaw rides in the tooltip when the payload carries it');
   assert.match(JS, /the host's own spelling was not recorded/, 'and says so when it does not');
   assert.match(CSS, /\.s-chip\.s-mode\[data-mode="unrestricted"\]/);
+});
+
+test('the fields the chips read are actually projected onto the session row', () => {
+  // The chip branches were written against a payload that did not yet carry
+  // these; upstream now projects them. This asserts the two halves meet, so a
+  // regression on either side goes red rather than silently rendering nothing.
+  const rec = usageRecord('ctx', {
+    end: NOW - 2 * DAY_MS,
+    mode: 'auto-edit',
+    usageRows: [{ day: '2026-08-18', model: 'claude-opus-5', input: 10, output: 5, cacheRead: 0, cacheWrite: 0, responses: 1 }],
+  });
+  Object.assign(rec, { modeRaw: 'acceptEdits', ctxWindow: 200_000, ctxLastTokens: 151_000 });
+  const agg = aggregate([rec], { days: 7, now: NOW, cutoff: NOW - 7 * DAY_MS, deps: FIXTURE_DEPS });
+  const row = agg.sessions[0];
+  assert.equal(row.modeRaw, 'acceptEdits', 'the badge tooltip has a raw spelling to print');
+  assert.equal(row.ctxWindow, 200_000, 'the ctx chip has a denominator');
+  assert.equal(row.ctxLastTokens, 151_000, 'the ctx chip has a numerator');
+  // …and the client reads exactly those names.
+  assert.match(JS, /rawSpelling\(sx\.modeRaw\)/);
+  assert.match(JS, /Number\(sx\.ctxLastTokens\),win=Number\(sx\.ctxWindow\)/);
+});
+
+test('a raw spelling that is a failed toString is refused, not printed into a tooltip', () => {
+  // Live data: every Codex row carries modeRaw "never/[object Object]" —
+  // usage-modes.mjs joins Codex's sandboxPolicy into the string and that field
+  // is an object. Printing it would put the dashboard's own rendering-artifact
+  // sentinel inside a tooltip, so it is treated as not-recorded.
+  assert.match(JS, /function rawSpelling\(v\)\{\s*var s=reportedIdentity\(v\);\s*return \(s&&s\.indexOf\("\[object "\)<0\)\?s:null;/);
+  assert.doesNotMatch(JS, /reportedIdentity\(sx\.modeRaw\)/, 'the unguarded read must not survive anywhere');
 });
 
 test('the context chip requires BOTH halves, and is omitted rather than divided by a guess', () => {

--- a/tests/kit/dashboard-usage-telemetry.test.mjs
+++ b/tests/kit/dashboard-usage-telemetry.test.mjs
@@ -497,6 +497,32 @@ test('the chips column keeps the .srow grid arithmetic closed on both breakpoint
   assert.match(JS, /esc\(cat\)\+"<\/span>"\s*\+'<span class="s-chips">'\+sessionChips\(sx\)\+"<\/span>"\s*\+'<span class="s-when mono">/);
 });
 
+test('a limit meter carries a pace tick derived from the window it is already reading', () => {
+  // resetsAt (epoch seconds) + windowMinutes are both on the limits payload,
+  // so elapsed = duration - remaining. Nothing is fetched, and no window
+  // length is assumed.
+  assert.match(JS, /function paceShare\(resetSec,windowMinutes\)/);
+  assert.match(JS, /var total=mins\*60000,elapsed=total-\(resetSec\*1000-Date\.now\(\)\)/);
+  assert.match(JS, /w\.usedPercent,w\.resetsAt,null,w\.windowMinutes/, 'both claude and codex rows pass the window length');
+  assert.match(JS, /class="pace" style="left:/);
+  assert.match(CSS, /\.lim \.mbar i\.pace\{/);
+  // Scoped to .lim: the scorecard's magnitude rows share .mbar and must not
+  // start positioning or un-clipping themselves.
+  assert.match(CSS, /\.lim \.mbar\{position:relative; overflow:visible\}/);
+  assert.doesNotMatch(CSS, /^\.mbar\{[^}]*position:relative/m);
+});
+
+test('a pace tick that cannot be computed is omitted, never pinned to an edge', () => {
+  // A snapshot older than its own window, or a browser clock that disagrees
+  // with the vendor's, puts elapsed outside [0,duration]. 0% or 100% would
+  // state a position; null admits there is none to state.
+  assert.match(JS, /if\(!isFinite\(elapsed\)\|\|elapsed<0\|\|elapsed>total\)return null/);
+  assert.match(JS, /if\(at==null\)return ""/);
+  // And the key is only printed when a tick actually rendered.
+  assert.match(JS, /\(paced\?PACE_LEGEND:""\)/);
+  assert.match(JS, /if\(paced\)html\+=PACE_LEGEND/);
+});
+
 test('the scorecard panel grafts are idempotent — a re-render reuses its container', () => {
   // renderScore runs on every poll. ensureBlock returns the existing node
   // instead of inserting a second one; without that the scorecard would grow

--- a/tests/kit/dashboard-usage-telemetry.test.mjs
+++ b/tests/kit/dashboard-usage-telemetry.test.mjs
@@ -30,6 +30,19 @@ test('the scorecard no longer ships a telemetry coverage panel', () => {
   assert.doesNotMatch(CSS, /\.telemetry-(card|grid)/);
 });
 
+// The tabbar pills outlived the panel, and they must not carry its leftovers:
+// a read of a field nothing populates renders nothing, but it reads as though
+// the payload still carries a capability matrix. Their real input is
+// status/reason (plus the counted diagnostics), asserted here alongside.
+test('the source-health pills read status and reason, never a capability field', () => {
+  assert.doesNotMatch(JS, /item\.capabilities/);
+  assert.doesNotMatch(JS, /pt\.capabilities/);
+  assert.doesNotMatch(JS, /caps\.toolCalls/);
+  assert.match(JS, /status:String\(item\.status\|\|"not-read"\),reason:item\.reason/);
+  assert.match(JS, /pt\.status\+\(pt\.reason\?" · "\+pt\.reason:""\)/);
+  assert.match(JS, /sp-status/, 'the pill still renders the lead status');
+});
+
 // ── /api/usage payload: rhythm, mode, provider, previous window ────────────
 //
 // The dashboard-server route delegates its entire aggregation to an

--- a/tests/kit/dashboard-usage-telemetry.test.mjs
+++ b/tests/kit/dashboard-usage-telemetry.test.mjs
@@ -445,6 +445,58 @@ test('reliability says why there is no per-day line rather than drawing an inven
   assert.doesNotMatch(JS, /sparklineSvg\([^)]*exception/i, 'no exceptions series is charted');
 });
 
+test('session chips render only what the transcript established, and nothing else', () => {
+  // Engaged length and the session's own p50 come from fields the row already
+  // carries; the p50 reuses the SAME bucket math the window's rhythm panel and
+  // the server both use, rather than a second, unpinned copy.
+  assert.match(JS, /bucketPercentile\(sx\.latHist,LAT_EDGES,0\.5\)/);
+  assert.match(JS, /Array\.isArray\(sx\.latHist\)\?bucketPercentile/, 'no histogram means no p50 chip');
+  assert.match(JS, /if\(len>0\)out\+=/, 'a session with no engaged seconds gets no length chip');
+  assert.match(JS, /fmtAtLeast\(p50,60,fmtSecs\)/, 'a p50 in the overflow bucket still reads ≥');
+});
+
+test('the mode badge is absent when no posture was observed, never a guessed one', () => {
+  assert.match(JS, /function modeBadge\(sx\)\{\s*var mode=reportedIdentity\(sx\.mode\);\s*if\(!mode\)return "";/);
+  assert.match(JS, /recorded by the host as/, 'modeRaw rides in the tooltip when the payload carries it');
+  assert.match(JS, /the host's own spelling was not recorded/, 'and says so when it does not');
+  assert.match(CSS, /\.s-chip\.s-mode\[data-mode="unrestricted"\]/);
+});
+
+test('the context chip requires BOTH halves, and is omitted rather than divided by a guess', () => {
+  assert.match(JS, /var used=Number\(sx\.ctxLastTokens\),win=Number\(sx\.ctxWindow\)/);
+  assert.match(JS, /if\(!isFinite\(used\)\|\|!isFinite\(win\)\|\|used<=0\|\|win<=0\)return ""/);
+  assert.match(JS, /both recorded by the transcript/);
+  // The window is only ever READ. No `||` or `??` fallback stands behind it,
+  // which is what a guessed denominator would have to look like.
+  assert.doesNotMatch(JS, /ctxWindow\s*(\|\||\?\?)/);
+  assert.doesNotMatch(JS, /CONTEXT_WINDOWS|DEFAULT_CTX_WINDOW/, 'no published-window lookup table');
+});
+
+test('the session detail strip spells out posture and rhythm, and never omits the line', () => {
+  assert.match(JS, /\["posture",posture\],\["rhythm",esc\(rhythm\)\]/);
+  assert.match(JS, /Not recorded <span class='sd-conf'>\(no posture evidence in this transcript\)/);
+  assert.match(JS, /latency samples/);
+  assert.match(JS, /aborts/);
+});
+
+test('the chips column keeps the .srow grid arithmetic closed on both breakpoints', () => {
+  // The row is a fixed grid: a column added to the desktop track list and
+  // forgotten in the mobile one shifts every cell by one, which renders
+  // perfectly while putting the wrong data under each heading.
+  const desktop = /\.srow\{\s*display:grid; grid-template-columns:([^;]+);/.exec(CSS);
+  assert.ok(desktop, 'the desktop .srow track list must be findable');
+  assert.equal(desktop[1].trim().split(/\s+/).length, 11, 'eleven desktop tracks for eleven cells');
+
+  const mobile = /@media\s*\(max-width:720px\)\{[\s\S]*?\.srow\{grid-template-columns:([^}]+)\}/.exec(CSS);
+  assert.ok(mobile, 'the mobile .srow track list must be findable');
+  assert.equal(mobile[1].trim().split(/\s+/).length, 5, 'five mobile tracks');
+  assert.match(CSS, /\.srow \.cat,\.srow \.s-chips\{display:none\}/, 'chips join the hidden set, keeping 5 cells over 5 tracks');
+
+  // Source order is what actually aligns a cell with its track: chips sit
+  // between the category and the timestamp in both the markup and the CSS.
+  assert.match(JS, /esc\(cat\)\+"<\/span>"\s*\+'<span class="s-chips">'\+sessionChips\(sx\)\+"<\/span>"\s*\+'<span class="s-when mono">/);
+});
+
 test('the scorecard panel grafts are idempotent — a re-render reuses its container', () => {
   // renderScore runs on every poll. ensureBlock returns the existing node
   // instead of inserting a second one; without that the scorecard would grow

--- a/tests/kit/dashboard-usage-telemetry.test.mjs
+++ b/tests/kit/dashboard-usage-telemetry.test.mjs
@@ -43,6 +43,22 @@ test('the source-health pills read status and reason, never a capability field',
   assert.match(JS, /sp-status/, 'the pill still renders the lead status');
 });
 
+// A Codex pool label is "GPT-5.3-Codex-Spark · weekly" — 183px of text in a
+// 137px column, so the shared .mrow grid ellipsised it to "GPT-5.3-Codex-Sp…".
+// That is what hid one pool being reported under two lanes: both rows truncated
+// to something plausible. Measured across 1000-1600px, the widened column fits
+// the full string with no row overflow; the tooltip covers the narrow band
+// below that, where two panels still sit side by side. The track is capped
+// rather than content-sized so every row's meter still starts at the same x.
+test('a limits row shows the whole pool label, and carries it as a tooltip regardless', () => {
+  assert.match(CSS, /\.lim \.mrow\{grid-template-columns:minmax\(0,190px\)/,
+    'the limits label column is widened past the shared magnitude grid, and stays a fixed track');
+  assert.match(JS, /class="mname" title="'\+esc\(label\)\+'">'\+esc\(label\)/,
+    'the full label is the title, so an ellipsised row is still readable on hover');
+  assert.match(JS, /limRow\(lane\.name\+" · "\+\(w\.label\|\|""\)/,
+    'a Codex row is named pool + window duration');
+});
+
 // ── /api/usage payload: rhythm, mode, provider, previous window ────────────
 //
 // The dashboard-server route delegates its entire aggregation to an

--- a/tests/kit/dashboard-usage-telemetry.test.mjs
+++ b/tests/kit/dashboard-usage-telemetry.test.mjs
@@ -447,8 +447,21 @@ test('model mix keeps four named families and folds the rest into one dim band',
 test('reliability states a rate with its denominator, and flags direction in words not only color', () => {
   assert.match(JS, /exceptions \/ 1k responses/);
   assert.match(JS, /\(Number\(t\.exceptions\)\|\|0\)\/r\*1000/);
+  // aborts is CODEX-ONLY evidence — turn_aborted is the only interrupt signal
+  // any host writes. These three assertions used to pin the opposite: they
+  // asserted the presence of an unconditional count and of the tooltip
+  // sentence "Turns the transcript recorded as interrupted", which is false
+  // for a claude-only corpus. They now pin the capability gate, so reverting
+  // to the measured-looking zero goes red instead of staying green.
   assert.match(JS, /aborted turns/, 'aborts are counted apart from exceptions');
-  assert.match(JS, /an abort is a choice, not a failure/);
+  assert.match(JS, /value:cxSess\?fmtNum\(ab\):"—"/,
+    'no codex sessions in the window → em dash, never a 0 that reads as "you never interrupted a turn"');
+  assert.match(JS, /ab\/cxResp\*1000\)\+" per 1k codex responses"/,
+    'the rate is over codex responses only — dividing by every host\'s responses dilutes it by host mix');
+  assert.match(JS, /no codex sessions — no other host records interrupts/);
+  assert.match(JS, /CODEX ONLY\./, 'the tooltip states the capability, not just the definition');
+  assert.doesNotMatch(JS, /relStat\(\{label:"aborted turns",value:fmtNum\(ab\)/,
+    'the unconditional count must not come back');
   // Icon + words + color, never color alone.
   assert.match(JS, /rel-flag" data-sev="warn"><i aria-hidden="true">▲<\/i>/);
   assert.match(JS, /higher than the previous window/);
@@ -577,7 +590,37 @@ test('the session detail strip spells out posture and rhythm, and never omits th
   assert.match(JS, /\["posture",posture\],\["rhythm",esc\(rhythm\)\]/);
   assert.match(JS, /Not recorded <span class='sd-conf'>\(no posture evidence in this transcript\)/);
   assert.match(JS, /latency samples/);
-  assert.match(JS, /aborts/);
+  // Per-row, the same capability rule the reliability panel applies: a
+  // claude/opencode row cannot have recorded an interrupt, so it says so
+  // rather than printing a 0 indistinguishable from a measured one.
+  assert.match(JS, /aborts "\+\(sx\.host==="codex"\?fmtNum\(Number\(sx\.aborts\)\|\|0\):"not recorded for this host"\)/);
+});
+
+test('an observed-but-unmapped posture shows the host spelling, never "no posture evidence"', () => {
+  // normalizeMode returns { mode: null, raw: 'yolo/workspace-write' } for a
+  // value outside the taxonomy — evidence preserved, no guess — and
+  // v11Projection ships both onto the session row. Printing "no posture
+  // evidence in this transcript" over a modeRaw sitting on that same row
+  // denies data that exists, which is the honesty rule inverted.
+  assert.match(JS, /return modeRaw\s*\?\s*"Unrecognized <span class='sd-conf'>\(host recorded \\""\+esc\(modeRaw\)\+"\\" — not in this taxonomy\)/,
+    'the unmapped branch is chosen on modeRaw, before the not-recorded fallback, and escapes the host spelling');
+  assert.match(JS, /"Not recorded <span class='sd-conf'>\(no posture evidence in this transcript\)/,
+    'the genuinely-absent state keeps its own wording');
+});
+
+test('the aggregate carries the evidence an unmapped posture is rendered from', () => {
+  // The behavioral half of the same rule, at the level that can be executed:
+  // an unrecognized host spelling must survive to the session row with
+  // mode null, or the client has nothing to render.
+  const rec = usageRecord('unmapped', {
+    end: NOW - 2 * DAY_MS,
+    usageRows: [{ day: '2026-08-18', model: 'claude-opus-5', input: 10, output: 5, cacheRead: 0, cacheWrite: 0, responses: 1 }],
+  });
+  Object.assign(rec, { mode: null, modeRaw: 'yolo/workspace-write' });
+  const agg = aggregate([rec], { days: 7, now: NOW, cutoff: NOW - 7 * DAY_MS, deps: FIXTURE_DEPS });
+  const row = agg.sessions[0];
+  assert.equal(row.mode, null, 'unmapped stays unmapped — never coerced into a real posture');
+  assert.equal(row.modeRaw, 'yolo/workspace-write', 'the evidence the transcript carried survives projection');
 });
 
 test('the chips column keeps the .srow grid arithmetic closed on both breakpoints', () => {

--- a/tests/kit/dashboard-usage-telemetry.test.mjs
+++ b/tests/kit/dashboard-usage-telemetry.test.mjs
@@ -10,7 +10,11 @@ import { blankSession, addUsage } from '../../src/lib/usage-parsers.mjs';
 import { MODES } from '../../src/lib/usage-modes.mjs';
 import {
   deltaChip, sparklineSvg, histogram, stackedDays, donut2, rankedRows,
+  bucketPercentile, bucketPositionPct,
 } from '../../src/lib/dashboard/client/usage-rhythm.mjs';
+import {
+  percentileFromBuckets, LAT_BUCKET_EDGES, LEN_BUCKET_EDGES,
+} from '../../src/lib/usage-aggregate.mjs';
 
 const PAGE = renderPage({ name: 'agentic-kit', version: 'test' });
 
@@ -259,4 +263,94 @@ test('usage styles append the rhythm/mode chart primitive classes with the mark-
   // histogram test) is the other half. This can't observe rendered paint
   // order itself; it only guards the CSS declaration that makes it possible.
   assert.match(CSS, /\.hist-bars\{[^}]*position:relative/, 'hist-bars must be positioned to paint over the positioned marker overlay');
+});
+
+// ── Task 9: the panels that consume all of the above ──────────────────────
+
+test('usage-rhythm.mjs reaches the served bundle, with exactly one escaper in it', () => {
+  // Without this splice every panel below throws ReferenceError in the browser
+  // while every test that imports the module directly stays green — so the
+  // bundle, not the module, is what this asserts against.
+  assert.match(JS, /function deltaChip\(/, 'the rhythm primitives must be in the served bundle');
+  assert.match(JS, /function bucketPercentile\(/);
+  assert.match(JS, /function stackedDays\(/);
+  // The module carries its own `esc` on disk (the direct-import tests above
+  // depend on it). Two `function esc` declarations would share one bundle
+  // scope and the later one would silently replace the injected groups.mjs
+  // escaper with a copy free to drift from it, so client.mjs strips it.
+  assert.equal((JS.match(/function esc\(/g) || []).length, 1, 'the bundle must declare exactly one esc');
+  assert.doesNotMatch(JS, /^export function/m, 'no export survives into the classic-script bundle');
+});
+
+test('bucketPercentile reproduces the server percentile it is printed beside', () => {
+  const cases = [
+    [[0, 0, 0, 0, 0, 0], LAT_BUCKET_EDGES],
+    [[10, 0, 0, 0, 0, 0], LAT_BUCKET_EDGES],
+    [[3, 7, 11, 2, 1, 4], LAT_BUCKET_EDGES],
+    [[0, 0, 0, 0, 0, 9], LAT_BUCKET_EDGES],
+    [[1, 1, 1, 1, 1], LEN_BUCKET_EDGES],
+    [[0, 0, 0, 0, 6], LEN_BUCKET_EDGES],
+  ];
+  for (const [counts, edges] of cases) {
+    for (const q of [0.5, 0.9, 0.95]) {
+      assert.equal(
+        bucketPercentile(counts, edges, q),
+        percentileFromBuckets(counts, edges, q),
+        `client and server disagree on p${q * 100} of ${JSON.stringify(counts)}`,
+      );
+    }
+  }
+});
+
+test('bucketPercentile reports the overflow bucket floor, never an invented ceiling', () => {
+  assert.equal(bucketPercentile([0, 0, 0, 0, 0, 5], LAT_BUCKET_EDGES, 0.95), 60);
+  assert.equal(bucketPercentile([0, 0, 0, 0, 5], LEN_BUCKET_EDGES, 0.9), 7200);
+  assert.equal(bucketPercentile([], LAT_BUCKET_EDGES, 0.5), null, 'an empty histogram is null, not 0');
+});
+
+test('bucketPositionPct lands a value inside the slot its own bucket occupies', () => {
+  // 6 slots for 5 edges: slot i spans [i/6,(i+1)/6] of the plot.
+  assert.equal(bucketPositionPct(LAT_BUCKET_EDGES, 0), 0, 'the low end of the first slot');
+  assert.ok(Math.abs(bucketPositionPct(LAT_BUCKET_EDGES, 1) - (0.5 / 6) * 100) < 0.001, 'halfway through slot 0');
+  assert.ok(Math.abs(bucketPositionPct(LAT_BUCKET_EDGES, 60) - (5 / 6) * 100) < 0.001, 'the 60s edge is the overflow boundary');
+  assert.ok(bucketPositionPct(LAT_BUCKET_EDGES, 900) <= 100, 'an overflow value never runs off the plot');
+  assert.equal(bucketPositionPct(LAT_BUCKET_EDGES, null), null, 'a missing percentile places no marker');
+});
+
+test('hero tiles carry a windowed delta and a per-day trend, with cost read down-is-good', () => {
+  assert.match(JS, /deltaChip\(t\.cost,p\.cost,\{downIsGood:true\}\)/, 'a cheaper window is the good direction');
+  assert.match(JS, /deltaChip\(t\.tokens,p\.tokens,\{neutral:true\}\)/, 'more tokens is neither good nor bad on its own');
+  assert.match(JS, /deltaChip\(t\.sessions,p\.sessions,\{\}\)/);
+  assert.match(JS, /deltaChip\(t\.engagedSeconds,p\.engagedSeconds,\{\}\)/);
+  // Cache SHARE is up-good (cache reads bill at 0.1x input) and its delta is
+  // in percentage points — a percent-of-a-percent would name the wrong move.
+  assert.match(JS, /deltaChip\(cacheShare,prevCacheShare,\{unit:" pp"\}\)/);
+  assert.match(JS, /saved &asymp; /, 'the cache tile states what the cache avoided');
+  assert.match(JS, /cacheSavedUsd/);
+  // engagedByDay is a sibling map with its own day set, not a byDay field.
+  assert.match(JS, /mapRows\(d\.engagedByDay\)/);
+});
+
+test('the cadence row is built once, after the hero, from totals the payload already carries', () => {
+  assert.match(JS, /ensureBlock\("u-cadence",/, 'the row creates its own container — page.mjs has none');
+  assert.match(JS, /"u-hero"\)/, 'anchored to the hero it continues');
+  assert.match(JS, /responsesPerPrompt/);
+  assert.match(JS, /humanPromptsPerHour/);
+  assert.match(JS, /costPerSessionMedian/);
+  assert.match(JS, /costPerSessionP90/);
+  assert.match(JS, /costPerEngagedHour/);
+  // Every new KPI states its formula AND its caveat, since each is a derived
+  // rate rather than a measured total.
+  assert.match(JS, /MAIN-THREAD only/, 'autonomy says whose prompts count');
+  assert.match(JS, /structurally \$0/, 'the median says what it excludes');
+  assert.match(JS, /15-minute silences/, 'cost-per-hour says which hours');
+  assert.match(JS, /Streak counts consecutive active days/, 'the streak says what it counts');
+  assert.match(JS, /a day worked but never billed is not counted/, 'the streak says what breaks it');
+});
+
+test('the scorecard panel grafts are idempotent — a re-render reuses its container', () => {
+  // renderScore runs on every poll. ensureBlock returns the existing node
+  // instead of inserting a second one; without that the scorecard would grow
+  // a duplicate panel every few seconds.
+  assert.match(JS, /function ensureBlock\(probeId,html,afterId\)\{\s*var existing=document\.getElementById\(probeId\);\s*if\(existing\)return existing;/);
 });

--- a/tests/kit/dashboard-usage-telemetry.test.mjs
+++ b/tests/kit/dashboard-usage-telemetry.test.mjs
@@ -348,6 +348,62 @@ test('the cadence row is built once, after the hero, from totals the payload alr
   assert.match(JS, /a day worked but never billed is not counted/, 'the streak says what breaks it');
 });
 
+test('donut2 draws the arc from the raw value while the legend prints the caller-formatted text', () => {
+  const html = donut2({
+    aValue: 12.3456, bValue: 4.1, aText: '$12.35', bText: '$4.10',
+    aLabel: 'main thread', bLabel: 'subagent', centerLabel: '75%',
+  });
+  assert.match(html, /\$12\.35/, 'the legend prints the formatted money, not the float');
+  assert.doesNotMatch(html, /12\.3456/, 'the unformatted value never reaches the legend');
+  assert.match(html, /conic-gradient/, 'the arc is still drawn');
+  // Without aText/bText the raw number is the label, as before.
+  assert.match(donut2({ aValue: 3, bValue: 1, aLabel: 'a', bLabel: 'b' }), /<b class="tnum">3<\/b>/);
+});
+
+test('the rhythm panel labels buckets on the same edges the server binned them with', () => {
+  // The payload ships COUNTS, never the edges. A drift here would relabel
+  // every bar without changing a single number, which is the silent failure
+  // this pin exists to make loud.
+  assert.match(JS, new RegExp(`var LAT_EDGES=\\[${LAT_BUCKET_EDGES.join(',')}\\]`));
+  assert.match(JS, new RegExp(`var LEN_EDGES=\\[${LEN_BUCKET_EDGES.join(',')}\\]`));
+  assert.match(JS, /var LAT_LABELS=\["≤2s","≤5s","≤10s","≤30s","≤60s","＞60s"\]/);
+  assert.match(JS, /var LEN_LABELS=\["≤5m","≤15m","≤45m","≤2h","＞2h"\]/);
+});
+
+test('an overflow-bucket percentile is printed with a ≥ prefix, never as a bare figure', () => {
+  // The overflow bucket has no upper edge, so its percentile is the FLOOR:
+  // latP95 === 60 must read "≥60s" and lenP90Seconds === 7200 must read "≥2h".
+  assert.match(JS, /function fmtAtLeast\(v,lastEdge,fmt\)\{[\s\S]{0,120}v>=lastEdge\?"≥":""/);
+  assert.match(JS, /fmtAtLeast\(p95,60,fmtSecs\)/, 'latency percentiles carry the 60s overflow floor');
+  assert.match(JS, /fmtAtLeast\(p90,7200,fmtSecs\)/, 'session-length percentiles carry the 2h overflow floor');
+});
+
+test('the latency card states how latency was measured, on the card itself', () => {
+  assert.match(JS, /codex host-measured · claude\/opencode derived from event gaps — not streaming TTFT/);
+  assert.match(JS, /latP50/);
+  assert.match(JS, /latP95/);
+  assert.match(JS, /latCount/, 'the card says how many gaps it measured');
+  assert.match(JS, /no response latency measured in window/, 'nothing measured renders an empty state, not a zero');
+});
+
+test('the posture stack ships its own legend, because stackedDays draws none', () => {
+  assert.match(JS, /stackedDays\(\{days:days,order:present,palette:MODE_COLOR\}\)/);
+  assert.match(JS, /\+chartLegend\(legend\)/, 'the stacked chart is followed by an external legend');
+  assert.match(JS, /function chartLegend\(items\)/);
+  // The unobserved bucket is de-emphasis ink, never a posture color — so it
+  // deliberately has no palette entry of its own.
+  assert.match(JS, /var MODE_COLOR=\{plan:"var\(--purple\)",guarded:"var\(--ok\)","auto-edit":"var\(--accent\)",\s*unrestricted:"var\(--fail\)"\}/);
+  assert.doesNotMatch(JS, /MODE_COLOR=\{[^}]*not-recorded/);
+});
+
+test('how-you-run splits source and provider without attributing unobserved spend', () => {
+  assert.match(JS, /aValue:main,bValue:sub/, 'the donut is main vs subagent cost');
+  assert.match(JS, /d\.bySource/);
+  assert.match(JS, /entries\(d\.byInferenceProvider\)/);
+  assert.match(JS, /dim:x\.name==="not-recorded"/, 'unobserved provenance renders dim, never as a provider');
+  assert.match(JS, /attributed to an assumption/, 'the panel says why unobserved spend is held apart');
+});
+
 test('the scorecard panel grafts are idempotent — a re-render reuses its container', () => {
   // renderScore runs on every poll. ensureBlock returns the existing node
   // instead of inserting a second one; without that the scorecard would grow

--- a/tests/kit/dashboard-usage-telemetry.test.mjs
+++ b/tests/kit/dashboard-usage-telemetry.test.mjs
@@ -410,12 +410,16 @@ test('the posture stack ships its own legend, because stackedDays draws none', (
   assert.doesNotMatch(JS, /MODE_COLOR=\{[^}]*not-recorded/);
 });
 
-test('how-you-run splits source and provider without attributing unobserved spend', () => {
+// The panel is posture + delegation. It once carried a third block ranking
+// window spend by inference provider; a transcript host does not prove which
+// vendor served the tokens, so that axis was removed rather than shipped with
+// most of its spend in a "Not recorded" row. Provider identity is still on the
+// session row, where the evidence for it actually lives.
+test('how-you-run is posture and delegation, with no aggregate provider ranking', () => {
   assert.match(JS, /aValue:main,bValue:sub/, 'the donut is main vs subagent cost');
   assert.match(JS, /d\.bySource/);
-  assert.match(JS, /entries\(d\.byInferenceProvider\)/);
-  assert.match(JS, /dim:x\.name==="not-recorded"/, 'unobserved provenance renders dim, never as a provider');
-  assert.match(JS, /attributed to an assumption/, 'the panel says why unobserved spend is held apart');
+  assert.doesNotMatch(JS, /byInferenceProvider/);
+  assert.doesNotMatch(JS, /function providerRows/);
 });
 
 test('the tool list folds its tail into a dim Other instead of dropping it', () => {

--- a/tests/kit/dashboard-usage-telemetry.test.mjs
+++ b/tests/kit/dashboard-usage-telemetry.test.mjs
@@ -404,6 +404,47 @@ test('how-you-run splits source and provider without attributing unobserved spen
   assert.match(JS, /attributed to an assumption/, 'the panel says why unobserved spend is held apart');
 });
 
+test('the tool list folds its tail into a dim Other instead of dropping it', () => {
+  // A top-8 list that silently loses the rest misstates the total every share
+  // above it is read against, so the tail is summed and labelled.
+  assert.match(JS, /var TOOL_TOP=8/);
+  assert.match(JS, /list\.slice\(TOOL_TOP\)/, 'the tail is kept, not discarded');
+  assert.match(JS, /label:"Other \("\+tail\.length\+" tool"/);
+  assert.match(JS, /share:pct\(other,max\),dim:true/, 'Other is a residue, drawn dim');
+});
+
+test('model mix keeps four named families and folds the rest into one dim band', () => {
+  assert.match(JS, /var FAMILY_TOP=4/);
+  assert.match(JS, /byModelFamily/);
+  assert.match(JS, /function foldFamilies\(parts,keep\)/);
+  assert.match(JS, /order:\["other"\]\.concat\(keep\.slice\(\)\.reverse\(\)\)/, 'the fold sits at the base of the stack');
+  assert.match(JS, /\+chartLegend\(legend\)/, 'the stack is named by an external legend');
+  // modelFamily()'s own catch-all never competes for a top slot — it IS the
+  // residue bucket, whatever its size.
+  assert.match(JS, /for\(k in tot\)if\(k!=="other"\)/);
+});
+
+test('reliability states a rate with its denominator, and flags direction in words not only color', () => {
+  assert.match(JS, /exceptions \/ 1k responses/);
+  assert.match(JS, /\(Number\(t\.exceptions\)\|\|0\)\/r\*1000/);
+  assert.match(JS, /aborted turns/, 'aborts are counted apart from exceptions');
+  assert.match(JS, /an abort is a choice, not a failure/);
+  // Icon + words + color, never color alone.
+  assert.match(JS, /rel-flag" data-sev="warn"><i aria-hidden="true">▲<\/i>/);
+  assert.match(JS, /higher than the previous window/);
+  assert.match(JS, /lower than the previous window/);
+  assert.match(CSS, /\.rel-flag\[data-sev="warn"\]\{color:var\(--warn\)\}/);
+});
+
+test('reliability says why there is no per-day line rather than drawing an invented one', () => {
+  // byDay rows carry tokens/cost/sessions only — exceptions exist as a window
+  // total, so a daily trend cannot be read from this payload.
+  assert.match(JS, /No per-day line/);
+  assert.match(JS, /A daily trend would have to be invented rather than /);
+  assert.match(JS, /exceptions exist only as a window total/);
+  assert.doesNotMatch(JS, /sparklineSvg\([^)]*exception/i, 'no exceptions series is charted');
+});
+
 test('the scorecard panel grafts are idempotent — a re-render reuses its container', () => {
   // renderScore runs on every poll. ensureBlock returns the existing node
   // instead of inserting a second one; without that the scorecard would grow

--- a/tests/kit/dashboard-usage-telemetry.test.mjs
+++ b/tests/kit/dashboard-usage-telemetry.test.mjs
@@ -8,6 +8,9 @@ import { startDashboard } from '../../src/lib/dashboard-server.mjs';
 import { aggregate } from '../../src/lib/usage-aggregate.mjs';
 import { blankSession, addUsage } from '../../src/lib/usage-parsers.mjs';
 import { MODES } from '../../src/lib/usage-modes.mjs';
+import {
+  deltaChip, sparklineSvg, histogram, stackedDays, donut2, rankedRows,
+} from '../../src/lib/dashboard/client/usage-rhythm.mjs';
 
 const PAGE = renderPage({ name: 'agentic-kit', version: 'test' });
 
@@ -138,4 +141,109 @@ test('/api/usage payload carries rhythm, mode, provider and a previous-window pr
   } finally {
     await srv.close();
   }
+});
+
+// ── usage-rhythm.mjs: rhythm/mode chart primitives (Task 8) ────────────────
+//
+// These are pure string builders, imported directly here — real ESM on disk,
+// not read through the concatenated client.mjs bundle (that concatenation is
+// exercised separately, above, via the `JS` import). Task 9 wires these
+// exports into usage.mjs's panels.
+
+test('deltaChip renders an up arrow and a rounded percent for a positive change', () => {
+  const html = deltaChip(584, 540, {});
+  assert.match(html, /▲/);
+  assert.match(html, /8/);
+});
+
+test('deltaChip returns empty string when there is no previous window', () => {
+  assert.equal(deltaChip(5, null, {}), '');
+  assert.equal(deltaChip(5, undefined, {}), '');
+  assert.equal(deltaChip(5, 0, {}), '', 'a zero previous value carries no meaning either — no window to compare against');
+});
+
+test('deltaChip tones a downIsGood decrease as good, and neutral forces flat styling', () => {
+  const good = deltaChip(90, 100, { downIsGood: true });
+  assert.match(good, /data-tone="good"/);
+  assert.match(good, /▼/);
+  const neutral = deltaChip(584, 540, { neutral: true });
+  assert.match(neutral, /data-tone="flat"/);
+});
+
+test('deltaChip renders a unit-suffixed absolute delta instead of a percent when unit is given', () => {
+  const html = deltaChip(120, 90, { unit: 'ms' });
+  assert.match(html, /30ms/);
+  assert.doesNotMatch(html, /%/);
+});
+
+test('sparklineSvg draws a polyline with an accent endpoint dot for 2+ finite points', () => {
+  const html = sparklineSvg([1, 2, 3]);
+  assert.match(html, /<svg/);
+  assert.match(html, /polyline/);
+  assert.match(html, /circle/);
+});
+
+test('sparklineSvg returns empty string for fewer than 2 finite points', () => {
+  assert.equal(sparklineSvg([1]), '');
+  assert.equal(sparklineSvg([]), '');
+  assert.equal(sparklineSvg([1, NaN]), '', 'NaN is not a finite point, so only one point remains');
+});
+
+test('histogram renders a marker and its label, emitted before the bars so bars paint over the marker line', () => {
+  const html = histogram({ counts: [1, 5, 2], labels: ['<1s', '1-3s', '3s+'], markers: [{ atPct: 50, label: 'p50' }] });
+  assert.match(html, /p50/);
+  assert.match(html, /hist-marker/);
+  const markersIdx = html.indexOf('hist-markers');
+  const barsIdx = html.indexOf('hist-bars');
+  assert.ok(markersIdx >= 0 && barsIdx > markersIdx, 'markers must be emitted before bars so bars paint over them');
+});
+
+test('stackedDays maps not-recorded and other to the de-emphasis token, never a series color', () => {
+  const html = stackedDays({
+    days: [{ day: '2026-08-18', parts: { 'auto-edit': 4, 'not-recorded': 1, other: 2 } }],
+    order: ['not-recorded', 'other', 'auto-edit'],
+    palette: { 'auto-edit': 'var(--accent)', 'not-recorded': 'var(--fail)', other: 'var(--purple)' },
+  });
+  // The palette's own (wrong) colors for the two special keys must never appear.
+  assert.doesNotMatch(html, /var\(--fail\)/);
+  assert.doesNotMatch(html, /var\(--purple\)/);
+  assert.match(html, /var\(--ink-dim\)/);
+});
+
+test('donut2 renders both side labels and the center label', () => {
+  const html = donut2({ aLabel: 'Claude', aValue: 584, bLabel: 'Codex', bValue: 212, centerLabel: '73%' });
+  assert.match(html, /Claude/);
+  assert.match(html, /Codex/);
+  assert.match(html, /73%/);
+});
+
+test('rankedRows renders a dim row with the de-emphasis fill class', () => {
+  const html = rankedRows([{ label: 'Unclassified', value: '12', share: 40, dim: true }]);
+  assert.match(html, /rrow-fill dim/);
+});
+
+test('every chart primitive with a free-text field escapes an injected <script> label', () => {
+  // sparklineSvg is excluded — its only input is a plain number series, with
+  // no free-text field for a caller to inject through.
+  assert.doesNotMatch(deltaChip(120, 90, { unit: '<script>' }), /<script>/);
+  assert.doesNotMatch(
+    histogram({ counts: [1], labels: ['<script>'], markers: [{ atPct: 1, label: '<script>' }] }),
+    /<script>/,
+  );
+  assert.doesNotMatch(
+    stackedDays({ days: [{ day: '<script>', parts: { a: 1 } }], order: ['a'], palette: { a: '<script>' } }),
+    /<script>/,
+  );
+  assert.doesNotMatch(
+    donut2({ aLabel: '<script>', aValue: 1, bLabel: '<script>', bValue: 1, centerLabel: '<script>' }),
+    /<script>/,
+  );
+  assert.doesNotMatch(rankedRows([{ label: '<script>', value: '<script>', share: 50 }]), /<script>/);
+});
+
+test('usage styles append the rhythm/mode chart primitive classes with the mark-rule geometry', () => {
+  assert.match(CSS, /\.hist-fill\{[^}]*border-radius:4px 4px 0 0/, 'histogram bars get a 4px top radius');
+  assert.match(CSS, /\.sday-bar\{[^}]*gap:2px/, 'stacked-day segments get a 2px gap');
+  assert.match(CSS, /\.spark-line\{[^}]*stroke:var\(--ink-dim\)/, 'sparkline stroke is the de-emphasis ink');
+  assert.match(CSS, /\.spark-dot\{[^}]*fill:var\(--accent\)/, 'sparkline endpoint dot is the accent color');
 });

--- a/tests/kit/dashboard-usage-telemetry.test.mjs
+++ b/tests/kit/dashboard-usage-telemetry.test.mjs
@@ -1,8 +1,13 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import http from 'node:http';
 import { JS } from '../../src/lib/dashboard/client.mjs';
 import { renderPage } from '../../src/lib/dashboard/page.mjs';
 import { CSS } from '../../src/lib/dashboard/styles.mjs';
+import { startDashboard } from '../../src/lib/dashboard-server.mjs';
+import { aggregate } from '../../src/lib/usage-aggregate.mjs';
+import { blankSession, addUsage } from '../../src/lib/usage-parsers.mjs';
+import { MODES } from '../../src/lib/usage-modes.mjs';
 
 const PAGE = renderPage({ name: 'agentic-kit', version: 'test' });
 
@@ -22,4 +27,115 @@ test('usage dashboard keeps unsupported and unavailable capability states distin
   assert.match(JS, /data-state=/);
   assert.match(JS, /source\.diagnostics&&source\.diagnostics\.common/);
   assert.match(JS, /source\.capabilities\|\|\{\}/);
+});
+
+// ── /api/usage payload: rhythm, mode, provider, previous window ────────────
+//
+// The dashboard-server route delegates its entire aggregation to an
+// INJECTED `usage.readIndex` (see tests/dashboard.test.cjs's spyUsage()
+// convention), so a real end-to-end exercise here means the fake readIndex
+// itself must behave like usage-index.mjs's corrected contract: always
+// aggregate the DISPLAYED window at `now - days*DAY_MS`, and forward
+// `previous` verbatim. That is deliberate — it is what actually proves
+// dashboard-server.mjs passes `lookbackDays`/`previous` through, rather than
+// a canned fixture that would pass regardless of what handleUsage sends.
+//
+// Fixture records are built with usage-parsers.mjs's own blankSession/
+// addUsage — the same construction tests/kit/usage-index.test.mjs's local
+// `record()` helper uses (that helper is not exported, so it is restated
+// here in miniature rather than imported).
+const DAY_MS = 86_400_000;
+const NOW = Date.parse('2026-08-20T12:00:00.000Z');
+
+function usageRecord(id, { end, mode = null, usageRows = [] }) {
+  const rec = blankSession(id, 'claude');
+  const start = end - 30 * 60_000;
+  Object.assign(rec, { title: id, project: 'proj', prompts: 1, responses: 1, start, end, mode });
+  rec.active = [[start, end]];
+  for (const u of usageRows) addUsage(rec, u.day, u.model, u);
+  rec.models = [...new Set(usageRows.map((u) => u.model))];
+  rec.lenSeconds = Math.round((end - start) / 1000);
+  return rec;
+}
+
+const FIXTURE_RECORDS = [
+  // Inside the displayed 7-day window.
+  usageRecord('cur', {
+    end: NOW - 2 * DAY_MS,
+    mode: 'auto-edit',
+    usageRows: [{ day: '2026-08-18', model: 'claude-opus-5', input: 1000, output: 500, cacheRead: 0, cacheWrite: 0, responses: 1 }],
+  }),
+  // 10 days back — outside the 7-day display window, but inside the
+  // previous [14d, 7d) window once lookbackDays widens discovery.
+  usageRecord('prev', {
+    end: NOW - 10 * DAY_MS,
+    usageRows: [{ day: '2026-08-10', model: 'claude-opus-5', input: 800, output: 400, cacheRead: 0, cacheWrite: 0, responses: 1 }],
+  }),
+];
+
+const FIXTURE_DEPS = {
+  costOf: ({ input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }) => (input + output + cacheRead + cacheWrite) / 1000,
+  pricesAsOf: '2026-08-01',
+  classify: () => ({ category: 'Unclassified', confidence: 0, basis: 'no signal' }),
+  detectInsights: () => [],
+};
+
+function get(url, token) {
+  return new Promise((resolve, reject) => {
+    http.get(url, { headers: { 'x-dash-token': token } }, (res) => {
+      let body = '';
+      res.setEncoding('utf8');
+      res.on('data', (c) => { body += c; });
+      res.on('end', () => resolve({ status: res.statusCode, body }));
+    }).on('error', reject);
+  });
+}
+
+test('/api/usage payload carries rhythm, mode, provider and a previous-window projection', async () => {
+  const calls = [];
+  // Mirrors usage-index.mjs's corrected buildIndex/scan contract (Task 7
+  // ruling B): `aggregate` always sees the DISPLAY cutoff, and `previous`
+  // rides through from the caller's own options unchanged.
+  const usage = {
+    readIndex: async (opts) => {
+      calls.push(opts);
+      const days = opts?.days ?? 14;
+      return aggregate(FIXTURE_RECORDS, {
+        days, now: NOW, cutoff: NOW - days * DAY_MS, deps: FIXTURE_DEPS, previous: !!opts?.previous,
+      });
+    },
+  };
+  const srv = await startDashboard({
+    port: 0, fetchStatus: async () => ({ overall: 'ok', rows: [] }), usage,
+  });
+  try {
+    const r = await get(`${srv.url}api/usage?days=7`, srv.token);
+    assert.equal(r.status, 200, `expected 200, got ${r.status}`);
+    const payload = JSON.parse(r.body);
+
+    assert.equal(payload.rhythm.latHist.length, 6, 'the latency histogram always has 6 buckets');
+
+    const allowedModes = new Set([...MODES, 'not-recorded']);
+    for (const key of Object.keys(payload.byMode)) {
+      assert.ok(allowedModes.has(key), `unexpected byMode key ${JSON.stringify(key)}`);
+    }
+
+    assert.equal(typeof payload.engagedByDay, 'object');
+    assert.ok(payload.engagedByDay && !Array.isArray(payload.engagedByDay), 'engagedByDay is a plain map, not an array');
+    for (const v of Object.values(payload.engagedByDay)) {
+      assert.ok(Number.isFinite(v), `engagedByDay value ${v} must be finite`);
+    }
+
+    assert.ok(payload.previous && typeof payload.previous === 'object', 'previous must be populated once fixture data spans two windows');
+    assert.ok(payload.previous.totals && typeof payload.previous.totals === 'object',
+      'previous.totals must exist — this is what proves lookbackDays/previous actually reached readIndex');
+    assert.equal(payload.previous.totals.sessions, 1, 'only the 10-day-old session falls in the previous window');
+
+    const call = calls.find((o) => o && o.days === 7);
+    assert.ok(call, `days must reach readIndex, got ${JSON.stringify(calls)}`);
+    assert.equal(call.lookbackDays, 14, 'lookbackDays must widen to 2x the displayed window');
+    assert.equal(call.previous, true, 'previous must be requested so agg.previous is populated');
+  } finally {
+    await srv.close();
+  }
 });

--- a/tests/kit/dashboard-usage-telemetry.test.mjs
+++ b/tests/kit/dashboard-usage-telemetry.test.mjs
@@ -189,13 +189,19 @@ test('sparklineSvg returns empty string for fewer than 2 finite points', () => {
   assert.equal(sparklineSvg([1, NaN]), '', 'NaN is not a finite point, so only one point remains');
 });
 
-test('histogram renders a marker and its label, emitted before the bars so bars paint over the marker line', () => {
+test('histogram renders a marker and its label, with the bars emitted after the markers in DOM order', () => {
+  // DOM order alone does not prove paint order (a positioned element paints
+  // above a non-positioned one regardless of DOM order — see the mark-rule
+  // geometry test below for the CSS half of this: .hist-bars must ALSO be
+  // positioned for "markers first" to actually put bars on top). This only
+  // asserts the half a string test can honestly observe: markup order.
+  // Task 9's screenshot verification is what confirms the rendered result.
   const html = histogram({ counts: [1, 5, 2], labels: ['<1s', '1-3s', '3s+'], markers: [{ atPct: 50, label: 'p50' }] });
   assert.match(html, /p50/);
   assert.match(html, /hist-marker/);
   const markersIdx = html.indexOf('hist-markers');
   const barsIdx = html.indexOf('hist-bars');
-  assert.ok(markersIdx >= 0 && barsIdx > markersIdx, 'markers must be emitted before bars so bars paint over them');
+  assert.ok(markersIdx >= 0 && barsIdx > markersIdx, 'markers must be emitted before bars in the markup');
 });
 
 test('stackedDays maps not-recorded and other to the de-emphasis token, never a series color', () => {
@@ -246,4 +252,11 @@ test('usage styles append the rhythm/mode chart primitive classes with the mark-
   assert.match(CSS, /\.sday-bar\{[^}]*gap:2px/, 'stacked-day segments get a 2px gap');
   assert.match(CSS, /\.spark-line\{[^}]*stroke:var\(--ink-dim\)/, 'sparkline stroke is the de-emphasis ink');
   assert.match(CSS, /\.spark-dot\{[^}]*fill:var\(--accent\)/, 'sparkline endpoint dot is the accent color');
+  // Structural half of "bars paint over marker lines": a positioned element
+  // paints above a non-positioned one regardless of DOM order, so .hist-bars
+  // must carry position:relative to even be eligible to win against the
+  // positioned .hist-markers overlay — DOM order (asserted above, in the
+  // histogram test) is the other half. This can't observe rendered paint
+  // order itself; it only guards the CSS declaration that makes it possible.
+  assert.match(CSS, /\.hist-bars\{[^}]*position:relative/, 'hist-bars must be positioned to paint over the positioned marker overlay');
 });

--- a/tests/kit/dashboard-usage-telemetry.test.mjs
+++ b/tests/kit/dashboard-usage-telemetry.test.mjs
@@ -18,22 +18,16 @@ import {
 
 const PAGE = renderPage({ name: 'agentic-kit', version: 'test' });
 
-test('usage dashboard includes a visible host-neutral telemetry coverage surface', () => {
-  assert.match(PAGE, /id="u-telemetry-grid"/);
-  assert.match(PAGE, />telemetry coverage</);
-  assert.match(JS, /function renderTelemetryCoverage/);
-  assert.match(JS, /coverage not reported by this API/);
-  assert.match(JS, /label:"Codex transcript"/);
-  assert.match(JS, /coverage unavailable/);
-  assert.match(JS, /data-state=/);
-  assert.match(CSS, /\.telemetry-card/);
-});
-
-test('usage dashboard keeps unsupported and unavailable capability states distinct', () => {
-  assert.match(JS, /String\(capabilities\[item\[0\]\]\|\|"unavailable"\)/);
-  assert.match(JS, /data-state=/);
-  assert.match(JS, /source\.diagnostics&&source\.diagnostics\.common/);
-  assert.match(JS, /source\.capabilities\|\|\{\}/);
+// The telemetry-coverage panel is gone: it published a per-host capability
+// matrix — a claim about what a parser could report — beside the scorecard's
+// measured figures, where a reader could not tell the two apart. Source
+// STATUS still reaches the reader, in the tabbar pills, on every tab.
+test('the scorecard no longer ships a telemetry coverage panel', () => {
+  assert.doesNotMatch(PAGE, /u-telemetry/);
+  assert.doesNotMatch(PAGE, /telemetry coverage/i);
+  assert.doesNotMatch(JS, /renderTelemetryCoverage/);
+  assert.doesNotMatch(JS, /telemetry coverage/i);
+  assert.doesNotMatch(CSS, /\.telemetry-(card|grid)/);
 });
 
 // ── /api/usage payload: rhythm, mode, provider, previous window ────────────

--- a/tests/kit/dashboard-usage-telemetry.test.mjs
+++ b/tests/kit/dashboard-usage-telemetry.test.mjs
@@ -548,17 +548,19 @@ test('the fields the chips read are actually projected onto the session row', ()
   assert.equal(row.ctxWindow, 200_000, 'the ctx chip has a denominator');
   assert.equal(row.ctxLastTokens, 151_000, 'the ctx chip has a numerator');
   // …and the client reads exactly those names.
-  assert.match(JS, /rawSpelling\(sx\.modeRaw\)/);
+  assert.match(JS, /reportedIdentity\(sx\.modeRaw\)/);
   assert.match(JS, /Number\(sx\.ctxLastTokens\),win=Number\(sx\.ctxWindow\)/);
 });
 
-test('a raw spelling that is a failed toString is refused, not printed into a tooltip', () => {
-  // Live data: every Codex row carries modeRaw "never/[object Object]" —
-  // usage-modes.mjs joins Codex's sandboxPolicy into the string and that field
-  // is an object. Printing it would put the dashboard's own rendering-artifact
-  // sentinel inside a tooltip, so it is treated as not-recorded.
-  assert.match(JS, /function rawSpelling\(v\)\{\s*var s=reportedIdentity\(v\);\s*return \(s&&s\.indexOf\("\[object "\)<0\)\?s:null;/);
-  assert.doesNotMatch(JS, /reportedIdentity\(sx\.modeRaw\)/, 'the unguarded read must not survive anywhere');
+test('the host spelling is rendered, not filtered — the "[object Object]" band-aid is gone', () => {
+  // The client used to refuse any modeRaw containing "[object " because every
+  // live Codex row carried "never/[object Object]": usage-parsers joined
+  // Codex's sandbox_policy OBJECT into the raw string. The parser now extracts
+  // `.type` (pinned end-to-end in usage-index-v6.test.mjs against the real wire
+  // shape), so the wreckage no longer exists to filter and the client renders
+  // the spelling the host actually recorded.
+  assert.doesNotMatch(JS, /rawSpelling/, 'the band-aid and every call to it are removed');
+  assert.doesNotMatch(JS, /indexOf\("\[object "\)/, 'no sentinel-string filtering survives');
 });
 
 test('the context chip requires BOTH halves, and is omitted rather than divided by a guess', () => {

--- a/tests/kit/quota.test.mjs
+++ b/tests/kit/quota.test.mjs
@@ -133,6 +133,66 @@ test('normalizeCodexLimits falls back to the legacy single-bucket view', () => {
   assert.equal(n.lanes[0].id, 'codex');
 });
 
+// ── One pool reported twice ─────────────────────────────────────────────────
+//
+// LIVE SHAPE, observed 2026-08-29: app-server reports the same weekly pool
+// under BOTH the named model-pool lane and the legacy generic `codex` lane —
+// identical windowDurationMins, identical resetsAt, identical usedPercent. The
+// panel drew two identical meters and the limit detectors counted one pool as
+// two. The named lane also carries a 5h window the generic lane never had.
+const CODEX_DUP_RESP = {
+  rateLimits: {
+    limitId: 'codex', limitName: null, planType: 'prolite',
+    primary: { usedPercent: 21, windowDurationMins: 10080, resetsAt: 1788624681 },
+    secondary: null,
+  },
+  rateLimitsByLimitId: {
+    codex_bengalfox: {
+      limitId: 'codex_bengalfox', limitName: 'GPT-5.3-Codex-Spark', planType: 'prolite',
+      primary: { usedPercent: 7, windowDurationMins: 300, resetsAt: 1788571234 },
+      secondary: { usedPercent: 21, windowDurationMins: 10080, resetsAt: 1788624681 },
+    },
+    codex: {
+      limitId: 'codex', limitName: null, planType: 'prolite',
+      primary: { usedPercent: 21, windowDurationMins: 10080, resetsAt: 1788624681 },
+      secondary: null,
+    },
+  },
+};
+
+test('a window reported under both the named pool and the generic codex lane renders once', () => {
+  const n = normalizeCodexLimits(CODEX_DUP_RESP);
+  // The generic lane held nothing but the duplicate, so it goes with it —
+  // an empty "codex" lane would still draw a "no window reported" row.
+  assert.deepEqual(n.lanes.map((l) => l.id), ['codex_bengalfox']);
+  const windows = n.lanes[0].windows;
+  assert.deepEqual(windows.map((w) => w.label), ['5h', 'weekly'],
+    'the named lane keeps BOTH its windows — dedup drops the copy, not the pool');
+  assert.equal(windows[1].usedPercent, 21);
+  assert.equal(windows[1].resetsAt, 1788624681);
+});
+
+test('lanes whose percentages differ are different pools, and both render', () => {
+  const resp = structuredClone(CODEX_DUP_RESP);
+  resp.rateLimitsByLimitId.codex.primary.usedPercent = 22;
+  const n = normalizeCodexLimits(resp);
+  assert.deepEqual(n.lanes.map((l) => l.id), ['codex_bengalfox', 'codex']);
+  assert.equal(n.lanes[1].windows.length, 1, 'the generic weekly survives on a percentage difference');
+  // Same guard on the reset instant: matching duration alone is not identity.
+  const other = structuredClone(CODEX_DUP_RESP);
+  other.rateLimitsByLimitId.codex.primary.resetsAt = 1788624999;
+  assert.equal(normalizeCodexLimits(other).lanes.length, 2);
+});
+
+test('a generic-only payload is untouched — older codex builds keep their one lane', () => {
+  const n = normalizeCodexLimits({
+    rateLimitsByLimitId: { codex: CODEX_DUP_RESP.rateLimitsByLimitId.codex },
+  });
+  assert.deepEqual(n.lanes.map((l) => l.id), ['codex']);
+  assert.equal(n.lanes[0].windows.length, 1);
+  assert.equal(n.lanes[0].windows[0].label, 'weekly');
+});
+
 test('normalizeCodexLimits returns null on nothing usable', () => {
   assert.equal(normalizeCodexLimits(null), null);
   assert.equal(normalizeCodexLimits({}), null);

--- a/tests/kit/usage-cli.test.mjs
+++ b/tests/kit/usage-cli.test.mjs
@@ -136,7 +136,9 @@ test('ak usage score prints the offline scorecard summary', () => {
   assert.equal(result.status, 0, result.stderr);
   assert.match(result.stdout, /AUTONOMY/, 'cadence must render an autonomy row');
   assert.match(result.stdout, /not-recorded/,
-    'a session with no mode/provider evidence must fold into an explicit not-recorded row');
+    'a session with no mode evidence must fold into an explicit not-recorded row');
+  assert.doesNotMatch(result.stdout, /served by/i,
+    'inference provider is per-session evidence, not one of the window tables');
   assert.match(result.stdout, /list price/i, 'the api-equivalent hero tile must carry the list-price disclaimer');
   assert.match(result.stdout, /not plan billing/, 'the disclaimer must say this is not plan billing');
   assert.match(result.stdout, /<\$0\.01/,
@@ -151,7 +153,7 @@ test('ak usage score --json emits the aggregate projection verbatim', () => {
   const result = ak(['usage', 'score', '--json'], sb);
   assert.equal(result.status, 0, result.stderr);
   const value = JSON.parse(result.stdout);
-  assert.deepEqual(Object.keys(value), ['window', 'totals', 'rhythm', 'byMode', 'byInferenceProvider', 'bySource', 'previous']);
+  assert.deepEqual(Object.keys(value), ['window', 'totals', 'rhythm', 'byMode', 'bySource', 'previous']);
   assert.equal(value.window, 14, 'default window is 14 days');
   assert.equal(value.totals.sessions, 1);
   // Latency histogram is a FIXED 6-slot shape (5 edges + one overflow bucket) —

--- a/tests/kit/usage-cli.test.mjs
+++ b/tests/kit/usage-cli.test.mjs
@@ -147,6 +147,25 @@ test('ak usage score prints the offline scorecard summary', () => {
   fs.rmSync(sb.home, { recursive: true, force: true });
 });
 
+// Section headings are Sentence case, the same tier and the same argument as
+// the dashboard panel titles they mirror. The command banner is not a section
+// heading and keeps the CLI's own spelling.
+test('ak usage score section headings are sentence-cased; the command banner is not', () => {
+  const sb = sandbox();
+  writeScoreSession(sb, 'score-fixture-headings');
+  const result = ak(['usage', 'score'], sb);
+  assert.equal(result.status, 0, result.stderr);
+  for (const heading of [
+    'Cadence',
+    'Your rhythm — session length',
+    'Mode — permission posture',
+    'Reliability — turns that never landed',
+  ]) assert.ok(result.stdout.includes(heading), `missing heading ${JSON.stringify(heading)}`);
+  assert.match(result.stdout, /ak usage — scorecard \(last \d+d\)/,
+    'the command banner keeps its own spelling');
+  fs.rmSync(sb.home, { recursive: true, force: true });
+});
+
 test('ak usage score --json emits the aggregate projection verbatim', () => {
   const sb = sandbox();
   writeScoreSession(sb, 'score-fixture-2');

--- a/tests/kit/usage-cli.test.mjs
+++ b/tests/kit/usage-cli.test.mjs
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { MODES } from '../../src/lib/usage-modes.mjs';
 
 const BIN = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../bin/agentic-kit.mjs');
 
@@ -17,6 +18,39 @@ function sandbox() {
   fs.writeFileSync(path.join(bin, 'npm'), `#!/bin/sh\nprintf called > "${sentinel}"\nexit 99\n`, { mode: 0o755 });
   fs.writeFileSync(path.join(bin, 'npm.cmd'), `@echo called>"${sentinel}"\r\nexit /b 99\r\n`);
   return { home, cfg, bin, sentinel };
+}
+
+/** One real, tiny-priced Claude session written straight to the sandbox HOME's
+ *  transcript root (`~/.claude/projects/**\/*.jsonl`, same shape `writeSession`
+ *  in usage-truncation.test.mjs already proves parseClaude accepts) — `ak usage
+ *  score` is a subprocess, so there is no `roots` override seam to inject a
+ *  fixture through; disk under the sandboxed HOME is the only lever available.
+ *  Recent timestamps (computed at call time, not hardcoded) keep the session
+ *  inside every supported --window without the test rotting as the calendar
+ *  moves on. `claude-opus-5` at 1 input + 1 output token prices to a REAL
+ *  positive figure that rounds away at two decimals ($0.00003) — this is how
+ *  the sub-cent cost/session case is exercised, with no injected pricing dep. */
+function writeScoreSession(sb, id) {
+  const projectDir = path.join(sb.home, '.claude', 'projects', '-tmp-score-fixture');
+  fs.mkdirSync(projectDir, { recursive: true });
+  const userAt = new Date(Date.now() - 60_000).toISOString();
+  const asstAt = new Date(Date.now() - 30_000).toISOString();
+  fs.writeFileSync(path.join(projectDir, `${id}.jsonl`), [
+    JSON.stringify({
+      type: 'user', sessionId: id, cwd: '/tmp/score-fixture',
+      timestamp: userAt,
+      message: { role: 'user', content: [{ type: 'text', text: 'hello scorecard' }] },
+    }),
+    JSON.stringify({
+      type: 'assistant', sessionId: id, cwd: '/tmp/score-fixture',
+      timestamp: asstAt,
+      message: {
+        role: 'assistant', model: 'claude-opus-5',
+        usage: { input_tokens: 1, output_tokens: 1 },
+        content: [{ type: 'text', text: 'hi there' }],
+      },
+    }),
+  ].join('\n') + '\n');
 }
 
 function ak(args, sb, extra = {}) {
@@ -91,4 +125,72 @@ test('ak usage rejects unsupported providers and actions', () => {
   assert.equal(result.status, 2);
   assert.match(result.stdout, /usage: ak usage status/);
   fs.rmSync(sb.home, { recursive: true, force: true });
+});
+
+// ── score: offline text scorecard over the dashboard's own aggregate ────────
+
+test('ak usage score prints the offline scorecard summary', () => {
+  const sb = sandbox();
+  writeScoreSession(sb, 'score-fixture-1');
+  const result = ak(['usage', 'score'], sb);
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /AUTONOMY/, 'cadence must render an autonomy row');
+  assert.match(result.stdout, /not-recorded/,
+    'a session with no mode/provider evidence must fold into an explicit not-recorded row');
+  assert.match(result.stdout, /list price/i, 'the api-equivalent hero tile must carry the list-price disclaimer');
+  assert.match(result.stdout, /not plan billing/, 'the disclaimer must say this is not plan billing');
+  assert.match(result.stdout, /<\$0\.01/,
+    'a real sub-cent priced session (1 input + 1 output token) must render as <$0.01, never $0.00');
+  assert.equal(fs.existsSync(sb.sentinel), false, 'score must never execute npm — offline only');
+  fs.rmSync(sb.home, { recursive: true, force: true });
+});
+
+test('ak usage score --json emits the aggregate projection verbatim', () => {
+  const sb = sandbox();
+  writeScoreSession(sb, 'score-fixture-2');
+  const result = ak(['usage', 'score', '--json'], sb);
+  assert.equal(result.status, 0, result.stderr);
+  const value = JSON.parse(result.stdout);
+  assert.deepEqual(Object.keys(value), ['window', 'totals', 'rhythm', 'byMode', 'byInferenceProvider', 'bySource', 'previous']);
+  assert.equal(value.window, 14, 'default window is 14 days');
+  assert.equal(value.totals.sessions, 1);
+  // Latency histogram is a FIXED 6-slot shape (5 edges + one overflow bucket) —
+  // structurally always this length, whether or not any session observed a
+  // latency sample, so this assertion needs no additional fixture tuning.
+  assert.equal(value.rhythm.latHist.length, 6);
+  const allowedModes = new Set([...MODES, 'not-recorded']);
+  for (const key of Object.keys(value.byMode)) {
+    assert.ok(allowedModes.has(key), `byMode key '${key}' must be in the closed mode taxonomy or 'not-recorded'`);
+  }
+  assert.ok(Object.hasOwn(value.byMode, 'not-recorded'), 'the fixture session carries no mode evidence');
+  assert.ok(value.totals.costPerSessionMedian > 0 && value.totals.costPerSessionMedian < 0.01,
+    'the fixture session is priced sub-cent');
+  fs.rmSync(sb.home, { recursive: true, force: true });
+});
+
+test('ak usage score --window 9 rejects an unsupported window cleanly', () => {
+  const sb = sandbox();
+  const result = ak(['usage', 'score', '--window', '9'], sb);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stdout, /--window/);
+  assert.match(result.stdout, /7.*14.*30|30.*14.*7/, 'the error must name the supported windows');
+  assert.equal(fs.existsSync(sb.sentinel), false);
+  fs.rmSync(sb.home, { recursive: true, force: true });
+});
+
+// The <$0.01 rendering rule itself (a positive figure that rounds away at two
+// decimals must not print as $0.00) is exercised end-to-end by the fixture
+// test above via a REAL priced session; this test additionally pins the exact
+// boundary (a true $0 stays "$0.00", never "<$0.01") that the fixture's single
+// data point cannot demonstrate on its own — both a real sub-cent session AND
+// a true-zero session are needed to prove the branch, and constructing a
+// SECOND fixture transcript whose priced total is exactly zero is
+// disproportionate (a session prices to exactly $0 only by carrying no usage
+// rows at all, which the aggregate already excludes from the priced set —
+// so this checks the pure formatter directly instead of a fixture.
+test('formatCostMin ("<$0.01" boundary) — true zero is never rendered as sub-cent', async () => {
+  const { __test } = await import('../../src/commands/usage.mjs');
+  assert.equal(__test.fmtUsdMin(0), '$0.00', 'a true zero is not "less than a cent" — it is nothing');
+  assert.equal(__test.fmtUsdMin(0.00003), '<$0.01', 'a real positive figure under a cent is not $0.00');
+  assert.equal(__test.fmtUsdMin(0.02), '$0.02', 'a figure that does not round away renders normally');
 });

--- a/tests/kit/usage-index-opencode.test.mjs
+++ b/tests/kit/usage-index-opencode.test.mjs
@@ -217,6 +217,48 @@ test('readSession returns the meta + turns payload for an opencode session', asy
   rm(sb.dir);
 });
 
+// The state the pricing fallback exists FOR: opencode's usageRow.costObserved
+// stays null when no assistant message carried a `cost` field (a local model
+// opencode does not price, an interrupted session). sessionCost must then reach
+// the pricer — so readSession's opencode branch has to hand one down, exactly
+// as its claude/codex branch does. Omitting it threw TypeError (costOf of
+// undefined) and surfaced as a 500 with the internal shape in the body.
+test('readSession prices an opencode session whose rows carry NO observed cost', async () => {
+  const at = NOW - DAY;
+  const sb = sandbox({
+    sessions: [{ id: 'ses_oc7', directory: '/x', title: 'uncosted transcript', timeCreated: at }],
+    messages: [
+      userMsg('u1', 'ses_oc7', at),
+      assistantMsg('a1', 'ses_oc7', at + 1000), // no `cost` field at all → costObserved stays null
+    ],
+  });
+  const db = new DatabaseSync(sb.dbFile);
+  const insP = db.prepare('INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)');
+  insP.run('p1', 'u1', 'ses_oc7', at, at, JSON.stringify({ type: 'text', text: 'run it locally' }));
+  insP.run('p2', 'a1', 'ses_oc7', at + 1000, at + 1000, JSON.stringify({ type: 'text', text: 'done' }));
+  db.close();
+
+  const out = await readSession('ses_oc7', { roots: sb.roots, deps: deps() });
+  assert.ok(out, 'payload returned rather than throwing');
+  assert.equal(out.meta.cost, (1000 + 100 + 200 + 10) / 1000,
+    'the injected pricer priced the row the transcript never costed');
+  rm(sb.dir);
+});
+
+// Same data state with NO injected deps: readSession must load the real pricer
+// rather than handing sessionCost `undefined`.
+test('readSession loads the default pricer for an uncosted opencode session', async () => {
+  const at = NOW - DAY;
+  const sb = sandbox({
+    sessions: [{ id: 'ses_oc8', directory: '/x', title: 'uncosted, real pricer', timeCreated: at }],
+    messages: [userMsg('u1', 'ses_oc8', at), assistantMsg('a1', 'ses_oc8', at + 1000)],
+  });
+  const out = await readSession('ses_oc8', { roots: sb.roots });
+  assert.ok(out, 'payload returned rather than throwing');
+  assert.equal(typeof out.meta.cost, 'number', 'a real number, from the real pricing table');
+  rm(sb.dir);
+});
+
 test('an opencode session with zero assistant responses never reaches the aggregate', async () => {
   const at = NOW - DAY;
   const sb = sandbox({

--- a/tests/kit/usage-index-opencode.test.mjs
+++ b/tests/kit/usage-index-opencode.test.mjs
@@ -168,8 +168,6 @@ test('a corrupt OpenCode store preserves last-good usage and surfaces degraded s
   const degraded = await buildIndex(opts(sb));
   assert.equal(degraded.sourceHealth.opencode.status, 'degraded');
   assert.equal(degraded.sourceHealth.opencode.reason, 'corrupt');
-  assert.equal(degraded.sourceHealth.opencode.capabilities.prompts, 'unavailable');
-  assert.equal(degraded.sourceHealth.opencode.capabilities.toolCalls, 'unavailable');
   assert.equal(degraded.sourceHealth.opencode.diagnostics.common.unitsSeen, 0);
   assert.equal(degraded.sessions.find((x) => x.id === 'ses_last_good').cost, 0.4,
     'a transient source failure must not become an observed zero');

--- a/tests/kit/usage-index-v6.test.mjs
+++ b/tests/kit/usage-index-v6.test.mjs
@@ -285,3 +285,15 @@ test('parseCodex v11: mode, duration, aborts, ctx window, typed tools', () => {
   assert.equal(rec.ctxWindow, 272000);
   assert.equal(rec.tools.CommandExecution, 1);
 });
+
+test('parseCodex v11: turn_aborted clears pending latency state so a later agent_message is not mis-sampled', () => {
+  const plusSec = (t, s) => new Date(Date.parse(t) + s * 1000).toISOString();
+  const lines = [
+    JSON.stringify({ type: 'session_meta', payload: { id: 'cx2', cwd: '/tmp/p', thread_source: 'user' }, timestamp: T0 }),
+    JSON.stringify({ type: 'event_msg', payload: { type: 'user_message', message: 'go' }, timestamp: T0 }),
+    JSON.stringify({ type: 'event_msg', payload: { type: 'turn_aborted', reason: 'user_interrupt', turn_id: 't1' }, timestamp: plusSec(T0, 3) }),
+    JSON.stringify({ type: 'event_msg', payload: { type: 'agent_message', message: 'unrelated' }, timestamp: plusSec(T0, 120) }),
+  ].join('\n');
+  const { session: rec } = parseCodex(lines, { id: 'cx2' });
+  assert.equal(rec.latCount, 0);
+});

--- a/tests/kit/usage-index-v6.test.mjs
+++ b/tests/kit/usage-index-v6.test.mjs
@@ -8,6 +8,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { buildIndex, readSession, _resetForTest } from '../../src/lib/usage-index.mjs';
+import { parseCodex } from '../../src/lib/usage-parsers.mjs';
 
 const NOW = Date.parse('2026-07-25T12:00:00.000Z');
 const T0 = '2026-07-24T09:00:00.000Z';
@@ -260,4 +261,27 @@ test('buildIndex applies an injected Codex ledger: subagent stripped without a r
   _resetForTest();
   const without = await buildIndex(opts(sb, { force: true, codexState: null }));
   assert.equal(without.sessions.find((x) => x.id === 'dddd4444').tokens, 604000);
+});
+
+test('parseCodex v11: mode, duration, aborts, ctx window, typed tools', () => {
+  const plusSec = (t, s) => new Date(Date.parse(t) + s * 1000).toISOString();
+  const lines = [
+    JSON.stringify({ type: 'session_meta', payload: { id: 'cx1', cwd: '/tmp/p', thread_source: 'user' }, timestamp: T0 }),
+    JSON.stringify({ type: 'turn_context', payload: { model: 'gpt-5.6', approval_policy: 'never', sandbox_policy: 'workspace-write' }, timestamp: T0 }),
+    JSON.stringify({ type: 'event_msg', payload: { type: 'task_started', started_at: T0, model_context_window: 272000, turn_id: 't1' }, timestamp: T0 }),
+    JSON.stringify({ type: 'event_msg', payload: { type: 'user_message', message: 'go' }, timestamp: T0 }),
+    JSON.stringify({ type: 'event_msg', payload: { type: 'agent_message', message: 'done' }, timestamp: plusSec(T0, 6) }),
+    JSON.stringify({ type: 'event_msg', payload: { type: 'item_completed', item: { type: 'CommandExecution' } }, timestamp: plusSec(T0, 7) }),
+    JSON.stringify({ type: 'event_msg', payload: { type: 'task_complete', duration_ms: 9000, error: null, turn_id: 't1' }, timestamp: plusSec(T0, 9) }),
+    JSON.stringify({ type: 'event_msg', payload: { type: 'turn_aborted', reason: 'user_interrupt', turn_id: 't2' }, timestamp: plusSec(T0, 20) }),
+    JSON.stringify({ type: 'event_msg', payload: { type: 'token_count', info: { total_token_usage: { input_tokens: 5000, cached_input_tokens: 4000, output_tokens: 300 } } }, timestamp: plusSec(T0, 21) }),
+  ].join('\n');
+  const { session: rec } = parseCodex(lines, { id: 'cx1' });
+  assert.equal(rec.mode, 'auto-edit');
+  assert.equal(rec.modeRaw, 'never/workspace-write');
+  assert.equal(rec.latCount, 1);
+  assert.equal(rec.latHist[2], 1);           // 6s prompt→agent gap
+  assert.equal(rec.aborts, 1);
+  assert.equal(rec.ctxWindow, 272000);
+  assert.equal(rec.tools.CommandExecution, 1);
 });

--- a/tests/kit/usage-index-v6.test.mjs
+++ b/tests/kit/usage-index-v6.test.mjs
@@ -400,3 +400,36 @@ test('parseCodex v11: turn_aborted clears pending latency state so a later agent
   const { session: rec } = parseCodex(lines, { id: 'cx2' });
   assert.equal(rec.latCount, 0);
 });
+
+// Sub-agent rollouts replay their PARENT thread's entire prior history before
+// their own new turns (openai/codex thread_spawn behavior — see parseCodex's
+// own doc comment), including the parent's OWN session_meta line further down
+// the file. handleCodexMeta was last-wins, so that replayed parent meta
+// relabeled rec.threadSource subagent→user and re-keyed rec.id to the
+// parent's — letting the subagent's (parent-duplicating) token totals escape
+// finalizeCodexUsage's guard entirely. Measured on the reference corpus: 155
+// of 318 subagent-first rollouts relabeled this way.
+test('parseCodex: FIRST session_meta wins identity — a replayed parent meta cannot relabel a subagent rollout', () => {
+  const subagentThenParentReplay = [
+    JSON.stringify({ type: 'session_meta', payload: { id: 'subA', cwd: '/tmp/p', thread_source: 'subagent' }, timestamp: T0 }),
+    JSON.stringify({ type: 'event_msg', payload: { type: 'user_message', message: 'delegated task' }, timestamp: T0 }),
+    JSON.stringify({ type: 'event_msg', payload: { type: 'token_count', info: { total_token_usage: { input_tokens: 900000, cached_input_tokens: 800000, output_tokens: 9000, total_tokens: 909000 } } }, timestamp: T0 }),
+    // The thread_spawn replay: the PARENT's own session_meta line, later in the same file.
+    JSON.stringify({ type: 'session_meta', payload: { id: 'parentB', cwd: '/tmp/p', thread_source: 'user' }, timestamp: T1 }),
+  ].join('\n');
+  const { session: sub } = parseCodex(subagentThenParentReplay, { id: 'subA' });
+  assert.equal(sub.id, 'subA', "the file's own id, not the replayed parent's");
+  assert.equal(sub.threadSource, 'subagent', "the file's own identity — not relabeled by the replay");
+  assert.deepEqual(sub.usage, [], 'subagent usage stays stripped, not billed to the parent a second time');
+
+  // Inverse control: an ordinary single-meta user rollout is unaffected.
+  const singleMeta = [
+    JSON.stringify({ type: 'session_meta', payload: { id: 'userC', cwd: '/tmp/p', thread_source: 'user' }, timestamp: T0 }),
+    JSON.stringify({ type: 'event_msg', payload: { type: 'user_message', message: 'go' }, timestamp: T0 }),
+    JSON.stringify({ type: 'event_msg', payload: { type: 'token_count', info: { total_token_usage: { input_tokens: 100, cached_input_tokens: 40, output_tokens: 20, total_tokens: 120 } } }, timestamp: T0 }),
+  ].join('\n');
+  const { session: user } = parseCodex(singleMeta, { id: 'userC' });
+  assert.equal(user.id, 'userC');
+  assert.equal(user.threadSource, 'user');
+  assert.equal(user.usage.length, 1, 'a genuine single-meta user rollout still bills normally');
+});

--- a/tests/kit/usage-index-v6.test.mjs
+++ b/tests/kit/usage-index-v6.test.mjs
@@ -286,6 +286,35 @@ test('parseCodex v11: mode, duration, aborts, ctx window, typed tools', () => {
   assert.equal(rec.tools.CommandExecution, 1);
 });
 
+// Codex's duration_ms is host-measured turn wall-clock and INCLUDES time the
+// turn spent blocked on an approval prompt, so a turn left awaiting approval
+// overnight is recorded as a multi-hour "response". The prompt-gap path
+// discards exactly that; the fallback must too, or the same wait becomes a
+// latency sample. Real corpus max: 94,079,450 ms ≈ 26.1 h.
+test('parseCodex: an idle-resume duration_ms is excluded from latency sampling, like the other two paths', () => {
+  const plusSec = (t, s) => new Date(Date.parse(t) + s * 1000).toISOString();
+  const lines = [
+    JSON.stringify({ type: 'session_meta', payload: { id: 'cx3', cwd: '/tmp/p', thread_source: 'user' }, timestamp: T0 }),
+    JSON.stringify({ type: 'event_msg', payload: { type: 'task_started', started_at: T0, model_context_window: 272000, turn_id: 't1' }, timestamp: T0 }),
+    JSON.stringify({ type: 'event_msg', payload: { type: 'task_complete', duration_ms: 94_079_450, error: null, turn_id: 't1' }, timestamp: plusSec(T0, 94_079) }),
+  ].join('\n');
+  const { session: rec } = parseCodex(lines, { id: 'cx3' });
+  assert.equal(rec.latCount, 0, '26.1 h is an idle resume / blocked approval, not a response latency');
+  assert.equal(rec.latHist, null, 'no sample at all — not an overflow-bucket entry beside genuinely slow turns');
+});
+
+test('parseCodex: a duration_ms inside the cap still samples through the fallback', () => {
+  const plusSec = (t, s) => new Date(Date.parse(t) + s * 1000).toISOString();
+  const lines = [
+    JSON.stringify({ type: 'session_meta', payload: { id: 'cx4', cwd: '/tmp/p', thread_source: 'user' }, timestamp: T0 }),
+    JSON.stringify({ type: 'event_msg', payload: { type: 'task_started', started_at: T0, model_context_window: 272000, turn_id: 't1' }, timestamp: T0 }),
+    JSON.stringify({ type: 'event_msg', payload: { type: 'task_complete', duration_ms: 45_000, error: null, turn_id: 't1' }, timestamp: plusSec(T0, 45) }),
+  ].join('\n');
+  const { session: rec } = parseCodex(lines, { id: 'cx4' });
+  assert.equal(rec.latCount, 1, 'the fallback is not disabled, only bounded');
+  assert.equal(rec.latHist[4], 1, '45s lands in the (30,60] bucket');
+});
+
 test('parseCodex v11: turn_aborted clears pending latency state so a later agent_message is not mis-sampled', () => {
   const plusSec = (t, s) => new Date(Date.parse(t) + s * 1000).toISOString();
   const lines = [

--- a/tests/kit/usage-index-v6.test.mjs
+++ b/tests/kit/usage-index-v6.test.mjs
@@ -433,3 +433,30 @@ test('parseCodex: FIRST session_meta wins identity — a replayed parent meta ca
   assert.equal(user.threadSource, 'user');
   assert.equal(user.usage.length, 1, 'a genuine single-meta user rollout still bills normally');
 });
+
+// Codex has no discipline of its own for distinguishing a typed prompt from
+// harness output or a mirrored cross-host envelope (Claude has isHumanPrompt
+// + HARNESS_OUTPUT_RE since schema v5). Measured on the reference corpus: 596
+// harness-shaped rows plus mirrored Claude-host envelopes (teammate
+// deliveries, cross-session messages) landing as Codex user_message events —
+// both distort prompts/humanPrompts/autonomy. Both message generations
+// (legacy user_message and item_completed UserMessage) must be gated.
+test('parseCodex: harness output and mirrored cross-host envelopes are excluded from prompts (both generations)', () => {
+  const legacyLines = [
+    JSON.stringify({ type: 'session_meta', payload: { id: 'cxh1', cwd: '/tmp/p', thread_source: 'user' }, timestamp: T0 }),
+    JSON.stringify({ type: 'event_msg', payload: { type: 'user_message', message: 'do the real thing' }, timestamp: T0 }),
+    JSON.stringify({ type: 'event_msg', payload: { type: 'user_message', message: '<task-notification>background task finished</task-notification>' }, timestamp: T0 }),
+    JSON.stringify({ type: 'event_msg', payload: { type: 'user_message', message: 'Another Claude session sent a message: hello' }, timestamp: T0 }),
+  ].join('\n');
+  const { session: legacy } = parseCodex(legacyLines, { id: 'cxh1' });
+  assert.equal(legacy.prompts, 1);
+
+  const itemLines = [
+    JSON.stringify({ type: 'session_meta', payload: { id: 'cxh2', cwd: '/tmp/p', thread_source: 'user' }, timestamp: T0 }),
+    JSON.stringify({ type: 'event_msg', payload: { type: 'item_completed', item: { type: 'UserMessage', content: [{ type: 'text', text: 'do the real thing' }] } }, timestamp: T0 }),
+    JSON.stringify({ type: 'event_msg', payload: { type: 'item_completed', item: { type: 'UserMessage', content: [{ type: 'text', text: '<task-notification>background task finished</task-notification>' }] } }, timestamp: T0 }),
+    JSON.stringify({ type: 'event_msg', payload: { type: 'item_completed', item: { type: 'UserMessage', content: [{ type: 'text', text: 'Another Claude session sent a message: hello' }] } }, timestamp: T0 }),
+  ].join('\n');
+  const { session: item } = parseCodex(itemLines, { id: 'cxh2' });
+  assert.equal(item.prompts, 1);
+});

--- a/tests/kit/usage-index-v6.test.mjs
+++ b/tests/kit/usage-index-v6.test.mjs
@@ -434,6 +434,29 @@ test('parseCodex: FIRST session_meta wins identity — a replayed parent meta ca
   assert.equal(user.usage.length, 1, 'a genuine single-meta user rollout still bills normally');
 });
 
+// M1 ruling (review round 2): provider/provenance join the SAME identity
+// latch as id/threadSource/cwd — a replayed parent's session_meta line is
+// not an observation about THIS record, for provider any more than for
+// identity. This is deliberately independent of handleCodexTurnContext's
+// own provider handling, which stays progressive (unrelated design choice).
+test('parseCodex: FIRST session_meta wins provider/provenance too — a replayed parent meta does not overwrite them', () => {
+  const subagentThenParentDifferentProvider = [
+    JSON.stringify({ type: 'session_meta', payload: { id: 'subP', cwd: '/tmp/p', thread_source: 'subagent', model_provider: 'openai' }, timestamp: T0 }),
+    JSON.stringify({ type: 'session_meta', payload: { id: 'parentP', cwd: '/tmp/p', thread_source: 'user', model_provider: 'azure' }, timestamp: T1 }),
+  ].join('\n');
+  const { session: sub } = parseCodex(subagentThenParentDifferentProvider, { id: 'subP' });
+  assert.equal(sub.inferenceProvider, 'openai', "the file's own provider, not the replayed parent's");
+  assert.equal(sub.providerProvenance, 'observed');
+
+  // Inverse control: an ordinary single-meta record is unaffected.
+  const singleMeta = [
+    JSON.stringify({ type: 'session_meta', payload: { id: 'userQ', cwd: '/tmp/p', thread_source: 'user', model_provider: 'openai' }, timestamp: T0 }),
+  ].join('\n');
+  const { session: user } = parseCodex(singleMeta, { id: 'userQ' });
+  assert.equal(user.inferenceProvider, 'openai');
+  assert.equal(user.providerProvenance, 'observed');
+});
+
 // Codex has no discipline of its own for distinguishing a typed prompt from
 // harness output or a mirrored cross-host envelope (Claude has isHumanPrompt
 // + HARNESS_OUTPUT_RE since schema v5). Measured on the reference corpus: 596

--- a/tests/kit/usage-index-v6.test.mjs
+++ b/tests/kit/usage-index-v6.test.mjs
@@ -286,6 +286,59 @@ test('parseCodex v11: mode, duration, aborts, ctx window, typed tools', () => {
   assert.equal(rec.tools.CommandExecution, 1);
 });
 
+// The REAL wire shape. Surveyed over this machine's rollouts (2026-08-28,
+// 400 files): `sandbox_policy` is an OBJECT keyed `.type` in 1,110/1,110
+// occurrences — {"type":"danger-full-access"} (1004), {"type":"read-only"}
+// (59), and {"type":"workspace-write", …} with extra fields (47). The string
+// form the taxonomy was written against occurred ZERO times, so before the
+// extraction only the approval-only 'guarded' rule could ever fire for codex:
+// plan/auto-edit/unrestricted were unreachable on live data and modeRaw
+// persisted the failed toString "never/[object Object]".
+// `approval_policy` is a plain string in the same corpus ("never" 1524,
+// "on-request" 39), so only the sandbox half needs extracting.
+const turnCtx = (approval, sandbox) => JSON.stringify({
+  type: 'turn_context',
+  payload: { model: 'gpt-5.6', approval_policy: approval, sandbox_policy: sandbox },
+  timestamp: T0,
+});
+const codexModeOf = (id, approval, sandbox) => parseCodex([
+  JSON.stringify({ type: 'session_meta', payload: { id, cwd: '/tmp/p', thread_source: 'user' }, timestamp: T0 }),
+  turnCtx(approval, sandbox),
+].join('\n'), { id }).session;
+
+test('parseCodex: the object form of sandbox_policy maps to the taxonomy — unrestricted', () => {
+  const rec = codexModeOf('cxm1', 'never', { type: 'danger-full-access' });
+  assert.equal(rec.mode, 'unrestricted', 'codex\'s riskiest posture is no longer invisible to detectUnrestrictedMode');
+  assert.equal(rec.modeRaw, 'never/danger-full-access', 'the host spelling, not "[object Object]"');
+});
+
+test('parseCodex: the object form of sandbox_policy maps to the taxonomy — auto-edit', () => {
+  // The real workspace-write object carries siblings; only `.type` is read.
+  const rec = codexModeOf('cxm2', 'never', {
+    type: 'workspace-write', network_access: false, exclude_tmpdir_env_var: false, exclude_slash_tmp: false,
+  });
+  assert.equal(rec.mode, 'auto-edit');
+  assert.equal(rec.modeRaw, 'never/workspace-write');
+});
+
+test('parseCodex: the object form of sandbox_policy maps to the taxonomy — plan', () => {
+  const rec = codexModeOf('cxm3', 'on-request', { type: 'read-only' });
+  assert.equal(rec.mode, 'plan');
+  assert.equal(rec.modeRaw, 'on-request/read-only');
+});
+
+test('parseCodex: the object form of sandbox_policy maps to the taxonomy — guarded', () => {
+  const rec = codexModeOf('cxm4', 'on-request', { type: 'workspace-write' });
+  assert.equal(rec.mode, 'guarded', 'human-in-the-loop approval is the posture');
+  assert.equal(rec.modeRaw, 'on-request/workspace-write');
+});
+
+test('parseCodex: a sandbox_policy object with no .type contributes no sandbox evidence, never a guess', () => {
+  const rec = codexModeOf('cxm5', 'never', { network_access: true });
+  assert.equal(rec.mode, null, 'approval "never" alone matches no rule — unmapped, not assumed permissive');
+  assert.equal(rec.modeRaw, 'never', 'only the half that was actually observed');
+});
+
 // Codex's duration_ms is host-measured turn wall-clock and INCLUDES time the
 // turn spent blocked on an approval prompt, so a turn left awaiting approval
 // overnight is recorded as a multi-hour "response". The prompt-gap path

--- a/tests/kit/usage-index-v6.test.mjs
+++ b/tests/kit/usage-index-v6.test.mjs
@@ -129,17 +129,23 @@ test('parseCodex normalizes current item_completed messages and exposes bounded 
   assert.equal(s.responses, 1);
   assert.equal(s.tokens, 120);
   assert.equal(agg.sourceHealth.codex.status, 'ok');
+  // CommandExecution is TALLIED as a tool, so it is a shape this parser
+  // understands and must not also be reported as an unknown kind: doing both
+  // raised the unknown-item-types warning for a type nothing failed to
+  // handle, and spent one of the 32 diagnostic slots that exist to surface
+  // genuinely new shapes.
+  assert.equal(s.tools.CommandExecution, 1, 'tallied as the tool it is');
   assert.deepEqual(agg.sourceHealth.codex.diagnostics, {
     files: 1, cachedFiles: 0, parsedFiles: 1, unparsedFiles: 0,
     filesWithTokens: 1, filesWithResponses: 1,
     legacyEvents: 0, itemCompletedEvents: 3, tokenCountEvents: 1,
-    prompts: 1, responses: 1, unknownItemTypes: { CommandExecution: 1 }, unknownItemTypeOverflow: 0,
-    warnings: ['unknown-item-types'],
+    prompts: 1, responses: 1, unknownItemTypes: {}, unknownItemTypeOverflow: 0,
+    warnings: [],
     common: {
       unitsSeen: 1, unitsParsed: 1, unitsWithUsage: 1,
       unitsWithPrompts: 1, unitsWithResponses: 1,
       prompts: 1, responses: 1,
-      warnings: ['unknown-item-types'], unknownKinds: { CommandExecution: 1 }, unknownKindOverflow: 0,
+      warnings: [], unknownKinds: {}, unknownKindOverflow: 0,
     },
   });
 
@@ -305,6 +311,21 @@ const codexModeOf = (id, approval, sandbox) => parseCodex([
   JSON.stringify({ type: 'session_meta', payload: { id, cwd: '/tmp/p', thread_source: 'user' }, timestamp: T0 }),
   turnCtx(approval, sandbox),
 ].join('\n'), { id }).session;
+
+test('a genuinely unrecognized item type still reaches the unknown-kind diagnostics', () => {
+  // The other half of the rule: narrowing the diagnostic to types the parser
+  // does NOT tally must not silence it for the shapes it exists to surface.
+  const lines = [
+    JSON.stringify({ type: 'session_meta', payload: { id: 'cxu1', cwd: '/tmp/p', thread_source: 'user' }, timestamp: T0 }),
+    JSON.stringify({ type: 'event_msg', payload: { type: 'item_completed', item: { type: 'CommandExecution' } }, timestamp: T0 }),
+    JSON.stringify({ type: 'event_msg', payload: { type: 'item_completed', item: { type: 'SomeBrandNewThing' } }, timestamp: T0 }),
+  ].join('\n');
+  const { session, parseStats } = parseCodex(lines, { id: 'cxu1' });
+  assert.deepEqual(parseStats.unknownItemTypes, { SomeBrandNewThing: 1 },
+    'the tallied tool type is absent; the genuinely unknown one is present');
+  assert.equal(session.tools.CommandExecution, 1);
+  assert.equal(session.tools.SomeBrandNewThing, undefined, 'an unrecognized item is never tallied as a tool');
+});
 
 test('parseCodex: the object form of sandbox_policy maps to the taxonomy — unrestricted', () => {
   const rec = codexModeOf('cxm1', 'never', { type: 'danger-full-access' });

--- a/tests/kit/usage-index.test.mjs
+++ b/tests/kit/usage-index.test.mjs
@@ -1558,10 +1558,32 @@ test("buildIndex({ days, lookbackDays }) widens discovery/parse; unset stays exa
   assert.equal(byId(undefinedLookback, 'old-session'), undefined, 'lookbackDays: undefined must not widen the window either');
   assert.deepEqual(undefinedLookback.totals, plain.totals, 'unset lookbackDays is identical to omitting it entirely');
 
+  // Task 7 (2026-08-28-scorecard-matrix-a SDD) ruling B: lookbackDays alone
+  // no longer widens what the CURRENT window's sessions/totals contain — only
+  // discovery/parse/cache. `aggregate` is always called with the DISPLAY
+  // cutoff (now - days*DAY_MS), so a `previous: true`-less caller must see
+  // exactly the same current-window sessions as the plain 7-day scan; the
+  // widened read is only observable via the on-disk cache (proving discovery/
+  // parse actually reached the file) or via `previous` below.
   _resetForTest();
   const widened = await buildIndex(opts(sb, { days: 7, lookbackDays: 14 }));
-  assert.ok(byId(widened, 'old-session'), 'lookbackDays: 14 widens discovery/parse so it is returned');
+  assert.equal(byId(widened, 'old-session'), undefined,
+    'lookbackDays alone must not leak the old session into the CURRENT window — that is the bug this ruling fixes');
+  assert.deepEqual(widened.totals, plain.totals, 'the current window is byte-identical to the plain 7-day scan');
   assert.equal(widened.windowDays, 7, 'the nominal window label still reports `days` unchanged');
+  const cache = JSON.parse(fs.readFileSync(sb.cachePath, 'utf8'));
+  assert.equal(cache.entries[file]?.session?.id, 'old-session',
+    'discovery/parse DID reach the old file — it is cached even though the current window excludes it');
+
+  // Paired with `previous: true`, the widened read is what makes the old
+  // session reachable at all — via the previous-window projection, not by
+  // hand-splitting a widened sessions[].
+  _resetForTest();
+  const withPrevious = await buildIndex(opts(sb, { days: 7, lookbackDays: 14, previous: true }));
+  assert.equal(byId(withPrevious, 'old-session'), undefined, 'still excluded from the current window');
+  assert.equal(withPrevious.totals.sessions, 0, 'the current 7-day window has no sessions at all');
+  assert.equal(withPrevious.previous.totals.sessions, 1,
+    'the 10-day-old session lands in the previous [14d, 7d) window instead');
 });
 
 // F-08-style regression guard (see the scanKey test above): lookbackDays now

--- a/tests/kit/usage-index.test.mjs
+++ b/tests/kit/usage-index.test.mjs
@@ -1738,10 +1738,61 @@ test('totals carry aborts and the per-hour / per-prompt / median rates', () => {
 
   assert.equal(a.totals.engagedSeconds, 3600, 'two disjoint half-hours = one engaged hour');
   assert.equal(a.totals.aborts, 2);
+  assert.equal(a.totals.humanPrompts, 4, 'both sessions are main-thread here');
   assert.equal(a.totals.humanPromptsPerHour, 4, '4 prompts in one engaged hour');
-  assert.equal(a.totals.responsesPerPrompt, 1.5, '6 responses / 4 prompts');
+  assert.equal(a.totals.responsesPerPrompt, 1.5, '6 responses / 4 human prompts');
   assert.equal(a.totals.costPerEngagedHour, 4, '$4 of spend in one engaged hour');
   assert.equal(a.totals.costPerSessionMedian, 2, 'the exact median of [1, 3]');
+});
+
+test('a subagent\'s prompts never inflate the per-prompt denominators', () => {
+  // The subagent's 9 prompts were written by the harness, not typed by a
+  // person: counting them would report 10 prompts an hour where a human typed 1.
+  const end = (d) => NOW - d * DAY;
+  const records = [
+    record('main1', {
+      end: end(3), start: end(3) - 3_600_000, prompts: 1, responses: 2,
+      usage: [usageRow('2026-07-22', 'claude-opus-5', { input: 1000 })],
+    }),
+    record('side1', {
+      end: end(3) - 1_800_000, start: end(3) - 3_600_000, sidechain: true,
+      prompts: 9, responses: 4,
+      usage: [usageRow('2026-07-22', 'claude-opus-5', { input: 1000 })],
+    }),
+  ];
+  const a = aggregate(records, aggOpts());
+
+  assert.equal(a.totals.prompts, 10, 'the raw count still records every prompt');
+  assert.equal(a.totals.humanPrompts, 1, 'only the main thread had a person typing');
+  assert.equal(a.totals.engagedSeconds, 3600, 'the sidechain runs inside the main session');
+  assert.equal(a.totals.humanPromptsPerHour, 1, 'one human prompt in one engaged hour');
+  assert.equal(a.totals.responsesPerPrompt, 6, '6 responses / 1 human prompt');
+});
+
+test('a structurally-$0 session does not drag the cost median or P90 down', () => {
+  // `zero` has no usage rows at all — a stripped Codex subagent or a session
+  // that never billed. Its $0 is missing evidence, not cheap work, so the
+  // distribution must be taken over the three priced sessions alone.
+  const end = (d) => NOW - d * DAY;
+  const priced = (id, d, input) => record(id, {
+    end: end(d), start: end(d) - 30 * MIN,
+    usage: [usageRow('2026-07-22', 'claude-opus-5', { input })],
+  });
+  const a = aggregate([
+    priced('p1', 2, 2000), priced('p2', 3, 4000), priced('p3', 4, 6000),
+    record('zero', { end: end(5), start: end(5) - 30 * MIN, provider: 'codex', threadSource: 'subagent' }),
+  ], aggOpts());
+
+  assert.equal(a.totals.sessions, 4, 'the unpriced session is still a session');
+  assert.equal(a.totals.costPerSessionMedian, 4, 'the median of [2, 4, 6], not of [0, 2, 4, 6]');
+  assert.equal(a.totals.costPerSessionP90, 6);
+});
+
+test('an all-unpriced window reports no cost distribution rather than $0', () => {
+  const a = aggregate([record('nousage')], aggOpts());
+  assert.equal(a.totals.costPerSessionMedian, null,
+    '"we measured nothing" is not "the typical session cost nothing"');
+  assert.equal(a.totals.costPerSessionP90, null);
 });
 
 test('a rate with no engaged time is null, not zero', () => {
@@ -1753,7 +1804,7 @@ test('a rate with no engaged time is null, not zero', () => {
   assert.equal(a.totals.costPerEngagedHour, null);
 });
 
-test('cacheSavedUsd is the 0.9 of the input rate a cache read did not pay', () => {
+test('cacheSavedUsd is the spend a cache read did not pay', () => {
   // 1M cache-read tokens at $3/1M input: charged 0.1 × $3 = $0.30, so $2.70 of
   // the $3.00 they would have cost as fresh input was avoided.
   const a = aggregate([record('c1', {
@@ -1769,6 +1820,33 @@ test('cacheSavedUsd is the 0.9 of the input rate a cache read did not pay', () =
   );
 });
 
+test('the cache discount comes from the pricer, not a constant baked in here', () => {
+  // Same 1M cache reads under a pricer that charges HALF the input rate for
+  // them instead of a tenth. A hardcoded "0.9 × input rate" would still answer
+  // $2.70; differencing the pricer's own two answers gives the true $1.50.
+  const half = () => ({
+    ...deps(),
+    costOf: ({ input = 0, cacheRead = 0 }) => ((input + cacheRead * 0.5) * RATE_IN) / 1e6,
+  });
+  const a = aggregate([record('c3', {
+    usage: [usageRow('2026-07-24', 'claude-opus-5', { cacheRead: 1e6 })],
+  })], aggOpts({ deps: half() }));
+
+  assert.equal(a.totals.cost, 1.5);
+  assert.equal(a.totals.cacheSavedUsd, 1.5, 'half of $3, because this pricer discounts by half');
+});
+
+test('a pricer with no cache discount at all reports no saving', () => {
+  const flat = () => ({
+    ...deps(),
+    costOf: ({ input = 0, cacheRead = 0 }) => ((input + cacheRead) * RATE_IN) / 1e6,
+  });
+  const a = aggregate([record('c4', {
+    usage: [usageRow('2026-07-24', 'claude-opus-5', { cacheRead: 1e6 })],
+  })], aggOpts({ deps: flat() }));
+  assert.equal(a.totals.cacheSavedUsd, 0, 'nothing was avoided, so nothing is claimed');
+});
+
 test('a session with no cache reads saved nothing', () => {
   const a = aggregate([record('c2', {
     usage: [usageRow('2026-07-24', 'claude-opus-5', { input: 1000 })],
@@ -1776,7 +1854,7 @@ test('a session with no cache reads saved nothing', () => {
   assert.equal(a.totals.cacheSavedUsd, 0);
 });
 
-test('byDay.engagedSeconds splits an over-midnight session at LOCAL midnight', () => {
+test('engagedByDay splits an over-midnight session at LOCAL midnight', () => {
   // 23:30 → 00:30 local: half an hour belongs to each day, not a whole hour to
   // the day it started on.
   const start = new Date(2026, 6, 23, 23, 30).getTime();
@@ -1785,21 +1863,81 @@ test('byDay.engagedSeconds splits an over-midnight session at LOCAL midnight', (
     start, end, usage: [usageRow('2026-07-23', 'claude-opus-5', { input: 100 })],
   })], aggOpts());
 
-  assert.equal(a.byDay['2026-07-23'].engagedSeconds, 1800);
-  assert.equal(a.byDay['2026-07-24'].engagedSeconds, 1800,
-    'the day the session ran into exists even though no tokens were billed to it');
-  assert.equal(a.byDay['2026-07-24'].tokens, 0);
+  assert.equal(a.engagedByDay['2026-07-23'], 1800);
+  assert.equal(a.engagedByDay['2026-07-24'], 1800, 'the day it ran into gets its real minutes');
   assert.equal(a.totals.engagedSeconds, 3600, 'the window-wide union is unchanged by the split');
 });
 
-test('byDay.engagedSeconds unions overlapping sessions instead of summing them', () => {
+test('engagedByDay is a sibling map — byDay keeps its billed-days-only contract', () => {
+  // The same over-midnight session. Work happened on two days; tokens billed on
+  // one. byDay must show exactly the billed day, with no synthetic zero-token
+  // row for the day that was only worked — the insight detectors count active
+  // days from those keys.
+  const start = new Date(2026, 6, 23, 23, 30).getTime();
+  const end = new Date(2026, 6, 24, 0, 30).getTime();
+  const a = aggregate([record('mid2', {
+    start, end, usage: [usageRow('2026-07-23', 'claude-opus-5', { input: 100 })],
+  })], aggOpts());
+
+  assert.deepEqual(Object.keys(a.byDay), ['2026-07-23'], 'only the billed day');
+  assert.equal(a.byDay['2026-07-24'], undefined, 'no invented zero-token row');
+  assert.equal('engagedSeconds' in a.byDay['2026-07-23'], false,
+    'engaged time is not a byDay field — detectors see byDay unchanged');
+  assert.deepEqual(Object.keys(a.engagedByDay).sort(), ['2026-07-23', '2026-07-24']);
+});
+
+test('engagedByDay unions overlapping sessions instead of summing them', () => {
   const base = new Date(2026, 6, 22, 10, 0).getTime();
   const a = aggregate([
     record('p1', { start: base, end: base + 60 * MIN }),
     record('p2', { start: base + 30 * MIN, end: base + 90 * MIN }),
   ], aggOpts());
-  assert.equal(a.byDay['2026-07-22'].engagedSeconds, 90 * 60,
+  assert.equal(a.engagedByDay['2026-07-22'], 90 * 60,
     'parallel sessions do not let a day claim more minutes than it had');
+});
+
+test('engagedByDay sums to totals.engagedSeconds, with no phantom day at an exact midnight', () => {
+  // One session ends exactly at midnight and another spans it, so the day
+  // boundary is hit both ways in the same window.
+  const d22 = new Date(2026, 6, 22, 22, 0).getTime();
+  const midnight = new Date(2026, 6, 23, 0, 0).getTime();
+  const a = aggregate([
+    record('ends-at-midnight', { start: d22, end: midnight }),
+    record('crosses', { start: midnight - 30 * MIN, end: midnight + 30 * MIN }),
+  ], aggOpts());
+
+  const summed = Object.values(a.engagedByDay).reduce((x, y) => x + y, 0);
+  assert.equal(summed, a.totals.engagedSeconds, 'the per-day unions partition the window union');
+  assert.deepEqual(Object.keys(a.engagedByDay).sort(), ['2026-07-22', '2026-07-23'],
+    'an interval ending exactly at midnight creates no next-day entry');
+  assert.equal(a.engagedByDay['2026-07-22'], 2 * 3600, '22:00 → 00:00, the overlap counted once');
+  assert.equal(a.engagedByDay['2026-07-23'], 30 * 60);
+});
+
+test('the midnight split follows the local clock across a DST transition', () => {
+  // America/New_York, 2026-03-08: the clocks jump 02:00 → 03:00, so that local
+  // day is 23 hours long. A session running 03-07 23:00 → 03-09 00:00 local
+  // must give the short day its real 23 hours, not a nominal 24.
+  const saved = process.env.TZ;
+  process.env.TZ = 'America/New_York';
+  try {
+    const start = Date.parse('2026-03-08T04:00:00Z');   // 2026-03-07 23:00 EST
+    const end = Date.parse('2026-03-09T04:00:00Z');     // 2026-03-09 00:00 EDT
+    const now = Date.parse('2026-03-10T12:00:00Z');
+    const a = aggregate([record('dst', { start, end })],
+      { days: 14, now, cutoff: now - 14 * DAY, deps: deps() });
+
+    assert.equal(a.engagedByDay['2026-03-07'], 3600, '23:00 → local midnight');
+    assert.equal(a.engagedByDay['2026-03-08'], 23 * 3600, 'the 23-hour day, not a nominal 24');
+    assert.equal(a.engagedByDay['2026-03-09'], undefined, 'it ended exactly at midnight');
+    assert.equal(a.totals.engagedSeconds, 24 * 3600, 'wall-clock elapsed is still 24 hours');
+    assert.equal(
+      Object.values(a.engagedByDay).reduce((x, y) => x + y, 0), a.totals.engagedSeconds,
+      'the invariant survives a day that is not 86400 seconds long',
+    );
+  } finally {
+    if (saved === undefined) delete process.env.TZ; else process.env.TZ = saved;
+  }
 });
 
 test('byDay carries cost by mode and by model family', () => {
@@ -1831,13 +1969,35 @@ test('previous window aggregates the prior equal span only', () => {
   assert.equal(a.previous.rhythm.lenHist.reduce((x, y) => x + y, 0), 2);
 });
 
-test('a session ending exactly at the cutoff belongs to the current window, never both', () => {
+test('a session ending exactly at the window start belongs to the current window, never both', () => {
   const days = 7;
   const cutoff = NOW - days * DAY;
   const a = aggregate([record('edge', { end: cutoff, start: cutoff - 30 * MIN })],
     { days, now: NOW, cutoff, deps: deps(), previous: true });
   assert.equal(a.totals.sessions, 1);
   assert.equal(a.previous.totals.sessions, 0, 'the previous window\'s upper bound is exclusive');
+});
+
+test('the previous window tracks the DISPLAYED span, not however far the cutoff was widened', () => {
+  // The caller widened `cutoff` to 21 days so older records survive to be
+  // compared against. The baseline must still be the 7 days before the
+  // displayed 7 — a delta measured against a silently-21-day window is not a
+  // delta against "last week".
+  const days = 7;
+  const end = (d) => NOW - d * DAY;
+  const records = [
+    record('cur', { end: end(3), start: end(3) - 30 * MIN }),      // displayed window
+    record('prevA', { end: end(9), start: end(9) - 30 * MIN }),    // the window before it
+    record('prevB', { end: end(12), start: end(12) - 30 * MIN }),  // still that window
+    record('older', { end: end(17), start: end(17) - 30 * MIN }),  // two windows back
+  ];
+  const a = aggregate(records, {
+    days, now: NOW, cutoff: NOW - 21 * DAY, deps: deps(), previous: true,
+  });
+
+  assert.equal(a.totals.sessions, 4, 'the widened cutoff is what the current window honours');
+  assert.equal(a.previous.totals.sessions, 2, 'exactly [now − 14d, now − 7d): prevA and prevB');
+  assert.equal(a.previous.rhythm.lenHist.reduce((x, y) => x + y, 0), 2);
 });
 
 test('previous is null unless the caller asks for it', () => {

--- a/tests/kit/usage-index.test.mjs
+++ b/tests/kit/usage-index.test.mjs
@@ -1602,6 +1602,21 @@ test('scanKey distinguishes calls that differ only by lookbackDays', async () =>
     'a call with lookbackDays set must not collide with one that omits it — they must not share the in-flight promise / result object');
 });
 
+// Task 7 fix round 1: the same F-08-style regression guard as the lookbackDays
+// test above, now for `previous` — added after review flagged that scanKey
+// folded lookbackDays into its identity but not previous, so a {previous:true}
+// caller (e.g. /api/usage) racing a {previous:false} caller (e.g. the Models
+// tab) with otherwise-identical options could have shared one memoized answer.
+test('scanKey distinguishes calls that differ only by previous', async () => {
+  _resetForTest();
+  const sb = sandbox();
+  const a = buildIndex(opts(sb, { previous: false }));
+  const b = buildIndex(opts(sb, { previous: true }));
+  const [aggA, aggB] = await Promise.all([a, b]);
+  assert.notEqual(aggA, aggB,
+    'a call with previous:true must not collide with one that omits it — they must not share the in-flight promise / result object');
+});
+
 // ── aggregate: buckets, rhythm, per-day engaged, previous window (Task 6) ───
 //
 // These suites drive `aggregate()` directly instead of through buildIndex: the

--- a/tests/kit/usage-index.test.mjs
+++ b/tests/kit/usage-index.test.mjs
@@ -2096,3 +2096,102 @@ test('previous is null unless the caller asks for it', () => {
   const a = aggregate([record('cur')], aggOpts());
   assert.equal(a.previous, null, 'null is "not requested" — an empty totals object would read as "measured nothing"');
 });
+
+// ── nested Claude subagent transcripts (Lane-P) ─────────────────────────────
+//
+// Claude Code writes sidechain/subagent transcripts one level below the main
+// session file, at <project>/<sessionId>/subagents/agent-*.jsonl — a shape
+// listClaude never walked into, so this cost-bearing work was invisible to
+// every index/aggregate consumer. parseClaude already prices these bytes
+// correctly and marks them sidechain from their own entries (isSidechain);
+// the gap was purely in discovery.
+
+/** Write a nested `<parentId>/subagents/<stem>.jsonl` transcript under a
+ *  soloSandbox()'s claude project dir — one prompt + one priced reply, both
+ *  entries carrying `isSidechain: true` exactly as Claude Code's real
+ *  on-disk format does. */
+function writeSubagentTranscript(sb, parentId, stem, usage) {
+  const subDir = path.join(sb.claude, parentId, 'subagents');
+  fs.mkdirSync(subDir, { recursive: true });
+  const T0 = '2026-08-20T10:00:00.000Z';
+  fs.writeFileSync(path.join(subDir, `${stem}.jsonl`), `${[
+    JSON.stringify({
+      type: 'user', sessionId: parentId, cwd: '/Users/me/proj', isSidechain: true,
+      timestamp: T0, message: { role: 'user', content: 'subtask' },
+    }),
+    JSON.stringify({
+      type: 'assistant', sessionId: parentId, cwd: '/Users/me/proj', isSidechain: true,
+      timestamp: T0, message: { role: 'assistant', model: 'claude-opus-5', usage, content: [] },
+    }),
+  ].join('\n')}\n`);
+}
+
+test('nested subagent transcripts get parent-namespaced ids — no collision across two parents', async () => {
+  _resetForTest();
+  const sb = soloSandbox();
+  const usage = { input_tokens: 10, output_tokens: 5 };
+  writeSubagentTranscript(sb, 'parent-a', 'agent-001', usage);
+  writeSubagentTranscript(sb, 'parent-b', 'agent-001', usage);
+
+  const agg = await buildIndex(opts(sb));
+  const ids = agg.sessions.map((s) => s.id).sort();
+  assert.deepEqual(ids, ['parent-a/agent-001', 'parent-b/agent-001'],
+    'the same agent-001 stem under two different parents must yield two distinct records, never one overwriting the other');
+});
+
+test('a nested subagent transcript is discovered, priced, and folded into bySource.subagent', async () => {
+  _resetForTest();
+  const sb = soloSandbox();
+  const T0 = '2026-08-20T10:00:00.000Z';
+  const mainId = 'main-session';
+
+  // The main, non-sidechain session.
+  fs.writeFileSync(path.join(sb.claude, `${mainId}.jsonl`), `${[
+    JSON.stringify({ type: 'user', sessionId: mainId, cwd: '/Users/me/proj', timestamp: T0, message: { role: 'user', content: 'do the thing' } }),
+    JSON.stringify({ type: 'assistant', sessionId: mainId, cwd: '/Users/me/proj', timestamp: T0, message: { role: 'assistant', model: 'claude-opus-5', usage: { input_tokens: 100, output_tokens: 20 }, content: [] } }),
+  ].join('\n')}\n`);
+
+  // Its own subagent transcript — real, cost-bearing work.
+  writeSubagentTranscript(sb, mainId, 'agent-001', { input_tokens: 1000, output_tokens: 200 });
+
+  const agg = await buildIndex(opts(sb));
+
+  assert.equal(agg.totals.sessions, 2, 'both the main session and its subagent transcript are counted');
+  assert.ok(byId(agg, mainId), 'the main session is present');
+  const sub = agg.sessions.find((s) => s.id === `${mainId}/agent-001`);
+  assert.ok(sub, 'the nested subagent session is present, namespaced under its parent');
+  assert.equal(sub.sidechain, true, 'parseClaude marks it sidechain from its own isSidechain entries');
+
+  assert.equal(agg.bySource.main.sessions, 1);
+  assert.equal(agg.bySource.subagent.sessions, 1);
+  assert.equal(agg.bySource.main.cost, 0.12);
+  assert.equal(agg.bySource.subagent.cost, 1.2, "the subagent transcript's own usage prices as real, nonzero cost — not swallowed as $0");
+  assert.equal(agg.totals.cost, 1.32, 'totals include the subagent cost alongside the main session');
+  // The codex ledger-strip path (applyCodexLedger) is untouched by this fix —
+  // this fixture has no codex candidates at all, so its absence here is the
+  // most direct evidence; the full existing codex-ledger test coverage
+  // elsewhere in this suite is unaffected (see the green-bar run).
+});
+
+test('an unreadable subagents dir degrades silently — the parent session is unaffected, no new health field invented', async () => {
+  _resetForTest();
+  const sb = soloSandbox();
+  const T0 = '2026-08-20T10:00:00.000Z';
+  const mainId = 'main-with-bad-subagents';
+
+  fs.writeFileSync(path.join(sb.claude, `${mainId}.jsonl`), `${JSON.stringify({
+    type: 'assistant', sessionId: mainId, cwd: '/Users/me/proj', timestamp: T0,
+    message: { role: 'assistant', model: 'claude-opus-5', usage: { input_tokens: 1, output_tokens: 1 }, content: [] },
+  })}\n`);
+
+  fs.mkdirSync(path.join(sb.claude, mainId));
+  // A FILE where the subagents directory is expected — readdirSync on this
+  // throws ENOTDIR, exactly like the pre-existing "unreadable root" test
+  // above (F-08 section). readDirSafe swallows it the same way it already
+  // swallows a bad nested project dir: no exception, no new health field.
+  fs.writeFileSync(path.join(sb.claude, mainId, 'subagents'), 'not a directory');
+
+  const agg = await buildIndex(opts(sb));
+  assert.ok(byId(agg, mainId), 'the main session still parses despite its unreadable subagents dir');
+  assert.equal(agg.sourceHealth.claude.status, 'ok', 'one bad nested subagents dir must not degrade the whole claude source');
+});

--- a/tests/kit/usage-index.test.mjs
+++ b/tests/kit/usage-index.test.mjs
@@ -853,7 +853,6 @@ test('an empty corpus yields a zeroed Aggregate rather than throwing', async () 
   // "zero sessions" and "we never found the directory" must stay distinguishable.
   assert.equal(agg.sourceHealth.claude.status, 'absent');
   assert.equal(agg.sourceHealth.claude.reason, null);
-  assert.equal(agg.sourceHealth.claude.capabilities.prompts, 'unavailable');
   assert.equal(agg.sourceHealth.claude.diagnostics.common.unitsSeen, 0);
   assert.equal(agg.sourceHealth.codex.status, 'absent');
   assert.equal(agg.sourceHealth.codex.reason, null);
@@ -866,7 +865,10 @@ test('buildIndex reports ok claude/codex root health when the transcript roots e
   const agg = await buildIndex(opts(sb));
   assert.equal(agg.sourceHealth.claude.status, 'ok');
   assert.equal(agg.sourceHealth.claude.reason, null);
-  assert.equal(agg.sourceHealth.claude.capabilities.prompts, 'supported');
+  // Source health reports what was READ, never what the parser could report:
+  // the old per-host capability matrix is not part of this payload.
+  assert.ok(!Object.hasOwn(agg.sourceHealth.claude, 'capabilities'),
+    'sourceHealth must not carry a capability matrix');
   assert.equal(agg.sourceHealth.claude.diagnostics.common.unitsParsed, 3);
   assert.equal(agg.sourceHealth.claude.diagnostics.common.prompts, 4);
   assert.equal(agg.sourceHealth.claude.diagnostics.common.responses, 5);

--- a/tests/kit/usage-index.test.mjs
+++ b/tests/kit/usage-index.test.mjs
@@ -1977,6 +1977,61 @@ test('the midnight split follows the local clock across a DST transition', () =>
   }
 });
 
+test('the session row projects the v11 posture and context-window evidence', () => {
+  const a = aggregate([record('ctx', {
+    mode: 'auto-edit', modeRaw: 'acceptEdits', ctxWindow: 200_000, ctxLastTokens: 151_000,
+    usage: [usageRow('2026-07-24', 'claude-opus-5', { input: 1000 })],
+  })], aggOpts());
+  const s = a.sessions[0];
+
+  assert.equal(s.mode, 'auto-edit');
+  assert.equal(s.modeRaw, 'acceptEdits', 'the raw string the transcript carried, beside the normalized one');
+  assert.equal(s.ctxWindow, 200_000);
+  assert.equal(s.ctxLastTokens, 151_000);
+});
+
+test('the v11 projection stays honest-absent when the transcript recorded nothing', () => {
+  // blankSession's defaults: a source that carries no posture or context
+  // evidence must project null, never a zero that reads as a measurement.
+  const a = aggregate([record('bare')], aggOpts());
+  const s = a.sessions[0];
+
+  assert.equal(s.modeRaw, null);
+  assert.equal(s.ctxWindow, null);
+  assert.equal(s.ctxLastTokens, null);
+});
+
+test('byDay carries exceptions and cacheRead for the reliability and cache trends', () => {
+  // `busted` bills on the 22nd and carries 2 exceptions; `clean` bills on the
+  // 23rd with none. Exceptions follow the first-billed-day convention the
+  // session count already uses.
+  const end = (d) => NOW - d * DAY;
+  const a = aggregate([
+    record('busted', {
+      end: end(3), start: end(3) - 30 * MIN, exceptions: 2,
+      usage: [
+        usageRow('2026-07-22', 'claude-opus-5', { input: 100, cacheRead: 900 }),
+        usageRow('2026-07-22', 'claude-sonnet-5', { input: 50, cacheRead: 150 }),
+      ],
+    }),
+    record('clean', {
+      end: end(2), start: end(2) - 30 * MIN, exceptions: 0,
+      usage: [usageRow('2026-07-23', 'claude-opus-5', { input: 400 })],
+    }),
+  ], aggOpts());
+
+  assert.equal(a.byDay['2026-07-22'].exceptions, 2, 'attributed to the day the session first billed');
+  assert.equal(a.byDay['2026-07-22'].cacheRead, 1050, 'summed across every usage row of the day');
+  assert.equal(a.byDay['2026-07-22'].tokens, 1200, 'cacheRead is a slice of tokens, not an addition to it');
+
+  // A day that saw neither an exception nor a cache read still carries both
+  // fields at zero — a chart reading `undefined` would render a gap where the
+  // truth is a measured zero.
+  assert.equal(a.byDay['2026-07-23'].exceptions, 0);
+  assert.equal(a.byDay['2026-07-23'].cacheRead, 0);
+  assert.equal(a.totals.exceptions, 2, 'the window total is unchanged by the per-day split');
+});
+
 test('byDay carries cost by mode and by model family', () => {
   const a = aggregate([
     record('d1', { mode: 'auto-edit', usage: [usageRow('2026-07-24', 'claude-opus-5-20260115', { input: 2000 })] }),

--- a/tests/kit/usage-index.test.mjs
+++ b/tests/kit/usage-index.test.mjs
@@ -2214,6 +2214,16 @@ test('readSession rejects hostile namespaced-shaped ids without ever resolving t
     'foo/agent-1\\..\\..\\etc', 'a/b/agent-1', 'a//agent-1', '/agent-1',
     'foo/', '/foo/agent-1', 'foo/notanagent', 'foo/Agent-1', 'foo/agent-',
     'foo/agent-1/extra',
+    // Dot-only PARENT segments. These are the cases the charset alone does
+    // not catch ('.' and '-' are both inside it), and the parent is the one
+    // place in this module where request-shaped text becomes a path SEGMENT
+    // rather than a filename stem — path.join collapses it, so '../agent-x'
+    // resolved to <claudeRoot>/subagents/agent-x.jsonl: still inside the
+    // root (so the realpath containment check cannot catch it) but outside
+    // the <project>/<session>/subagents shape the grammar exists to enforce.
+    // The route tier rejects these; this tier must too, or the doc claim of
+    // parity above readSession is false.
+    '../agent-x', './agent-x',
     // 'agent-1' and '..' (bare, no slash) are deliberately NOT here — both
     // are syntactically valid PLAIN ids under VALID_ID's own pre-existing
     // charset (VALID_ID, unlike session-security.mjs's parseSessionId, has

--- a/tests/kit/usage-index.test.mjs
+++ b/tests/kit/usage-index.test.mjs
@@ -1460,6 +1460,34 @@ test('parseClaude derives latency, mode, ctx from entries', () => {
   assert.equal(rec.ctxLastTokens, 151000);    // input + cacheRead of last turn
 });
 
+// The same evidence gate opencode's parser was ruled to need. decodeClaudeRecord
+// normalizes an ABSENT message.usage to all-zeros, so an unconditional write
+// let a token-less assistant entry overwrite real context pressure with a
+// fabricated 0 — the honest-absent rule inverted.
+test('parseClaude: a token-less assistant entry does not zero a real ctxLastTokens', () => {
+  const T0 = '2026-08-20T10:00:00.000Z';
+  const plusSec = (t, s) => new Date(Date.parse(t) + s * 1000).toISOString();
+  const lines = [
+    JSON.stringify({ type: 'user', timestamp: T0, message: { role: 'user', content: 'do it' } }),
+    JSON.stringify({ type: 'assistant', timestamp: plusSec(T0, 8), message: { role: 'assistant', model: 'claude-opus-5', usage: { input_tokens: 1000, cache_read_input_tokens: 150000, output_tokens: 50 }, content: [] } }),
+    // No `usage` key at all — claudeUsage() reads all four fields as 0.
+    JSON.stringify({ type: 'assistant', timestamp: plusSec(T0, 12), message: { role: 'assistant', model: 'claude-opus-5', content: [] } }),
+  ].join('\n');
+  const { session: rec } = parseClaude(lines, { id: 'sess-ctx-gate' });
+  assert.equal(rec.ctxLastTokens, 151000,
+    'the last turn that actually recorded context wins; a token-less one carries no evidence to overwrite it with');
+});
+
+test('parseClaude: a session whose only assistant entry is token-less records no context at all', () => {
+  const T0 = '2026-08-20T10:00:00.000Z';
+  const lines = [
+    JSON.stringify({ type: 'user', timestamp: T0, message: { role: 'user', content: 'do it' } }),
+    JSON.stringify({ type: 'assistant', timestamp: T0, message: { role: 'assistant', model: 'claude-opus-5', content: [] } }),
+  ].join('\n');
+  const { session: rec } = parseClaude(lines, { id: 'sess-ctx-none' });
+  assert.equal(rec.ctxLastTokens, null, 'honest-absent, not a measured zero');
+});
+
 // ── v11 index carry-through + lookback (Task 5) ─────────────────────────────
 
 test('cached session entries round-trip the v11 fields across a cache hit', async () => {

--- a/tests/kit/usage-index.test.mjs
+++ b/tests/kit/usage-index.test.mjs
@@ -2195,3 +2195,84 @@ test('an unreadable subagents dir degrades silently — the parent session is un
   assert.ok(byId(agg, mainId), 'the main session still parses despite its unreadable subagents dir');
   assert.equal(agg.sourceHealth.claude.status, 'ok', 'one bad nested subagents dir must not degrade the whole claude source');
 });
+
+// ── namespaced subagent ids reach readSession (Lane-P round 2) ─────────────
+//
+// Round 1 ingested the transcripts (buildIndex/scan); round 2 makes them
+// OPENABLE by id — readSession/locate previously rejected any id containing
+// '/' (VALID_ID's charset excludes it), so every subagent row was a dead
+// link. VALID_SUBAGENT_ID accepts EXACTLY `<parentId>/<stem>` — the parent
+// segment reuses VALID_ID's own charset, the child segment matches the real
+// on-disk `agent-<hex>` / `agent-<name>-<hex>` shape — and locate()
+// constructs the resolved path from the validated capture groups only,
+// never by joining raw request input.
+
+test('readSession rejects hostile namespaced-shaped ids without ever resolving to a file', async () => {
+  const sb = soloSandbox();
+  const hostile = [
+    '../etc/agent-1', 'foo/..', 'foo/../agent-1', 'foo\\bar/agent-1',
+    'foo/agent-1\\..\\..\\etc', 'a/b/agent-1', 'a//agent-1', '/agent-1',
+    'foo/', '/foo/agent-1', 'foo/notanagent', 'foo/Agent-1', 'foo/agent-',
+    'foo/agent-1/extra',
+    // 'agent-1' and '..' (bare, no slash) are deliberately NOT here — both
+    // are syntactically valid PLAIN ids under VALID_ID's own pre-existing
+    // charset (VALID_ID, unlike session-security.mjs's parseSessionId, has
+    // no extra '.'/'..' exclusion — out of THIS fix's scope, which is the
+    // namespaced grammar, not auditing the plain-id one). They resolve to
+    // null (no such file), never throw. Only the NAMESPACED shape — a
+    // string that actually contains a slash — is this test's concern.
+  ];
+  for (const id of hostile) {
+    await assert.rejects(
+      () => readSession(id, { roots: sb.roots, cachePath: sb.cachePath }),
+      { code: 'ERR_INVALID_SESSION_ID' },
+      `must reject ${JSON.stringify(id)}`,
+    );
+  }
+});
+
+test('a well-formed namespaced id round-trips to the right nested subagent transcript (cold cache, fallback scan)', async () => {
+  _resetForTest();
+  const sb = soloSandbox();
+  const mainId = 'parent-session';
+  writeSubagentTranscript(sb, mainId, 'agent-a2fc4593254cc01b9', { input_tokens: 10, output_tokens: 5 });
+
+  const found = await readSession(`${mainId}/agent-a2fc4593254cc01b9`, { roots: sb.roots, cachePath: sb.cachePath });
+  assert.ok(found, 'a valid namespaced id must resolve');
+  assert.equal(found.meta.id, `${mainId}/agent-a2fc4593254cc01b9`);
+  assert.equal(found.meta.sidechain, true, 'the resolved session must carry the sidechain evidence its own entries recorded');
+});
+
+test('a namespaced id also round-trips once the index cache already has it, resolving the REAL project (not "subagents")', async () => {
+  _resetForTest();
+  const sb = soloSandbox();
+  const mainId = 'parent-no-cwd';
+  const subDir = path.join(sb.claude, mainId, 'subagents');
+  fs.mkdirSync(subDir, { recursive: true });
+  const T0 = '2026-08-20T10:00:00.000Z';
+  // No `cwd` on either entry: parseClaude can only learn the project from
+  // the FALLBACK dirName locate() computes for the resolved file — this is
+  // what proves the cache-hit path's dirName is the real project directory,
+  // not the literal "subagents" directory that sits between the parent id
+  // and the stem on disk.
+  fs.writeFileSync(path.join(subDir, 'agent-nocwd00000000001.jsonl'), `${[
+    JSON.stringify({ type: 'user', sessionId: mainId, isSidechain: true, timestamp: T0, message: { role: 'user', content: 'subtask' } }),
+    JSON.stringify({
+      type: 'assistant', sessionId: mainId, isSidechain: true, timestamp: T0,
+      message: { role: 'assistant', model: 'claude-opus-5', usage: { input_tokens: 1, output_tokens: 1 }, content: [] },
+    }),
+  ].join('\n')}\n`);
+
+  await buildIndex(opts(sb)); // populates the id→file cache, exactly like a normal dashboard poll
+  const found = await readSession(`${mainId}/agent-nocwd00000000001`, opts(sb));
+  assert.ok(found, 'a cache-hit namespaced id must still resolve');
+  assert.equal(found.meta.project, 'proj', 'the real project, decoded from the project dir name — never the literal "subagents" placeholder');
+});
+
+test('a plain id is byte-identical to before namespaced ids existed', async () => {
+  _resetForTest();
+  const sb = sandbox();
+  const found = await readSession('aaaa1111', opts(sb));
+  assert.equal(found.meta.id, 'aaaa1111');
+  assert.equal(found.meta.host, 'claude');
+});

--- a/tests/kit/usage-index.test.mjs
+++ b/tests/kit/usage-index.test.mjs
@@ -1452,3 +1452,123 @@ test('parseClaude derives latency, mode, ctx from entries', () => {
   assert.equal(rec.latHist[2], 1);            // 8s → 5-10s bucket
   assert.equal(rec.ctxLastTokens, 151000);    // input + cacheRead of last turn
 });
+
+// ── v11 index carry-through + lookback (Task 5) ─────────────────────────────
+
+test('cached session entries round-trip the v11 fields across a cache hit', async () => {
+  _resetForTest();
+  const sb = soloSandbox();
+  const T0 = '2026-08-20T10:00:00.000Z';
+  const plusSec = (t, s) => new Date(Date.parse(t) + s * 1000).toISOString();
+
+  // "Evidence" session: the same shape as the parseClaude unit test above (a
+  // permissionMode-carrying prompt, a cache-heavy reply) so mode/modeRaw/
+  // latHist/latCount/lenSeconds/ctxLastTokens land on real, non-default
+  // values to round-trip through the cache.
+  const evidenceFile = path.join(sb.claude, 'sess-evidence.jsonl');
+  fs.writeFileSync(evidenceFile, `${[
+    JSON.stringify({
+      type: 'user', sessionId: 'sess-evidence', cwd: '/Users/me/proj',
+      timestamp: T0, permissionMode: 'acceptEdits',
+      message: { role: 'user', content: 'do it' },
+    }),
+    JSON.stringify({
+      type: 'assistant', sessionId: 'sess-evidence', cwd: '/Users/me/proj',
+      timestamp: plusSec(T0, 8),
+      message: {
+        role: 'assistant', model: 'claude-opus-5',
+        usage: { input_tokens: 1000, cache_read_input_tokens: 150000, output_tokens: 50 },
+        content: [],
+      },
+    }),
+  ].join('\n')}\n`);
+
+  // "Blank" session: a prompt with no assistant reply at all — no mode
+  // signal, no latency sample, no context-window turn — so every v11 field
+  // must stay at blankSession's honest-absent default. Proves absent
+  // evidence round-trips as absent, never fabricated by the cache cycle.
+  const blankFile = path.join(sb.claude, 'sess-blank.jsonl');
+  fs.writeFileSync(blankFile, `${JSON.stringify({
+    type: 'user', sessionId: 'sess-blank', cwd: '/Users/me/proj', timestamp: T0,
+    message: { role: 'user', content: 'hi' },
+  })}\n`);
+
+  const assertBoth = () => {
+    const cache = JSON.parse(fs.readFileSync(sb.cachePath, 'utf8'));
+    const evidence = cache.entries[evidenceFile].session;
+    assert.equal(evidence.mode, 'auto-edit');
+    assert.equal(evidence.modeRaw, 'acceptEdits');
+    assert.equal(evidence.latCount, 1);
+    assert.deepEqual(evidence.latHist, [0, 0, 1, 0, 0, 0]); // 8s -> 5-10s bucket
+    assert.equal(evidence.lenSeconds, 8);
+    assert.equal(evidence.ctxLastTokens, 151000);           // input + cacheRead of last turn
+    assert.equal(evidence.ctxWindow, null, 'ctxWindow is codex-only evidence');
+    assert.equal(evidence.aborts, 0, 'aborts is codex-only evidence');
+
+    const blank = cache.entries[blankFile].session;
+    assert.equal(blank.mode, null);
+    assert.equal(blank.modeRaw, null);
+    assert.equal(blank.latHist, null);
+    assert.equal(blank.latCount, 0);
+    assert.equal(blank.lenSeconds, 0);
+    assert.equal(blank.ctxWindow, null);
+    assert.equal(blank.ctxLastTokens, null);
+    assert.equal(blank.aborts, 0);
+  };
+
+  await buildIndex(opts(sb));
+  assertBoth(); // fresh parse
+
+  _resetForTest(); // clears the in-process single-flight/memo, NOT the on-disk cache
+  await buildIndex(opts(sb)); // same (path, mtime, size) on both files — must hit the cache
+  assertBoth(); // cache-hit read: identical values prove the round trip
+});
+
+// ── lookback (Task 5) ────────────────────────────────────────────────────────
+
+test("buildIndex({ days, lookbackDays }) widens discovery/parse; unset stays exactly today's behavior", async () => {
+  _resetForTest();
+  const sb = soloSandbox();
+  const DAY = 86_400_000;
+  const tenDaysAgo = NOW - 10 * DAY;
+
+  const file = path.join(sb.claude, 'old-session.jsonl');
+  fs.writeFileSync(file, `${JSON.stringify({
+    type: 'assistant', sessionId: 'old-session', cwd: '/Users/me/proj',
+    timestamp: new Date(tenDaysAgo).toISOString(),
+    message: { role: 'assistant', model: 'claude-opus-5', usage: { input_tokens: 1, output_tokens: 1 }, content: [] },
+  })}\n`);
+  // Backdate the file's REAL mtime to match its content: a genuinely 10-day-
+  // old transcript, not just an old timestamp inside a freshly-written file —
+  // so this exercises the candidates mtime filter too, not only aggregate's.
+  fs.utimesSync(file, new Date(tenDaysAgo), new Date(tenDaysAgo));
+
+  const plain = await buildIndex(opts(sb, { days: 7 }));
+  assert.equal(byId(plain, 'old-session'), undefined, 'a 10-day-old session is outside a plain 7-day window');
+
+  _resetForTest();
+  const undefinedLookback = await buildIndex(opts(sb, { days: 7, lookbackDays: undefined }));
+  assert.equal(byId(undefinedLookback, 'old-session'), undefined, 'lookbackDays: undefined must not widen the window either');
+  assert.deepEqual(undefinedLookback.totals, plain.totals, 'unset lookbackDays is identical to omitting it entirely');
+
+  _resetForTest();
+  const widened = await buildIndex(opts(sb, { days: 7, lookbackDays: 14 }));
+  assert.ok(byId(widened, 'old-session'), 'lookbackDays: 14 widens discovery/parse so it is returned');
+  assert.equal(widened.windowDays, 7, 'the nominal window label still reports `days` unchanged');
+});
+
+// F-08-style regression guard (see the scanKey test above): lookbackDays now
+// changes scan()'s RESULT the same way days/force/roots/cachePath already do,
+// so it must be folded into the single-flight/memo identity too — concurrent
+// calls differing only by lookbackDays must not collapse into one answer and
+// serve a { days: 7 } caller the { days: 7, lookbackDays: 14 } aggregate (or
+// vice versa).
+test('scanKey distinguishes calls that differ only by lookbackDays', async () => {
+  _resetForTest();
+  const sb = sandbox();
+  const a = buildIndex(opts(sb, { lookbackDays: undefined }));
+  const b = buildIndex(opts(sb, { lookbackDays: 28 }));
+  const [aggA, aggB] = await Promise.all([a, b]);
+  assert.notEqual(aggA, aggB,
+    'a call with lookbackDays set must not collide with one that omits it — they must not share the in-flight promise / result object');
+});

--- a/tests/kit/usage-index.test.mjs
+++ b/tests/kit/usage-index.test.mjs
@@ -1721,7 +1721,7 @@ test('the aggregate buckets on the same histogram edges the parsers fill', () =>
   assert.deepEqual(AGG_LEN_EDGES, LEN_BUCKET_EDGES);
 });
 
-test('byMode, byInferenceProvider, bySource and byTool bucket honestly', () => {
+test('byMode, bySource and byTool bucket honestly, and no provider axis is aggregated', () => {
   const records = [
     record('m1', { mode: 'auto-edit', inferenceProvider: 'openai', providerProvenance: 'observed', tools: { Edit: 2 } }),
     record('m2', { mode: null, tools: { Read: 1 } }),
@@ -1731,15 +1731,25 @@ test('byMode, byInferenceProvider, bySource and byTool bucket honestly', () => {
 
   assert.equal(a.byMode['auto-edit'].sessions, 1);
   assert.equal(a.byMode['not-recorded'].sessions, 2, 'no mode evidence is its own bucket, never folded into a real mode');
-  assert.equal(a.byInferenceProvider.openai.sessions, 1);
-  assert.equal(a.byInferenceProvider['not-recorded'].sessions, 2,
-    'a provider string without observed provenance is an assumption, not an attribution');
-  // The contrast that makes the new bucket worth having: byProvider still
-  // trusts the string it was handed.
+  // Inference provider is per-session evidence, not a window axis: a
+  // transcript host does not prove which vendor served the tokens, so there
+  // is no aggregate bucket for it. byProvider — the transcript host identity
+  // this repository has always recorded — is unaffected.
+  assert.ok(!Object.hasOwn(a, 'byInferenceProvider'),
+    'the aggregate must not carry an inference-provider bucket');
   assert.equal(a.byProvider.anthropic.sessions, 1);
   assert.equal(a.bySource.main.sessions, 2);
   assert.equal(a.bySource.subagent.sessions, 1);
   assert.deepEqual({ ...a.byTool }, { Edit: 3, Read: 1 });
+});
+
+test('per-session provider provenance survives even though the aggregate axis is gone', () => {
+  const a = aggregate([
+    record('p1', { inferenceProvider: 'openai', providerProvenance: 'observed' }),
+  ], aggOpts());
+  const row = a.sessions.find((s) => s.id === 'p1');
+  assert.equal(row.provider, 'openai');
+  assert.equal(row.providerProvenance, 'observed');
 });
 
 test('bySource always carries both rows, even with no subagent work', () => {

--- a/tests/kit/usage-index.test.mjs
+++ b/tests/kit/usage-index.test.mjs
@@ -8,7 +8,14 @@ import {
   buildIndex, readIndex, readSession, mergeIntervals, maskSecrets, projectLabel,
   SCHEMA_VERSION, IDLE_GAP_MS, _resetForTest,
 } from '../../src/lib/usage-index.mjs';
-import { blankSession, noteLatencySample, parseClaude } from '../../src/lib/usage-parsers.mjs';
+import {
+  addUsage, blankSession, noteLatencySample, parseClaude,
+  LAT_BUCKET_EDGES, LEN_BUCKET_EDGES,
+} from '../../src/lib/usage-parsers.mjs';
+import {
+  aggregate, percentileFromBuckets, modelFamily,
+  LAT_BUCKET_EDGES as AGG_LAT_EDGES, LEN_BUCKET_EDGES as AGG_LEN_EDGES,
+} from '../../src/lib/usage-aggregate.mjs';
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const FIXTURES = path.join(HERE, '..', 'fixtures', 'usage');
@@ -1571,4 +1578,269 @@ test('scanKey distinguishes calls that differ only by lookbackDays', async () =>
   const [aggA, aggB] = await Promise.all([a, b]);
   assert.notEqual(aggA, aggB,
     'a call with lookbackDays set must not collide with one that omits it — they must not share the in-flight promise / result object');
+});
+
+// ── aggregate: buckets, rhythm, per-day engaged, previous window (Task 6) ───
+//
+// These suites drive `aggregate()` directly instead of through buildIndex: the
+// previous-window projection reads records OLDER than the cutoff, which only
+// reach the aggregate when the index was built with a lookback, and the mode /
+// provenance / latency permutations they pin are cheaper to state as records
+// than as transcripts. Fixtures are still built from the parsers' own
+// blankSession/addUsage (never a hand-mirrored record literal), so they go
+// stale loudly if the record contract moves.
+
+const DAY = 86_400_000;
+
+const usageRow = (day, model, u = {}) =>
+  ({ day, model, input: 0, output: 0, cacheRead: 0, cacheWrite: 0, responses: 1, ...u });
+
+/** One parsed record. `end` is what the window filter reads; `active` defaults
+ *  to the whole span and `lenSeconds` is derived from it the way `seal()` does,
+ *  so a fixture cannot claim a length its intervals do not support. */
+function record(id, { start, end = NOW - DAY, usage = [], active, ...over } = {}) {
+  const rec = blankSession(id, over.provider ?? 'claude');
+  const from = start ?? end - 30 * MIN;
+  Object.assign(rec, { title: id, project: 'proj', prompts: 1, responses: 1, ...over, start: from, end });
+  rec.active = active ?? [[from, end]];
+  for (const u of usage) addUsage(rec, u.day, u.model, u);
+  if (!rec.models.length) rec.models = [...new Set(usage.map((u) => u.model))];
+  rec.lenSeconds = over.lenSeconds
+    ?? Math.round(rec.active.reduce((n, [a, b]) => n + (b - a), 0) / 1000);
+  return rec;
+}
+
+const aggOpts = (extra = {}) => ({ days: 14, now: NOW, cutoff: NOW - 14 * DAY, deps: deps(), ...extra });
+
+/** Rates in $/1M tokens, and a pricer shaped like the real one (cache reads
+ *  meter at a tenth of the input rate) so `cacheSavedUsd` can be hand-worked. */
+const RATE_IN = 3;
+const RATE_OUT = 15;
+const pricedDeps = () => ({
+  ...deps(),
+  costOf: ({ input = 0, output = 0, cacheRead = 0, cacheWrite = 0 }) =>
+    ((input + cacheWrite * 1.25 + cacheRead * 0.1) * RATE_IN + output * RATE_OUT) / 1e6,
+});
+
+test('percentileFromBuckets interpolates inside the bucket and is null when empty', () => {
+  assert.equal(percentileFromBuckets([0, 0, 0, 0, 0, 0], LAT_BUCKET_EDGES, 0.5), null,
+    'nothing measured is null, never 0 — they are different claims');
+  // 10 samples all in the 5–10s bucket: p50 sits exactly mid-bucket.
+  const p = percentileFromBuckets([0, 0, 10, 0, 0, 0], LAT_BUCKET_EDGES, 0.5);
+  assert.ok(p > 5 && p <= 10, `p50 must land inside the 5–10s bucket, got ${p}`);
+  assert.equal(p, 7.5);
+  // The overflow bucket has no upper bound to interpolate towards, so it
+  // reports its floor: "at least 60s", never an invented ceiling.
+  assert.equal(percentileFromBuckets([0, 0, 0, 0, 0, 4], LAT_BUCKET_EDGES, 0.5), 60);
+  assert.equal(percentileFromBuckets(null, LAT_BUCKET_EDGES, 0.5), null);
+});
+
+test('modelFamily folds an id to its family and never guesses', () => {
+  assert.equal(modelFamily('claude-opus-5-20260115'), 'opus');
+  assert.equal(modelFamily('gpt-5.6-sol'), 'gpt-5');
+  assert.equal(modelFamily('claude-haiku-4-5-20251001'), 'haiku');
+  assert.equal(modelFamily('anthropic/claude-sonnet-5'), 'sonnet');
+  assert.equal(modelFamily('gpt-4o-mini'), 'gpt-4');
+  assert.equal(modelFamily('unknown'), 'other', 'the parsers\' own placeholder is not a family');
+  assert.equal(modelFamily('gemini-3.5-flash'), 'other');
+  assert.equal(modelFamily(null), 'other');
+});
+
+test('the aggregate buckets on the same histogram edges the parsers fill', () => {
+  // usage-aggregate.mjs cannot import usage-parsers.mjs (the dependency is
+  // one-way, by design), so the edges are restated there. This is the pin that
+  // makes the restatement safe.
+  assert.deepEqual(AGG_LAT_EDGES, LAT_BUCKET_EDGES);
+  assert.deepEqual(AGG_LEN_EDGES, LEN_BUCKET_EDGES);
+});
+
+test('byMode, byInferenceProvider, bySource and byTool bucket honestly', () => {
+  const records = [
+    record('m1', { mode: 'auto-edit', inferenceProvider: 'openai', providerProvenance: 'observed', tools: { Edit: 2 } }),
+    record('m2', { mode: null, tools: { Read: 1 } }),
+    record('m3', { mode: null, inferenceProvider: 'anthropic', providerProvenance: 'unknown', sidechain: true, tools: { Edit: 1 } }),
+  ];
+  const a = aggregate(records, aggOpts());
+
+  assert.equal(a.byMode['auto-edit'].sessions, 1);
+  assert.equal(a.byMode['not-recorded'].sessions, 2, 'no mode evidence is its own bucket, never folded into a real mode');
+  assert.equal(a.byInferenceProvider.openai.sessions, 1);
+  assert.equal(a.byInferenceProvider['not-recorded'].sessions, 2,
+    'a provider string without observed provenance is an assumption, not an attribution');
+  // The contrast that makes the new bucket worth having: byProvider still
+  // trusts the string it was handed.
+  assert.equal(a.byProvider.anthropic.sessions, 1);
+  assert.equal(a.bySource.main.sessions, 2);
+  assert.equal(a.bySource.subagent.sessions, 1);
+  assert.deepEqual({ ...a.byTool }, { Edit: 3, Read: 1 });
+});
+
+test('bySource always carries both rows, even with no subagent work', () => {
+  const a = aggregate([record('solo')], aggOpts());
+  assert.equal(a.bySource.main.sessions, 1);
+  assert.equal(a.bySource.subagent.sessions, 0, '"no subagents" is a zero worth rendering, not a missing row');
+});
+
+test('a Codex thread_source of subagent counts as subagent work too', () => {
+  const a = aggregate([record('sub', { provider: 'codex', threadSource: 'subagent' })], aggOpts());
+  assert.equal(a.bySource.subagent.sessions, 1);
+});
+
+test('rhythm merges the per-session latency histograms and buckets session lengths', () => {
+  const end = (d) => NOW - d * DAY;
+  const records = [
+    record('r1', { end: end(3), start: end(3) - 120_000, latHist: [0, 0, 2, 0, 0, 0], latCount: 2 }),
+    record('r2', { end: end(2), start: end(2) - 1_800_000, latHist: [1, 0, 0, 0, 0, 1], latCount: 2 }),
+    record('r3', { end: end(1), start: end(1) - 5_400_000, latHist: null, latCount: 0 }),
+  ];
+  const a = aggregate(records, aggOpts());
+
+  assert.deepEqual(a.rhythm.latHist, [1, 0, 2, 0, 0, 1]);
+  assert.equal(a.rhythm.latCount, 4, 'the session that observed no latency contributes nothing, not a row of zeroes');
+  assert.equal(a.rhythm.latP50, 7.5);
+  assert.equal(a.rhythm.latP95, 60, 'the >60s bucket reports its floor');
+  // 120s → ≤300 bucket, 1800s → ≤2700 bucket, 5400s → ≤7200 bucket.
+  assert.deepEqual(a.rhythm.lenHist, [1, 0, 1, 1, 0]);
+  assert.equal(a.rhythm.lenMedianSeconds, 1800);
+  assert.equal(a.rhythm.lenP90Seconds, 5850);
+});
+
+test('a session past the last length edge lands in the overflow bucket', () => {
+  const end = NOW - DAY;
+  const a = aggregate([record('long', { end, start: end - 3 * 3600_000 })], aggOpts());
+  assert.deepEqual(a.rhythm.lenHist, [0, 0, 0, 0, 1], 'three hours is past the 2h edge');
+  assert.equal(a.rhythm.lenMedianSeconds, 7200, 'an unbounded bucket reports its floor, not a made-up ceiling');
+});
+
+test('rhythm is a zeroed histogram, not a fabricated one, when nothing was measured', () => {
+  const a = aggregate([], aggOpts());
+  assert.deepEqual(a.rhythm.latHist, [0, 0, 0, 0, 0, 0], 'always six slots, even empty');
+  assert.equal(a.rhythm.latCount, 0);
+  assert.equal(a.rhythm.latP50, null);
+  assert.equal(a.rhythm.latP95, null);
+  assert.deepEqual(a.rhythm.lenHist, [0, 0, 0, 0, 0]);
+  assert.equal(a.rhythm.lenMedianSeconds, null);
+});
+
+test('totals carry aborts and the per-hour / per-prompt / median rates', () => {
+  const end = (d) => NOW - d * DAY;
+  const records = [
+    record('t1', {
+      end: end(3), start: end(3) - 1_800_000, prompts: 3, responses: 4, aborts: 2,
+      usage: [usageRow('2026-07-22', 'claude-opus-5', { input: 1000 })],
+    }),
+    record('t2', {
+      end: end(2), start: end(2) - 1_800_000, prompts: 1, responses: 2, aborts: 0,
+      usage: [usageRow('2026-07-23', 'claude-opus-5', { input: 3000 })],
+    }),
+  ];
+  const a = aggregate(records, aggOpts());
+
+  assert.equal(a.totals.engagedSeconds, 3600, 'two disjoint half-hours = one engaged hour');
+  assert.equal(a.totals.aborts, 2);
+  assert.equal(a.totals.humanPromptsPerHour, 4, '4 prompts in one engaged hour');
+  assert.equal(a.totals.responsesPerPrompt, 1.5, '6 responses / 4 prompts');
+  assert.equal(a.totals.costPerEngagedHour, 4, '$4 of spend in one engaged hour');
+  assert.equal(a.totals.costPerSessionMedian, 2, 'the exact median of [1, 3]');
+});
+
+test('a rate with no engaged time is null, not zero', () => {
+  // A single-instant session: real, but it has no duration to divide by.
+  const at = NOW - DAY;
+  const a = aggregate([record('instant', { start: at, end: at, active: [[at, at]] })], aggOpts());
+  assert.equal(a.totals.engagedSeconds, 0);
+  assert.equal(a.totals.humanPromptsPerHour, null, '"not measured" is not "zero per hour"');
+  assert.equal(a.totals.costPerEngagedHour, null);
+});
+
+test('cacheSavedUsd is the 0.9 of the input rate a cache read did not pay', () => {
+  // 1M cache-read tokens at $3/1M input: charged 0.1 × $3 = $0.30, so $2.70 of
+  // the $3.00 they would have cost as fresh input was avoided.
+  const a = aggregate([record('c1', {
+    usage: [usageRow('2026-07-24', 'claude-opus-5', { cacheRead: 1e6 })],
+  })], aggOpts({ deps: pricedDeps() }));
+
+  assert.equal(a.totals.cost, 0.3);
+  assert.equal(a.totals.cacheSavedUsd, 2.7);
+  assert.equal(a.sessions[0].cacheSavedUsd, 2.7, 'the total is auditable per session');
+  assert.equal(
+    Math.round((a.totals.cost + a.totals.cacheSavedUsd) * 1e6) / 1e6, 3,
+    'charged + saved = what those tokens would have cost as fresh input',
+  );
+});
+
+test('a session with no cache reads saved nothing', () => {
+  const a = aggregate([record('c2', {
+    usage: [usageRow('2026-07-24', 'claude-opus-5', { input: 1000 })],
+  })], aggOpts({ deps: pricedDeps() }));
+  assert.equal(a.totals.cacheSavedUsd, 0);
+});
+
+test('byDay.engagedSeconds splits an over-midnight session at LOCAL midnight', () => {
+  // 23:30 → 00:30 local: half an hour belongs to each day, not a whole hour to
+  // the day it started on.
+  const start = new Date(2026, 6, 23, 23, 30).getTime();
+  const end = new Date(2026, 6, 24, 0, 30).getTime();
+  const a = aggregate([record('mid', {
+    start, end, usage: [usageRow('2026-07-23', 'claude-opus-5', { input: 100 })],
+  })], aggOpts());
+
+  assert.equal(a.byDay['2026-07-23'].engagedSeconds, 1800);
+  assert.equal(a.byDay['2026-07-24'].engagedSeconds, 1800,
+    'the day the session ran into exists even though no tokens were billed to it');
+  assert.equal(a.byDay['2026-07-24'].tokens, 0);
+  assert.equal(a.totals.engagedSeconds, 3600, 'the window-wide union is unchanged by the split');
+});
+
+test('byDay.engagedSeconds unions overlapping sessions instead of summing them', () => {
+  const base = new Date(2026, 6, 22, 10, 0).getTime();
+  const a = aggregate([
+    record('p1', { start: base, end: base + 60 * MIN }),
+    record('p2', { start: base + 30 * MIN, end: base + 90 * MIN }),
+  ], aggOpts());
+  assert.equal(a.byDay['2026-07-22'].engagedSeconds, 90 * 60,
+    'parallel sessions do not let a day claim more minutes than it had');
+});
+
+test('byDay carries cost by mode and by model family', () => {
+  const a = aggregate([
+    record('d1', { mode: 'auto-edit', usage: [usageRow('2026-07-24', 'claude-opus-5-20260115', { input: 2000 })] }),
+    record('d2', { mode: null, usage: [usageRow('2026-07-24', 'gpt-5.6-sol', { input: 1000 })] }),
+  ], aggOpts());
+
+  assert.deepEqual({ ...a.byDay['2026-07-24'].byMode }, { 'auto-edit': 2, 'not-recorded': 1 });
+  assert.deepEqual({ ...a.byDay['2026-07-24'].byModelFamily }, { opus: 2, 'gpt-5': 1 });
+});
+
+test('previous window aggregates the prior equal span only', () => {
+  const days = 7;
+  const cutoff = NOW - days * DAY;
+  const end = (d) => NOW - d * DAY;
+  const records = [
+    record('cur1', { end: end(2), start: end(2) - 30 * MIN }),
+    record('prev1', { end: end(8), start: end(8) - 30 * MIN }),
+    record('prev2', { end: end(13), start: end(13) - 30 * MIN }),
+    record('older', { end: end(20), start: end(20) - 30 * MIN }),
+  ];
+  const a = aggregate(records, { days, now: NOW, cutoff, deps: deps(), previous: true });
+
+  assert.equal(a.totals.sessions, 1, 'the current window is untouched by asking for the previous one');
+  assert.equal(a.previous.totals.sessions, 2, 'only the two sessions aged 7–14 days');
+  assert.deepEqual(Object.keys(a.previous).sort(), ['rhythm', 'totals'],
+    'a totals+rhythm projection — nothing downstream compares project trees across windows');
+  assert.equal(a.previous.rhythm.lenHist.reduce((x, y) => x + y, 0), 2);
+});
+
+test('a session ending exactly at the cutoff belongs to the current window, never both', () => {
+  const days = 7;
+  const cutoff = NOW - days * DAY;
+  const a = aggregate([record('edge', { end: cutoff, start: cutoff - 30 * MIN })],
+    { days, now: NOW, cutoff, deps: deps(), previous: true });
+  assert.equal(a.totals.sessions, 1);
+  assert.equal(a.previous.totals.sessions, 0, 'the previous window\'s upper bound is exclusive');
+});
+
+test('previous is null unless the caller asks for it', () => {
+  const a = aggregate([record('cur')], aggOpts());
+  assert.equal(a.previous, null, 'null is "not requested" — an empty totals object would read as "measured nothing"');
 });

--- a/tests/kit/usage-index.test.mjs
+++ b/tests/kit/usage-index.test.mjs
@@ -8,6 +8,7 @@ import {
   buildIndex, readIndex, readSession, mergeIntervals, maskSecrets, projectLabel,
   SCHEMA_VERSION, IDLE_GAP_MS, _resetForTest,
 } from '../../src/lib/usage-index.mjs';
+import { blankSession, noteLatencySample } from '../../src/lib/usage-parsers.mjs';
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const FIXTURES = path.join(HERE, '..', 'fixtures', 'usage');
@@ -1419,4 +1420,20 @@ test('worktree detection is separator-agnostic (Windows CI carries POSIX fixture
 
   assert.equal(projectLabel('C:\\Users\\x\\ai\\agentic-kit').project, 'agentic-kit',
     'a plain backslash checkout must not return the whole string as the project');
+});
+
+test('noteLatencySample buckets on the shared edges', () => {
+  const rec = blankSession('s1', 'claude');
+  noteLatencySample(rec, 1.2);   // bucket 0 (<2s)
+  noteLatencySample(rec, 8.4);   // bucket 2 (5-10s)
+  noteLatencySample(rec, 700);   // bucket 5 (>60s)
+  assert.deepEqual(rec.latHist, [1, 0, 1, 0, 0, 1]);
+  assert.equal(rec.latCount, 3);
+});
+
+test('blankSession v11 fields default honest-absent', () => {
+  const rec = blankSession('s1', 'codex');
+  assert.equal(rec.mode, null);
+  assert.equal(rec.ctxWindow, null);
+  assert.equal(rec.aborts, 0);
 });

--- a/tests/kit/usage-index.test.mjs
+++ b/tests/kit/usage-index.test.mjs
@@ -8,7 +8,7 @@ import {
   buildIndex, readIndex, readSession, mergeIntervals, maskSecrets, projectLabel,
   SCHEMA_VERSION, IDLE_GAP_MS, _resetForTest,
 } from '../../src/lib/usage-index.mjs';
-import { blankSession, noteLatencySample } from '../../src/lib/usage-parsers.mjs';
+import { blankSession, noteLatencySample, parseClaude } from '../../src/lib/usage-parsers.mjs';
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const FIXTURES = path.join(HERE, '..', 'fixtures', 'usage');
@@ -1436,4 +1436,19 @@ test('blankSession v11 fields default honest-absent', () => {
   assert.equal(rec.mode, null);
   assert.equal(rec.ctxWindow, null);
   assert.equal(rec.aborts, 0);
+});
+
+test('parseClaude derives latency, mode, ctx from entries', () => {
+  const T0 = '2026-08-20T10:00:00.000Z';
+  const plusSec = (t, s) => new Date(Date.parse(t) + s * 1000).toISOString();
+  const lines = [
+    JSON.stringify({ type: 'user', timestamp: T0, permissionMode: 'acceptEdits', message: { role: 'user', content: 'do it' } }),
+    JSON.stringify({ type: 'assistant', timestamp: plusSec(T0, 8), message: { role: 'assistant', model: 'claude-opus-5', usage: { input_tokens: 1000, cache_read_input_tokens: 150000, output_tokens: 50 }, content: [] } }),
+  ].join('\n');
+  const { session: rec } = parseClaude(lines, { id: 'sess-lat' });
+  assert.equal(rec.mode, 'auto-edit');
+  assert.equal(rec.modeRaw, 'acceptEdits');
+  assert.equal(rec.latCount, 1);
+  assert.equal(rec.latHist[2], 1);            // 8s → 5-10s bucket
+  assert.equal(rec.ctxLastTokens, 151000);    // input + cacheRead of last turn
 });

--- a/tests/kit/usage-insights.test.mjs
+++ b/tests/kit/usage-insights.test.mjs
@@ -780,6 +780,60 @@ test('_detectors[latency-regression] fires/does not fire directly, matching dete
   assert.equal(_detectors['latency-regression'](ctxFrom(latencyFiresAgg())).length, 1);
 });
 
+// ── AND-gate pinning ─────────────────────────────────────────────────────────
+// The two floors (relative and absolute) are combined with AND, not OR — each
+// of the next two fixtures clears exactly one floor and must still not fire.
+// p50s are placed by exact bucket arithmetic (verified against the real
+// percentileFromBuckets before being written here), not eyeballed.
+
+// Bucket [2,5): lo=2, hi=5. All 30 samples in that one bucket → cum=0, n=30,
+// frac=(N/2-cum)/n=0.5 → p50 = 2 + 3*0.5 = 3.5.
+// Bucket [5,10): lo=5, hi=10, cum=23 (bucket [2,5)), n=25 (bucket [5,10)),
+// N=48 → frac=(24-23)/25=0.04 → p50 = 5 + 5*0.04 = 5.2.
+// Delta: +1.7s absolute (<2s floor — FAILS), +48.6% relative (>=25% floor —
+// PASSES). Percent passes, absolute fails: must not fire.
+const latencyPercentOnlyAgg = () => makeAgg({
+  sessions: [
+    latSession('2026-03-01T00:00:00.000Z', [0, 30, 0, 0, 0, 0], 30),
+    latSession('2026-03-20T00:00:00.000Z', [0, 23, 25, 0, 0, 0], 48),
+  ],
+});
+
+test('latency-regression does not fire when only the relative floor clears (percent passes, absolute fails)', () => {
+  assert.equal(fired(latencyPercentOnlyAgg(), 'latency-regression'), false);
+});
+
+// Bucket [30,60): lo=30, hi=60. First half: cum=10 (bucket [10,30)), n=30
+// (bucket [30,60)), N=40 → frac=(20-10)/30=0.3333 → p50 = 30 + 30*0.3333 = 40.
+// Second half: cum=2, n=30, N=32 → frac=(16-2)/30=0.4667 → p50 = 30 + 30*0.4667 = 44.
+// Delta: +4s absolute (>=2s floor — PASSES), +10% relative (<25% floor —
+// FAILS). Absolute passes, percent fails: must not fire.
+const latencyAbsoluteOnlyAgg = () => makeAgg({
+  sessions: [
+    latSession('2026-02-01T00:00:00.000Z', [0, 0, 0, 10, 30, 0], 40),
+    latSession('2026-02-20T00:00:00.000Z', [0, 0, 0, 2, 30, 0], 32),
+  ],
+});
+
+test('latency-regression does not fire when only the absolute floor clears (absolute passes, percent fails)', () => {
+  assert.equal(fired(latencyAbsoluteOnlyAgg(), 'latency-regression'), false);
+});
+
+// Reuses the fires-fixture's own bucket shapes (p50 7.5s -> 12s: +4.5s
+// absolute and +60% relative, both comfortably clearing) but drops the first
+// half to 29 samples — one under the 30-sample floor. Both delta floors pass;
+// the sample floor alone must still suppress the finding.
+const latencySampleFloorAgg = () => makeAgg({
+  sessions: [
+    latSession('2026-01-01T00:00:00.000Z', [0, 0, 29, 0, 0, 0], 29),
+    latSession('2026-01-20T00:00:00.000Z', [0, 0, 16, 20, 0, 0], 36),
+  ],
+});
+
+test('latency-regression does not fire at 29 samples even when both delta floors would otherwise pass', () => {
+  assert.equal(fired(latencySampleFloorAgg(), 'latency-regression'), false);
+});
+
 // unrestricted-mode
 const unrestrictedAgg = () => makeAgg({
   sessions: [
@@ -797,6 +851,7 @@ test('unrestricted-mode fires on a recorded unrestricted session, naming count/c
   assert.match(ins.finding, /1 session/);
   assert.match(ins.finding, /1 project/);
   assert.match(ins.finding, /\$42/);
+  assert.match(ins.evidence, /post-ledger/);
 });
 
 test('unrestricted-mode does not fire on null or not-recorded modes', () => {

--- a/tests/kit/usage-insights.test.mjs
+++ b/tests/kit/usage-insights.test.mjs
@@ -600,10 +600,10 @@ test('the kitchen-sink fixture fires each detector at most once', () => {
 });
 
 // ── Direct per-detector unit tests ───────────────────────────────────────────
-// detectInsights composes these 13 detect() functions from a shared `ctx`
+// detectInsights composes these 15 detect() functions from a shared `ctx`
 // prelude (a/totals/sessions/windowCost/sessionCount). Calling each one
-// directly — bypassing detectInsights's flatMap+sort — proves the extraction
-// preserved firing behavior in isolation, independent of the other 12.
+// directly — bypassing detectInsights's flatMap+sort — proves each one's
+// firing behavior holds in isolation, independent of the other 14.
 
 function ctxFrom(agg) {
   const a = agg && typeof agg === 'object' ? agg : {};
@@ -700,4 +700,118 @@ const longSessionAgg = (longCost, totalCost) => makeAgg({
 test('_detectors[long-session-share] fires/does not fire directly on 8h+ session spend share', () => {
   assert.equal(_detectors['long-session-share'](ctxFrom(longSessionAgg(20, 100))).length, 0);
   assert.equal(_detectors['long-session-share'](ctxFrom(longSessionAgg(30, 100))).length, 1);
+});
+
+// ── latency-regression / unrestricted-mode ───────────────────────────────────
+// Brand new detectors, not extractions — so both the boundary-style and the
+// direct _detectors[] coverage are written together, same as everything above.
+
+// Session end time is start + minutes (see sessionEndMs in the source), so
+// each fixture gets a distinct `start` to make the half-split unambiguous.
+// latHist buckets: [0]<2s [1]2-5s [2]5-10s [3]10-30s [4]30-60s [5]60s+
+// (LAT_BUCKET_EDGES = [2, 5, 10, 30, 60] — pinned equal to the source's copy
+// by usage-index.test.mjs, not re-pinned here).
+const latSession = (start, latHist, latCount) => session({ start, minutes: 10, latHist, latCount });
+
+// First half: two sessions merging to [0,0,30,0,0,0] → bucket-interpolated
+// p50 7.5s. Second half: two sessions merging to [0,0,16,20,0,0] → p50 12s.
+// +4.5s absolute and +60% relative clear both floors.
+const latencyFiresAgg = () => makeAgg({
+  sessions: [
+    latSession('2026-07-01T00:00:00.000Z', [0, 0, 15, 0, 0, 0], 15),
+    latSession('2026-07-02T00:00:00.000Z', [0, 0, 15, 0, 0, 0], 15),
+    latSession('2026-07-20T00:00:00.000Z', [0, 0, 8, 10, 0, 0], 18),
+    latSession('2026-07-21T00:00:00.000Z', [0, 0, 8, 10, 0, 0], 18),
+  ],
+});
+
+// First half: 20 samples — under the 30-sample floor. Second half: 40
+// samples all in the 10-30s bucket (p50 20s), a jump that would clear both
+// the relative and absolute floors on delta alone if the sample gate did not
+// suppress it first.
+const latencyInsufficientAgg = () => makeAgg({
+  sessions: [
+    latSession('2026-05-01T00:00:00.000Z', [0, 0, 20, 0, 0, 0], 20),
+    latSession('2026-05-20T00:00:00.000Z', [0, 0, 0, 40, 0, 0], 40),
+  ],
+});
+
+// p50 15s -> 16s: +1s absolute (<2s) and +6.7% relative (<25%) — fails both
+// floors, not just one.
+const latencyModestAgg = () => makeAgg({
+  sessions: [
+    latSession('2026-06-01T00:00:00.000Z', [0, 0, 10, 20, 0, 0], 30),
+    latSession('2026-06-20T00:00:00.000Z', [0, 0, 10, 25, 0, 0], 35),
+  ],
+});
+
+test('latency-regression fires when the second half is both 25%+ and 2s+ slower', () => {
+  const ins = byId(detectInsights(latencyFiresAgg()), 'latency-regression');
+  assert.ok(ins);
+  assert.equal(ins.kind, 'trend');
+  assert.equal(ins.severity, 'warn');
+  assert.equal(ins.impact, null);
+  assert.match(ins.finding, /7\.5s/);
+  assert.match(ins.finding, /12s/);
+  assert.match(ins.evidence, /30/);
+  assert.match(ins.evidence, /36/);
+});
+
+test('latency-regression does not fire when either half has fewer than 30 samples', () => {
+  assert.equal(fired(latencyInsufficientAgg(), 'latency-regression'), false);
+});
+
+test('latency-regression does not fire on a modest increase that fails both thresholds', () => {
+  assert.equal(fired(latencyModestAgg(), 'latency-regression'), false);
+});
+
+test('latency-regression does not fire when sessions carry no latency histogram', () => {
+  const agg = makeAgg({
+    sessions: [
+      latSession('2026-04-01T00:00:00.000Z', null, 0),
+      latSession('2026-04-20T00:00:00.000Z', null, 0),
+    ],
+  });
+  assert.equal(fired(agg, 'latency-regression'), false);
+});
+
+test('_detectors[latency-regression] fires/does not fire directly, matching detectInsights', () => {
+  assert.equal(_detectors['latency-regression'](ctxFrom(latencyInsufficientAgg())).length, 0);
+  assert.equal(_detectors['latency-regression'](ctxFrom(latencyFiresAgg())).length, 1);
+});
+
+// unrestricted-mode
+const unrestrictedAgg = () => makeAgg({
+  sessions: [
+    session({ mode: 'unrestricted', cost: 42, project: 'alpha' }),
+    session({ mode: 'guarded', cost: 58, project: 'beta' }),
+  ],
+});
+
+test('unrestricted-mode fires on a recorded unrestricted session, naming count/cost/project', () => {
+  const ins = byId(detectInsights(unrestrictedAgg()), 'unrestricted-mode');
+  assert.ok(ins);
+  assert.equal(ins.kind, 'coach');
+  assert.equal(ins.severity, 'info');
+  assert.equal(ins.impact, null);
+  assert.match(ins.finding, /1 session/);
+  assert.match(ins.finding, /1 project/);
+  assert.match(ins.finding, /\$42/);
+});
+
+test('unrestricted-mode does not fire on null or not-recorded modes', () => {
+  const agg = makeAgg({
+    sessions: [
+      session({ mode: null, cost: 10 }),
+      session({ mode: 'not-recorded', cost: 10 }),
+      session({ cost: 10 }),   // no mode key observed at all
+    ],
+  });
+  assert.equal(fired(agg, 'unrestricted-mode'), false);
+});
+
+test('_detectors[unrestricted-mode] fires/does not fire directly, matching detectInsights', () => {
+  const none = makeAgg({ sessions: [session({ mode: 'guarded', cost: 10 })] });
+  assert.equal(_detectors['unrestricted-mode'](ctxFrom(none)).length, 0);
+  assert.equal(_detectors['unrestricted-mode'](ctxFrom(unrestrictedAgg())).length, 1);
 });

--- a/tests/kit/usage-modes.test.mjs
+++ b/tests/kit/usage-modes.test.mjs
@@ -1,0 +1,34 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { MODES, normalizeMode } from '../../src/lib/usage-modes.mjs';
+
+test('MODES is the closed four-value taxonomy', () => {
+  assert.deepEqual(MODES, ['guarded', 'auto-edit', 'plan', 'unrestricted']);
+});
+
+test('claude permissionMode maps per table', () => {
+  assert.equal(normalizeMode({ host: 'claude', permissionMode: 'default' }).mode, 'guarded');
+  assert.equal(normalizeMode({ host: 'claude', permissionMode: 'acceptEdits' }).mode, 'auto-edit');
+  assert.equal(normalizeMode({ host: 'claude', permissionMode: 'auto' }).mode, 'auto-edit');
+  assert.equal(normalizeMode({ host: 'claude', permissionMode: 'plan' }).mode, 'plan');
+  assert.equal(normalizeMode({ host: 'claude', permissionMode: 'bypassPermissions' }).mode, 'unrestricted');
+});
+
+test('codex approval x sandbox maps per table, read-only sandbox wins as plan', () => {
+  assert.equal(normalizeMode({ host: 'codex', approvalPolicy: 'never', sandboxPolicy: 'danger-full-access' }).mode, 'unrestricted');
+  assert.equal(normalizeMode({ host: 'codex', approvalPolicy: 'never', sandboxPolicy: 'workspace-write' }).mode, 'auto-edit');
+  assert.equal(normalizeMode({ host: 'codex', approvalPolicy: 'on-request', sandboxPolicy: 'workspace-write' }).mode, 'guarded');
+  assert.equal(normalizeMode({ host: 'codex', approvalPolicy: 'never', sandboxPolicy: 'read-only' }).mode, 'plan');
+});
+
+test('opencode mode maps build/plan', () => {
+  assert.equal(normalizeMode({ host: 'opencode', opencodeMode: 'build' }).mode, 'auto-edit');
+  assert.equal(normalizeMode({ host: 'opencode', opencodeMode: 'plan' }).mode, 'plan');
+});
+
+test('absent or unrecognized evidence is null, raw preserved, never guessed', () => {
+  assert.equal(normalizeMode({ host: 'claude' }).mode, null);
+  const odd = normalizeMode({ host: 'claude', permissionMode: 'superSafe9000' });
+  assert.equal(odd.mode, null);
+  assert.equal(odd.raw, 'superSafe9000');
+});

--- a/tests/kit/usage-modes.test.mjs
+++ b/tests/kit/usage-modes.test.mjs
@@ -10,6 +10,7 @@ test('claude permissionMode maps per table', () => {
   assert.equal(normalizeMode({ host: 'claude', permissionMode: 'default' }).mode, 'guarded');
   assert.equal(normalizeMode({ host: 'claude', permissionMode: 'acceptEdits' }).mode, 'auto-edit');
   assert.equal(normalizeMode({ host: 'claude', permissionMode: 'auto' }).mode, 'auto-edit');
+  assert.equal(normalizeMode({ host: 'claude', permissionMode: 'dontAsk' }).mode, 'auto-edit');
   assert.equal(normalizeMode({ host: 'claude', permissionMode: 'plan' }).mode, 'plan');
   assert.equal(normalizeMode({ host: 'claude', permissionMode: 'bypassPermissions' }).mode, 'unrestricted');
 });
@@ -18,7 +19,18 @@ test('codex approval x sandbox maps per table, read-only sandbox wins as plan', 
   assert.equal(normalizeMode({ host: 'codex', approvalPolicy: 'never', sandboxPolicy: 'danger-full-access' }).mode, 'unrestricted');
   assert.equal(normalizeMode({ host: 'codex', approvalPolicy: 'never', sandboxPolicy: 'workspace-write' }).mode, 'auto-edit');
   assert.equal(normalizeMode({ host: 'codex', approvalPolicy: 'on-request', sandboxPolicy: 'workspace-write' }).mode, 'guarded');
+  assert.equal(normalizeMode({ host: 'codex', approvalPolicy: 'on-failure', sandboxPolicy: 'workspace-write' }).mode, 'guarded');
+  assert.equal(normalizeMode({ host: 'codex', approvalPolicy: 'untrusted', sandboxPolicy: 'workspace-write' }).mode, 'guarded');
   assert.equal(normalizeMode({ host: 'codex', approvalPolicy: 'never', sandboxPolicy: 'read-only' }).mode, 'plan');
+});
+
+test('codex approval evidence alone is sufficient for guarded (ADR-0038 ruling)', () => {
+  assert.equal(normalizeMode({ host: 'codex', approvalPolicy: 'on-request' }).mode, 'guarded');
+  assert.equal(normalizeMode({ host: 'codex', approvalPolicy: 'on-request' }).raw, 'on-request');
+});
+
+test('codex raw format preserves both fields when present', () => {
+  assert.equal(normalizeMode({ host: 'codex', approvalPolicy: 'never', sandboxPolicy: 'workspace-write' }).raw, 'never/workspace-write');
 });
 
 test('opencode mode maps build/plan', () => {
@@ -28,7 +40,13 @@ test('opencode mode maps build/plan', () => {
 
 test('absent or unrecognized evidence is null, raw preserved, never guessed', () => {
   assert.equal(normalizeMode({ host: 'claude' }).mode, null);
-  const odd = normalizeMode({ host: 'claude', permissionMode: 'superSafe9000' });
-  assert.equal(odd.mode, null);
-  assert.equal(odd.raw, 'superSafe9000');
+  const oddClaude = normalizeMode({ host: 'claude', permissionMode: 'superSafe9000' });
+  assert.equal(oddClaude.mode, null);
+  assert.equal(oddClaude.raw, 'superSafe9000');
+  const oddOpencode = normalizeMode({ host: 'opencode', opencodeMode: 'debug' });
+  assert.equal(oddOpencode.mode, null);
+  assert.equal(oddOpencode.raw, 'debug');
+  const oddCodex = normalizeMode({ host: 'codex', approvalPolicy: 'yolo', sandboxPolicy: 'workspace-write' });
+  assert.equal(oddCodex.mode, null);
+  assert.equal(oddCodex.raw, 'yolo/workspace-write');
 });

--- a/tests/kit/usage-opencode.test.mjs
+++ b/tests/kit/usage-opencode.test.mjs
@@ -54,13 +54,15 @@ const userMsg = (id, sessionId, at, text = null) => ({
   id, sessionId, at,
   data: { role: 'user', time: { created: at }, agent: 'build', ...(text ? { text } : {}) },
 });
-const assistantMsg = (id, sessionId, at, { model = 'kimi-k3', provider = 'opencode', tokens = {}, cost = null } = {}) => ({
+const assistantMsg = (id, sessionId, at, { model = 'kimi-k3', provider = 'opencode', tokens = {}, cost = null, mode = null, error = null } = {}) => ({
   id, sessionId, at,
   data: {
     role: 'assistant', agent: 'build', path: { cwd: '/x', root: '/' },
     modelID: model, providerID: provider,
     tokens: { total: 0, input: 100, output: 20, reasoning: 5, cache: { read: 40, write: 3 }, ...tokens },
     ...(cost != null ? { cost } : {}),
+    ...(mode != null ? { mode } : {}),
+    ...(error != null ? { error } : {}),
     time: { created: at, completed: at + 1000 }, finish: 'stop',
   },
 });
@@ -194,6 +196,25 @@ test('withTurns emits user/assistant turn rows with text and tool names; tool co
   // and without turns, tool counts still land
   const lean = parseSession({ dbFile, id: 'ses_1' });
   assert.equal(lean.session.tools.bash, 1);
+  rm(d);
+});
+
+test('assistant messages: mode (last wins), user→assistant latency gap, error → exception, ctxLastTokens', () => {
+  const d = tmp();
+  const dbFile = buildDb(path.join(d, 'opencode.db'), {
+    sessions: [{ id: 'ses_1', directory: '/x', title: 't', timeCreated: T }],
+    messages: [
+      userMsg('u1', 'ses_1', T, 'fix the auth flow'),
+      assistantMsg('a1', 'ses_1', T + 4_000, { mode: 'build', tokens: { input: 900, cache: { read: 20000 }, output: 10 } }),
+      assistantMsg('a2', 'ses_1', T + 8_000, { error: { name: 'ProviderAuthError' } }),
+    ],
+  });
+  const { session } = parseSession({ dbFile, id: 'ses_1' });
+  assert.equal(session.mode, 'auto-edit');
+  assert.equal(session.modeRaw, 'build');
+  assert.equal(session.latHist[1], 1);        // 4s → 2-5s bucket
+  assert.equal(session.exceptions, 1);
+  assert.equal(session.ctxLastTokens, 20900);
   rm(d);
 });
 

--- a/tests/kit/usage-opencode.test.mjs
+++ b/tests/kit/usage-opencode.test.mjs
@@ -54,12 +54,16 @@ const userMsg = (id, sessionId, at, text = null) => ({
   id, sessionId, at,
   data: { role: 'user', time: { created: at }, agent: 'build', ...(text ? { text } : {}) },
 });
+// tokens: null (an explicit, not-default, override) omits the `tokens` key
+// entirely — a token-LESS row, distinct from `tokens: {}` which still merges
+// onto the hardcoded defaults below. Same conditional-spread convention as
+// mode/error.
 const assistantMsg = (id, sessionId, at, { model = 'kimi-k3', provider = 'opencode', tokens = {}, cost = null, mode = null, error = null } = {}) => ({
   id, sessionId, at,
   data: {
     role: 'assistant', agent: 'build', path: { cwd: '/x', root: '/' },
     modelID: model, providerID: provider,
-    tokens: { total: 0, input: 100, output: 20, reasoning: 5, cache: { read: 40, write: 3 }, ...tokens },
+    ...(tokens !== null ? { tokens: { total: 0, input: 100, output: 20, reasoning: 5, cache: { read: 40, write: 3 }, ...tokens } } : {}),
     ...(cost != null ? { cost } : {}),
     ...(mode != null ? { mode } : {}),
     ...(error != null ? { error } : {}),
@@ -206,7 +210,9 @@ test('assistant messages: mode (last wins), user→assistant latency gap, error 
     messages: [
       userMsg('u1', 'ses_1', T, 'fix the auth flow'),
       assistantMsg('a1', 'ses_1', T + 4_000, { mode: 'build', tokens: { input: 900, cache: { read: 20000 }, output: 10 } }),
-      assistantMsg('a2', 'ses_1', T + 8_000, { error: { name: 'ProviderAuthError' } }),
+      // token-LESS: the error row must never overwrite ctxLastTokens with a
+      // fabricated 0 (evidence-gated — see recordAssistantUsage).
+      assistantMsg('a2', 'ses_1', T + 8_000, { error: { name: 'ProviderAuthError' }, tokens: null }),
     ],
   });
   const { session } = parseSession({ dbFile, id: 'ses_1' });
@@ -215,6 +221,30 @@ test('assistant messages: mode (last wins), user→assistant latency gap, error 
   assert.equal(session.latHist[1], 1);        // 4s → 2-5s bucket
   assert.equal(session.exceptions, 1);
   assert.equal(session.ctxLastTokens, 20900);
+  rm(d);
+});
+
+test('an error row WITH evidence still records mode/model/usage/cost/ctx — only exceptions++ and no latency sample are error-specific', () => {
+  const d = tmp();
+  const dbFile = buildDb(path.join(d, 'opencode.db'), {
+    sessions: [{ id: 'ses_2', directory: '/x', title: 't', timeCreated: T }],
+    messages: [
+      userMsg('u1', 'ses_2', T, 'deploy the fix'),
+      assistantMsg('a1', 'ses_2', T + 3_000, {
+        model: 'claude-opus-5', mode: 'plan', cost: 0.5, error: { name: 'ProviderAuthError' },
+        tokens: { input: 10, cache: { read: 5 } },
+      }),
+    ],
+  });
+  const { session } = parseSession({ dbFile, id: 'ses_2' });
+  assert.equal(session.mode, 'plan', 'mode is recorded even on an error row');
+  assert.equal(session.modeRaw, 'plan');
+  const row = session.usage.find((r) => r.model === 'claude-opus-5');
+  assert.equal(row.costObserved, 0.5, 'cost is recorded even on an error row');
+  assert.deepEqual(session.models, ['claude-opus-5'], 'modelID is recorded even on an error row');
+  assert.equal(session.ctxLastTokens, 15, 'ctx is recorded even on an error row, when it carries tokens');
+  assert.equal(session.latHist, null, 'an error row never produces a latency sample');
+  assert.equal(session.exceptions, 1);
   rm(d);
 });
 

--- a/tests/kit/usage-telemetry.test.mjs
+++ b/tests/kit/usage-telemetry.test.mjs
@@ -1,29 +1,24 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import * as telemetry from '../../src/lib/usage-telemetry.mjs';
 import {
-  HOST_TELEMETRY_CAPABILITIES, MAX_TELEMETRY_UNKNOWN_KINDS, TELEMETRY_CATEGORIES,
+  MAX_TELEMETRY_UNKNOWN_KINDS,
   addTelemetryDiagnostics, emptyTelemetryDiagnostics,
-  finalizeTelemetryDiagnostics, recordTelemetryUnit, telemetryCapabilities,
+  finalizeTelemetryDiagnostics, recordTelemetryUnit,
 } from '../../src/lib/usage-telemetry.mjs';
 
-test('the host matrix uses shared meanings and never maps Codex wire items to tool calls', () => {
-  assert.deepEqual(Object.keys(HOST_TELEMETRY_CAPABILITIES), ['claude', 'codex', 'opencode']);
-  assert.deepEqual(TELEMETRY_CATEGORIES, [
-    'prompts', 'responses', 'toolCalls', 'commandExecutions',
-    'fileChanges', 'mcpCalls', 'collaboration',
+// The module is counted evidence only. A static per-host capability matrix
+// once lived here and was rendered as its own panel; it declared what a parser
+// COULD report rather than what it did, so it was removed. Pinning the export
+// surface keeps that declaration from reappearing beside the real counters.
+test('the module exports the diagnostics envelope and nothing that declares capability', () => {
+  assert.deepEqual(Object.keys(telemetry).sort(), [
+    'MAX_TELEMETRY_UNKNOWN_KINDS',
+    'addTelemetryDiagnostics',
+    'emptyTelemetryDiagnostics',
+    'finalizeTelemetryDiagnostics',
+    'recordTelemetryUnit',
   ]);
-  assert.equal(HOST_TELEMETRY_CAPABILITIES.claude.toolCalls, 'supported');
-  assert.equal(HOST_TELEMETRY_CAPABILITIES.opencode.toolCalls, 'supported');
-  assert.equal(HOST_TELEMETRY_CAPABILITIES.codex.toolCalls, 'unsupported');
-});
-
-test('supported categories become unavailable when the source is not readable', () => {
-  assert.equal(telemetryCapabilities('claude', 'ok').prompts, 'supported');
-  assert.equal(telemetryCapabilities('claude', 'ok').toolCalls, 'supported');
-  assert.equal(telemetryCapabilities('claude', 'absent').prompts, 'unavailable');
-  assert.equal(telemetryCapabilities('claude', 'degraded').toolCalls, 'unavailable');
-  assert.equal(telemetryCapabilities('claude', 'absent').commandExecutions, 'unsupported');
-  assert.equal(telemetryCapabilities('unknown-host', 'ok').responses, 'unavailable');
 });
 
 test('common diagnostics distinguish observed zero from an unavailable source', () => {

--- a/tests/ui/dashboard-ui.mjs
+++ b/tests/ui/dashboard-ui.mjs
@@ -301,9 +301,21 @@ const LIMITS_STUB = async () => ({
   },
   codex: {
     provider: 'codex', source: 'app-server', fetchedAt: Date.now() - 60_000, planType: 'prolite',
+    // Post-dedup shape (quota.mjs): app-server reports the weekly pool under
+    // BOTH the named lane and the legacy generic `codex` one, and the
+    // normalizer keeps the named copy — so what reaches the browser is a named
+    // lane carrying both windows, never a generic twin. The long pool name is
+    // the point: it is what the label column used to ellipsise.
     lanes: [
-      { id: 'codex', name: 'codex', planType: 'prolite', windows: [{ label: 'weekly', usedPercent: 3, windowMinutes: 10080, resetsAt: Math.round(Date.now() / 1000) + 500000 }] },
-      { id: 'codex_bengalfox', name: 'GPT-5.3-Codex-Spark', planType: 'prolite', windows: [] },
+      {
+        id: 'codex_bengalfox', name: 'GPT-5.3-Codex-Spark', planType: 'prolite',
+        windows: [
+          { label: '5h', usedPercent: 7, windowMinutes: 300, resetsAt: Math.round(Date.now() / 1000) + 9000 },
+          { label: 'weekly', usedPercent: 21, windowMinutes: 10080, resetsAt: Math.round(Date.now() / 1000) + 500000 },
+        ],
+      },
+      // A named pool whose windows are all unusable still gets a row saying so.
+      { id: 'codex_othermodel', name: 'GPT-5.3-Codex-Mini', planType: 'prolite', windows: [] },
     ],
     resetCredits: { availableCount: 2, credits: [{ status: 'available', title: 'Full reset', expiresAt: null }] },
   },
@@ -2241,6 +2253,27 @@ async function main() {
       const arts = artifactsIn(text);
       check(`usage/${view} is free of rendering artifacts`, arts.length === 0,
         `found ${arts.join(', ')} — this is the class of bug unit tests cannot see`);
+      if (view === 'limits') {
+        // Truncation is what hid one pool being reported under two lanes: both
+        // rows ellipsised to the same plausible prefix. Measure the RENDERED
+        // row — a grid template that looks right in the stylesheet is not proof
+        // the string fits. Bars must also share an x, or the panel stops
+        // reading as a stack of comparable meters.
+        const rows = await page.evaluate(() => ({
+          labels: [...document.querySelectorAll('#u-lim-codex .mname, #u-lim-claude .mname')]
+            .map((el) => ({ text: el.textContent, title: el.getAttribute('title'), clipped: el.scrollWidth > el.clientWidth })),
+          barLefts: [...new Set([...document.querySelectorAll('#u-lim-codex .mbar')]
+            .map((el) => Math.round(el.getBoundingClientRect().left)))],
+        }));
+        check('a Codex pool label renders in full at desktop width',
+          rows.labels.length > 0 && rows.labels.every((l) => !l.clipped),
+          `clipped: ${JSON.stringify(rows.labels.filter((l) => l.clipped))}`);
+        check('every limits label carries its full text as a tooltip',
+          rows.labels.every((l) => l.title === l.text),
+          `labels were ${JSON.stringify(rows.labels)}`);
+        check('limits meters all start at the same x',
+          rows.barLefts.length === 1, `bar left edges were ${JSON.stringify(rows.barLefts)}`);
+      }
       if (view !== 'models') {
         const modelBoundary = await page.evaluate(() => {
           const models = document.getElementById('v-models');


### PR DESCRIPTION
Ships the **Matrix A** consistent cross-host session metrics from the [Metric Evidence Matrix](https://claude.ai/code/artifact/1682c1ea-2bbd-4970-8cdd-2cc5e17efcdf) research, rendered per the [Scorecard Additions mockup](https://claude.ai/code/artifact/36adf798-625a-4d44-a84b-1dba7093e752). 42 commits, plan-driven (`docs/superpowers/plans/2026-08-28-scorecard-matrix-a.md`), decisions in **ADR-0038**.

## What ships

| Area | Additions |
|---|---|
| Evidence (schema **v12** — first run re-parses the corpus once) | Cross-host mode taxonomy (`usage-modes.mjs`); per-session latency/length histograms, ctx pressure, aborts; codex host-measured timing incl. `sandbox_policy` **object form** (`.type`); opencode mode/error/ctx; **nested claude subagent transcripts ingested** (`<project>/<sessionId>/subagents/`) with strictly-validated namespaced ids |
| Aggregate | `byMode`, `byInferenceProvider` (observed-only, `not-recorded` first-class), `bySource`, `byTool`, rhythm percentiles (bucket-interpolated, ≥-floored), `engagedByDay`, previous-window deltas (display-window arithmetic), priced-only cost median/P90, main-prompt ratios, `cacheSavedUsd` |
| Dashboard | Hero deltas + sparklines, cadence row, Rhythm & responsiveness, How-you-run (posture/delegation/served-by), tool & model-family mix, reliability strip, session chips (posture badge, ctx%), Limits pace tick — dark+light verified by screenshot |
| CLI | `ak usage score [--window 7\|14\|30] [--json]` — offline, same machinery as the dashboard |
| Findings | `latency-regression` (AND-gated, mutation-tested), `unrestricted-mode` |
| Docs | Metrics doc §15–§19 + full citation re-anchor (machine-checked green); **stale §13.3 tier/geo claim corrected against a live census**; `byProvider` vs `byInferenceProvider` clarified; TRANSCRIPTS/DASHBOARD updated; ADR-0038 |

## Headline discoveries (found by the review tier, fixed in-branch)

- **39% of window cost was invisible**: claude subagent transcripts were never ingested (178 sessions / $2,376 in the verification window). Now ingested, priced, and openable.
- **Codex's riskiest posture was undetectable**: `sandbox_policy` arrives as an object (1,110/1,110 live occurrences), so `never`+`danger-full-access` mapped to nothing. Post-fix: 235 unrestricted sessions visible; the `unrestricted-mode` detector actually works.
- **Uncapped fallback latencies**: 26-hour codex turn durations entered the "response latency" histogram (an earlier in-branch ruling, reversed on review evidence).
- **Docs said tier/geo were unrecordable** — current transcripts record `service_tier`/`inference_geo` per turn; §13.3 now states the censused truth.

## Process & verification

Subagent-driven: 15 tasks, each with a fresh implementer + independent reviewer gate (TDD, RED evidence required); 8 fix rounds, none past round 1 of 5. Final wave: three parallel review seats — whole-branch (most capable model), **brutal-honesty QE code review** (verdict: request changes → all addressed), **brutal-honesty security review** (0 exploitable over HTTP; both MEDIUMs fixed; traversal probed across 5 encodings) — consolidated into one fix wave (8 commits), then a final scoped re-review: **APPROVED FOR PUSH**, all parked items verified parked-cleanly. `pnpm run check` EXIT 0 (typecheck, lint, markdown lint, build, 2416 tests incl. machine-checked doc citations).

## Known follow-ups (each parked with a recorded ruling)

§13.2 OpenAI rate-table reconciliation (doc vs `pricing.mjs`, with a verify-which-is-true mandate) · Limits history sparkline (both hosts) · `usage.mjs` panel-split + shared `usage-format` module (also retires bundle-text assertions) · rhythm/punchcard main-vs-subagent filter question (needs its own ruling + RED tests) · `unclassified` byMode wire key · scanKey deps identity (comment-documented) · `/api/footprint` 503 message redaction · four cosmetic doc-reference nits from the final re-review (incl. one §2→§3 cross-ref) · sourceHealth counter for silently-dropped nonconforming subagent filenames.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0112PukWM7fhreH9F7qa9rEE
