### PR TITLE
feat(audit): add host-neutral hook assurance

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -62,6 +62,22 @@ jobs:
           APPDATA: ${{ runner.temp }}/kit-home/AppData/Roaming
         run: node bin/agentic-kit.mjs x verify security
 
+      - name: Host-neutral hook contract fixtures
+        run: node --test tests/kit/hook-audit.test.mjs tests/kit/hook-audit-hosts.test.mjs
+
+      - name: Report current host releases for schema review
+        shell: bash
+        run: |
+          {
+            echo "### Host hook schema release watch"
+            echo
+            echo "- Codex: $(npm view @openai/codex version 2>/dev/null || echo unavailable)"
+            echo "- Claude Code: $(npm view @anthropic-ai/claude-code version 2>/dev/null || echo unavailable)"
+            echo "- OpenCode: $(npm view opencode-ai version 2>/dev/null || echo unavailable)"
+            echo
+            echo "Compare these versions with ADR-0041's evidence profiles before widening compatibility."
+          } >> "$GITHUB_STEP_SUMMARY"
+
       # Non-blocking: a native libc++abi mutex abort on macos-latest poisons ruflo
       # exit codes, tracked upstream at ruvnet/ruflo#2885 (open as of 2026-08-13).
       # Scope is NOT neural-train-specific: upstream evidence (2026-08-12) shows the

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,10 @@ node_modules/
 
 # Claude Code local config
 CLAUDE.local.md
+
+# Ruflo local secrets and runtime data
+.env.local
+.env.*.local
+.claude-flow/data/
+.claude-flow/logs/
+.claude-flow/sessions/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,40 +1,488 @@
-<!-- Codex-side project instructions (mirror of CLAUDE.md). Full ruflo + agentic-qe
-     operating guidance lives machine-wide at ~/.codex/AGENTS.md / ~/.claude/CLAUDE.md. -->
+# agentic-kit
 
-# Ruflo Machine Ref (Codex / AGENTS.md)
+> Multi-agent orchestration framework for agentic coding
 
-This repo (`@pacphi/agentic-kit`) is a plain-ESM Node.js CLI — **zero runtime
-dependencies**; only `bin/`, `src/`, and `claude/` ship. Tooling (eslint, tsc
-`--checkJs`, markdownlint, lychee) is devDependencies only. Codex reads this file
-the way Claude Code reads `CLAUDE.md`; keep the two in sync.
+## Project Overview
 
-## Swarm Config
+A Claude Flow powered project
 
-- **Topology**: hierarchical-mesh (anti-drift)
-- **Max Agents**: 15
-- **Memory**: hybrid
-- **HNSW**: Enabled
-- **Neural**: Enabled
+**Tech Stack**: TypeScript, Node.js
+**Architecture**: Domain-Driven Design with bounded contexts
+
+## Quick Start
+
+### Installation
 
 ```bash
-ruflo swarm init --topology hierarchical --max-agents 15 --strategy specialized
-```
+npm install
+```text
 
-## Build & Test
+### Build
 
 ```bash
-pnpm test          # node --test unit suite + statusline segments
-pnpm run check     # typecheck + lint + markdown lint + build + test
-pnpm run build     # packaging + CLI-load validation (no transpile — plain ESM)
+npm run build
 ```
 
-## Operating rules
+### Test
 
-- Do what's asked; nothing more. Prefer editing existing files over new ones.
-- Never commit secrets or `.env` files. Never auto-commit/push without an explicit ask.
-- **No `Co-Authored-By` trailer** unless `.claude/settings.json` sets `attribution.commit`.
-- Keep files under ~500 lines; validate input at boundaries.
+```bash
+npm test
+```
 
-## Agentic QE v3
-<!-- managed by ruflo-setup-aqe — aqe init skips regeneration when this sentinel is present -->
-<!-- see ~/.claude/CLAUDE.md for full AQE operating guidance -->
+### Development
+
+```bash
+npm run dev
+```
+
+## Agent Coordination
+
+### Swarm Configuration
+
+This project uses hierarchical swarm coordination for complex tasks:
+
+| Setting | Value | Purpose |
+|---------|-------|---------|
+| Topology | `hierarchical` | Queen-led coordination (anti-drift) |
+| Max Agents | 8 | Optimal team size |
+| Strategy | `specialized` | Clear role boundaries |
+| Consensus | `raft` | Leader-based consistency |
+
+### When to Use Swarms
+
+**Invoke swarm for:**
+
+- Multi-file changes (3+ files)
+- New feature implementation
+- Cross-module refactoring
+- API changes with tests
+- Security-related changes
+- Performance optimization
+
+**Skip swarm for:**
+
+- Single file edits
+- Simple bug fixes (1-2 lines)
+- Documentation updates
+- Configuration changes
+
+### Available Skills
+
+Use `$skill-name` syntax to invoke:
+
+| Skill | Use Case |
+|-------|----------|
+| `$swarm-orchestration` | Multi-agent task coordination |
+| `$memory-management` | Pattern storage and retrieval |
+| `$sparc-methodology` | Structured development workflow |
+| `$security-audit` | Security scanning and CVE detection |
+| `$performance-analysis` | Profiling and optimization |
+| `$github-automation` | CI/CD and PR management |
+
+### Agent Types
+
+| Type | Role | Use Case |
+|------|------|----------|
+| `researcher` | Requirements analysis | Understanding scope |
+| `architect` | System design | Planning structure |
+| `coder` | Implementation | Writing code |
+| `tester` | Test creation | Quality assurance |
+| `reviewer` | Code review | Security and quality |
+
+## Execution Model
+
+- **claude-flow** = LEDGER (coordinates: memory, routing, swarm state)
+- **Codex** = EXECUTOR (writes code, runs tests, creates files)
+
+**Critical rule:** DON'T STOP after calling claude-flow commands. Coordination commands return instantly — continue immediately with the next implementation step.
+
+## Ruflo + Codex Automated Workflow
+
+Ruflo is the coordination ledger and policy decision point; Codex workers execute code, tests, and commands. A Ruflo coordination call records work but never replaces implementation.
+
+Use `guidance_brain({ mode: "recommend", task: "..." })` when the task can
+benefit from Ruflo-specific capabilities. Its live registry is authoritative
+for tool presence; registration alone does not prove configuration,
+reachability, health, or authorization. If it is not registered, use compatible
+`guidance_recommend`, CLI discovery, and repository instructions.
+
+1. **Recall** — search AgentDB memory and relevant ADRs for patterns and constraints.
+2. **Inspect** — read source, runtime, dependency, policy, and health state.
+3. **Route** — choose the smallest capable topology, agents, skills, and tools.
+4. **Plan** — define acceptance criteria, safety envelope, ownership, and validation.
+5. **Execute** — Codex workers implement in isolated scopes; Ruflo records coordination.
+6. **Test** — run focused tests, regression tests, and failure-path checks.
+7. **Validate** — check types, security, policy, compatibility, and artifact integrity.
+8. **Benchmark** — compare a source-bound candidate with a source-bound baseline.
+9. **Optimize** — improve measured bottlenecks without weakening the safety envelope.
+10. **Receipt** — bind claims, evidence, and decisions to exact source/build inputs.
+11. **Handoff** — reconcile concurrent work and disclose unresolved limitations.
+12. **Publish** — only an independently authorized release gate may publish immutable artifacts.
+
+### Concurrency and authority invariants
+
+- Never allow two writers in one worktree.
+- Read-only research agents may share a checkout; writing agents may not.
+- A child may drop capabilities but can never add tools, servers, namespaces, network access, spend, concurrency, or delegation depth.
+- Cancel dependent and not-yet-started sibling work when policy denies an action or a required dependency fails.
+- MetaHarness may benchmark candidates concurrently, but it cannot promote, serve, or expand its own SafetyEnvelope.
+- Only the integration agent changes shared manifests or lockfiles.
+- Do not auto-commit, push, merge, release, or delete worktrees unless the user authorized that operation.
+- Every consequential action must produce a policy decision receipt; production, destructive, spend, and promotion actions may require human approval.
+
+### Repository harness adapter
+
+When tracked repository instructions define a local collaboration harness:
+
+1. Assign the isolated worktree before starting a writing session.
+2. Start or register the session, inspect current claims, and acquire only the
+   exact paths, resources, and development ports needed for the task.
+3. Renew leases during long work, check acknowledged inbox messages at integration
+   boundaries, and release claims when handing off or ending.
+4. Record focused and integration evidence against the exact source state,
+   then let the designated integration owner decide release.
+
+A repository lease coordinates ownership; it does not grant authorization.
+In-memory reference adapters demonstrate semantics but are not distributed,
+restart-durable release authorities.
+The worker still needs the current ADR-324/325 action capability and fencing
+epoch for every protected side effect. Heartbeat and lease expiry establish
+liveness; a PID is diagnostic only. HEAD alone is not an exact source-state
+identity when tracked or untracked changes exist, so a release receipt must
+bind a clean commit or an immutable snapshot including those changes.
+
+## MCP Runtime Integration
+
+Use MCP tools for coordination, then keep coding:
+
+| Tool | Purpose | Example |
+|------|---------|---------|
+| `swarm_init` | Start coordination | `swarm_init({topology: "hierarchical"})` |
+| `memory_store` | Save patterns | `memory_store({key: "auth", value: "JWT"})` |
+| `memory_search` | Find patterns | `memory_search({query: "auth patterns"})` |
+| `task_orchestrate` | Assign work | `task_orchestrate({task: "implement"})` |
+
+## Code Standards
+
+### File Organization
+
+- **NEVER** save to root folder
+- `/src` - Source code files
+- `/tests` - Test files
+- `/docs` - Documentation
+- `/config` - Configuration files
+
+### Quality Rules
+
+- Files under 500 lines
+- No hardcoded secrets
+- Input validation at boundaries
+- Typed interfaces for public APIs
+- TDD London School (mock-first) preferred
+
+### Commit Messages
+
+```text
+<type>(<scope>): <description>
+
+[optional body]
+```
+
+Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`
+
+Do not add a `Co-Authored-By` trailer unless the repository explicitly
+configures and authorizes that attribution.
+
+## Security
+
+### Critical Rules
+
+- NEVER commit secrets, credentials, or .env files
+- NEVER hardcode API keys
+- Always validate user input
+- Use parameterized queries for SQL
+- Sanitize output to prevent XSS
+
+### Path Security
+
+- Validate all file paths
+- Prevent directory traversal (../)
+- Use absolute paths internally
+
+## Memory System
+
+### Storing Patterns
+
+```bash
+npx @claude-flow/cli memory store \
+  --key "pattern-name" \
+  --value "pattern description" \
+  --namespace patterns
+```
+
+### Searching Memory
+
+```bash
+npx @claude-flow/cli memory search \
+  --query "search terms" \
+  --namespace patterns
+```
+
+## Quick Commands
+
+```bash
+npx @claude-flow/cli memory search --query "relevant patterns"
+npx @claude-flow/cli hooks route --task "current task description"
+npx @claude-flow/cli swarm init --topology hierarchical
+npx @claude-flow/cli hooks pre-task --description "task summary"
+```
+
+## Links
+
+- Documentation: <https://github.com/ruvnet/ruflo>
+- Issues: <https://github.com/ruvnet/ruflo/issues>
+
+## Performance Targets
+
+| Metric | Target | Notes |
+|--------|--------|-------|
+| HNSW Search | 150x-12,500x faster | Vector operations |
+| Memory Reduction | 50-75% | Int8 quantization |
+| MCP Response | <100ms | API latency |
+| CLI Startup | <500ms | Cold start |
+| SONA Adaptation | <0.05ms | Neural learning |
+
+## Testing
+
+### Running Tests
+
+```bash
+# Unit tests
+npm test
+
+# Integration tests
+npm run test:integration
+
+# Coverage
+npm run test:coverage
+
+# Security tests
+npm run test:security
+```
+
+### Test Philosophy
+
+- TDD London School (mock-first)
+- Unit tests for business logic
+- Integration tests for boundaries
+- E2E tests for critical paths
+- Security tests for sensitive operations
+
+### Coverage Requirements
+
+- Minimum 80% line coverage
+- 100% coverage for security-critical code
+- All public APIs must have tests
+
+## MCP Integration
+
+Claude Flow exposes tools via Model Context Protocol:
+
+```bash
+# Start MCP server
+npx ruflo mcp start
+
+# List available tools
+npx ruflo mcp tools
+```
+
+### Available Tools
+
+| Tool | Purpose | Example |
+|------|---------|---------|
+| `swarm_init` | Initialize swarm coordination | `swarm_init({topology: "hierarchical"})` |
+| `agent_spawn` | Spawn new agents | `agent_spawn({type: "coder", name: "dev-1"})` |
+| `memory_store` | Store in AgentDB | `memory_store({key: "pattern", value: "..."})` |
+| `memory_search` | Semantic search | `memory_search({query: "auth patterns"})` |
+| `task_orchestrate` | Task coordination | `task_orchestrate({task: "implement feature"})` |
+| `neural_train` | Train neural patterns | `neural_train({iterations: 10})` |
+| `benchmark_run` | Performance benchmarks | `benchmark_run({type: "all"})` |
+
+## Hooks System
+
+Claude Flow uses hooks for lifecycle automation:
+
+### Core Hooks
+
+| Hook | Trigger | Purpose |
+|------|---------|---------|
+| `pre-task` | Before task starts | Get context, load patterns |
+| `post-task` | After task completes | Record completion, train |
+| `pre-edit` | Before file changes | Validate, backup |
+| `post-edit` | After file changes | Train patterns, verify |
+| `pre-command` | Before shell commands | Security check |
+| `post-command` | After shell commands | Log results |
+
+### Session Hooks
+
+| Hook | Purpose |
+|------|---------|
+| `session-start` | Initialize context, load memory |
+| `session-end` | Export metrics, consolidate memory |
+| `session-restore` | Resume from checkpoint |
+| `notify` | Send notifications |
+
+### Intelligence Hooks
+
+| Hook | Purpose |
+|------|---------|
+| `route` | Route task to appropriate agents |
+| `explain` | Generate explanations |
+| `pretrain` | Pre-train neural patterns |
+| `build-agents` | Build specialized agents |
+| `transfer` | Transfer learning between domains |
+
+### Example Usage
+
+```bash
+# Before starting a task
+npx @claude-flow/cli hooks pre-task \
+  --description "implementing authentication"
+
+# After completing a task
+npx @claude-flow/cli hooks post-task \
+  --task-id "task-123" \
+  --success true
+
+# Route a task to agents
+npx @claude-flow/cli hooks route \
+  --task "implement OAuth2 login flow"
+```
+
+## Background Workers
+
+12 background workers provide continuous optimization:
+
+| Worker | Priority | Purpose |
+|--------|----------|---------|
+| `ultralearn` | normal | Deep knowledge acquisition |
+| `optimize` | high | Performance optimization |
+| `consolidate` | low | Memory consolidation |
+| `predict` | normal | Predictive preloading |
+| `audit` | critical | Security analysis |
+| `map` | normal | Codebase mapping |
+| `preload` | low | Resource preloading |
+| `deepdive` | normal | Deep code analysis |
+| `document` | normal | Auto-documentation |
+| `refactor` | normal | Refactoring suggestions |
+| `benchmark` | normal | Performance benchmarking |
+| `testgaps` | normal | Test coverage analysis |
+
+### Managing Workers
+
+```bash
+# List workers
+npx @claude-flow/cli hooks worker list
+
+# Trigger specific worker
+npx @claude-flow/cli hooks worker dispatch --trigger audit
+
+# Check worker status
+npx @claude-flow/cli hooks worker status
+```
+
+## Intelligence System
+
+The RuVector Intelligence System provides neural learning:
+
+### Components
+
+- **SONA**: Self-Optimizing Neural Architecture (<0.05ms adaptation)
+- **MoE**: Mixture of Experts for specialized routing
+- **HNSW**: Hierarchical Navigable Small World for fast search
+- **EWC++**: Elastic Weight Consolidation (prevents forgetting)
+- **Flash Attention**: Optimized attention mechanism
+
+### 4-Step Pipeline
+
+1. **RETRIEVE** - Fetch relevant patterns via HNSW
+2. **JUDGE** - Evaluate with verdicts (success/failure)
+3. **DISTILL** - Extract key learnings via LoRA
+4. **CONSOLIDATE** - Prevent catastrophic forgetting via EWC++
+
+## Debugging
+
+### Log Levels
+
+```bash
+# Set log level
+export CLAUDE_FLOW_LOG_LEVEL=debug
+
+# Enable verbose mode
+npx @claude-flow/cli --verbose <command>
+```
+
+### Health Checks
+
+```bash
+# Run diagnostics
+npx @claude-flow/cli doctor --fix
+
+# Check system status
+npx @claude-flow/cli status
+```
+
+---
+
+<!-- BEGIN AGENTIC-QE CODEX -->
+## Quality Engineering Standards (Agentic QE)
+
+## AQE MCP Server
+
+This project uses Agentic QE for AI-powered quality engineering. The AQE MCP server provides tools for test generation, coverage analysis, quality assessment, and learning.
+
+## Setup
+
+Always call `fleet_init` before using other AQE tools to initialize the QE fleet.
+
+## Available Tools
+
+### Test Generation
+
+- `test_generate_enhanced` — AI-powered test generation with pattern recognition and anti-pattern detection
+- Supports unit, integration, and e2e test types
+
+### Coverage Analysis
+
+- `coverage_analyze_sublinear` — O(log n) coverage gap detection with ML-powered analysis
+- Target: 80% statement coverage minimum, focus on risk-weighted coverage
+
+### Quality Assessment
+
+- `quality_assess` — Quality gate evaluation with configurable thresholds
+- Run before marking tasks complete
+
+### Security Scanning
+
+- `security_scan_comprehensive` — SAST/DAST vulnerability scanning
+- Run after changes to auth, security, or middleware code
+
+### Defect Prediction
+
+- `defect_predict` — AI analysis of code complexity and change history
+
+### Learning & Memory
+
+- `memory_store` — Store patterns and learnings for future reference
+- `memory_query` — Query past patterns before starting work
+- Always store successful patterns after task completion
+
+## Best Practices
+
+1. **Test Pyramid**: 70% unit, 20% integration, 10% e2e
+2. **AAA Pattern**: Arrange-Act-Assert for clear test structure
+3. **One assertion per test**: Test one behavior at a time
+4. **Descriptive names**: `should_returnValue_when_condition`
+5. **Mock at boundaries**: Only mock external dependencies
+6. **Edge cases first**: Test boundary conditions, not just happy paths
+<!-- END AGENTIC-QE CODEX -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,26 +1,16 @@
-<!-- Full ruflo CLI reference: see machine-wide ruflo reference at ~/.claude/CLAUDE.md -->
+<!-- Full ruflo reference: machine-wide ~/.claude/CLAUDE.md (managed by agentic-kit) -->
 
-# Ruflo Machine Ref
+# agentic-kit
 
 ## Swarm Config
 
 - **Topology**: hierarchical-mesh (anti-drift)
 - **Max Agents**: 15
 - **Memory**: hybrid
-- **HNSW**: Enabled
-- **Neural**: Enabled
 
 ```bash
 ruflo swarm init --topology hierarchical --max-agents 15 --strategy specialized
 ```
 
-## Build & Test
-
-```bash
-pnpm test          # full unit suite (node --test tests/kit + the cjs suites)
-pnpm run check     # typecheck + lint + markdown lint + build + test
-```
-
 ## Agentic QE v3
-<!-- managed by ruflo-setup-aqe — aqe init skips regeneration when this sentinel is present -->
-<!-- see ~/.claude/CLAUDE.md for full AQE operating guidance -->
+<!-- managed by agentic-kit — aqe init skips regeneration when this sentinel is present -->

--- a/bin/agentic-kit.mjs
+++ b/bin/agentic-kit.mjs
@@ -25,6 +25,7 @@ const PORCELAIN = Object.assign(Object.create(null), {
   models: () => import('../src/commands/models.mjs'),
   system: () => import('../src/commands/system.mjs'),
   about: () => import('../src/commands/about.mjs'),
+  audit: () => import('../src/commands/audit.mjs'),
   run: () => import('../src/commands/run.mjs'),
   host: () => import('../src/commands/x/host.mjs'),
   uninstall: () => import('../src/commands/uninstall.mjs'),
@@ -57,6 +58,7 @@ Usage (ak = alias of agentic-kit):
   ak models          inspect/refresh model lifecycle evidence  [status|refresh|diff|explain|plan]
   ak system          what this stack occupies on your machine   [--deep] [--json]
   ak about           what agentic-kit installs and configures, and why  [--category N]
+  ak audit hooks     read-only host-neutral hook inventory + remediation plan [--host HOST] [--json]
   ak run             execute a host-neutral activity pipeline  [template "task"] [--dry-run]
   ak host            manage agent hosts, routing, and provider bindings  [status|pick|refresh|off]
   ak uninstall       leave cleanly                                      [--this-project] [--purge]
@@ -200,7 +202,7 @@ async function main() {
   // setup and host own complete mutation/reporting flows. Running the generic
   // nudge after a declined trust preflight could write version-cache state and
   // violate their "before any changes" boundary.
-  if (!values.json && !values['dry-run'] && !['sync', 'usage', 'models', 'setup', 'host', 'ruflo-mcp', 'aqe-provider'].includes(cmd)) {
+  if (!values.json && !values['dry-run'] && !['sync', 'usage', 'models', 'setup', 'host', 'audit', 'ruflo-mcp', 'aqe-provider'].includes(cmd)) {
     try {
       const { driftReport } = await import('../src/lib/versions.mjs');
       for (const r of await driftReport()) {

--- a/config/agentic-dependency-constraints.json
+++ b/config/agentic-dependency-constraints.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "lastVerifiedAt": "2026-09-01",
+  "recheckPolicy": {
+    "cadence": "weekly-and-before-upgrade",
+    "staleAfterDays": 14,
+    "requirePrimarySource": true
+  },
+  "constraints": [
+    {
+      "dependency": "ruflo",
+      "kind": "blocked-version",
+      "affected": ["3.38.17", "3.38.18"],
+      "issue": "https://github.com/ruvnet/ruflo/issues/2885",
+      "issueState": "open-at-last-verification",
+      "strategy": "retain the last proven version and re-run host conformance before removing the block",
+      "sunsetWhen": "an upstream release closes the issue and passes agentic-kit's host-neutral hook and lifecycle conformance suite"
+    },
+    {
+      "dependency": "ruflo",
+      "kind": "upstream-capability-gap",
+      "affected": ["3.x"],
+      "issue": "https://github.com/ruvnet/ruflo/issues/3046",
+      "issueState": "open-at-last-verification",
+      "strategy": "keep agentic-kit detection read-only and treat registration, health, reachability, and authorization as separate facts",
+      "sunsetWhen": "upstream exposes the required evidence and agentic-kit verifies it against a released artifact"
+    },
+    {
+      "dependency": "agentic-qe",
+      "kind": "upstream-capability-gap",
+      "affected": ["3.x"],
+      "issue": "https://github.com/ruvnet/agentic-qe/issues/628",
+      "issueState": "open-at-last-verification",
+      "strategy": "qualify external-provider and cross-host results as transport evidence rather than a host-neutral QE verdict",
+      "sunsetWhen": "a released host-neutral runner passes the live participant and provider conformance tests"
+    }
+  ]
+}

--- a/docs/adr/0033-retire-codex-mcp-and-bound-qe-court-participants.md
+++ b/docs/adr/0033-retire-codex-mcp-and-bound-qe-court-participants.md
@@ -3,12 +3,19 @@
 - **Status:** Implemented; handoff transport amended by
   [ADR-0034](0034-schema-native-handoffs-and-hermetic-seats.md)
 - **Date:** 2026-08-25
-- **Updated:** 2026-08-26
+- **Updated:** 2026-08-31
 - **Update note:** Initial implementation retires only receipt-owned legacy MCP state,
   diagnoses effective Codex MCP topology, extends POSIX cleanup to process groups, and adds
   fail-closed QE-Court readiness plus a reciprocal live participant-transport regression.
   2026-08-26: the soak exposed the free-text handoff as the weak link; ADR-0034 moves
   handoff-bearing seats to schema-native output and hermetic isolation.
+  2026-08-31: `ak sync` now discloses and confirmation-gates repair of user-owned recursive
+  Codex and legacy duplicate Ruflo entries, using Codex's supported removal command and
+  verifying the resulting topology. Sync also carries failed mutation results into its final
+  convergence proof so stale on-disk presence cannot be reported as success. RuvNet Brain
+  release drift is now actionable only when GitHub publishes the exact bundle asset consumed
+  by the installer; tag-only releases remain visible but are deferred without touching the
+  healthy installed Brain.
 - **Deciders:** agentic-kit maintainers
 - **Related:** [ADR-0001](0001-one-routing-policy-many-projections.md),
   [ADR-0006](0006-primary-host-and-ambidextrous-mirroring.md),
@@ -42,8 +49,9 @@ seats. A successful Claude/Codex transport check therefore cannot be called a co
    Codex-primary policies select leadership without changing the transport contract.
 2. Setup, sync, and host selection stop creating `codex mcp-server`. They remove a legacy project
    registration only when `integrations.ownership.codex.mcp === "ak"`, confirm its absence, and
-   clear the receipt only after confirmation. User-owned entries are preserved with a deprecation
-   warning and an exact manual remedy.
+   clear the receipt only after confirmation. User-owned recursive and legacy duplicate entries
+   are disclosed by `ak sync`, removed only after explicit confirmation (or `--yes`), and verified;
+   unrelated user-owned entries remain preserved.
 3. Codex keeps one independent, workspace-aware Ruflo MCP registration. Agentic-QE continues to
    own its Codex platform/MCP integration. Agentic-kit detects recursive Codex self-registration,
    missing concrete Agentic-QE registration, and duplicate Ruflo transports without rewriting
@@ -66,6 +74,10 @@ seats. A successful Claude/Codex transport check therefore cannot be called a co
    store→retrieve proofs in validated handoffs, independently confirms the project-memory values,
    rejects repository mutation and orphaned state, and never substitutes for Agentic-QE's court
    protocol.
+8. Sync distinguishes advertised RuvNet Brain tags from installable releases. Its release probe
+   requires the installer's exact `ruvnet-brain.zip` asset before prescribing a KB refresh. A
+   missing asset is reported as an upstream deferral with no automatic action; an installer that
+   was already launched still fails closed and preserves its causal error in convergence output.
 
 ## Consequences
 
@@ -77,6 +89,9 @@ seats. A successful Claude/Codex transport check therefore cannot be called a co
 - A transport regression can prove bounded participant lifecycle in both leadership directions,
   but full QE-Court parity remains blocked on an upstream Agentic-QE execution surface and complete
   Codex projection.
+- A malformed upstream Brain release no longer creates an endless `ak sync` retry loop or rewrites
+  a usable local Brain; the update becomes actionable automatically after a later release check sees
+  the required bundle asset.
 - ADR-0001's MCP projection is historical. ADR-0006's leadership decision, ADR-0016's ownership
   boundary, ADR-0018's worker lifecycle, and ADR-0020's stable execution surface remain in force.
 

--- a/docs/adr/0040-codex-hook-audit-and-conservative-remediation.md
+++ b/docs/adr/0040-codex-hook-audit-and-conservative-remediation.md
@@ -1,0 +1,219 @@
+# ADR-0040 — Codex hook audit and conservative remediation
+
+- **Status:** Implemented (Codex Wave 1); extended by ADR-0041
+- **Date:** 2026-09-01
+- **Deciders:** agentic-kit maintainers
+- **Related:** [ADR-0016](0016-capability-driven-integration-adapters.md),
+  [ADR-0023](0023-fail-closed-operations-and-explicit-degradation.md),
+  [ADR-0027](0027-shared-project-census.md),
+  [ADR-0029](0029-host-adapter-extension-point.md)
+- **Evidence:** [2026-09-01 hook audit](../audits/codex-hooks-audit-2026-09-01.md)
+- **Extended by:** [ADR-0041](0041-host-neutral-hook-configuration-assurance.md)
+
+## Context
+
+Codex composes hook definitions from global, project, and enabled-plugin sources. Those
+sources merge; one does not override another. Each non-managed definition also has a
+separate exact-definition trust state.
+
+The 2026-09-01 machine audit found 161 selected occurrences across 14 source files and
+45 behavior fingerprints. Ten source files currently request a `SessionEnd` timeout above
+Codex's documented and implemented three-second maximum. Nine are generated project
+projections whose timeout values originated in a Claude-oriented generator and were
+copied without unit translation; one is an installed plugin-cache generation whose
+authoritative repair belongs upstream.
+
+The same audit found generated project files with no ownership receipt, stale behavior
+duplicating current plugin ownership, an exact Beads duplicate, no-op handlers, a hook
+presented as enforcement despite using the wrong Codex blocking contract, and a RuvNet
+Brain manifest/runtime version skew that silently drops two actions. A timeout-only patch
+would suppress one warning while leaving the larger ownership and security failures
+untouched.
+
+Agentic-kit already has pieces of the necessary boundary:
+
+- `codex-plugins.mjs` inspects enabled cache generations without adopting ownership;
+- the project census provides one bounded set of known Git projects;
+- adapters use `detect → plan → apply → verify → undo`;
+- ownership logic preserves later user drift;
+- file writers use backup-first atomic replacement.
+
+It does not yet have a normalized hook domain, version-aware hook schemas, occurrence
+deduplication, provenance resolution, or transaction receipts for multi-file hook healing.
+
+The initial dual-host architecture gate was degraded because Claude Code was not signed
+in. The follow-up Ruflo architecture/test/review lanes and Agentic-QE gates are recorded
+by ADR-0041; Codex Wave 1 is therefore implemented while host-neutral extension is owned
+by the later decision.
+
+## Decision
+
+### 1. Hook audit is a separate bounded context
+
+Runtime hook discovery is not a host lifecycle adapter and is not a setup trust manifest.
+The first public surface is:
+
+```text
+ak audit hooks
+```
+
+Its default is read-only. It performs no hook execution and no file writes. The first
+implemented wave discovers direct global hooks, selected project hooks, and enabled
+plugin hook files; records source hashes and JSON pointers; normalizes behavior; and
+classifies remediations.
+
+Future providers implement three distinct contracts:
+
+```js
+HookDiscoveryProvider.discover(context) -> HookSource[]
+HookSchemaProfile.select(runtimeFacts) -> rules
+HookRemediator.detect/plan/apply/verify/undo
+```
+
+External providers remain declarative plus bounded subprocesses under ADR-0029. Their
+code is never imported into the agentic-kit process, and plugin-cache code is never
+executed for discovery.
+
+### 2. Every occurrence survives deduplication
+
+A normalized occurrence records host, scope, event, matcher, group/hook indexes, type,
+raw and parsed command, timeout declaration/units/effective bound, source path and JSON
+pointer, digest, owner/authority/generated status, runtime versions, side-effect hints,
+risk, trust recommendation, diagnostics, raw fingerprint, and behavior fingerprint.
+
+Behavior fingerprints normalize event/matcher, implementation target, material arguments,
+cwd/environment policy, and side effects. Timeout and presentation fields remain
+diagnostics and do not erase behavioral identity. Deduplication links occurrences; it
+never drops their provenance.
+
+### 3. Schemas are version-aware and evidence-bearing
+
+Each schema profile records supported events/fields/matchers, timeout units and
+event-specific bounds, output/blocking rules, version range, evidence source, and
+verification date. The verified three-second `SessionEnd` maximum belongs in the Codex
+profile rather than an ad hoc string check.
+
+Unknown/future versions receive syntax-only validation. Agentic-kit must not automatically
+rewrite compatibility values unless authoritative local implementation or current primary
+documentation proves the selected rule.
+
+Diagnostics remain separate categories:
+
+- compatibility;
+- trust;
+- security;
+- provenance;
+- ownership;
+- duplicate;
+- performance;
+- runtime.
+
+Trust never suppresses compatibility, and compatibility never establishes trust.
+
+### 4. Healing has three action classes
+
+An action is **automatic** only when all of the following are true:
+
+- the canonical source is proven;
+- it is agentic-kit-owned or covered by an exact ownership receipt;
+- the change is semantics-preserving;
+- the selected version schema is authoritative;
+- the preimage digest still matches;
+- trust state is untouched;
+- no generated/cache target is written directly.
+
+An action is **approval required** when it changes a user-owned source, generator,
+behavior, matcher, order, environment, side effect, timeout, or more than one project.
+Approval names a specific action ID and does not broaden the plan.
+
+An action is **never automatic** when it writes plugin cache, staging, generated copies
+instead of canonical sources, trust hashes/project trust, unknown-ownership commands,
+unknown schemas, symlinks, or special files. Duplicate/stale/expensive appearance alone
+never authorizes deletion.
+
+No current finding qualifies for automatic mutation.
+
+### 5. Trust remains user-owned
+
+The auditor may report observed trust evidence and one of:
+
+- `TRUST`
+- `TRUST AFTER CHANGE`
+- `DO NOT TRUST`
+- `HUMAN REVIEW REQUIRED`
+
+Those are review recommendations, not authorization. Agentic-kit will not set
+`trusted_hash`, modify project `trust_level`, invoke a bypass, or equate a successful
+benchmark with trust.
+
+### 6. Future apply is transactional
+
+The current command intentionally exposes no apply surface. A later wave may add it only
+with these invariants:
+
+1. plan includes canonical owner, action ID, target, expected preimage digest, desired
+   digest, mode, unified diff, behavior impact, trust impact, and rollback description;
+2. apply rechecks regular non-symlink targets and every preimage before the first write;
+3. exact bytes/modes are backed up in a unique transaction directory;
+4. temporary files use random exclusive creation and atomic rename;
+5. post-write bytes, schema, and effective behavior are verified;
+6. receipts bind pre/post digests, backups, actions, modes, and verification;
+7. rollback proceeds only while current digest equals the receipt postimage;
+8. a complete second audit must clear the targeted plan without changing trust;
+9. a third plan must leave bytes and mtimes unchanged.
+
+Partial failures report exact state. Already-written targets are rolled back only when
+their postimage digest still matches, preserving later user drift.
+
+### 7. Benchmarks are explicit evidence, never status-time behavior
+
+Future benchmark mode parses and classifies a command before execution. It refuses
+network, package-manager, credential, trust, process-control, mutation, model, detached,
+and unbounded-shell candidates unless the user approves that exact action. It never
+blindly passes a raw hook string to `sh -c`.
+
+Safe candidates run with synthetic input, isolated temporary home/cwd, minimal
+environment, absolute timeout, process-group cleanup, and bounded stdout/stderr. Five
+samples report min/median/max; p95 is reported only with at least 20 samples. Skips and
+refusals are first-class results.
+
+## Consequences
+
+### Positive
+
+- Timeout clamping and trust can no longer be conflated in agentic-kit output.
+- The cache boundary remains read-only and upstream ownership remains visible.
+- Behavior duplication becomes measurable without losing source occurrences.
+- Unknown provenance fails closed to a plan rather than becoming a guessed mutation.
+- Hook auditing is reusable across projects and can later admit other hosts through an
+  explicit provider contract.
+- Future healing has an auditable backup/rollback/no-op proof rather than best-effort
+  edits.
+
+### Negative
+
+- The first wave reports problems it deliberately cannot heal.
+- Occurrence-level inventory is larger than a deduplicated list.
+- Version/source resolution adds complexity and can return unknown rather than advice.
+- Canonical owner repairs must land in Ruflo, Agentic-QE, RuvNet Brain, Beads, or OpenAI
+  sources before installed copies become clean.
+- A full all-project audit is too expensive and nuanced for normal `ak status`/`ak sync`.
+
+### Deferred
+
+- transactional apply and rollback;
+- safe benchmark execution;
+- declarative external hook providers;
+- cheap status summary;
+- narrowly scoped sync integration for proven automatic actions;
+- independent Claude-led architecture review and acceptance decision.
+
+## Compliance
+
+Wave 1 is additive: `src/lib/hook-audit/index.mjs`, `src/commands/audit.mjs`, CLI dispatch,
+tests, a structured hook-versus-skill plugin issue channel, and durable audit artifacts.
+Discovery rejects traversal references, canonical cache escapes, symlink ancestors,
+broken symlinks, malformed nested groups, non-string matchers, and invalid timeout values.
+It does not modify setup/sync, current hooks, trust, plugin cache, or user state. This
+preserves existing dirty work in integration modules and keeps the behavioral repair gate
+explicit.

--- a/docs/adr/0041-host-neutral-hook-configuration-assurance.md
+++ b/docs/adr/0041-host-neutral-hook-configuration-assurance.md
@@ -1,0 +1,148 @@
+# ADR-0041 — Host-neutral hook configuration assurance
+
+- **Status:** Accepted; read-only implementation complete
+- **Date:** 2026-09-01
+- **Deciders:** agentic-kit maintainers
+- **Extends:** [ADR-0040](0040-codex-hook-audit-and-conservative-remediation.md)
+- **Related:** [ADR-0016](0016-capability-driven-integration-adapters.md),
+  [ADR-0029](0029-host-adapter-extension-point.md),
+  [ADR-0031](0031-capability-graduation-and-upstream-requests.md),
+  [ADR-0032](0032-model-lifecycle-intelligence.md)
+- **DDD:** [Hook configuration assurance](../ddd/hook-configuration-assurance.md)
+- **Evidence:** [Host-neutral follow-up](../audits/host-neutral-hooks-follow-up-2026-09-01.md)
+
+## Context
+
+ADR-0040 proved the Codex problem but left the abstraction named and shaped around one
+host. Claude Code composes settings, managed policy and plugin hook documents. Codex
+composes JSON, inline TOML, managed policy and plugin sources, then applies independent
+definition trust. OpenCode loads configuration and full-process plugins rather than a
+settings-hook document. External agentic-kit host adapters declare subprocess hooks in
+validated manifests and require separate consent and capability grants.
+
+Treating these as one file format would lose the differences that matter. Treating them
+as unrelated would repeat the original timeout-unit, generated-copy and provenance
+failures for every new host. Releases also change schemas and lifecycle events, while
+Ruflo, Agentic-QE, RuvNet Brain and other managed dependencies can require bounded local
+workarounds until an upstream issue is released and proven.
+
+## Decision
+
+### 1. One bounded context, multiple evidence providers
+
+Hook configuration assurance owns a normalized read model and remediation proposals. It
+consumes host identity and admitted adapter manifests from Integration Management, but
+it is not a host lifecycle adapter, execution runner, plugin runtime or trust authority.
+
+Built-in providers are registered for `codex`, `claude`, `opencode` and `external`.
+`ak audit hooks` keeps Codex as its compatibility default; repeatable `--host` selects a
+provider and `--host all` runs the complete registry. Every provider returns sources,
+occurrences, diagnostics, coverage gaps and proposals without executing hook code.
+
+### 2. Effective state is never guessed
+
+Every report states `complete`, `partial` or `unsupported` coverage. Static discovery may
+record a selected state only when the inspected layers prove it. Trust hashes, project
+trust, organization policy, environment overrides, runtime reachability, consent and
+capability grants remain independent facts. Unknown effective selection is `null`, not
+`true`.
+
+OpenCode plugin modules are hashed and inspected as text but never imported. JSONC is
+reported as an opaque later layer rather than rewritten or weakly parsed. Remote adapter
+manifests are reported but never fetched by the default offline audit.
+
+### 3. Behavior identity includes every material execution field
+
+The behavior fingerprint includes host, event, matcher, handler type, command identity,
+Windows command, MCP server/tool/input contract, asynchronous mode, context limit,
+status message, timeout and effective working directory. Occurrences from different
+working directories are not deduplicated merely because their command strings match.
+Public reports redact credential-shaped command assignments and retain only the original
+command digest for identity.
+
+### 4. Version profiles are exact and evidence-bearing
+
+Profiles name the exact locally verified host versions and a primary documentation
+source. Unknown versions receive syntax-only validation and no automatic compatibility
+repair. A newer version does not inherit a prior profile by optimistic range matching.
+
+The initial profiles are Codex CLI `0.151.0`, Claude Code `2.1.258` and OpenCode
+`1.18.25`. The profile registry is updated only after source or authoritative docs and
+fixtures agree. Host releases trigger the conformance suite before widening a range or
+adding a new exact profile.
+
+### 5. Remediation authority has four classes
+
+- `automatic-eligible`: proven agentic-kit ownership, exact schema, semantics-preserving
+  change and matching preimage; still only a proposal in this read-only wave.
+- `approval-required`: user/project sources or any behavioral change.
+- `prohibited`: trust bypasses, generated/cache targets, unsafe files, unknown schemas or
+  unproven canonical ownership.
+- `upstream-required`: generated dependency behavior whose authoritative repair belongs
+  in the producing project.
+
+The implemented command has no apply flag. A future writer must satisfy ADR-0040's
+backup, preimage, rollback, receipt and idempotency contract. It may never programmatically
+approve or bypass host trust.
+
+### 6. External adapters stay declarative and independently authorized
+
+Local external manifests are validated through the existing adapter contract and their
+declared hook files are content-hashed. The audit does not import adapter code, admit the
+adapter, grant capabilities or run a hook. Because the current contract does not declare
+a target host-version compatibility range, every external hook carries an explicit
+human-review proposal until a later contract version adds and validates that evidence.
+
+### 7. Upstream constraints are lifecycle data
+
+`config/agentic-dependency-constraints.json` records dependency, affected versions,
+primary issue, independently tracked issue state, bounded strategy, verification date
+and an objective sunset condition. It is not a grant store and never authorizes a patch.
+
+Constraints are rechecked weekly, before a managed upgrade, and when host/dependency
+release automation observes a new version. A workaround is removed only after a released
+artifact passes the relevant host-neutral audit and conformance tests. Issue closure alone
+does not prove a fix; an open issue does not by itself prove the installed version is
+affected.
+
+## Consequences
+
+### Positive
+
+- One command exposes the same evidence model across built-in and external hosts.
+- Host-specific semantics remain visible instead of being flattened into Codex JSON.
+- Releases fail safely into syntax-only/partial coverage.
+- Generated dependency defects have a durable notification, workaround and sunset path.
+- No audit path executes hooks, changes trust, imports plugins or fetches remote manifests.
+
+### Negative
+
+- Partial coverage is expected for runtime-only and organization-controlled state.
+- OpenCode modules remain opaque without execution, and JSONC remains unnormalized.
+- Exact profiles require maintenance when hosts release.
+- External adapter compatibility cannot be complete until its versioned contract grows a
+  target-host range.
+
+## Implementation status
+
+Implemented in this decision:
+
+- provider registry and host-neutral orchestrator;
+- Claude, Codex, OpenCode and external manifest discovery;
+- Codex inline TOML and inline plugin-hook discovery;
+- material-field fingerprints, source containment, size bounds and command redaction;
+- explicit provider coverage gaps;
+- upstream constraint registry;
+- repeatable `--host` and `--host all` CLI selection;
+- adversarial cross-host fixtures and read-only tests.
+- post-open inode/path verification for every bounded source read;
+- Claude optional-manifest plugin provenance and host-specific `SessionEnd` budget rules.
+
+Deferred behind a separate decision and explicit approval design:
+
+- transactional apply/rollback;
+- host trust inspection or mutation;
+- JSONC normalization;
+- network retrieval of remote adapter manifests;
+- automatic upstream issue creation;
+- external adapter target-version declarations.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -46,6 +46,9 @@ Consequences**, and cites the grounded source it rests on where relevant.
 | [0036](0036-dashboard-client-modularization-and-shared-loopback-server.md) | Dashboard client modularization and shared loopback server | Implemented |
 | [0037](0037-complexity-program-structural-patterns.md) | Complexity program: structural patterns and gates | Implemented |
 | [0038](0038-consistent-cross-host-session-metrics.md) | Consistent cross-host session metrics | Accepted |
+| [0039](0039-prompts-intelligence.md) | Prompts intelligence: fingerprints, coaching, and layer-3 enrichment | Accepted |
+| [0040](0040-codex-hook-audit-and-conservative-remediation.md) | Codex hook audit and conservative remediation | Implemented (Codex Wave 1) |
+| [0041](0041-host-neutral-hook-configuration-assurance.md) | Host-neutral hook configuration assurance | Accepted; read-only implementation complete |
 
 Theme: ADRs **0001–0006** define **dual-host LLM routing and leadership** — how `ak` lets ruflo route
 each development activity (architecture, implementation, testing, review, …) to the right host (Claude
@@ -294,3 +297,17 @@ discovery gains exactly one nested shape — Claude Code's `<sessionId>/subagent
 transcripts, whose absence had made a quarter of the sessions and 39% of the cost in a reference
 window invisible — behind a namespaced id grammar that narrows the traversal guard rather than
 loosening it.
+
+**0039** adds privacy-preserving prompts intelligence to the usage scorecard. It separates human
+prompts from control/agent/adapter turns, retains bounded fingerprints rather than text, uses
+history-backed baselines where evidence permits, and keeps model enrichment opt-in and
+receipt-bound.
+
+**0040** proposes a separate hook-audit bounded context. It discovers direct, project, and
+selected-plugin Codex lifecycle hooks without executing them; preserves every occurrence while
+behavior-deduplicating; keeps compatibility, trust, security, provenance, ownership, duplicate,
+performance, and runtime diagnostics independent; and classifies healing as automatic,
+approval-required, or never-automatic. Plugin caches and trust state remain unwritable. A later
+apply wave requires exact preimages, transaction-specific backups/receipts, guarded rollback, a
+clean second audit, and a byte/mtime no-op proof. The ADR remains Proposed pending independent
+dual-host review.

--- a/docs/audits/codex-hooks-audit-2026-09-01.md
+++ b/docs/audits/codex-hooks-audit-2026-09-01.md
@@ -1,0 +1,429 @@
+# Codex Hooks Audit — 2026-09-01
+
+Review mode: discovery, provenance analysis, isolated safe benchmarks, and additive
+doctor implementation
+
+Scope: Codex global configuration, enabled plugins and cache generations, this
+repository, sibling repositories found by bounded development-root and shared project
+census discovery, upstream/local generators, and agentic-kit setup/sync/status code
+
+Companion artifacts:
+
+- [machine-readable inventory](codex-hooks-inventory-2026-09-01.json)
+- [remediation plan](codex-hooks-remediation-2026-09-01.md)
+- [ADR-0040 proposal](../adr/0040-codex-hook-audit-and-conservative-remediation.md)
+
+## Executive summary
+
+The Hooks UI is reporting two independent facts, and they must stay independent:
+
+1. `SessionEnd` timeout clamping is a schema/runtime compatibility warning. Codex
+   interprets `timeout` as seconds and permits at most three seconds for `SessionEnd`.
+2. “Needs review” is an exact-definition trust decision. Project trust enables the
+   project `.codex` layer, while each current non-managed hook definition is separately
+   reviewed by hash. Changing a timeout can cause a new review prompt, but accepting a
+   hook does not make its timeout valid and changing the timeout does not grant trust.
+
+The timeout problem is systemic. Nine project files carry a Claude-oriented Ruflo hook
+projection whose millisecond-style values became seconds in Codex. Their `SessionEnd`
+value is `10000`, so Codex clamps it to three seconds. The enabled OpenAI Codex Companion
+plugin 1.0.6 declares five seconds and is also clamped. Other project values such as
+`5000`, `8000`, and `15000` are not clamped because they are on other events, but Codex
+still interprets them as 83–250 minute timeouts. This is a host-schema translation defect,
+not a slow-hook diagnosis.
+
+The repeated project files are generated/ignored artifacts with unresolved writer
+provenance. Eight full files are byte-identical; Ampel contains a subset. Their content
+traces to Ruflo's Claude settings generator, while the installed Codex bridge delegates
+Codex lifecycle ownership to the `ruflo-core@ruflo` plugin to avoid double firing.
+Therefore the local projections are stale relative to current ownership, but removing
+them still changes runtime behavior and is not safe to automate.
+
+The highest-risk finding is not the timeout warning. RuvNet Brain's selected 4.2.2-dev
+manifest invokes the machine's active 4.0.1 adapter. That runtime does not implement
+the manifest's `decision-gate` or `session-snapshot` actions; both exit zero silently.
+The decision gate must be treated as **HIGH / DO NOT TRUST as a security control** until
+the active runtime and manifest are compatibility-checked and aligned. The plugin as a
+whole remains **HUMAN REVIEW REQUIRED**.
+
+No active hook, trust hash, project trust setting, plugin cache file, or source generator
+was changed in this audit. The conservative implementation adds `ak audit hooks`, a
+read-only occurrence-level inventory and remediation planner. On this machine it reports
+161 selected hook occurrences, 45 behavior fingerprints, 10 current timeout warnings,
+zero invalid sources, zero hook-discovery configuration issues, and zero automatic
+remediations.
+
+## Evidence and limits
+
+Labels used below:
+
+- **M — measured:** observed from local files, binaries, hashes, isolated execution, or
+  command output.
+- **D — documented:** supported by current primary documentation/source.
+- **I — inferred:** a causal conclusion from measured/documented evidence whose remaining
+  uncertainty is stated.
+
+The audit did not read credential values. It inspected commands before execution. Hooks
+that could kill processes, delete broker state, run a package-manager fallback, invoke a
+model, use network credentials, spawn detached work, or mutate user learning/memory were
+not benchmarked. The representative project hooks were copied into fresh temporary
+fixtures with relevant state; the real repository was not used as their write target.
+
+One optional direct frozen-body RuvNet Brain benchmark updated its warning-rate marker at
+`~/.cache/ruvnet-brain/.spine-fallback-notice`. It did not change a repository, Codex
+configuration, trust state, plugin cache, or active runtime. Because the prior marker
+bytes were not recoverable, the audit did not attempt a blind reversal. Its timing is not
+used as evidence for current runtime behavior.
+
+Claude Code was not signed in during the dual-host architecture gate. The implementation
+and ADR therefore remain Codex-reviewed and the ADR status is **Proposed**, not accepted.
+
+## Runtime and version map
+
+| Component | Observed version/state | Evidence |
+|---|---|---|
+| Codex Desktop | 26.831.20005, build 7524 | M: application `Info.plist` |
+| Desktop-bundled Codex CLI | 0.152.0 | M: direct bundled executable |
+| `PATH` Codex CLI | 0.151.0 | M: mise/npm executable |
+| agentic-kit | 4.0.0-alpha.44 | M: `package.json` |
+| Ruflo | 3.38.20 | M: installed package |
+| Agentic-QE | 3.14.0 | M: installed package |
+| RuvNet Brain plugin cache | 4.2.2-dev | M: enabled plugin generation |
+| RuvNet Brain active code root | 4.0.1 | M: `~/.cache/ruvnet-brain/active.json` |
+| OpenAI Codex Companion plugin | 1.0.6 | M: enabled cache generation |
+| Ruflo Core plugin | 0.2.6 | M: enabled cache generation |
+| Beads plugin | 1.2.2 | M: enabled cache generation |
+
+The two Codex CLI versions matter for reproducibility: Desktop runs its bundled 0.152.0
+binary, while a shell normally resolves 0.151.0 first. Both local implementation evidence
+and current docs agree on the `SessionEnd` cap.
+
+## Codex timeout and trust rules
+
+Codex's current official documentation states that hook timeouts are seconds and that
+`SessionEnd` defaults to one second with a maximum of three seconds. The current source
+defines the same constants and clamps larger values during discovery:
+
+- [Codex Hooks documentation](https://developers.openai.com/codex/hooks)
+- [Codex `SessionEnd` implementation](https://github.com/openai/codex/blob/main/codex-rs/hooks/src/events/session_end.rs)
+
+The same documentation states that matching hooks merge and run rather than overriding
+one another. New or modified non-managed definitions are skipped until reviewed. Local
+source inspection confirms current-hash comparison against `trusted_hash` is separate
+from project `trust_level`.
+
+No trust-bypass flag was used. This report does not recommend one.
+
+## Inventory summary
+
+The bounded full audit selected 14 runtime source files:
+
+- 10 project `.codex/hooks.json` files;
+- four manifest-selected enabled plugin hook files;
+- no direct executable global `~/.codex/hooks.json`.
+
+Those sources contain 161 physical hook occurrences and 45 behavior fingerprints.
+Occurrence rows are retained in the command output so provenance is never lost when
+behaviors are deduplicated.
+
+### Project hooks
+
+Eight full Ruflo projections are byte-identical (SHA-256
+`53398d1ac227a34cf3e9ee466f327cfbacf9464bfec55b4f3588b4a644576d3`):
+
+- agentic-kit
+- java-spring-modernization-marketplace
+- finima
+- keel
+- prompt-genie
+- reelbox-cli
+- tub-vault
+- site
+
+Ampel contains seven entries from the same projection. Emailibrium contains four Beads
+lifecycle hooks that are behavior-identical to the enabled Beads plugin. The earlier UI
+reported `scripts`, but no current project hook file was found for it in the bounded roots;
+that diagnostic is likely stale or points outside current discovery.
+
+The full Ruflo projection contains 15 occurrences:
+
+| Event / matcher | Implementation | Declared timeout | Current behavior |
+|---|---|---:|---|
+| PreToolUse / Bash | `hook-handler.cjs pre-bash` | 5000 | implemented weak denylist; wrong Codex blocking contract |
+| PreToolUse / Write/Edit/MultiEdit | `hook-handler.cjs pre-edit` | 5000 | unknown-success no-op |
+| PostToolUse / Write/Edit/MultiEdit | `hook-handler.cjs post-edit` | 10000 | records edit/intelligence state |
+| PostToolUse / Bash | `hook-handler.cjs post-bash` | 5000 | unknown-success no-op |
+| PreCompact / manual | `compact-manual` | default | unknown-success no-op |
+| PreCompact / manual | `session-end` | 5000 | state consolidation/end |
+| PreCompact / auto | `compact-auto` | default | unknown-success no-op |
+| PreCompact / auto | `session-end` | 6000 | state consolidation/end |
+| SessionStart | `session-restore` | 15000 | restore/start, state writes, detached refresh possibilities |
+| SessionStart | `auto-memory import` | 8000 | dynamic sidecar import |
+| SessionEnd | `session-end` | 10000 | clamped to 3 |
+| UserPromptSubmit | `route` | 10000 | local routing/advisory output |
+| SubagentStart | `status` | 3000 | unknown-success no-op |
+| SubagentStop | `post-task` | 5000 | records outcome |
+| Stop | `auto-memory sync` | 10000 | project/user auto-memory write |
+
+Every command is a `sh -c` wrapper that tries
+`${CLAUDE_PROJECT_DIR}/.claude/helpers/...` and falls back to
+`${HOME}/.claude/helpers/...`. `CLAUDE_PROJECT_DIR` is not a documented Codex project-hook
+environment contract. The fallback can cross the repository boundary, and launching in a
+subdirectory can select a different helper or fail to find the intended one.
+
+### Enabled plugin hooks
+
+| Plugin | Selected occurrences | Canonical source | Cache posture |
+|---|---:|---|---|
+| RuvNet Brain 4.2.2-dev | 16 | `stuinfla/ruvnet-brain` marketplace/local installer | read-only runtime copy |
+| Ruflo Core 0.2.6 | 7 | `ruvnet/ruflo` marketplace | read-only runtime copy |
+| Beads 1.2.2 | 4 | `steveyegge/beads` marketplace | read-only runtime copy |
+| OpenAI Codex 1.0.6 | 3 | `openai/codex-plugin-cc` marketplace | read-only runtime copy |
+
+Non-selected cache files were recorded as provenance but not counted as active. In
+particular, RuvNet Brain's Claude-oriented `hooks/hooks.json` is shadowed by the explicit
+`hooks/codex-hooks.json` manifest declaration. Its larger SessionEnd values are therefore
+not current clamp warnings. Disabled n8n/security-guidance hook files and Superpowers'
+shadowed conventional file are also not active sources.
+
+## Source-to-runtime ownership maps
+
+### Historic project projection
+
+```text
+Ruflo Claude settings generator
+  -> unknown historic copier/projection step
+    -> <project>/.codex/hooks.json (ignored, generated-origin-unknown)
+      -> <project>/.claude/helpers/* or ~/.claude/helpers/*
+        -> Codex runtime / Hooks UI
+```
+
+The commands and numeric timeout values trace exactly to Ruflo's Claude settings
+generator. The inspected Ruflo code does not prove which historical process copied them
+into Codex files, so the project artifacts remain `authority: unknown`.
+
+### Current Ruflo ownership
+
+```text
+ruvnet/ruflo marketplace source
+  -> Codex installed cache ruflo-core/0.2.6
+    -> plugin hooks/hooks.json
+      -> ruflo-hook.cjs
+        -> local Ruflo CLI, else npx ruflo@latest fallback
+          -> Codex runtime / Hooks UI
+```
+
+The installed Codex bridge explicitly delegates lifecycle ownership to the upstream
+plugin to avoid double firing. This makes the project projections stale, but
+not safe to delete without a reviewed diff and backup.
+
+### Agentic-QE installation
+
+```text
+agentic-qe/.codex/hooks.json + .codex/hooks/*
+  -> CodexInstaller.installCodexHooks()
+    -> merge into <project>/.codex/hooks.json
+    -> copy <project>/.codex/hooks/*
+      -> Codex runtime / Hooks UI
+```
+
+Agentic-kit invokes `aqe init --auto --with-codex`. Agentic-QE's installer is an
+authoritative generator for its owned groups, but the current project file does not match
+that packaged template. The installer writes the merged target without a backup,
+transaction receipt, rollback, or post-write schema proof—an architectural gap addressed
+by the remediation proposal.
+
+### Plugin source chains
+
+```text
+openai/codex-plugin-cc checkout -> cache 1.0.6 -> hooks/hooks.json
+ruvnet/ruflo checkout           -> cache 0.2.6 -> hooks/hooks.json
+steveyegge/beads checkout       -> cache 1.2.2 -> .codex-plugin/hooks/hooks.json
+stuinfla/ruvnet-brain checkout  -> managed marketplace -> cache 4.2.2-dev
+```
+
+Source and cache hashes matched in the inspected chains. That proves the cache is a
+faithful installed payload; it does not make the cache authoritative or writable.
+
+## Root causes
+
+### RC1 — Claude-to-Codex timeout-unit translation defect
+
+Claude-oriented generator values in the thousands were copied into a Codex schema whose
+unit is seconds. Only `SessionEnd` has the explicit three-second cap and warning, so the UI
+exposes one symptom while much larger effective budgets remain on other events.
+
+### RC2 — Hook ownership migrated without removing old project projections
+
+Current Ruflo Codex ownership lives in the `ruflo-core` plugin, but generated project
+copies remain. Codex merges matching sources, so this is process duplication rather than
+configuration override.
+
+### RC3 — Generated files lack receipts and canonical provenance
+
+Project `.codex/hooks.json` files are ignored/untracked. The current Agentic-QE installer
+merges generated groups directly and does not emit backup/ownership receipts. Once two
+generators have touched the same file, safe healing cannot distinguish user intent from
+generated residue using content alone.
+
+### RC4 — Manifest/runtime compatibility is not validated
+
+RuvNet Brain loads a 4.2.2-dev hook manifest through an active 4.0.1 runtime. Unknown
+action IDs return success, and the adapter forwards stderr only on nonzero status. The
+result is silent control loss.
+
+### RC5 — Lifecycle hooks are treated as both enforcement and telemetry
+
+The project `pre-bash` hook looks like a safety gate, but it exits 1 on rejection while
+Codex's blocking contract uses a structured deny result or exit 2 with a reason. Ruflo's
+plugin shim always exits zero and suppresses errors. These may provide telemetry, but
+must not be described or trusted as a fail-closed security wall.
+
+## Security and trust review
+
+| Behavior | Risk | Recommendation | Reason |
+|---|---|---|---|
+| Project shell bootstrap | MEDIUM | TRUST AFTER CHANGE | dynamic shell, undocumented project env, `$HOME` fallback |
+| Project `pre-bash` as enforcement | HIGH | DO NOT TRUST | weak substring list and wrong Codex rejection contract |
+| Project no-op handlers | LOW | TRUST AFTER CHANGE | pure process cost and misleading success |
+| Project post-edit/session lifecycle | MEDIUM | TRUST AFTER CHANGE | project learning/state mutation; dedupe/root fix first |
+| Project auto-memory import/sync | HIGH | HUMAN REVIEW REQUIRED | absolute dynamic import; project/user writes; inherited authority |
+| Ruflo Core plugin shim | HIGH | HUMAN REVIEW REQUIRED | child CLI; unpinned `npx ... ruflo@latest` fallback; errors hidden |
+| Brain `decision-gate` | HIGH | DO NOT TRUST | silently missing from active 4.0.1 runtime |
+| Brain snapshot body | LOW | TRUST AFTER CHANGE | append-only minimal receipt, but currently unreachable |
+| Brain learning/update/signal hooks | HIGH | HUMAN REVIEW REQUIRED | detached work, cache/learning writes, possible network/credentials |
+| OpenAI Companion SessionEnd | HIGH | HUMAN REVIEW REQUIRED | broker IPC, process-tree kill, state/path deletion |
+| OpenAI Companion Stop review | HIGH | HUMAN REVIEW REQUIRED | nested model task, inherited credentials, may block for 15 minutes |
+| Beads lifecycle | MEDIUM | HUMAN REVIEW REQUIRED | external command; duplicated in Emailibrium |
+
+Trust recommendations are review outcomes, not authorization for agentic-kit to modify
+Codex trust state.
+
+## Benchmark results
+
+Ten samples were used for each representative candidate. With fewer than 20 samples the
+table reports max rather than presenting a low-sample max as a stable p95.
+
+| Candidate | Min ms | Median ms | Max ms | Exit/signal | Bounded output |
+|---|---:|---:|---:|---|---|
+| project `session-end` | 62.776 | 64.797 | 68.078 | 10×0 / none | consolidation summary + session ended |
+| project `pre-bash` | 20.504 | 21.308 | 22.714 | 10×0 / none | command validated |
+| project `pre-edit` no-op | 20.441 | 20.918 | 21.686 | 10×0 / none | unknown-hook success |
+| project `post-bash` no-op | 20.777 | 21.469 | 22.534 | 10×0 / none | unknown-hook success |
+| project `post-edit` | 20.779 | 22.390 | 26.743 | 10×0 / none | edit recorded |
+| current Brain wrapper `session-snapshot` | 59.857 | 62.475 | 66.515 | 10×0 / none | empty; no receipt |
+
+The representative project-only Bash pre/post pair costs about 42.8 ms median, while the
+post hook is a no-op. The edit pair costs about 43.3 ms median, while the pre hook is a
+no-op. Across selected project/plugin definitions, one Bash event can launch eight hook
+processes and one edit can launch seven, subject to each exact definition's trust state.
+
+The Brain wrapper result is functional evidence of version skew: all runs reported
+success, no output, and no snapshot receipt.
+
+Not benchmarked after inspection:
+
+- OpenAI Companion SessionEnd/Stop review: process kill/deletion/model behavior;
+- Ruflo Core fallback: possible package/network execution;
+- Brain update, signal-watch, learn-flush: network, credentials, detached work, or global
+  learning/cache writes;
+- project auto-memory and SessionStart: user/project writes and detached refreshes.
+
+## Architecture overhead assessment
+
+The project PreToolUse/PostToolUse layer is presently the worst cost/clarity trade:
+
+- `pre-edit` and `post-bash` consume a Node process but implement no behavior;
+- `pre-bash` is not a valid Codex enforcement gate;
+- post-edit and session persistence overlap with Ruflo Core;
+- Emailibrium duplicates Beads exactly;
+- only post-edit/session-end have a temp-file dedupe path, and that does not avoid process
+  startup;
+- plugin sources merge, so a second source is additive overhead, not a replacement.
+
+The target architecture should assign one canonical owner per behavior and treat other
+sources as provenance-bearing duplicates. Deduplication must never discard occurrences;
+it should make their relationships and costs visible.
+
+## Remediation decision
+
+The current estate has **no automatic mutation that satisfies the safety rules**.
+
+- Plugin cache fixes are never automatic; repair upstream/source and reinstall.
+- Project projections have unresolved authoritative writers and behavior changes; retire
+  only with explicit per-action approval, backup, diff, and verification.
+- Brain manifest/runtime alignment belongs in the Brain installer/activation source, not
+  this repository or cache.
+- Trust remains manual in Codex.
+
+The safe change implemented here is additive and read-only:
+
+```text
+ak audit hooks
+ak audit hooks --all-projects
+ak audit hooks --all-projects --json
+```
+
+It discovers only direct global, current project(s), and selected enabled plugin hook
+definitions; rejects unsafe plugin references and canonical cache escapes; refuses
+symlink, broken-symlink, and special-file sources; validates nested group, matcher, hook,
+and timeout syntax; records source digests and JSON pointers; preserves material command
+whitespace in behavior fingerprints; reports schema compatibility independently of
+trust; and classifies every current timeout action as approval-required or
+never-automatic. Unknown or future Codex versions receive syntax-only findings and no
+timeout remediation plan.
+
+It does not run hook commands, write reports implicitly, alter trust, edit generated
+projects, or touch plugin cache files. Running it a second time is therefore a no-op by
+construction; verification below confirms target hook hashes/mtimes were unchanged.
+
+## Implemented-wave verification
+
+Fresh verification after the additive implementation:
+
+| Gate | Result |
+|---|---|
+| Focused hook-audit and plugin-boundary tests | 25 passed, 0 failed |
+| Measured hook-audit module coverage | 92.94% lines, 76.30% branches, 100% functions |
+| Full repository `npm test` | exit 0 outside the filesystem/network sandbox |
+| TypeScript check | exit 0 |
+| ESLint | 0 errors; 34 pre-existing complexity/size warnings across the repository |
+| Build/package check | exit 0; syntax checked 254 shipped files; 287 package files resolved |
+| New/updated Markdown files | 0 issues |
+| Inventory JSON parse | valid |
+| Agentic-QE targeted SAST before the final fail-closed boundary patches | 0 vulnerabilities at all severities |
+
+Agentic-QE's coverage analyzer also returned a 19.7% static estimate, but its own result
+states that no instrumentation ran and confidence was 0.2. That estimate is not treated as
+coverage evidence; the measured Node coverage above supersedes it. The targetless generic
+AQE quality assessor ran against its server workspace rather than this repository and is
+likewise excluded from the artifact gate.
+
+A final Agentic-QE SAST rerun was refused by the environment's source-export guard because
+the MCP scan could transmit private repository source. No workaround was attempted. The
+final patches are instead covered by focused traversal, canonical-containment, malformed
+schema, and broken-symlink regressions plus local lint, the full suite, and independent
+read-only code review.
+
+Two consecutive explicit-scope audits returned the same 14 valid sources, zero
+hook-discovery configuration issues, 161 occurrences, 45 behaviors, 10 compatibility
+warnings, and zero automatic actions. Every source digest and mtime remained unchanged.
+The second run is an exact report no-op.
+
+## Verification requirements for future healing
+
+Any later apply wave must implement:
+
+1. version-aware schema proof;
+2. proven canonical ownership and exact preimage digest;
+3. unique transaction backups preserving bytes and modes;
+4. a disclosed per-action diff and behavior impact;
+5. refusal of symlinks/special files and cache/trust targets;
+6. atomic writes plus post-write schema/behavior verification;
+7. rollback only while the current digest still matches the transaction postimage;
+8. a complete second audit with no targeted finding;
+9. a third run with unchanged bytes and mtimes;
+10. no trust-state mutation.
+
+The full contract and provider boundaries are recorded in ADR-0040 and the remediation
+plan.

--- a/docs/audits/codex-hooks-inventory-2026-09-01.json
+++ b/docs/audits/codex-hooks-inventory-2026-09-01.json
@@ -1,0 +1,383 @@
+{
+  "schemaVersion": 1,
+  "capturedAt": "2026-09-01T23:00:00-07:00",
+  "mode": "read-only",
+  "scope": {
+    "codexHome": "/Users/cphillipson/.codex",
+    "currentProject": "/Users/cphillipson/Development/active/ai/agentic-kit",
+    "projectDiscovery": "agentic-kit bounded git-project census plus explicit development roots",
+    "credentialsIncluded": false,
+    "hookCommandsExecutedDuringDiscovery": false
+  },
+  "runtime": {
+    "desktop": {
+      "version": "26.831.20005",
+      "build": "7524",
+      "bundledCodexCli": "0.152.0"
+    },
+    "pathCodexCli": "0.151.0",
+    "node": "26.4.0",
+    "agenticKit": "4.0.0-alpha.44",
+    "ruflo": "3.38.20",
+    "agenticQe": "3.14.0"
+  },
+  "summary": {
+    "selectedSourceFiles": 14,
+    "projectHookFiles": 10,
+    "enabledPluginHookFiles": 4,
+    "invalidSourceFiles": 0,
+    "hookDiscoveryConfigurationIssues": 0,
+    "hookOccurrences": 161,
+    "uniqueBehaviorFingerprints": 45,
+    "sessionEndWarningFiles": 10,
+    "automaticRemediations": 0,
+    "approvalRequiredOrNeverAutomaticRemediations": 10
+  },
+  "schemaProfile": {
+    "id": "codex-hooks-2026-09-01",
+    "confidence": "verified",
+    "verifiedCodexCliVersions": ["0.151.x", "0.152.x"],
+    "unknownOrFutureVersionPolicy": "syntax-only; no compatibility rewrite plan",
+    "timeoutUnits": "seconds",
+    "sessionEndDefaultSeconds": 1,
+    "sessionEndMaximumSeconds": 3,
+    "documentation": "https://developers.openai.com/codex/hooks",
+    "source": "https://github.com/openai/codex/blob/main/codex-rs/hooks/src/events/session_end.rs",
+    "verifiedAt": "2026-09-01"
+  },
+  "sources": [
+    {
+      "id": "project-agentic-kit",
+      "kind": "project",
+      "file": "/Users/cphillipson/Development/active/ai/agentic-kit/.codex/hooks.json",
+      "status": "active-if-project-layer-and-definition-are-trusted",
+      "authority": "unknown",
+      "generatedStatus": "suspected-generated",
+      "owner": "historic-ruflo-projection",
+      "digest": "53398d1ac227a34cf3e9ee466f327cfbacf9464bfec55b4f3588b4a644576d3",
+      "occurrences": 15
+    },
+    {
+      "id": "project-java-spring-modernization-marketplace",
+      "kind": "project",
+      "file": "/Users/cphillipson/Development/active/agentic-incubator/java-spring-modernization-marketplace/.codex/hooks.json",
+      "status": "active-if-project-layer-and-definition-are-trusted",
+      "authority": "unknown",
+      "generatedStatus": "suspected-generated",
+      "owner": "historic-ruflo-projection",
+      "digest": "53398d1ac227a34cf3e9ee466f327cfbacf9464bfec55b4f3588b4a644576d3",
+      "occurrences": 15
+    },
+    {
+      "id": "project-finima",
+      "kind": "project",
+      "file": "/Users/cphillipson/Development/active/ai/finima/.codex/hooks.json",
+      "status": "active-if-project-layer-and-definition-are-trusted",
+      "authority": "unknown",
+      "generatedStatus": "suspected-generated",
+      "owner": "historic-ruflo-projection",
+      "digest": "53398d1ac227a34cf3e9ee466f327cfbacf9464bfec55b4f3588b4a644576d3",
+      "occurrences": 15
+    },
+    {
+      "id": "project-keel",
+      "kind": "project",
+      "file": "/Users/cphillipson/Development/active/ai/keel/.codex/hooks.json",
+      "status": "active-if-project-layer-and-definition-are-trusted",
+      "authority": "unknown",
+      "generatedStatus": "suspected-generated",
+      "owner": "historic-ruflo-projection",
+      "digest": "53398d1ac227a34cf3e9ee466f327cfbacf9464bfec55b4f3588b4a644576d3",
+      "occurrences": 15
+    },
+    {
+      "id": "project-prompt-genie",
+      "kind": "project",
+      "file": "/Users/cphillipson/Development/active/ai/prompt-genie/.codex/hooks.json",
+      "status": "active-if-project-layer-and-definition-are-trusted",
+      "authority": "unknown",
+      "generatedStatus": "suspected-generated",
+      "owner": "historic-ruflo-projection",
+      "digest": "53398d1ac227a34cf3e9ee466f327cfbacf9464bfec55b4f3588b4a644576d3",
+      "occurrences": 15
+    },
+    {
+      "id": "project-reelbox-cli",
+      "kind": "project",
+      "file": "/Users/cphillipson/Development/active/ai/reelbox-cli/.codex/hooks.json",
+      "status": "active-if-project-layer-and-definition-are-trusted",
+      "authority": "unknown",
+      "generatedStatus": "suspected-generated",
+      "owner": "historic-ruflo-projection",
+      "digest": "53398d1ac227a34cf3e9ee466f327cfbacf9464bfec55b4f3588b4a644576d3",
+      "occurrences": 15
+    },
+    {
+      "id": "project-tub-vault",
+      "kind": "project",
+      "file": "/Users/cphillipson/Development/active/ai/tub-vault/.codex/hooks.json",
+      "status": "active-if-project-layer-and-definition-are-trusted",
+      "authority": "unknown",
+      "generatedStatus": "suspected-generated",
+      "owner": "historic-ruflo-projection",
+      "digest": "53398d1ac227a34cf3e9ee466f327cfbacf9464bfec55b4f3588b4a644576d3",
+      "occurrences": 15
+    },
+    {
+      "id": "project-site",
+      "kind": "project",
+      "file": "/Users/cphillipson/Documents/professional/2026/chrisphillipson.me/site/.codex/hooks.json",
+      "status": "active-if-project-layer-and-definition-are-trusted",
+      "authority": "unknown",
+      "generatedStatus": "suspected-generated",
+      "owner": "historic-ruflo-projection",
+      "digest": "53398d1ac227a34cf3e9ee466f327cfbacf9464bfec55b4f3588b4a644576d3",
+      "occurrences": 15
+    },
+    {
+      "id": "project-ampel",
+      "kind": "project",
+      "file": "/Users/cphillipson/Development/active/ai/ampel/.codex/hooks.json",
+      "status": "active-if-project-layer-and-definition-are-trusted",
+      "authority": "unknown",
+      "generatedStatus": "suspected-generated",
+      "owner": "historic-ruflo-projection",
+      "occurrences": 7
+    },
+    {
+      "id": "project-emailibrium",
+      "kind": "project",
+      "file": "/Users/cphillipson/Development/active/ai/emailibrium/.codex/hooks.json",
+      "status": "active-if-project-layer-and-definition-are-trusted",
+      "authority": "unknown",
+      "generatedStatus": "suspected-generated",
+      "owner": "beads-projection",
+      "occurrences": 4
+    },
+    {
+      "id": "plugin-ruvnet-brain",
+      "kind": "plugin-cache",
+      "file": "/Users/cphillipson/.codex/plugins/cache/ruvnet-brain/ruvnet-brain/4.2.2-dev/hooks/codex-hooks.json",
+      "status": "selected-enabled-generation",
+      "authority": "generated-runtime-copy",
+      "canonicalOwner": "stuinfla/ruvnet-brain marketplace source",
+      "version": "4.2.2-dev",
+      "occurrences": 16
+    },
+    {
+      "id": "plugin-ruflo-core",
+      "kind": "plugin-cache",
+      "file": "/Users/cphillipson/.codex/plugins/cache/ruflo/ruflo-core/0.2.6/hooks/hooks.json",
+      "status": "selected-enabled-generation",
+      "authority": "generated-runtime-copy",
+      "canonicalOwner": "ruvnet/ruflo marketplace source",
+      "version": "0.2.6",
+      "occurrences": 7
+    },
+    {
+      "id": "plugin-beads",
+      "kind": "plugin-cache",
+      "file": "/Users/cphillipson/.codex/plugins/cache/beads-marketplace/beads/1.2.2/.codex-plugin/hooks/hooks.json",
+      "status": "selected-enabled-generation",
+      "authority": "generated-runtime-copy",
+      "canonicalOwner": "steveyegge/beads marketplace source",
+      "version": "1.2.2",
+      "occurrences": 4
+    },
+    {
+      "id": "plugin-openai-codex",
+      "kind": "plugin-cache",
+      "file": "/Users/cphillipson/.codex/plugins/cache/openai-codex/codex/1.0.6/hooks/hooks.json",
+      "status": "selected-enabled-generation",
+      "authority": "generated-runtime-copy",
+      "canonicalOwner": "openai/codex-plugin-cc marketplace source",
+      "version": "1.0.6",
+      "occurrences": 3
+    }
+  ],
+  "behaviorSets": [
+    {
+      "id": "historic-ruflo-project-projection",
+      "occurrences": 127,
+      "uniqueActions": 15,
+      "implementationTargets": [
+        ".claude/helpers/hook-handler.cjs pre-bash",
+        ".claude/helpers/hook-handler.cjs pre-edit",
+        ".claude/helpers/hook-handler.cjs post-edit",
+        ".claude/helpers/hook-handler.cjs post-bash",
+        ".claude/helpers/hook-handler.cjs compact-manual",
+        ".claude/helpers/hook-handler.cjs compact-auto",
+        ".claude/helpers/hook-handler.cjs session-restore",
+        ".claude/helpers/hook-handler.cjs session-end",
+        ".claude/helpers/hook-handler.cjs route",
+        ".claude/helpers/hook-handler.cjs status",
+        ".claude/helpers/hook-handler.cjs post-task",
+        ".claude/helpers/auto-memory-hook.mjs import",
+        ".claude/helpers/auto-memory-hook.mjs sync"
+      ],
+      "canonicalOwner": "ruflo-core@ruflo plugin for current Codex lifecycle ownership",
+      "diagnostics": [
+        "Claude millisecond-style timeout values interpreted by Codex as seconds",
+        "SessionEnd 10000s is clamped to 3s",
+        "dynamic sh -c and undocumented CLAUDE_PROJECT_DIR fallback",
+        "pre-edit, post-bash, compact-manual, compact-auto, and status are unknown-success no-ops",
+        "pre-bash exit 1 is not Codex's blocking contract",
+        "stale duplicate of current ruflo-core plugin ownership"
+      ],
+      "risk": "HIGH",
+      "trustRecommendation": "TRUST AFTER CHANGE; pre-bash enforcement DO NOT TRUST"
+    },
+    {
+      "id": "beads-lifecycle",
+      "occurrences": 8,
+      "uniqueActions": 4,
+      "implementationTargets": [
+        "bd codex-hook SessionStart",
+        "bd codex-hook PreCompact",
+        "bd codex-hook PostCompact",
+        "bd codex-hook UserPromptSubmit"
+      ],
+      "duplicate": "emailibrium local projection duplicates enabled Beads plugin",
+      "canonicalOwner": "beads@beads-marketplace",
+      "risk": "MEDIUM",
+      "trustRecommendation": "HUMAN REVIEW REQUIRED"
+    },
+    {
+      "id": "ruflo-core-plugin",
+      "occurrences": 7,
+      "uniqueActions": 7,
+      "canonicalOwner": "ruflo-core@ruflo",
+      "sideEffects": [
+        "project and user telemetry/state",
+        "child CLI invocation",
+        "npx --prefer-offline --yes ruflo@latest fallback when no local CLI is found"
+      ],
+      "risk": "HIGH",
+      "trustRecommendation": "HUMAN REVIEW REQUIRED"
+    },
+    {
+      "id": "ruvnet-brain-plugin",
+      "occurrences": 16,
+      "uniqueActions": 16,
+      "canonicalOwner": "ruvnet-brain@ruvnet-brain",
+      "runtimeCompatibility": "manifest 4.2.2-dev invokes active 4.0.1 adapter",
+      "silentMissingActions": ["decision-gate", "session-snapshot"],
+      "sideEffects": [
+        "project and user learning/cache writes",
+        "detached update and learn-flush jobs",
+        "possible gh network/credential use in signal-watch",
+        "routing and continuation advisories"
+      ],
+      "risk": "HIGH",
+      "trustRecommendation": "DO NOT TRUST decision-gate as enforcement; plugin HUMAN REVIEW REQUIRED"
+    },
+    {
+      "id": "openai-codex-companion-plugin",
+      "occurrences": 3,
+      "uniqueActions": 3,
+      "canonicalOwner": "codex@openai-codex",
+      "diagnostics": ["SessionEnd 5s is clamped to 3s"],
+      "sideEffects": [
+        "session environment propagation",
+        "broker IPC and process-tree termination",
+        "pid/log/socket/session cleanup",
+        "optional nested Codex Stop review lasting up to 15 minutes"
+      ],
+      "risk": "HIGH",
+      "trustRecommendation": "HUMAN REVIEW REQUIRED"
+    }
+  ],
+  "sessionEndWarnings": [
+    {
+      "source": "openai-codex plugin 1.0.6",
+      "declaredSeconds": 5,
+      "effectiveSeconds": 3,
+      "remediationClass": "never-automatic",
+      "implementationTarget": "openai/codex-plugin-cc source or a corrected plugin upgrade"
+    },
+    {
+      "source": "nine historic Ruflo project projections",
+      "declaredSeconds": 10000,
+      "effectiveSeconds": 3,
+      "remediationClass": "never-automatic-until-authority-proven",
+      "implementationTarget": "historic copier/generator, then approved retirement of generated projections"
+    }
+  ],
+  "benchmarkSummary": [
+    {
+      "candidate": "project session-end",
+      "samples": 10,
+      "minMs": 62.776,
+      "medianMs": 64.797,
+      "maxMs": 68.078,
+      "exitStatuses": [0],
+      "signalStatuses": [],
+      "stderr": "",
+      "stdout": "[INTELLIGENCE] Consolidated: 189 entries, 6079 edges, 34 new, PageRank recomputed\n[OK] Session ended\n"
+    },
+    {
+      "candidate": "project pre-bash",
+      "samples": 10,
+      "minMs": 20.504,
+      "medianMs": 21.308,
+      "maxMs": 22.714,
+      "exitStatuses": [0],
+      "stdout": "[OK] Command validated\n"
+    },
+    {
+      "candidate": "project pre-edit unknown/no-op",
+      "samples": 10,
+      "minMs": 20.441,
+      "medianMs": 20.918,
+      "maxMs": 21.686,
+      "exitStatuses": [0],
+      "stdout": "[OK] Hook: pre-edit\n"
+    },
+    {
+      "candidate": "project post-bash unknown/no-op",
+      "samples": 10,
+      "minMs": 20.777,
+      "medianMs": 21.469,
+      "maxMs": 22.534,
+      "exitStatuses": [0],
+      "stdout": "[OK] Hook: post-bash\n"
+    },
+    {
+      "candidate": "project post-edit",
+      "samples": 10,
+      "minMs": 20.779,
+      "medianMs": 22.39,
+      "maxMs": 26.743,
+      "exitStatuses": [0],
+      "stdout": "[OK] Edit recorded\n"
+    },
+    {
+      "candidate": "current Brain wrapper session-snapshot",
+      "samples": 10,
+      "minMs": 59.857,
+      "medianMs": 62.475,
+      "maxMs": 66.515,
+      "exitStatuses": [0],
+      "stdout": "",
+      "stderr": "",
+      "receiptWritten": false,
+      "interpretation": "active 4.0.1 runtime silently accepts the unknown 4.2.2 manifest action"
+    }
+  ],
+  "trust": {
+    "projectLayerTrust": "selects whether the project .codex layer loads",
+    "hookDefinitionTrust": "exact current definition hash; new or changed hooks are skipped pending review",
+    "relationshipToCompatibility": "none",
+    "programmaticChangesMade": false,
+    "bypassUsed": false
+  },
+  "notes": [
+    "No global executable hook definition exists at ~/.codex/hooks.json.",
+    "Stale trusted-hash keys are bookkeeping residue and were not counted as active hook definitions.",
+    "RuvNet Brain hooks/hooks.json is not selected; hooks/codex-hooks.json is the active manifest.",
+    "No current scripts project hook file was found in the bounded roots; the prior UI path may be stale or outside scope.",
+    "Plugin references and canonical roots are containment-checked against the plugin cache; unrelated skill metadata issues do not fail hook discovery.",
+    "Malformed nested groups, matchers, hooks, timeout values, symlink ancestors, and broken hook symlinks fail closed.",
+    "The complete occurrence-level inventory can be regenerated with: ak audit hooks --all-projects --json."
+  ]
+}

--- a/docs/audits/codex-hooks-remediation-2026-09-01.md
+++ b/docs/audits/codex-hooks-remediation-2026-09-01.md
@@ -1,0 +1,74 @@
+# Codex Hooks Remediation Plan — 2026-09-01
+
+Related: [audit](codex-hooks-audit-2026-09-01.md),
+[inventory](codex-hooks-inventory-2026-09-01.json), and
+[ADR-0040](../adr/0040-codex-hook-audit-and-conservative-remediation.md).
+
+## Safety envelope
+
+Every action starts as a preview. `--yes` may confirm disclosed actions but must never
+expand them. No action may modify Codex project or hook trust, write plugin cache, infer an
+authoritative source from a generated copy, or run an uninspected hook command.
+
+## Action plan
+
+| ID | Priority | Action | Target owner | Class | Completion proof |
+|---|---:|---|---|---|---|
+| H01 | P0 | Add manifest/action compatibility preflight so every Brain manifest action exists in the selected active runtime | RuvNet Brain installer/runtime | approval required upstream | 4.2.2 manifest + active runtime agree; unknown action fails visibly; decision-gate/snapshot integration tests pass |
+| H02 | P0 | Stop describing project `pre-bash` as enforcement; replace with a Codex-native fail-closed result only if a reviewed owner still needs it | historic Ruflo generator/current canonical owner | approval required | malicious fixture is blocked using documented contract; advisory failures cannot claim enforcement |
+| H03 | P1 | Change OpenAI Companion SessionEnd timeout from 5 to at most 3 in authoritative plugin source and upgrade/reinstall | openai/codex-plugin-cc | approval required upstream; cache never automatic | selected installed generation no longer emits clamp; cache equals source artifact |
+| H04 | P1 | Resolve the historical project copier, then preview retirement of obsolete Ruflo project groups in nine projects | Ruflo/AQE generator and each project owner | approval required per project | transaction backup, exact diff, current plugin behavior retained, second audit removes duplication/clamp |
+| H05 | P1 | Remove Emailibrium's local Beads projection or disable the plugin for that project, after choosing one owner | Emailibrium owner / Beads | approval required | one occurrence per Beads lifecycle event; behavior smoke test passes |
+| H06 | P1 | Replace `CLAUDE_PROJECT_DIR`/`$HOME` shell fallback with a stable validated repository-root contract | authoritative generator | approval required | subdirectory fixture resolves the same regular in-repo helper; path escape/symlink tests fail closed |
+| H07 | P1 | Convert every generated Codex timeout from the source host's units to seconds and validate event-specific bounds | Ruflo/AQE Codex generator | approval required upstream | schema tests cover every generated event; no millisecond-style seconds remain |
+| H08 | P2 | Remove or implement the five unknown-success project actions | canonical Ruflo owner | approval required | no no-op process launches; manifest and handler tables have bidirectional coverage |
+| H09 | P2 | Remove unpinned `npx ... ruflo@latest` fallback from hook-time execution or pin/verify an installer-owned executable | ruflo-core | approval required upstream | offline/missing-CLI case fails visibly without network/package execution |
+| H10 | P2 | Give Agentic-QE's Codex installer transaction backups, ownership receipts, verify, and undo | Agentic-QE / agentic-kit integration | approval required upstream | failure injection proves no silent partial merge; rollback preserves later user drift |
+| H11 | P2 | Align Desktop and shell Codex CLI versions for reproducible diagnostics | machine owner | approval required | `PATH` and bundled versions are intentionally documented/aligned |
+
+## What agentic-kit may do automatically
+
+Only a semantics-preserving change to a proven agentic-kit-owned canonical source, under
+a verified version schema and exact preimage receipt, may be automatic. No current
+finding qualifies.
+
+## What always requires approval
+
+- modify any user-owned authoritative hook definition;
+- change a command, matcher, order, environment, side effect, or timeout in a way that
+  changes the reviewed definition;
+- remove a duplicate or stale behavior;
+- run a benchmark whose implementation can write, use network/credentials, spawn a
+  model/background job, or control processes;
+- apply across more than one project;
+- modify an upstream Ruflo, Agentic-QE, Brain, Beads, or OpenAI source/installer.
+
+## What is never automatic
+
+- edit `~/.codex/plugins/cache` or marketplace staging copies;
+- edit `[hooks.state]`, `trusted_hash`, project trust, or use a trust bypass;
+- rewrite generated copies while an authoritative source exists;
+- guess ownership from similar content;
+- heal against an unknown/future schema;
+- follow symlinks or touch special files;
+- delete behavior merely because it is slow, duplicated, stale-looking, or untrusted.
+
+## Transaction and rollback design
+
+Each approved apply operation must record target path, canonical owner, action ID,
+expected preimage digest, desired digest, file mode, unified diff, trust impact, and
+verification. Before the first write, copy exact bytes/mode into a unique transaction
+directory under agentic-kit's config directory. Recheck all preimages, use random
+exclusive temporary files and atomic rename, then verify schema/effective behavior.
+
+Rollback is allowed only when the current digest still equals the transaction postimage.
+If a user or another generator changed the file afterward, preserve that drift and stop.
+
+## Implemented wave
+
+Wave 1 adds only the read-only `ak audit hooks` command and durable baseline artifacts.
+It never executes a hook or exposes an apply flag. It validates version confidence,
+nested syntax, exact occurrence IDs, plugin-cache containment, and symlink boundaries;
+hook-discovery failures are distinct from unrelated plugin skill diagnostics.
+Transactional apply/rollback remains a later wave after the proposed ADR receives
+independent architecture review and the canonical owners for H01–H10 are resolved.

--- a/docs/audits/host-neutral-hooks-follow-up-2026-09-01.md
+++ b/docs/audits/host-neutral-hooks-follow-up-2026-09-01.md
@@ -1,0 +1,126 @@
+# Host-neutral hooks audit follow-up — 2026-09-01
+
+## Outcome
+
+The Codex audit is now a host-neutral, read-only assurance capability. The implementation
+supports Codex, Claude Code, OpenCode and declarative external host adapters without
+pretending those hosts share one hook format or one trust mechanism.
+
+No active hook behavior, trust decision, plugin cache generation or project configuration
+was changed. The new remediation output is a proposal only; the CLI has no apply flag.
+
+A live `--host all` run after implementation and adversarial remediation found 37 bounded sources and 100 physical
+occurrences: Codex 47, Claude Code 46, OpenCode 7 and no configured external adapter
+hooks. It reported zero invalid sources, zero discovery configuration errors and zero
+automatic actions. The proposal set contains 34 approval-required, two prohibited and two
+upstream-required actions for generated Claude plugin occurrences.
+These numbers describe the current command scope, not the
+earlier all-sibling Codex census in the companion audit.
+
+## Normalized coverage
+
+| Provider | Sources | What is normalized | Honest limit |
+|---|---|---|---|
+| Codex | global/project JSON and inline TOML; enabled plugin files and inline manifests | command and MCP-tool handlers, event/matcher, seconds, cwd, async/context/presentation fields | trust hashes, project trust and undiscovered managed/session paths remain unknown |
+| Claude Code | user/project/local/managed settings; installed plugin registry, manifest and hook documents | handler types, event/matcher, type-specific timeout defaults, SessionEnd budget semantics, command identity and source ownership | effective organization policy and runtime selection are not inferred |
+| OpenCode | global/project plugin configuration and local plugin modules | package/module identity, digest and statically visible lifecycle event names | JSONC and module behavior stay opaque; modules are never imported |
+| External adapters | local manifest lifecycle, execution and AQE provider hooks | validated argv, timeout, declared files and combined content identity | remote sources are offline; compatibility, consent, grants and reachability stay separate |
+
+Every provider emits `partial` coverage with concrete gaps where the local files cannot
+prove effective runtime state. That is deliberate: a static audit must not turn absence of
+evidence into a false green check.
+
+## Root causes generalized from the Codex findings
+
+1. **Host schemas differ.** Codex and Claude both use seconds, but event defaults, limits,
+   handlers and trust differ. OpenCode's extension point is executable plugin code.
+2. **Generated copies obscure ownership.** Project projections and plugin caches are
+   runtime copies; repair belongs in the proven generator or upstream package.
+3. **Configuration composes.** A higher-precedence host setting does not always replace a
+   lower hook layer, and OpenCode JSONC can load after JSON.
+4. **Registration is not effectiveness.** Installed/configured, selected, trusted,
+   reachable, healthy and authorized are independent facts.
+5. **Version drift is recurring work.** A schema verified against one release cannot be
+   assumed for the next release.
+
+## Remediation policy
+
+- Safe discovery, hashing, normalization and informational diagnostics are automatic.
+- User/project behavior changes require approval.
+- Generated dependency fixes are upstream-required and applied only to authoritative
+  sources.
+- Cache edits, trust bypasses, unknown schemas, unsafe files and unproven ownership are
+  prohibited.
+- The current implementation performs none of the proposed writes.
+
+## Release and dependency maintenance
+
+The version profile is exact and evidence-bearing. On a Claude, Codex or OpenCode release,
+CI fixtures run first; unknown releases fall back to syntax-only validation until source
+or current primary documentation proves the new contract.
+
+Managed dependencies use `config/agentic-dependency-constraints.json`. Each entry keeps
+issue state separate from installed lifecycle state and records a bounded workaround plus
+objective sunset proof. The registry is rechecked weekly, before an upgrade and when a new
+dependency release is observed. Upstream notification should include the smallest
+reproducible source, host/dependency versions, expected/observed behavior and the local
+workaround. Patches are kept narrow and removable; issue closure is followed by
+released-artifact conformance before the workaround is retired.
+
+The Claude provider is grounded in the current primary [hooks reference](https://code.claude.com/docs/en/hooks)
+and [plugin reference](https://code.claude.com/docs/en/plugins-reference). In particular,
+the plugin manifest is optional, default hook discovery uses `hooks/hooks.json`, the
+`SessionEnd` default is 1.5 seconds, the settings-derived budget is capped at 60 seconds,
+and a plugin-provided timeout cannot raise that budget.
+
+## Post-implementation brutal-honesty review
+
+The review crossed its action threshold and found four substantive defects before commit:
+
+1. **HIGH — file identity race:** containment was checked before `open`, but the opened
+   inode was not compared with the inspected inode. The bounded reader now verifies
+   device/inode identity and repeats real-path containment after opening; a replacement
+   race fixture proves refusal.
+2. **HIGH — incomplete Claude provenance:** valid plugin registries and manifests were
+   used for discovery but omitted from the public source chain, and a manifest-free
+   plugin could be missed. Both sources are now reported and conventional optional-manifest
+   discovery is tested.
+3. **HIGH — incorrect Claude `SessionEnd` model:** the first implementation applied the
+   generic 600-second command timeout. It now models the documented 1.5-second default,
+   60-second settings cap and plugin-budget dependence separately.
+4. **MEDIUM — provider coupling:** a Codex-only audit probed every host binary and loaded
+   agentic-kit's adapter config. Version probes and config loading are now limited to the
+   selected providers, preserving Codex-only audit independence.
+
+Agentic-QE's local coverage analysis and security scan were run after implementation. Its
+security scanner reported three lexical false positives (`RegExp.exec` and two relative
+imports); manual inspection rejected them. The scanner's coverage result explicitly said
+it was a low-confidence static estimate, so the decision used Node's measured coverage:
+hook-audit source files are 83.64–100% line-covered in the focused suite, with the core
+Codex parser, TOML parser and bounded reader at 96.79–100%. QE test generation and defect
+prediction were not retried after the execution policy rejected transmitting nonpublic
+source/history to a service boundary.
+
+## Verification added
+
+Adversarial fixtures cover:
+
+- exact-version fallback;
+- Codex inline TOML and MCP handlers;
+- inline plugin hook manifests;
+- symlinked manifest and hook-source refusal;
+- credential redaction;
+- cwd-sensitive behavior identity;
+- Claude timeout-unit diagnostics;
+- Claude optional-manifest plugin discovery and complete registry/manifest provenance;
+- Claude `SessionEnd` settings clamping versus plugin budget dependence;
+- OpenCode opaque full-process plugins;
+- external manifest validation and hook-file identity;
+- deterministic read-only output across repeated runs.
+- source replacement between inspection and open;
+- provider-scoped version probes and adapter-config loading.
+
+See [ADR-0041](../adr/0041-host-neutral-hook-configuration-assurance.md) and the
+[DDD boundary](../ddd/hook-configuration-assurance.md) for the permanent contracts. A
+sanitized [machine-readable audit receipt](host-neutral-hooks-report-2026-09-01.json)
+records the post-implementation run; the CLI emits the complete reusable inventory.

--- a/docs/audits/host-neutral-hooks-report-2026-09-01.json
+++ b/docs/audits/host-neutral-hooks-report-2026-09-01.json
@@ -1,0 +1,54 @@
+{
+  "schemaVersion": 2,
+  "mode": "read-only",
+  "capturedAt": "2026-09-01",
+  "command": "ak audit hooks --host all --json",
+  "hosts": ["codex", "claude", "opencode", "external"],
+  "summary": {
+    "sources": 37,
+    "invalidSources": 0,
+    "configurationIssues": 0,
+    "hookOccurrences": 100,
+    "uniqueBehaviors": 96,
+    "automaticActions": 0,
+    "approvalRequiredActions": 34,
+    "neverAutomaticActions": 2,
+    "upstreamRequiredActions": 2
+  },
+  "providers": {
+    "codex": {
+      "profile": "codex-hooks-2026-09-01",
+      "coverage": "partial",
+      "sources": 27,
+      "hookOccurrences": 47,
+      "uniqueBehaviors": 47,
+      "compatibilityWarnings": 2
+    },
+    "claude": {
+      "profile": "claude-hooks-2.1.258",
+      "coverage": "partial",
+      "sources": 7,
+      "hookOccurrences": 46,
+      "uniqueBehaviors": 42
+    },
+    "opencode": {
+      "profile": "opencode-plugins-1.18.25",
+      "coverage": "partial",
+      "sources": 3,
+      "hookOccurrences": 7,
+      "uniqueBehaviors": 7
+    },
+    "external": {
+      "profile": "agentic-kit-host-adapter-v1",
+      "coverage": "partial",
+      "sources": 0,
+      "hookOccurrences": 0,
+      "uniqueBehaviors": 0
+    }
+  },
+  "notes": [
+    "The full reusable inventory is emitted by the command; this checked-in receipt omits command text and user paths.",
+    "Trust, consent, grants, reachability, health, and authorization remain separate evidence dimensions.",
+    "No hook, trust state, plugin cache generation, or project configuration was modified."
+  ]
+}

--- a/docs/ddd/README.md
+++ b/docs/ddd/README.md
@@ -12,6 +12,7 @@ describe the current system unless a section is explicitly marked as future work
 | [Integration management](integration-management.md) | Hosts, inference providers, bindings, capabilities, lifecycle, facts, and ownership |
 | [Routing and orchestration](routing-and-orchestration.md) | Activities, routes, leadership, escalation, projections, and canonical `ak run` execution |
 | [Model lifecycle intelligence](model-lifecycle-intelligence.md) | Model identities, evidence dimensions, catalogue snapshots, lifecycle diff, and read-only impact plans |
+| [Hook configuration assurance](hook-configuration-assurance.md) | Host-neutral lifecycle source discovery, behavior identity, coverage, diagnostics, and remediation authority |
 | [Observability](observability.md) | Evidence acquisition, observed-session aggregates, replay, and dashboard delivery |
 | [Project intelligence](project-intelligence.md) | Pattern store, learning counters, reasoning-graph size, and live delivery for Overview's Intelligence view |
 

--- a/docs/ddd/context-map.md
+++ b/docs/ddd/context-map.md
@@ -9,6 +9,7 @@ Configuration Intent
         +----> Integration Management ----> Native Configuration Surfaces
         |                 |       |
         |                 |       +----> Managed Companion Surfaces
+        |                 +----> Hook Configuration Assurance
         |                 +----> Routing and Orchestration
         |
 Native Evidence ----> Evidence Acquisition ----> Canonical Evidence
@@ -46,6 +47,16 @@ representations. A managed companion consumes enabled-host identity but gains no
 routing, observability, or curated-memory authority.
 
 See [Integration management](integration-management.md).
+
+### Hook configuration assurance
+
+Owns read-only, host-neutral discovery of lifecycle sources; normalized occurrences and
+material behavior identity; coverage gaps; diagnostics; and remediation authority
+proposals. It consumes host identity, project scope and validated external adapter
+manifests. It never executes hook or plugin code and owns no host trust, consent, grant,
+installation, route or configuration write.
+
+See [Hook configuration assurance](hook-configuration-assurance.md).
 
 ### Routing and orchestration
 
@@ -152,6 +163,9 @@ and credential policy is distinct from the offline-first dashboard and integrati
 | Integration management | Native surfaces | Configuration projections with ownership receipts |
 | Integration management | Managed companion surfaces | Opt-in package and explicit per-host projections; plugin/data ownership stays separate |
 | Integration management | Routing and orchestration | Capability-qualified host and binding facts |
+| Integration management | Hook configuration assurance | Host identity and validated external adapter data; admission, consent, grants and execution stay upstream |
+| Project census | Hook configuration assurance | Explicit project roots for bounded source discovery; no project trust is inferred |
+| Native hook configuration | Hook configuration assurance | Host-specific anti-corruption providers produce normalized sources, occurrences, diagnostics and gaps |
 | Native evidence | Evidence acquisition | Source-specific anti-corruption adapters |
 | Evidence acquisition | Observability | Versioned canonical events |
 | Evidence acquisition | Historical usage | Normalized transcript and provider evidence |
@@ -218,3 +232,5 @@ observed before the split was made explicit.
 - Managed companion surfaces stay downstream of Integration management. Their ability to read host
   history or inject recalled context does not make them hosts, evidence owners, or policy
   authorities; consent, content-free observation, and ownership-safe teardown remain upstream.
+- Hook configuration assurance is read-only. It never imports an OpenCode plugin, executes a hook,
+  fetches a remote adapter by default, changes trust, or treats a diagnostic as write authority.

--- a/docs/ddd/hook-configuration-assurance.md
+++ b/docs/ddd/hook-configuration-assurance.md
@@ -1,0 +1,103 @@
+# Hook configuration assurance bounded context
+
+## Purpose
+
+Answer four questions without running hook code or changing trust:
+
+1. Which lifecycle behaviors can each host discover?
+2. Which exact source and owner produced every occurrence?
+3. Which compatibility, security, ownership and duplication findings are proven?
+4. Which remediation authority class applies, if any?
+
+## Boundary
+
+Hook configuration assurance consumes host identity, project scope and validated external
+adapter manifests. It owns no host installation, route, model, session, plugin execution,
+consent, capability grant or trust decision.
+
+```text
+Project Census ────────┐
+Integration Management ├──> Hook Configuration Assurance ──> audit report / proposal
+Host binaries + files ─┘                 │
+                                        └──> no execution, no trust, no write
+```
+
+## Aggregate and value objects
+
+`HookAudit` is the aggregate root for one deterministic run. Its identity is the selected
+host set plus source digests and exact version facts.
+
+- `HookSource`: path/reference, scope, digest, authority, owner, generation posture and
+  read status.
+- `HookOccurrence`: one event/matcher/handler at one source pointer.
+- `HookBehavior`: material execution identity shared only by genuinely equivalent
+  occurrences.
+- `SchemaProfile`: exact host version, supported shape, units, defaults, limits, evidence
+  and verification date.
+- `CoverageStatement`: complete/partial/unsupported plus concrete gaps.
+- `Diagnostic`: category, severity, stable code, evidence and message.
+- `RemediationProposal`: target, expected source digest, authority class, rationale,
+  behavior impact and trust impact.
+- `UpstreamConstraint`: dependency range, issue state, local strategy and sunset proof.
+
+## Provider contract
+
+Each built-in provider performs this lifecycle:
+
+```text
+detect version facts -> discover bounded sources -> validate without execution
+-> normalize occurrences -> classify diagnostics -> propose authority -> summarize gaps
+```
+
+Providers may reduce capability when evidence is incomplete; they may never fabricate a
+selected state or widen authority. External providers are data from admitted-format
+manifests, not imported implementation modules.
+
+## Invariants
+
+1. Discovery never executes a hook, imports a plugin or invokes a host debug/effective
+   config command.
+2. Files are bounded regular files contained by a proven root; symlinks and special files
+   are refused, and the opened inode/path must still match the inspected source.
+3. Public command text is redacted while behavior identity retains a one-way digest.
+4. Every physical occurrence survives deduplication.
+5. Working directory, async mode, platform command, MCP contract and timeout are material.
+6. Unknown versions cannot produce an automatic compatibility repair.
+7. Compatibility, trust, security, provenance, ownership and performance are independent
+   diagnostic dimensions.
+8. Plugin caches and generated projections are never direct healing targets.
+9. Audit results never confer trust, consent, grants, reachability or health.
+10. The read-only wave has no mutation port.
+
+## Host anti-corruption layers
+
+### Codex
+
+Translates `hooks.json`, documented inline TOML and enabled plugin manifests. It preserves
+Codex's merge semantics, seconds-based timeout rules, MCP-tool handlers and independent
+definition trust.
+
+### Claude Code
+
+Translates user/project/managed settings and installed plugin registry, manifest and hook
+documents. It honors optional manifests, conventional `hooks/hooks.json`,
+`CLAUDE_CONFIG_DIR`, type-specific timeout defaults and `SessionEnd` budget rules; runtime
+policy and organization state remain explicit gaps.
+
+### OpenCode
+
+Translates configured package plugins and local plugin modules. A plugin runs inside the
+host process, so the normalized record describes the whole module as a trust unit. Static
+event-name evidence is not a behavioral proof.
+
+### External adapters
+
+Translates validated manifest lifecycle, execution and Agentic-QE provider subprocess
+hooks. Content identity includes declared hook files. Admission, consent and grants stay
+owned by Integration Management.
+
+## Future remediation process
+
+A future command may add `plan -> apply -> verify -> undo` only through a separate
+mutation port with exact preimages, backups, atomic replacement, receipts and guarded
+rollback. The domain rejects trust bypasses and cache writes before the port is reached.

--- a/docs/ddd/ubiquitous-language.md
+++ b/docs/ddd/ubiquitous-language.md
@@ -25,6 +25,13 @@ contradictory meaning.
 | Companion fact | Content-free observation of companion package ownership, target wiring, plugin/trust state, schema compatibility, and data health |
 | Companion projection | Exact host-native wiring by which a companion exposes MCP or consented automatic events to one enabled host |
 | Auto-recall | Explicitly consented injection of untrusted historical context at a named host event; not a uniform session-start capability |
+| Hook source | One host-native settings, TOML, JSON, plugin or adapter-manifest origin inspected without executing its contents |
+| Hook occurrence | One physical event/matcher/handler definition retained with its source pointer and digest |
+| Hook behavior | Material execution identity used to link only genuinely equivalent occurrences |
+| Schema profile | Exact host-version rules plus evidence and verification date; unknown versions fall back to syntax-only validation |
+| Coverage statement | `complete`, `partial`, or `unsupported` audit reach plus concrete gaps; it is not a health or trust verdict |
+| Remediation proposal | Read-only action description classified as automatic-eligible, approval-required, prohibited, or upstream-required |
+| Upstream constraint | Versioned dependency issue, affected range, bounded local strategy, verification date, and objective sunset condition |
 
 ## State and evidence language
 
@@ -195,6 +202,8 @@ runtime state is a chip word, never a prose word. See
 - Do not call a managed companion a host, memory authority, or observability source. Name the exact
   companion projection or automatic event when injection behavior matters.
 - Do not replace an unknown fact with a convenient default.
+- Do not call a hook configured, selected, trusted, reachable, healthy, or authorized unless the
+  evidence establishes that exact dimension. A coverage statement never upgrades those facts.
 - Say **System** for the dashboard area and the command; say **Machine footprint** only for the
   bounded context and its module directory. No user-facing string says "footprint".
 - Say **About** for the dashboard area and the command; say **Component directory** only for the

--- a/src/commands/audit.mjs
+++ b/src/commands/audit.mjs
@@ -1,0 +1,114 @@
+// ak audit hooks — explicit, read-only configuration audit. It does not run
+// hook commands, mutate trust, rewrite generated files, or edit plugin caches.
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+
+import { auditHooks, BUILTIN_HOOK_AUDIT_HOSTS } from '../lib/hook-audit/orchestrator.mjs';
+import { loadKitConfig } from '../lib/config.mjs';
+import { projectCensus, projectsInScope } from '../lib/project-census.mjs';
+
+export const options = {
+  json: { type: 'boolean', default: false },
+  project: { type: 'string', multiple: true },
+  host: { type: 'string', multiple: true },
+  'all-projects': { type: 'boolean', default: false },
+};
+
+export const help = `ak audit hooks — read-only host-neutral hook inventory and remediation plan
+
+Discovers Codex, Claude, OpenCode, and external-adapter hook definitions; normalizes
+behavior; keeps compatibility separate from trust; and classifies possible
+repairs. It never executes hooks, changes trust, or writes hook files.
+
+Usage: ak audit hooks [options]
+
+Options:
+  --project PATH   add an explicit project (repeatable)
+  --host HOST      audit codex, claude, opencode, external, or all (repeatable; default: codex)
+  --all-projects   include Git projects in agentic-kit's bounded project census
+  --json           emit the deterministic machine-readable report
+
+Examples:
+  ak audit hooks
+  ak audit hooks --host all --project ../another-repo --json
+  ak audit hooks --all-projects --json`;
+
+function detectedVersion(binary, pattern = /(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)/) {
+  try {
+    const result = spawnSync(binary, ['--version'], {
+      encoding: 'utf8', timeout: 3_000, stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    return pattern.exec(result.stdout)?.[1] ?? 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
+function selectedHosts(flags) {
+  const hosts = flags.host?.length ? flags.host : ['codex'];
+  const unknown = hosts.filter((host) => host !== 'all' && !BUILTIN_HOOK_AUDIT_HOSTS.includes(host));
+  if (unknown.length) throw new TypeError(`unknown --host value(s): ${unknown.join(', ')}`);
+  return hosts;
+}
+
+function includesHost(hosts, host) {
+  return hosts.includes('all') || hosts.includes(host);
+}
+
+function projectRoots(flags) {
+  const roots = new Set([process.cwd()]);
+  for (const project of flags.project ?? []) roots.add(path.resolve(project));
+  if (flags['all-projects']) {
+    for (const project of projectsInScope(projectCensus(), 'gitRepos')) roots.add(project.path);
+  }
+  return [...roots].sort();
+}
+
+export async function run({
+  flags,
+  positionals,
+  detectVersionFn = detectedVersion,
+  loadConfigFn = loadKitConfig,
+}) {
+  if (positionals.length !== 1 || positionals[0] !== 'hooks') {
+    console.error('ak audit requires the hooks subcommand');
+    console.log(help);
+    return 2;
+  }
+  let report;
+  try {
+    const hosts = selectedHosts(flags);
+    report = auditHooks({
+      hosts,
+      projectRoots: projectRoots(flags),
+      versions: {
+        ...(includesHost(hosts, 'codex') ? { codex: detectVersionFn('codex') } : {}),
+        ...(includesHost(hosts, 'claude') ? { claude: detectVersionFn('claude') } : {}),
+        ...(includesHost(hosts, 'opencode') ? { opencode: detectVersionFn('opencode') } : {}),
+      },
+      config: includesHost(hosts, 'external') ? loadConfigFn() : {},
+    });
+  } catch (error) {
+    console.error(`hook audit failed: ${error.message}`);
+    return 2;
+  }
+  if (flags.json) {
+    console.log(JSON.stringify(report, null, 2));
+    return report.summary.invalidSources || report.summary.configurationIssues ? 1 : 0;
+  }
+
+  const { summary } = report;
+  console.log(`ak audit hooks (read-only: ${report.hosts.join(', ')})`);
+  console.log(`  sources: ${summary.sources} (${summary.invalidSources} invalid)`);
+  console.log(`  configuration issues: ${summary.configurationIssues}`);
+  console.log(`  hooks: ${summary.hookOccurrences} occurrences / ${summary.uniqueBehaviors} behaviors`);
+  console.log(`  remediation: ${summary.automaticActions} automatic, ${summary.approvalRequiredActions} approval-required, ${summary.neverAutomaticActions} never-automatic`);
+  console.log('  trust: unchanged; every host permission/review decision remains separate');
+  for (const host of report.hosts) {
+    const hostReport = report.reports[host];
+    console.log(`  ${host}: ${hostReport.summary.hookOccurrences} occurrence(s), ${hostReport.coverage.status} coverage`);
+    for (const action of hostReport.plan) console.log(`    - [${action.classification}] ${action.target}: ${action.reason}`);
+    for (const issue of hostReport.issues ?? []) console.log(`    - [configuration] ${issue}`);
+  }
+  return summary.invalidSources || summary.configurationIssues ? 1 : 0;
+}

--- a/src/commands/status/sections/ruvnet-brain.mjs
+++ b/src/commands/status/sections/ruvnet-brain.mjs
@@ -3,6 +3,42 @@
 import { drift as ruvnetBrainDrift, nightlyAgentPresent as rbNightlyPresent, NIGHTLY_LABEL as RB_NIGHTLY_LABEL } from '../../../lib/ruvnet-brain.mjs';
 import { row } from '../row.mjs';
 
+/** One status row for the installed/release state. A GitHub tag without the
+ *  installer's required bundle asset is visible but deliberately non-actionable:
+ *  giving it a fix would make `ak sync` prescribe a download known to 404. */
+export function brainReleaseRow(b) {
+  const releaseBlocked = !!b.latest && b.releaseAssetAvailable === false;
+  const releaseUnverified = !!b.latest && b.releaseAssetAvailable == null;
+  if (!b.present) {
+    if (releaseBlocked) {
+      return row('ruvnet-brain', 'warn',
+        `RuvNet Brain not installed; release v${b.latest} is missing ruvnet-brain.zip — automatic install blocked upstream`);
+    }
+    if (releaseUnverified) {
+      return row('ruvnet-brain', 'info',
+        `RuvNet Brain not installed; release v${b.latest} bundle availability awaits a live sync check`);
+    }
+    return row('ruvnet-brain', 'warn', 'RuvNet Brain not installed', 'setup installs it (or `ak sync`)');
+  }
+  if (b.outdated && releaseBlocked) {
+    const have = b.installedRelease ? `release v${b.installedRelease}` : 'the existing unversioned install';
+    return row('ruvnet-brain', 'info',
+      `ruvnet-brain ${have} retained; release v${b.latest} is missing ruvnet-brain.zip — update deferred upstream`);
+  }
+  if (b.outdated && releaseUnverified) {
+    const have = b.installedRelease ? `release v${b.installedRelease}` : 'the existing unversioned install';
+    return row('ruvnet-brain', 'info',
+      `ruvnet-brain ${have} retained; release v${b.latest} bundle availability awaits a live sync check`);
+  }
+  if (b.outdated) {
+    const have = b.installedRelease ? `release v${b.installedRelease}` : 'present (unversioned install)';
+    return row('ruvnet-brain', 'warn',
+      `ruvnet-brain ${have}, release v${b.latest} available`, 'sync refreshes the KB');
+  }
+  const shown = b.installedRelease ? `release v${b.installedRelease}${b.latest ? ' (latest)' : ''}` : 'present';
+  return row('ruvnet-brain', 'ok', `ruvnet-brain ${shown}`);
+}
+
 export default {
   id: 'ruvnet-brain',
   async collect({ cfg }) {
@@ -10,16 +46,7 @@ export default {
     if (!cfg.ruvnetBrain) return rows;
     try {
       const b = await ruvnetBrainDrift();
-      if (!b.present) {
-        rows.push(row('ruvnet-brain', 'warn', 'RuvNet Brain not installed', 'setup installs it (or `ak sync`)'));
-      } else if (b.outdated) {
-        const have = b.installedRelease ? `release v${b.installedRelease}` : 'present (unversioned install)';
-        rows.push(row('ruvnet-brain', 'warn',
-          `ruvnet-brain ${have}, release v${b.latest} available`, 'sync refreshes the KB'));
-      } else {
-        const shown = b.installedRelease ? `release v${b.installedRelease}${b.latest ? ' (latest)' : ''}` : 'present';
-        rows.push(row('ruvnet-brain', 'ok', `ruvnet-brain ${shown}`));
-      }
+      rows.push(brainReleaseRow(b));
     } catch (e) {
       rows.push(row('ruvnet-brain', 'warn', `ruvnet-brain check unavailable: ${e.message}`));
     }

--- a/src/commands/sync.mjs
+++ b/src/commands/sync.mjs
@@ -2,12 +2,16 @@
 // uses; --dry-run prints it and stops. Apply order: upgrades first (they wipe
 // natives), then heals, then re-collect to prove convergence.
 import path from 'node:path';
+import readline from 'node:readline/promises';
 import { collect } from './status.mjs';
 import * as heal from '../lib/heal.mjs';
 import { have } from '../lib/exec.mjs';
 import { fixStatusline, helperStampStale } from '../lib/statusline.mjs';
 import { reconcileGuidance } from '../lib/blocks.mjs';
-import { register as mcpRegister, applyExclusions } from '../lib/mcp.mjs';
+import {
+  register as mcpRegister, applyExclusions, codexMcpTopology, codexMcpRepairPlan,
+  repairCodexMcpTopology,
+} from '../lib/mcp.mjs';
 import { runLifecycle } from '../lib/adapters/lifecycle.mjs';
 import { hostsWithLifecycle, lifecycleAdapterFor, lifecycleExecutionEnabled, detectionBinFor } from '../lib/adapters/lifecycle-registry.mjs';
 import { companionLifecycleFor } from '../lib/adapters/companion-lifecycle-registry.mjs';
@@ -16,6 +20,7 @@ import { listDaemons, staleDaemons, reap } from '../lib/daemons.mjs';
 import { loadKitConfig, saveKitConfig } from '../lib/config.mjs';
 import { commandHosts, hostInstallState, installHost, convergeProviderStack, guidanceContext, reportRetiredRouteChanges } from '../lib/providers.mjs';
 import { driftReport, selfDrift } from '../lib/versions.mjs';
+import { drift as ruvnetBrainDrift } from '../lib/ruvnet-brain.mjs';
 import { RUVECTOR_PKG, managed as ruvectorManaged } from '../lib/ruvector.mjs';
 import { pruneNpxStale } from '../lib/npx.mjs';
 import { runScaffoldAgentsFix } from '../lib/scaffold.mjs';
@@ -37,9 +42,28 @@ function printReportLine(line) {
   else info(line.text);
 }
 
+/** Preserve a failed mutation for the final convergence proof. A failed heal
+ * may leave an existing but stale capability on disk, so post-heal presence
+ * alone is not success evidence. */
+export function recordApplyFailure(state, name, result) {
+  if (result?.ok === false) state.applyFailures.push({ name, detail: result.detail || `exit ${result.status || 'failed'}` });
+}
+
+/** Refresh every network-backed fact that can open an upgrade gate. Kept out
+ *  of run() so adding one release boundary does not grow the command's already
+ *  broad orchestration complexity. Sequential: both probes persist kit.json. */
+async function refreshPlanDrift(flags, fetchLatest) {
+  if (flags['dry-run'] || flags['no-upgrade']) return;
+  await driftReport({ force: true, ...(fetchLatest ? { fetchLatest } : {}) });
+  // Brain releases have a second executability fact beyond the tag: the
+  // required ruvnet-brain.zip asset. A tag-only release is not actionable.
+  if (loadKitConfig().ruvnetBrain) await ruvnetBrainDrift({ force: true });
+}
+
 export const options = {
   'dry-run': { type: 'boolean', default: false },
   'no-upgrade': { type: 'boolean', default: false },
+  yes: { type: 'boolean', default: false },
   json: { type: 'boolean', default: false },
 };
 
@@ -54,6 +78,7 @@ Usage: ak sync [options]
 Options:
   --dry-run       print the plan and stop; change nothing
   --no-upgrade    heal only; don't upgrade ruflo/aqe/kit versions
+  --yes           approve disclosed repairs without prompting
   --json          emit results as JSON
 
 Examples:
@@ -76,6 +101,15 @@ Examples:
 // (`dejaVuApplyFailed`, `aqeRouterApplyFailure`) the final convergence check
 // needs — the only state that survives past its own step.
 export const SYNC_STEPS = [
+  {
+    id: 'codex-mcp-repair',
+    when: (subs) => subs.has('codex-mcp'),
+    run: async (ctx) => {
+      if (!ctx.codexRepairPlan.length) return;
+      const result = await ctx.step('codex MCP repair', () => repairCodexMcpTopology(ctx.codexRepairPlan, ctx.cwd));
+      if (!result.ok) ctx.state.codexRepairFailure = result.detail;
+    },
+  },
   {
     id: 'codex-statusline',
     when: (subs, flags, cfg) => subs.has('codex-statusline') && !!cfg.statusline?.codex?.preset,
@@ -401,9 +435,7 @@ export async function run({
   // versions gate it needed to open). Dry-runs skip the refresh: it writes
   // kit.json, and --dry-run is pinned to touch nothing — so a dry-run
   // preview may be cache-stale by up to one TTL window.
-  if (!flags['dry-run'] && !flags['no-upgrade']) {
-    await driftReport({ force: true, ...(fetchLatest ? { fetchLatest } : {}) });
-  }
+  await refreshPlanDrift(flags, fetchLatest);
   const rows = await collectFn({ pkgRoot, cwd, dejaVuAdapter, dejaVuPlanOptions });
   const plan = rows.filter((r) => r.fix)
     // Model lifecycle actions are explicit advisory commands. `ak status` must
@@ -420,14 +452,47 @@ export async function run({
 
   const cfg = loadKitConfig();
   const subsystems = new Set(plan.map((p) => p.subsystem));
+  const codexRepairPlan = plan.some((p) => p.subsystem === 'codex-mcp')
+    ? codexMcpRepairPlan(codexMcpTopology({ cwd })) : [];
+  if (codexRepairPlan.length) {
+    console.log(bold(`Codex repair plan (${codexRepairPlan.length} action(s)):`));
+    for (const action of codexRepairPlan) {
+      console.log(`  • remove ${action.file} → [mcp_servers.${action.name}] — ${action.reason}`);
+    }
+    let confirmed = flags.yes;
+    if (!confirmed) {
+      if (!process.stdin.isTTY) {
+        fail('Codex repairs need confirmation; re-run with --yes in a non-interactive session');
+        return 1;
+      }
+      const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+      const answer = await rl.question('Apply these Codex repairs? [y/N] ');
+      rl.close();
+      confirmed = /^y(?:es)?$/i.test(answer.trim());
+    }
+    if (!confirmed) {
+      info('Codex configuration was left unchanged; no sync actions were applied');
+      return 1;
+    }
+  }
   const report = reportOutcome;
+  const state = {
+    dejaVuApplyFailed: false,
+    aqeRouterApplyFailure: null,
+    codexRepairFailure: null,
+    applyFailures: [],
+  };
   // Run a managed heal under a live elapsed-time ticker, then print its result.
   // Keeps every slow tool (npm upgrades, brain KB download, native rebuild)
   // visibly alive instead of freezing the prompt; fast/local steps clear in <1s.
-  const step = async (name, thunk) => { const r = await withProgress(name, thunk); report(name, r); return r; };
-  const state = { dejaVuApplyFailed: false, aqeRouterApplyFailure: null };
+  const step = async (name, thunk) => {
+    const r = await withProgress(name, thunk);
+    report(name, r);
+    recordApplyFailure(state, name, r);
+    return r;
+  };
   const ctx = {
-    cfg, cwd, pkgRoot, flags, dejaVuAdapter, subsystems, report, step, state,
+    cfg, cwd, pkgRoot, flags, dejaVuAdapter, codexRepairPlan, subsystems, report, step, state,
   };
 
   for (const s of SYNC_STEPS) {
@@ -476,6 +541,14 @@ export async function run({
   }
   if (state.dejaVuApplyFailed && !remaining.some((r) => r.subsystem === 'deja-vu')) {
     remaining.push({ subsystem: 'deja-vu', message: 'companion lifecycle apply failed' });
+  }
+  if (state.codexRepairFailure && !remaining.some((r) => r.subsystem === 'codex-mcp')) {
+    remaining.push({ subsystem: 'codex-mcp', message: state.codexRepairFailure });
+  }
+  for (const failure of state.applyFailures) {
+    if (!remaining.some((r) => r.message === `${failure.name}: ${failure.detail}`)) {
+      remaining.push({ subsystem: failure.name, message: `${failure.name}: ${failure.detail}` });
+    }
   }
   if (remaining.length === 0) {
     ok(bold('converged — no failing subsystems'));

--- a/src/lib/codex-plugins.mjs
+++ b/src/lib/codex-plugins.mjs
@@ -16,6 +16,9 @@ const ADVISORIES = [{
 
 function readJson(file) {
   try {
+    const stat = fs.lstatSync(file);
+    if (!stat.isFile() || stat.isSymbolicLink()) return { value: null, error: 'must be a regular non-symlink file' };
+    if (stat.size > 2 * 1024 * 1024) return { value: null, error: 'exceeds 2097152 byte inspection limit' };
     return { value: JSON.parse(fs.readFileSync(file, 'utf8')), error: null };
   } catch (error) {
     return { value: null, error: error.message };
@@ -40,9 +43,20 @@ export function enabledPluginRefs(source) {
 
 function splitRef(ref) {
   const at = ref.lastIndexOf('@');
-  return at > 0 && at < ref.length - 1
-    ? { plugin: ref.slice(0, at), marketplace: ref.slice(at + 1) }
-    : null;
+  if (at <= 0 || at >= ref.length - 1) return null;
+  const parsed = { plugin: ref.slice(0, at), marketplace: ref.slice(at + 1) };
+  const safeSegment = (value) => value !== '.' && value !== '..' && !/[\\/\0]/.test(value);
+  return safeSegment(parsed.plugin) && safeSegment(parsed.marketplace) ? parsed : null;
+}
+
+function canonicallyContained(root, target) {
+  try {
+    const realRoot = fs.realpathSync(root);
+    const realTarget = fs.realpathSync(target);
+    return realTarget === realRoot || realTarget.startsWith(`${realRoot}${path.sep}`);
+  } catch {
+    return false;
+  }
 }
 
 function newestVersionDir(base) {
@@ -149,8 +163,15 @@ function advisoryIssues(ref, version) {
 function hookTargets(hooks, root) {
   if (hooks === undefined) {
     const conventional = path.join(root, 'hooks', 'hooks.json');
-    return fs.existsSync(conventional) ? [{ kind: 'file', value: conventional }] : [];
+    try {
+      fs.lstatSync(conventional);
+      return [{ kind: 'file', value: conventional }];
+    } catch (error) {
+      return error.code === 'ENOENT' ? [] : [{ kind: 'file', value: conventional }];
+    }
   }
+  if (hooks && !Array.isArray(hooks) && typeof hooks === 'object'
+      && Object.keys(hooks).length === 0) return [];
   const values = Array.isArray(hooks) ? hooks : [hooks];
   return values.map((value) => {
     if (typeof value !== 'string') return { kind: 'inline', value };
@@ -163,52 +184,86 @@ function hookTargets(hooks, root) {
 
 function inspectPlugin(ref, cacheDir) {
   const parsed = splitRef(ref);
-  if (!parsed) return { ref, version: null, root: null, hookFiles: [], skillFiles: [], issues: [`invalid plugin reference "${ref}"`] };
+  if (!parsed) {
+    const hookIssues = [`invalid plugin reference "${ref}"`];
+    return { ref, version: null, root: null, hookFiles: [], inlineHookDocuments: [], skillFiles: [], hookIssues, skillIssues: [], issues: hookIssues };
+  }
   const base = path.join(cacheDir, parsed.marketplace, parsed.plugin);
   const version = newestVersionDir(base);
   if (!version) {
-    return { ref, version: null, root: null, hookFiles: [], skillFiles: [], issues: [`${ref}: enabled but no cached version is installed`] };
+    const hookIssues = [`${ref}: enabled but no cached version is installed`];
+    return { ref, version: null, root: null, hookFiles: [], inlineHookDocuments: [], skillFiles: [], hookIssues, skillIssues: [], issues: hookIssues };
   }
   const root = path.join(base, version);
-  const manifestFile = [
+  if (!canonicallyContained(cacheDir, root)) {
+    const hookIssues = [`${ref}: cached generation escapes the plugin cache root`];
+    return { ref, version, root: null, hookFiles: [], inlineHookDocuments: [], skillFiles: [], hookIssues, skillIssues: [], issues: hookIssues };
+  }
+  const manifestCandidates = [
     path.join(root, '.codex-plugin', 'plugin.json'),
     path.join(root, '.agent-plugin', 'plugin.json'),
     path.join(root, '.claude-plugin', 'plugin.json'),
-  ].find((file) => fs.existsSync(file));
+  ];
+  let manifestFile = null;
+  let unsafeManifest = null;
+  for (const file of manifestCandidates) {
+    try {
+      const stat = fs.lstatSync(file);
+      if (!stat.isFile() || stat.isSymbolicLink() || !canonicallyContained(root, file)) {
+        unsafeManifest = file;
+        break;
+      }
+      manifestFile = file;
+      break;
+    } catch (error) {
+      if (error.code !== 'ENOENT') { unsafeManifest = file; break; }
+    }
+  }
+  if (unsafeManifest) {
+    const hookIssues = [`${ref}: plugin manifest must be a contained regular non-symlink file: ${unsafeManifest}`];
+    return { ref, version, root, hookFiles: [], inlineHookDocuments: [], skillFiles: [], hookIssues, skillIssues: [], issues: hookIssues };
+  }
   if (!manifestFile) {
+    const hookIssues = [`${ref}: cached generation ${version} has no supported plugin manifest`];
     return {
-      ref, version, root, hookFiles: [], skillFiles: [],
-      issues: [`${ref}: cached generation ${version} has no supported plugin manifest`],
+      ref, version, root, hookFiles: [], inlineHookDocuments: [], skillFiles: [], hookIssues, skillIssues: [], issues: hookIssues,
     };
   }
   const manifest = readJson(manifestFile);
   if (manifest.error) {
-    return { ref, version, root, hookFiles: [], skillFiles: [], issues: [`${manifestFile}: ${manifest.error}`] };
+    const hookIssues = [`${manifestFile}: ${manifest.error}`];
+    return { ref, version, root, hookFiles: [], inlineHookDocuments: [], skillFiles: [], hookIssues, skillIssues: [], issues: hookIssues };
   }
 
   const hookFiles = [];
-  const issues = advisoryIssues(ref, version);
+  const inlineHookDocuments = [];
+  const hookIssues = advisoryIssues(ref, version);
   for (const target of hookTargets(manifest.value?.hooks, root)) {
     if (target.kind === 'outside') {
-      issues.push(`${ref}: hook path escapes the plugin root: ${target.value}`);
+      hookIssues.push(`${ref}: hook path escapes the plugin root: ${target.value}`);
       continue;
     }
     if (target.kind === 'invalid-path') {
-      issues.push(`${ref}: hook path must start with "./": ${target.value}`);
+      hookIssues.push(`${ref}: hook path must start with "./": ${target.value}`);
       continue;
     }
     if (target.kind === 'inline') {
-      issues.push(...validateHookDocument(target.value, `${ref} inline hooks`));
+      const inlineIssues = validateHookDocument(target.value, `${ref} inline hooks`);
+      hookIssues.push(...inlineIssues);
+      if (inlineIssues.length === 0) inlineHookDocuments.push(target.value);
       continue;
     }
     hookFiles.push(target.value);
     const hook = readJson(target.value);
-    if (hook.error) issues.push(`${target.value}: ${hook.error}`);
-    else issues.push(...validateHookDocument(hook.value, target.value));
+    if (hook.error) hookIssues.push(`${target.value}: ${hook.error}`);
+    else hookIssues.push(...validateHookDocument(hook.value, target.value));
   }
   const skills = inspectSkills(root);
-  issues.push(...skills.issues);
-  return { ref, version, root, hookFiles, skillFiles: skills.files, issues };
+  const skillIssues = skills.issues;
+  return {
+    ref, version, root, manifestFile, hookFiles, inlineHookDocuments, skillFiles: skills.files,
+    hookIssues, skillIssues, issues: [...hookIssues, ...skillIssues],
+  };
 }
 
 /** Inspect every explicitly enabled plugin's newest cached generation. */
@@ -220,7 +275,7 @@ export function inspectCodexPlugins({
   try {
     source = fs.readFileSync(configFile, 'utf8');
   } catch {
-    return { configPresent: false, enabled: [], plugins: [], issues: [] };
+    return { configPresent: false, enabled: [], plugins: [], hookIssues: [], skillIssues: [], issues: [] };
   }
   const enabled = enabledPluginRefs(source);
   const plugins = enabled.map((ref) => inspectPlugin(ref, cacheDir));
@@ -228,6 +283,8 @@ export function inspectCodexPlugins({
     configPresent: true,
     enabled,
     plugins,
+    hookIssues: plugins.flatMap((plugin) => plugin.hookIssues),
+    skillIssues: plugins.flatMap((plugin) => plugin.skillIssues),
     issues: plugins.flatMap((plugin) => plugin.issues),
   };
 }

--- a/src/lib/dashboard-server.mjs
+++ b/src/lib/dashboard-server.mjs
@@ -449,7 +449,9 @@ export function foldBrainDrift(drift, b) {
     pkg: 'ruvnet-brain',
     installed: b.installedRelease ?? '(unversioned)',
     latest: b.latest,
-    outdated: !!b.outdated,
+    // A tag without the installer's required bundle is visible on the status
+    // card, but must not become an actionable dashboard update banner.
+    outdated: !!b.outdated && b.releaseAssetAvailable === true,
   }];
 }
 

--- a/src/lib/heal.mjs
+++ b/src/lib/heal.mjs
@@ -12,7 +12,7 @@ import { rufloRoot, aqeRoot } from './paths.mjs';
 import { agentdbLocations, bsq3IsNative, bsq3Root, deriveBsq3Spec, selfSpecConflicts, rufloMemoryContexts, aidefencePresent } from './natives.mjs';
 import { KIT_PKG } from './versions.mjs';
 import { scanRvf, quarantine } from './rvf.mjs';
-import { INSTALL_SPEC, INSTALL_ARGS, NIGHTLY_LABEL as RB_NIGHTLY_LABEL, nightlyAgentPlist as rbNightlyPlist, present as rbPresent, latestVersion as rbLatest, recordInstalledRelease as rbRecord } from './ruvnet-brain.mjs';
+import { INSTALL_SPEC, INSTALL_ARGS, RELEASE_ASSET as RB_RELEASE_ASSET, NIGHTLY_LABEL as RB_NIGHTLY_LABEL, nightlyAgentPlist as rbNightlyPlist, present as rbPresent, latestRelease as rbLatestRelease, recordInstalledRelease as rbRecord } from './ruvnet-brain.mjs';
 import { PKG as ADB_PKG, present as adbPresent, coherence as adbCoherence } from './agentdb.mjs';
 
 // Packages whose install scripts must run for natives to build (npm >=11.17
@@ -187,7 +187,7 @@ export async function selfUpdate(version) {
  *  check saw a newer release). Runs `--no-stack --no-enhance`: ak already
  *  manages ruflo/RuVector and owns the CLAUDE.md grounding block. */
 export async function installRuvnetBrain({
-  force = false, runner = run, latestVersion = rbLatest,
+  force = false, runner = run, latestRelease = rbLatestRelease,
   present = rbPresent, recordRelease = rbRecord,
 } = {}) {
   // Resolve the release tag FIRST and pin the installer to it (--version v<tag>),
@@ -195,7 +195,18 @@ export async function installRuvnetBrain({
   // install-then-stamp order left a window where a release published mid-install
   // made the stamp disagree with disk. Offline (tag null): the installer's own
   // latest logic applies and the stamp is best-effort afterwards, as before.
-  const tag = await latestVersion();
+  const release = await latestRelease();
+  const tag = release?.version ?? null;
+  // Do not launch the installer for a release that cannot possibly land. Its
+  // own fallback constructs the same absent /ruvnet-brain.zip URL, waits for
+  // that 404, then emits a generic half-install footer. Preserve the existing
+  // install and surface the upstream publishing defect directly.
+  if (release?.releaseAssetAvailable === false) {
+    return {
+      ok: false, status: 'failed', usable: present(),
+      detail: `release v${tag} is missing ${RB_RELEASE_ASSET}; automatic update is blocked upstream and the existing Brain was left unchanged`,
+    };
+  }
   const args = ['-y', INSTALL_SPEC, ...INSTALL_ARGS,
     ...(tag ? ['--version', `v${tag}`] : []),
     ...(force ? ['--force'] : [])];
@@ -203,7 +214,7 @@ export async function installRuvnetBrain({
   if (r.code === 0) {
     // Stamp the release-tag namespace so drift converges — the plugin's own
     // semver never tracks the KB release, so we can't use it.
-    const stamped = tag ?? await latestVersion();
+    const stamped = tag ?? (await latestRelease())?.version ?? null;
     if (stamped) recordRelease(stamped);
     return {
       ok: true, status: 'ok', usable: true,
@@ -214,8 +225,19 @@ export async function installRuvnetBrain({
   // is useful evidence for `usable`, never proof that this install succeeded.
   return {
     ok: false, status: 'failed', usable: present(),
-    detail: (r.stderr || `exit ${r.code}`).trim().split('\n').slice(-2).join(' ').slice(0, 200),
+    detail: brainInstallFailure(r),
   };
+}
+
+/** Prefer the installer's causal error over its generic closing reassurance.
+ *  Newer updater failures write the release-asset error to stdout while the
+ *  final "Nothing is left half-installed" footer lands on stderr. */
+export function brainInstallFailure(result) {
+  const lines = `${result?.stdout ?? ''}\n${result?.stderr ?? ''}`
+    .split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+  const causal = lines.filter((line) => /\[forge-update\]\s*ERROR:|install stopped:|HTTP\s+\d{3}|no matching .*\.zip asset/i.test(line));
+  const chosen = causal.slice(-2).join(' | ') || lines.slice(-2).join(' ') || `exit ${result?.code ?? 1}`;
+  return chosen.slice(0, 320);
 }
 
 /** Disable the brain installer's nightly self-update LaunchAgent (macOS-only —

--- a/src/lib/hook-audit/codex-toml.mjs
+++ b/src/lib/hook-audit/codex-toml.mjs
@@ -1,0 +1,101 @@
+import { readBoundedFile } from './common.mjs';
+
+function unquote(value) {
+  if (value.startsWith("'") && value.endsWith("'")) return value.slice(1, -1);
+  if (value.startsWith('"') && value.endsWith('"')) {
+    try { return JSON.parse(value); } catch { return null; }
+  }
+  return null;
+}
+
+function scalar(value) {
+  const trimmed = value.trim();
+  const string = unquote(trimmed);
+  if (string !== null) return { ok: true, value: string };
+  if (/^(?:true|false)$/.test(trimmed)) return { ok: true, value: trimmed === 'true' };
+  if (/^-?(?:\d+\.?\d*|\.\d+)$/.test(trimmed)) return { ok: true, value: Number(trimmed) };
+  if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+    try { return { ok: true, value: JSON.parse(trimmed) }; } catch { /* TOML inline tables are deliberately unsupported */ }
+  }
+  return { ok: false, value: null };
+}
+
+function applyHookHeader(raw, state) {
+  const match = /^\[\[hooks\.([A-Za-z][A-Za-z0-9]*)(\.hooks)?\]\]$/.exec(raw);
+  if (!match) return false;
+  const [, event, handlerTable] = match;
+  state.sawHookTable = true;
+  state.document.hooks[event] ??= [];
+  if (!handlerTable) {
+    state.currentGroup = { hooks: [] };
+    state.document.hooks[event].push(state.currentGroup);
+    state.currentHook = null;
+    state.currentEvent = event;
+    state.table = 'group';
+    return true;
+  }
+  if (!state.currentGroup || state.currentEvent !== event) {
+    state.currentGroup = { hooks: [] };
+    state.document.hooks[event].push(state.currentGroup);
+  }
+  state.currentHook = {};
+  state.currentGroup.hooks.push(state.currentHook);
+  state.currentEvent = event;
+  state.table = 'hook';
+  return true;
+}
+
+function applyOrdinaryHeader(raw, state) {
+  const match = /^\[([^\]]+)\]$/.exec(raw);
+  if (!match) return false;
+  state.table = match[1] === 'features' ? 'features' : match[1] === 'hooks' ? 'hooks-meta' : null;
+  state.currentGroup = null;
+  state.currentHook = null;
+  state.currentEvent = null;
+  return true;
+}
+
+function applyAssignment(raw, lineIndex, state) {
+  const assignment = /^([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.+?)\s*$/.exec(raw);
+  if (!assignment) {
+    if (state.table === 'group' || state.table === 'hook') {
+      state.errors.push(`line ${lineIndex + 1}: unsupported inline hook syntax`);
+    }
+    return;
+  }
+  const parsed = scalar(assignment[2]);
+  if (!parsed.ok) {
+    if (state.table === 'group' || state.table === 'hook') {
+      state.errors.push(`line ${lineIndex + 1}: unsupported inline hook value`);
+    }
+    return;
+  }
+  const key = assignment[1] === 'command_windows' ? 'commandWindows' : assignment[1];
+  if (state.table === 'group') state.currentGroup[key] = parsed.value;
+  else if (state.table === 'hook') state.currentHook[key] = parsed.value;
+  else if (state.table === 'features' && (key === 'hooks' || key === 'codex_hooks')) state.features.hooks = parsed.value;
+  else if (state.table === null && key === 'allow_managed_hooks_only') state.features.allowManagedHooksOnly = parsed.value;
+}
+
+/** Parse only Codex's documented inline hook tables; never pretend to parse arbitrary TOML. */
+/** @returns {any} */
+export function readCodexInlineHooks(file, containmentRoot, metadata = {}) {
+  const read = readBoundedFile(file, containmentRoot);
+  if (read.status === 'absent') return null;
+  if (read.status !== 'valid') return { ...metadata, file, ...read };
+  const state = {
+    document: { hooks: {} }, features: {}, table: null,
+    currentGroup: null, currentHook: null, currentEvent: null,
+    sawHookTable: false, errors: [],
+  };
+  const lines = read.text.replaceAll('\r\n', '\n').split('\n');
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
+    const raw = lines[lineIndex].trim();
+    if (!raw || raw.startsWith('#')) continue;
+    if (applyHookHeader(raw, state) || applyOrdinaryHeader(raw, state)) continue;
+    applyAssignment(raw, lineIndex, state);
+  }
+  if (!state.sawHookTable && Object.keys(state.features).length === 0) return null;
+  if (state.errors.length) return { ...metadata, file, status: 'invalid', digest: read.digest, error: state.errors.join('; ') };
+  return { ...metadata, file, status: 'valid', digest: read.digest, document: state.document, features: state.features };
+}

--- a/src/lib/hook-audit/common.mjs
+++ b/src/lib/hook-audit/common.mjs
@@ -1,0 +1,195 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { createHash } from 'node:crypto';
+
+export const MAX_AUDIT_SOURCE_BYTES = 2 * 1024 * 1024;
+export const sha256 = (value) => createHash('sha256').update(value).digest('hex');
+export const isRecord = (value) => Boolean(value) && !Array.isArray(value) && typeof value === 'object';
+
+export function stableValue(value) {
+  if (Array.isArray(value)) return value.map(stableValue);
+  if (!isRecord(value)) return value;
+  return Object.fromEntries(Object.keys(value).sort().map((key) => [key, stableValue(value[key])]));
+}
+
+export const stableJson = (value) => JSON.stringify(stableValue(value));
+
+function contained(realRoot, realFile) {
+  return realFile === realRoot || realFile.startsWith(`${realRoot}${path.sep}`);
+}
+
+/** Read a bounded regular file without following a final symlink. */
+/** @returns {any} */
+export function readBoundedFile(file, containmentRoot, maxBytes = MAX_AUDIT_SOURCE_BYTES) {
+  let descriptor;
+  try {
+    const stat = fs.lstatSync(file);
+    if (!stat.isFile() || stat.isSymbolicLink()) {
+      return { status: 'refused', error: 'source must be a regular non-symlink file' };
+    }
+    if (stat.size > maxBytes) return { status: 'refused', error: `source exceeds ${maxBytes} byte limit` };
+    const realRoot = fs.realpathSync(containmentRoot);
+    const realFile = fs.realpathSync(file);
+    if (!contained(realRoot, realFile)) {
+      return { status: 'refused', error: 'source escapes its containment root through a symlinked ancestor' };
+    }
+    const flags = fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW ?? 0);
+    descriptor = fs.openSync(file, flags);
+    const opened = fs.fstatSync(descriptor);
+    if (!opened.isFile() || opened.size > maxBytes) {
+      return { status: 'refused', error: 'opened source is not a bounded regular file' };
+    }
+    if (opened.dev !== stat.dev || opened.ino !== stat.ino) {
+      return { status: 'refused', error: 'source identity changed between inspection and open' };
+    }
+    const reopenedRealFile = fs.realpathSync(file);
+    if (reopenedRealFile !== realFile || !contained(realRoot, reopenedRealFile)) {
+      return { status: 'refused', error: 'source path changed between inspection and open' };
+    }
+    const bytes = Buffer.alloc(opened.size);
+    let offset = 0;
+    while (offset < bytes.length) {
+      const count = fs.readSync(descriptor, bytes, offset, bytes.length - offset, offset);
+      if (count === 0) break;
+      offset += count;
+    }
+    if (offset !== bytes.length) return { status: 'invalid', error: 'source changed while it was read' };
+    return { status: 'valid', bytes, text: bytes.toString('utf8'), digest: sha256(bytes) };
+  } catch (error) {
+    if (error?.code === 'ENOENT') return { status: 'absent' };
+    return { status: 'invalid', error: error?.message ?? String(error) };
+  } finally {
+    if (descriptor !== undefined) fs.closeSync(descriptor);
+  }
+}
+
+/** @returns {any} */
+export function readJsonSource(file, containmentRoot, metadata = {}) {
+  const read = readBoundedFile(file, containmentRoot);
+  if (read.status === 'absent') return null;
+  if (read.status !== 'valid') return { ...metadata, file, ...read };
+  try {
+    return { ...metadata, file, status: 'valid', digest: read.digest, document: JSON.parse(read.text) };
+  } catch (error) {
+    return { ...metadata, file, status: 'invalid', digest: read.digest, error: `JSON parse failed: ${error.message}` };
+  }
+}
+
+const SECRET_ASSIGNMENT = /\b([A-Z][A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|PASS|KEY|CREDENTIAL)[A-Z0-9_]*)=([^\s]+)/gi;
+const BEARER = /\b(Bearer\s+)[A-Za-z0-9._~+/=-]+/gi;
+
+export function redactCommand(value) {
+  if (typeof value !== 'string') return '';
+  return value.replace(SECRET_ASSIGNMENT, '$1=<redacted>').replace(BEARER, '$1<redacted>');
+}
+
+export function commandFacts(command) {
+  const normalized = typeof command === 'string' ? command.trim() : '';
+  const redacted = redactCommand(normalized);
+  return {
+    normalized: redacted,
+    digest: sha256(normalized),
+    shell: /(?:^|[\s/])(?:env\s+)?(?:sh|bash|zsh|fish|cmd(?:\.exe)?|powershell|pwsh)(?:\s|$)|(?:&&|\|\||[|;<>`])/i.test(normalized),
+    projectDirReferences: [...new Set(normalized.match(/\$\{?[A-Z][A-Z0-9_]+/g) ?? [])].sort(),
+    redacted: redacted !== normalized,
+  };
+}
+
+export function sideEffectHints(command) {
+  const normalized = typeof command === 'string' ? command.trim() : '';
+  const hints = [];
+  if (/\bnpx\b/.test(normalized)) hints.push('package-resolution-or-network-possible');
+  if (/\b(?:gh|curl|wget)\b/.test(normalized)) hints.push('network-possible');
+  if (/\.claude-flow|\.swarm|auto-memory|session-end|post-(?:edit|task|command)/.test(normalized)) hints.push('state-write-possible');
+  if (/\b(?:rm|unlink|kill|shutdown)\b/.test(normalized)) hints.push('destructive-process-or-file-action-possible');
+  return hints.length ? hints : ['unknown-inspect-implementation'];
+}
+
+export function publicSource(source) {
+  const result = { ...source };
+  delete result.document;
+  delete result.text;
+  return result;
+}
+
+export function summarizeHostReport({ sources, records, plan, issues = [], coverage }) {
+  return {
+    sources: sources.length,
+    invalidSources: sources.filter((source) => !['valid', 'opaque'].includes(source.status)).length,
+    configurationIssues: issues.length,
+    hookOccurrences: records.length,
+    uniqueBehaviors: new Set(records.map((record) => record.behaviorFingerprint)).size,
+    automaticActions: plan.filter((action) => action.classification === 'automatic-eligible').length,
+    approvalRequiredActions: plan.filter((action) => action.classification === 'approval-required').length,
+    neverAutomaticActions: plan.filter((action) => action.classification === 'prohibited').length,
+    upstreamRequiredActions: plan.filter((action) => action.classification === 'upstream-required').length,
+    coverage,
+  };
+}
+
+function materialHandler(handler, command, source) {
+  return stableValue({
+    commandDigest: command ? sha256(command) : null,
+    commandWindowsDigest: handler.commandWindows ? sha256(handler.commandWindows) : null,
+    server: handler.server ?? null,
+    tool: handler.tool ?? null,
+    input: handler.input ?? null,
+    async: handler.async ?? false,
+    statusMessage: handler.statusMessage ?? null,
+    additionalContextLimit: handler.additionalContextLimit ?? null,
+    cwd: handler.cwd ?? source.baseDir ?? null,
+  });
+}
+
+function publicHandler(handler) {
+  return {
+    server: handler.server ?? null,
+    tool: handler.tool ?? null,
+    inputDigest: handler.input === undefined ? null : sha256(stableJson(handler.input)),
+    async: handler.async ?? false,
+    statusMessage: handler.statusMessage ?? null,
+    additionalContextLimit: handler.additionalContextLimit ?? null,
+  };
+}
+
+/**
+ * @param {{host:string,event:string,matcher?:string,type?:string,
+ * handler?:Record<string,any>,source:Record<string,any>,indices?:Record<string,number>,
+ * timeout?:any,diagnostics?:any[],selected?:boolean|null,risk?:string}} input
+ */
+export function normalizedOccurrence({
+  host, event, matcher = '', type = 'command', handler = {}, source, indices = {},
+  timeout = null, diagnostics = [], selected = null, risk = 'HUMAN REVIEW REQUIRED',
+} = /** @type {any} */ ({})) {
+  const command = Array.isArray(handler.command) ? handler.command.join(' ') : handler.command ?? '';
+  const material = {
+    host, event, matcher, type,
+    handler: materialHandler(handler, command, source),
+    timeout,
+  };
+  const behaviorFingerprint = sha256(stableJson(material));
+  return {
+    schemaVersion: 2,
+    host,
+    event,
+    matcher,
+    type,
+    indices,
+    command: commandFacts(command),
+    handler: publicHandler(handler),
+    timeout,
+    source,
+    selected,
+    sideEffects: sideEffectHints(command),
+    risk,
+    trust: {
+      observedState: 'unknown',
+      recommendation: 'HUMAN REVIEW REQUIRED',
+      evidence: 'Audit evidence never establishes host trust or approval state',
+    },
+    rawFingerprint: sha256(stableJson(handler)),
+    behaviorFingerprint,
+    duplicateGroupId: behaviorFingerprint,
+    diagnostics,
+  };
+}

--- a/src/lib/hook-audit/index.mjs
+++ b/src/lib/hook-audit/index.mjs
@@ -1,0 +1,415 @@
+// Read-only Codex lifecycle-hook discovery and normalization. This module
+// deliberately does not expose a writer: trust, generated project files, and
+// plugin-cache generations are outside agentic-kit's automatic authority.
+import path from 'node:path';
+import os from 'node:os';
+import { createHash } from 'node:crypto';
+
+import { inspectCodexPlugins } from '../codex-plugins.mjs';
+import { readBoundedFile, redactCommand, stableJson } from './common.mjs';
+import { readCodexInlineHooks } from './codex-toml.mjs';
+
+const SCHEMA = Object.freeze({
+  id: 'codex-hooks-2026-09-01',
+  timeoutUnits: 'seconds',
+  sessionEnd: { default: 1, maximum: 3 },
+  evidence: 'https://developers.openai.com/codex/hooks',
+  verifiedAt: '2026-09-01',
+  confidence: 'verified',
+});
+
+const VERIFIED_CODEX_VERSION = /^0\.151(?:\.|$)/;
+const CODEX_EVENTS = new Set([
+  'PreToolUse', 'PermissionRequest', 'PostToolUse', 'PreCompact', 'PostCompact',
+  'UserPromptSubmit', 'SubagentStop', 'Stop', 'SessionStart', 'SubagentStart', 'SessionEnd',
+]);
+const CODEX_HANDLER_TYPES = new Set(['command', 'mcp_tool', 'prompt', 'agent']);
+
+const sha256 = (value) => createHash('sha256').update(value).digest('hex');
+const pointerPart = (value) => String(value).replaceAll('~', '~0').replaceAll('/', '~1');
+
+function schemaFor(codexVersion) {
+  if (VERIFIED_CODEX_VERSION.test(codexVersion)) return SCHEMA;
+  return Object.freeze({
+    id: 'codex-hooks-syntax-only',
+    timeoutUnits: 'unknown',
+    sessionEnd: { default: null, maximum: null },
+    evidence: SCHEMA.evidence,
+    verifiedAt: SCHEMA.verifiedAt,
+    confidence: 'unknown',
+  });
+}
+
+const isRecord = (value) => Boolean(value) && !Array.isArray(value) && typeof value === 'object';
+
+function validateMcpHook(hook, event, location) {
+  if (event === 'SessionEnd') return `${location} mcp_tool is not supported for SessionEnd`;
+  if (typeof hook.server !== 'string' || !hook.server.trim()) return `${location} mcp_tool requires server`;
+  if (typeof hook.tool !== 'string' || !hook.tool.trim()) return `${location} mcp_tool requires tool`;
+  if (hook.input !== undefined && !isRecord(hook.input)) return `${location} mcp_tool input must be an object`;
+  return null;
+}
+
+function validateCommonHookFields(hook, location) {
+  if (hook.async !== undefined && typeof hook.async !== 'boolean') return `${location} async must be a boolean`;
+  if (hook.commandWindows !== undefined && typeof hook.commandWindows !== 'string') return `${location} commandWindows must be a string`;
+  if (hook.statusMessage !== undefined && typeof hook.statusMessage !== 'string') return `${location} statusMessage must be a string`;
+  if (hook.additionalContextLimit !== undefined
+      && (!Number.isInteger(hook.additionalContextLimit) || hook.additionalContextLimit < 0)) {
+    return `${location} additionalContextLimit must be a nonnegative integer`;
+  }
+  return null;
+}
+
+function validateHook(hook, event, groupIndex, hookIndex) {
+  const location = `${event} hook ${groupIndex}/${hookIndex}`;
+  if (!isRecord(hook)) return `${location} must be an object`;
+  if (hook.type !== undefined && typeof hook.type !== 'string') {
+    return `${location} type must be a string`;
+  }
+  const type = hook.type ?? 'command';
+  if (!CODEX_HANDLER_TYPES.has(type)) return `${location} has unsupported type ${type}`;
+  if (hook.timeout !== undefined
+      && (typeof hook.timeout !== 'number' || !Number.isFinite(hook.timeout) || hook.timeout < 0)) {
+    return `${location} timeout must be a finite nonnegative number`;
+  }
+  if (type === 'command'
+      && (typeof hook.command !== 'string' || hook.command.trim() === '')) {
+    return `${event} command hook ${groupIndex}/${hookIndex} requires a non-empty command`;
+  }
+  if (type === 'mcp_tool') return validateMcpHook(hook, event, location);
+  return validateCommonHookFields(hook, location);
+}
+
+function validateHookGroup(group, event, groupIndex) {
+  if (!isRecord(group)) return `${event} hook group ${groupIndex} must be an object`;
+  if (group.matcher !== undefined && typeof group.matcher !== 'string') {
+    return `${event} hook group ${groupIndex} matcher must be a string`;
+  }
+  if (!Array.isArray(group.hooks)) return `${event} hook group ${groupIndex} hooks must be an array`;
+  for (const [hookIndex, hook] of group.hooks.entries()) {
+    const error = validateHook(hook, event, groupIndex, hookIndex);
+    if (error) return error;
+  }
+  return null;
+}
+
+function validateHookDocument(document) {
+  if (!isRecord(document) || !isRecord(document.hooks)) {
+    return 'hook JSON requires a top-level hooks object';
+  }
+  for (const [event, groups] of Object.entries(document.hooks)) {
+    if (!CODEX_EVENTS.has(event)) return `unsupported Codex hook event ${event}`;
+    if (!Array.isArray(groups)) return `${event} hook groups must be an array`;
+    for (const [groupIndex, group] of groups.entries()) {
+      const error = validateHookGroup(group, event, groupIndex);
+      if (error) return error;
+    }
+  }
+  return null;
+}
+
+function readHookSource(file, metadata, containmentRoot) {
+  const read = readBoundedFile(file, containmentRoot);
+  if (read.status === 'absent') return null;
+  if (read.status !== 'valid') return { ...metadata, file, ...read };
+  try {
+    const document = JSON.parse(read.text);
+    const schemaError = validateHookDocument(document);
+    if (schemaError) return { ...metadata, file, status: 'invalid', digest: read.digest, error: `hook schema failed: ${schemaError}` };
+    return { ...metadata, file, status: 'valid', digest: read.digest, document };
+  } catch (error) {
+    return {
+      ...metadata,
+      file,
+      status: 'invalid',
+      digest: read.digest,
+      error: `JSON parse failed: ${error.message}`,
+    };
+  }
+}
+
+function normalizeCommand(raw) {
+  if (typeof raw !== 'string') return '';
+  return raw.trim();
+}
+
+function commandFacts(command) {
+  const normalized = normalizeCommand(command);
+  const redacted = redactCommand(normalized);
+  return {
+    normalized: redacted,
+    digest: sha256(normalized),
+    redacted: redacted !== normalized,
+    shell: /(?:^|[\s/])(?:env\s+)?(?:sh|bash|zsh|fish|cmd(?:\.exe)?|powershell|pwsh)(?:\s|$)|(?:&&|\|\||[|;<>`])/i.test(normalized),
+    projectDirReferences: [...new Set(normalized.match(/\$\{?[A-Z][A-Z0-9_]+/g) ?? [])].sort(),
+  };
+}
+
+function implementationTarget(command) {
+  const normalized = normalizeCommand(command);
+  const script = normalized.match(/(?:^|[\s"'])([^\s"']+\.(?:cjs|mjs|js))(?:[\s"']|$)/)?.[1];
+  if (script) return script;
+  return normalized.split(' ')[0] || '(none)';
+}
+
+function sideEffectHints(command) {
+  const normalized = normalizeCommand(command);
+  const hints = [];
+  if (/\bnpx\b/.test(normalized)) hints.push('package-resolution-or-network-possible');
+  if (/\b(?:gh|curl|wget)\b/.test(normalized)) hints.push('network-possible');
+  if (/\.claude-flow|\.swarm|auto-memory|session-end|post-(?:edit|task|command)/.test(normalized)) {
+    hints.push('state-write-possible');
+  }
+  if (/\b(?:rm|unlink|kill|shutdown)\b/.test(normalized)) hints.push('destructive-process-or-file-action-possible');
+  return hints.length ? hints : ['unknown-inspect-implementation'];
+}
+
+function sourcePosture(source) {
+  if (source.kind.startsWith('plugin-cache')) {
+    return { owner: source.pluginRef, authority: 'generated-runtime-copy', generatedStatus: 'generated' };
+  }
+  if (source.kind.startsWith('project')) {
+    return { owner: 'unknown-generator', authority: 'unknown', generatedStatus: 'suspected-generated' };
+  }
+  return { owner: 'user', authority: 'user-owned', generatedStatus: 'direct' };
+}
+
+function timeoutFacts(event, hook, schema) {
+  const declared = typeof hook.timeout === 'number' ? hook.timeout : null;
+  const maximum = event === 'SessionEnd' ? schema.sessionEnd.maximum : null;
+  const defaultValue = event === 'SessionEnd' ? schema.sessionEnd.default : 600;
+  const effective = schema.confidence === 'verified'
+    ? maximum !== null ? Math.min(declared ?? defaultValue, maximum) : (declared ?? defaultValue)
+    : null;
+  return {
+    declared,
+    default: schema.confidence === 'verified' ? defaultValue : null,
+    units: schema.timeoutUnits,
+    effective,
+    maximum,
+    status: schema.confidence !== 'verified'
+      ? 'unverified'
+      : maximum !== null && declared !== null && declared > maximum ? 'clamped' : 'valid-or-default',
+    ruleEvidence: maximum !== null ? schema.evidence : null,
+  };
+}
+
+function diagnosticsFor(event, hook, source, command, schema) {
+  const diagnostics = [];
+  if (event === 'SessionEnd' && typeof hook.timeout === 'number'
+      && schema.sessionEnd.maximum !== null && hook.timeout > schema.sessionEnd.maximum) {
+    diagnostics.push({
+      category: 'compatibility',
+      severity: 'warning',
+      code: 'session-end-timeout-clamped',
+      message: `SessionEnd timeout ${hook.timeout}s exceeds Codex's ${schema.sessionEnd.maximum}s maximum and is clamped at runtime`,
+    });
+  }
+  if (source.kind === 'project' && command.includes('.claude/')) {
+    diagnostics.push({
+      category: 'provenance',
+      severity: 'warning',
+      code: 'claude-projection-in-codex',
+      message: 'Codex hook invokes a Claude-oriented project helper; generator provenance must be resolved before healing',
+    });
+  }
+  if (commandFacts(command).shell) {
+    diagnostics.push({
+      category: 'security', severity: 'review', code: 'dynamic-shell',
+      message: 'Command uses a shell wrapper and requires human review of expansion, cwd, and environment behavior',
+    });
+  }
+  diagnostics.push({
+    category: 'trust', severity: 'info', code: 'trust-independent',
+    message: 'Compatibility and security findings do not establish Codex hook trust',
+  });
+  return diagnostics;
+}
+
+function recordsFromSource(source, codexVersion, schema) {
+  if (source.status !== 'valid') return [];
+  const posture = sourcePosture(source);
+  const records = [];
+  for (const [event, groups] of Object.entries(source.document.hooks)) {
+    if (!Array.isArray(groups)) continue;
+    groups.forEach((group, groupIndex) => {
+      if (!group || typeof group !== 'object' || !Array.isArray(group.hooks)) return;
+      group.hooks.forEach((hook, hookIndex) => {
+        if (!hook || typeof hook !== 'object') return;
+        const rawCommand = typeof hook.command === 'string' ? hook.command : '';
+        const matcher = typeof group.matcher === 'string' ? group.matcher : '';
+        const behaviorInput = stableJson({
+          event,
+          matcher,
+          type: hook.type ?? 'command',
+          command: normalizeCommand(rawCommand),
+          commandWindows: hook.commandWindows ?? null,
+          server: hook.server ?? null,
+          tool: hook.tool ?? null,
+          input: hook.input ?? null,
+          async: hook.async ?? false,
+          statusMessage: hook.statusMessage ?? null,
+          additionalContextLimit: hook.additionalContextLimit ?? null,
+          timeout: typeof hook.timeout === 'number' ? hook.timeout : null,
+          cwd: source.baseDir ?? source.projectPath ?? path.dirname(source.file),
+        });
+        records.push({
+          schemaVersion: 1,
+          host: 'codex',
+          scope: {
+            kind: source.kind,
+            projectPath: source.projectPath ?? null,
+            pluginRef: source.pluginRef ?? null,
+            pluginVersion: source.pluginVersion ?? null,
+          },
+          event,
+          matcher,
+          indices: { group: groupIndex, hook: hookIndex },
+          type: hook.type ?? 'command',
+          rawCommand: redactCommand(rawCommand),
+          command: commandFacts(rawCommand),
+          implementationTarget: implementationTarget(rawCommand),
+          timeout: timeoutFacts(event, hook, schema),
+          source: {
+            file: source.file,
+            jsonPointer: `/hooks/${pointerPart(event)}/${groupIndex}/hooks/${hookIndex}`,
+            digest: source.digest,
+            sourceKind: source.kind,
+            owner: posture.owner,
+            authority: posture.authority,
+            generatedStatus: posture.generatedStatus,
+            provenanceConfidence: source.kind === 'global' || source.kind === 'global-inline' ? 'high' : source.kind.startsWith('plugin-cache') ? 'high' : 'low',
+          },
+          runtime: { codexCliVersion: codexVersion },
+          sideEffects: sideEffectHints(rawCommand),
+          risk: 'HUMAN REVIEW REQUIRED',
+          trust: {
+            observedState: 'unknown',
+            recommendation: 'HUMAN REVIEW REQUIRED',
+            evidence: 'Trust hashes are intentionally not inferred from project trust or compatibility state',
+          },
+          rawFingerprint: sha256(JSON.stringify(hook)),
+          behaviorFingerprint: sha256(behaviorInput),
+          duplicateGroupId: sha256(behaviorInput),
+          diagnostics: diagnosticsFor(event, hook, source, rawCommand, schema),
+        });
+      });
+    });
+  }
+  return records;
+}
+
+function planFor(records) {
+  return records
+    .filter((record) => record.timeout.status === 'clamped')
+    .map((record) => ({
+      id: `codex-hook-timeout-${record.behaviorFingerprint.slice(0, 12)}-${sha256(`${record.source.file}\0${record.source.jsonPointer}`).slice(0, 12)}`,
+      diagnostic: 'session-end-timeout-clamped',
+      target: record.source.file,
+      sourceDigest: record.source.digest,
+      classification: record.scope.kind === 'global' ? 'approval-required' : 'never-automatic',
+      reason: record.scope.kind.startsWith('plugin-cache')
+        ? 'repair the authoritative plugin source and reinstall; never edit the cache generation'
+        : record.scope.kind.startsWith('project')
+          ? 'project generator/authority is unresolved; repair the proven canonical source first'
+          : 'user-owned direct hook changes require an explicit per-action approval',
+      trustImpact: 'none; Codex will separately require review if a definition changes',
+    }))
+    .sort((a, b) => a.id.localeCompare(b.id));
+}
+
+/** Produce a deterministic, read-only hook inventory and remediation plan. */
+export function auditCodexHooks({
+  codexHome = process.env.CODEX_HOME || path.join(os.homedir(), '.codex'),
+  projectRoots = [process.cwd()],
+  pluginCacheDir = path.join(codexHome, 'plugins', 'cache'),
+  codexVersion = 'unknown',
+} = {}) {
+  const schema = schemaFor(codexVersion);
+  const sources = [];
+  const globalSource = readHookSource(path.join(codexHome, 'hooks.json'), { kind: 'global' }, codexHome);
+  if (globalSource) sources.push(globalSource);
+  const globalInline = readCodexInlineHooks(path.join(codexHome, 'config.toml'), codexHome, {
+    kind: 'global-inline', authority: 'user-owned', generatedStatus: 'direct', baseDir: codexHome,
+  });
+  if (globalInline) {
+    const error = globalInline.status === 'valid' ? validateHookDocument(globalInline.document) : null;
+    sources.push(error ? { ...globalInline, status: 'invalid', error: `hook schema failed: ${error}` } : globalInline);
+  }
+  for (const projectPath of [...new Set(projectRoots.map((root) => path.resolve(root)))].sort()) {
+    const source = readHookSource(path.join(projectPath, '.codex', 'hooks.json'), { kind: 'project', projectPath }, projectPath);
+    if (source) sources.push(source);
+    const inline = readCodexInlineHooks(path.join(projectPath, '.codex', 'config.toml'), projectPath, {
+      kind: 'project-inline', projectPath, authority: 'project-owned', generatedStatus: 'unknown', baseDir: projectPath,
+    });
+    if (inline) {
+      const error = inline.status === 'valid' ? validateHookDocument(inline.document) : null;
+      sources.push(error ? { ...inline, status: 'invalid', error: `hook schema failed: ${error}` } : inline);
+    }
+  }
+  const plugins = inspectCodexPlugins({
+    configFile: path.join(codexHome, 'config.toml'),
+    cacheDir: pluginCacheDir,
+  });
+  for (const plugin of plugins.plugins) {
+    for (const file of plugin.hookFiles) {
+      const source = readHookSource(file, {
+        kind: 'plugin-cache', pluginRef: plugin.ref, pluginVersion: plugin.version,
+      }, plugin.root);
+      if (source) sources.push(source);
+    }
+    for (const [index, document] of (plugin.inlineHookDocuments ?? []).entries()) {
+      const schemaError = validateHookDocument(document);
+      sources.push(schemaError ? {
+        kind: 'plugin-cache-inline', pluginRef: plugin.ref, pluginVersion: plugin.version,
+        file: `${plugin.manifestFile ?? `${plugin.root}/.codex-plugin/plugin.json`}#hooks/${index}`, status: 'invalid', error: schemaError,
+      } : {
+        kind: 'plugin-cache-inline', pluginRef: plugin.ref, pluginVersion: plugin.version,
+        file: `${plugin.manifestFile ?? `${plugin.root}/.codex-plugin/plugin.json`}#hooks/${index}`, status: 'valid',
+        digest: sha256(stableJson(document)), document, baseDir: plugin.root,
+      });
+    }
+  }
+
+  sources.sort((a, b) => a.file.localeCompare(b.file));
+  const records = sources.flatMap((source) => recordsFromSource(source, codexVersion, schema))
+    .sort((a, b) => a.source.file.localeCompare(b.source.file)
+      || a.event.localeCompare(b.event)
+      || a.indices.group - b.indices.group
+      || a.indices.hook - b.indices.hook);
+  const plan = planFor(records);
+  const pluginIssues = plugins.hookIssues ?? plugins.issues;
+  const publicSources = sources.map((source) => {
+    const result = { ...source };
+    delete result.document;
+    return result;
+  });
+  return {
+    schemaVersion: 1,
+    mode: 'read-only',
+    hostSchema: schema,
+    sources: publicSources,
+    records,
+    plan,
+    pluginIssues,
+    coverage: {
+      status: 'partial',
+      gaps: [
+        'Trust hashes and project trust are intentionally not inferred',
+        'Managed requirements and session override layers require explicit paths when they are outside the inspected user/project roots',
+      ],
+    },
+    summary: {
+      sources: sources.length,
+      invalidSources: sources.filter((source) => source.status !== 'valid').length,
+      configurationIssues: pluginIssues.length,
+      hookOccurrences: records.length,
+      uniqueBehaviors: new Set(records.map((record) => record.behaviorFingerprint)).size,
+      compatibilityWarnings: records.filter((record) => record.diagnostics.some((d) => d.category === 'compatibility')).length,
+      automaticActions: plan.filter((action) => action.classification === 'automatic').length,
+      approvalRequiredActions: plan.filter((action) => action.classification === 'approval-required').length,
+      neverAutomaticActions: plan.filter((action) => action.classification === 'never-automatic').length,
+    },
+  };
+}

--- a/src/lib/hook-audit/orchestrator.mjs
+++ b/src/lib/hook-audit/orchestrator.mjs
@@ -1,0 +1,83 @@
+import { auditCodexHooks } from './index.mjs';
+import { auditClaudeHooks } from './providers/claude.mjs';
+import { auditOpenCodeHooks } from './providers/opencode.mjs';
+import { auditExternalHooks } from './providers/external.mjs';
+import { loadUpstreamConstraints } from './upstream.mjs';
+
+export const BUILTIN_HOOK_AUDIT_HOSTS = Object.freeze(['codex', 'claude', 'opencode', 'external']);
+
+function requestedHosts(hosts) {
+  const values = Array.isArray(hosts) && hosts.length ? hosts : ['codex'];
+  const expanded = values.includes('all') ? BUILTIN_HOOK_AUDIT_HOSTS : values;
+  const unique = [...new Set(expanded)];
+  const unknown = unique.filter((host) => !BUILTIN_HOOK_AUDIT_HOSTS.includes(host));
+  if (unknown.length) throw new TypeError(`unknown hook audit host(s): ${unknown.join(', ')}`);
+  return BUILTIN_HOOK_AUDIT_HOSTS.filter((host) => unique.includes(host));
+}
+
+function codexReport(options) {
+  const report = auditCodexHooks(options);
+  const plan = report.plan.map((action) => ({
+    ...action,
+    legacyClassification: action.classification,
+    classification: action.classification === 'never-automatic'
+      ? 'prohibited'
+      : action.classification === 'automatic' ? 'automatic-eligible' : action.classification,
+  }));
+  const gaps = [
+    'Runtime trust hashes and project trust are intentionally not inferred',
+    'Managed and inline TOML layers are reported by the Codex provider only when statically parseable',
+  ];
+  return {
+    ...report, host: 'codex', schemaVersion: 2, plan,
+    coverage: report.coverage ?? { status: 'partial', gaps },
+    summary: { ...report.summary, coverage: report.coverage?.status ?? 'partial' },
+    issues: report.issues ?? report.pluginIssues ?? [],
+  };
+}
+
+/** Run deterministic host providers. This function never executes hook code. */
+/**
+ * @param {{hosts?:string[],projectRoots?:string[],versions?:Record<string,string>,config?:any,
+ * codex?:any,claude?:any,opencode?:any,external?:any,upstream?:any}} options
+ */
+export function auditHooks({
+  hosts, projectRoots = [process.cwd()], versions = {}, config = {},
+  codex = {}, claude = {}, opencode = {}, external = {}, upstream = {},
+} = /** @type {any} */ ({})) {
+  const selected = requestedHosts(hosts);
+  const reports = {};
+  if (selected.includes('codex')) reports.codex = codexReport({ ...codex, projectRoots, codexVersion: versions.codex ?? codex.codexVersion ?? 'unknown' });
+  if (selected.includes('claude')) reports.claude = auditClaudeHooks({ ...claude, projectRoots, claudeVersion: versions.claude ?? claude.claudeVersion ?? 'unknown' });
+  if (selected.includes('opencode')) reports.opencode = auditOpenCodeHooks({
+    ...opencode, projectRoots, opencodeVersion: versions.opencode ?? opencode.opencodeVersion ?? 'unknown',
+    ownership: opencode.ownership ?? config?.integrations?.ownership?.opencode ?? null,
+  });
+  if (selected.includes('external')) reports.external = auditExternalHooks({ ...external, config });
+  const constraints = loadUpstreamConstraints(upstream);
+  const totals = Object.values(reports).reduce((summary, report) => ({
+    sources: summary.sources + report.summary.sources,
+    invalidSources: summary.invalidSources + report.summary.invalidSources,
+    configurationIssues: summary.configurationIssues + report.summary.configurationIssues,
+    hookOccurrences: summary.hookOccurrences + report.summary.hookOccurrences,
+    uniqueBehaviors: summary.uniqueBehaviors + report.summary.uniqueBehaviors,
+    automaticActions: summary.automaticActions + report.summary.automaticActions,
+    approvalRequiredActions: summary.approvalRequiredActions + report.summary.approvalRequiredActions,
+    neverAutomaticActions: summary.neverAutomaticActions + report.summary.neverAutomaticActions,
+    upstreamRequiredActions: summary.upstreamRequiredActions + (/** @type {any} */ (report.summary).upstreamRequiredActions ?? 0),
+  }), {
+    sources: 0, invalidSources: 0, configurationIssues: 0, hookOccurrences: 0,
+    uniqueBehaviors: 0, automaticActions: 0, approvalRequiredActions: 0,
+    neverAutomaticActions: 0, upstreamRequiredActions: 0,
+  });
+  return {
+    schemaVersion: 2, mode: 'read-only', hosts: selected, reports,
+    upstream: constraints,
+    maintenance: {
+      schemaStrategy: 'exact-version evidence profiles; unknown versions receive syntax-only validation and no automatic healing',
+      releaseStrategy: 're-audit on host or dependency release, weekly for open constraints, and before every managed upgrade',
+      notificationStrategy: 'open or refresh upstream issues with minimal reproductions; retain bounded workarounds until a released artifact passes conformance',
+    },
+    summary: totals,
+  };
+}

--- a/src/lib/hook-audit/providers/claude.mjs
+++ b/src/lib/hook-audit/providers/claude.mjs
@@ -1,0 +1,237 @@
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  isRecord, normalizedOccurrence, publicSource, readJsonSource, sha256,
+  stableJson, summarizeHostReport,
+} from '../common.mjs';
+
+const SCHEMA = Object.freeze({
+  id: 'claude-hooks-2.1.258',
+  verifiedVersions: ['2.1.258'],
+  timeoutUnits: 'seconds',
+  evidence: 'https://code.claude.com/docs/en/hooks',
+  verifiedAt: '2026-09-01',
+});
+
+const MANAGED = Object.freeze({
+  darwin: '/Library/Application Support/ClaudeCode/managed-settings.json',
+  linux: '/etc/claude-code/managed-settings.json',
+  win32: 'C:\\Program Files\\ClaudeCode\\managed-settings.json',
+});
+
+function validateDocument(document) {
+  if (!isRecord(document)) return 'settings must be an object';
+  if (document.hooks !== undefined && !isRecord(document.hooks)) return 'settings hooks must be an object';
+  for (const [event, groups] of Object.entries(document.hooks ?? {})) {
+    if (!Array.isArray(groups)) return `${event} hook groups must be an array`;
+    for (const [groupIndex, group] of groups.entries()) {
+      if (!isRecord(group) || !Array.isArray(group.hooks)) return `${event} hook group ${groupIndex} requires a hooks array`;
+      if (group.matcher !== undefined && typeof group.matcher !== 'string') return `${event} hook group ${groupIndex} matcher must be a string`;
+      for (const [hookIndex, hook] of group.hooks.entries()) {
+        if (!isRecord(hook) || typeof hook.type !== 'string') return `${event} hook ${groupIndex}/${hookIndex} requires a type`;
+        if (hook.timeout !== undefined && (!Number.isFinite(hook.timeout) || hook.timeout < 0)) {
+          return `${event} hook ${groupIndex}/${hookIndex} timeout must be a nonnegative number`;
+        }
+        if (hook.type === 'command' && (typeof hook.command !== 'string' || !hook.command.trim())) {
+          return `${event} command hook ${groupIndex}/${hookIndex} requires a command`;
+        }
+      }
+    }
+  }
+  return null;
+}
+
+function readSettings(file, metadata, root) {
+  const source = readJsonSource(file, root, metadata);
+  if (!source || source.status !== 'valid') return source;
+  const error = validateDocument(source.document);
+  return error ? { ...source, status: 'invalid', error: `hook schema failed: ${error}` } : source;
+}
+
+function sourcesForPluginInstall(ref, install) {
+  const sources = [];
+  if (!isRecord(install) || typeof install.installPath !== 'string') return sources;
+  const root = path.resolve(install.installPath);
+  const manifestCandidates = [
+    path.join(root, '.claude-plugin', 'plugin.json'),
+    path.join(root, '.agent-plugin', 'plugin.json'),
+  ];
+  const manifest = manifestCandidates.map((file) => readJsonSource(file, root)).find(Boolean);
+  if (manifest) sources.push({
+    ...manifest, kind: 'plugin-manifest', pluginRef: ref,
+    pluginVersion: install.version ?? manifest.document?.version ?? null,
+    authority: 'generated-runtime-copy', generatedStatus: 'generated', baseDir: root,
+  });
+  const targets = [];
+  if (manifest?.status === 'valid' && manifest.document?.hooks !== undefined) {
+    const declared = Array.isArray(manifest.document.hooks) ? manifest.document.hooks : [manifest.document.hooks];
+    for (const value of declared) {
+      if (typeof value === 'string' && value.startsWith('./')) targets.push(path.resolve(root, value));
+      else if (isRecord(value)) {
+        const error = validateDocument(value);
+        sources.push(error
+          ? { kind: 'plugin-cache-inline', pluginRef: ref, pluginVersion: install.version ?? null, file: `${manifest.file}#hooks`, status: 'invalid', error }
+          : { kind: 'plugin-cache-inline', pluginRef: ref, pluginVersion: install.version ?? null, file: `${manifest.file}#hooks`, status: 'valid', digest: sha256(stableJson(value)), document: value, baseDir: root });
+      }
+    }
+  } else {
+    // Claude plugin manifests are optional. Default component discovery still
+    // loads hooks/hooks.json, so the auditor must not require a manifest.
+    targets.push(path.join(root, 'hooks', 'hooks.json'));
+  }
+  for (const file of targets) {
+    const source = readSettings(file, {
+      kind: 'plugin-cache', pluginRef: ref, pluginVersion: install.version ?? null,
+      authority: 'generated-runtime-copy', generatedStatus: 'generated', baseDir: root,
+    }, root);
+    if (source) sources.push(source);
+  }
+  return sources;
+}
+
+function pluginSources(claudeRoot) {
+  let registry = readJsonSource(path.join(claudeRoot, 'plugins', 'installed_plugins.json'), claudeRoot, {
+    kind: 'plugin-registry', authority: 'claude-managed-registry', generatedStatus: 'generated',
+  });
+  if (registry?.status === 'valid' && !isRecord(registry.document?.plugins)) {
+    registry = { ...registry, status: 'invalid', error: 'plugin registry requires a plugins object' };
+  }
+  if (!registry || registry.status !== 'valid') return { registry, sources: [] };
+  const sources = [];
+  for (const [ref, installs] of Object.entries(registry.document.plugins)) {
+    if (!Array.isArray(installs)) continue;
+    for (const install of installs) sources.push(...sourcesForPluginInstall(ref, install));
+  }
+  return { registry, sources };
+}
+
+function defaultTimeout(event, type) {
+  if (event === 'SessionEnd') return 1.5;
+  if (event === 'UserPromptSubmit' && ['command', 'http', 'mcp_tool'].includes(type)) return 30;
+  if (type === 'prompt') return 30;
+  if (type === 'agent') return 60;
+  return 600;
+}
+
+function timeoutFor(hook, verified, event, sourceKind) {
+  const declared = typeof hook.timeout === 'number' ? hook.timeout : null;
+  const fallback = defaultTimeout(event, hook.type);
+  const plugin = sourceKind === 'plugin-cache' || sourceKind === 'plugin-cache-inline';
+  if (verified && event === 'SessionEnd' && plugin) {
+    return {
+      declared, units: 'seconds', effective: null, default: 1.5, maximum: null,
+      status: 'plugin-session-budget-dependent',
+      sessionBudget: 'plugin timeouts do not raise the SessionEnd budget; effective time depends on settings-level hooks or the environment override',
+    };
+  }
+  if (verified && event === 'SessionEnd') {
+    return {
+      declared, units: 'seconds', effective: Math.min(declared ?? fallback, 60),
+      default: fallback, maximum: 60, status: declared !== null && declared > 60 ? 'clamped' : 'valid-or-default',
+    };
+  }
+  return {
+    declared,
+    units: verified ? 'seconds' : 'unknown',
+    effective: verified ? (declared ?? fallback) : null,
+    default: verified ? fallback : null,
+    maximum: null,
+    status: verified ? 'valid-or-default' : 'unverified',
+  };
+}
+
+function recordsFrom(source, version) {
+  if (source.status !== 'valid') return [];
+  if (source.kind === 'plugin-registry' || source.kind === 'plugin-manifest') return [];
+  const verified = SCHEMA.verifiedVersions.includes(version);
+  const records = [];
+  for (const [event, groups] of Object.entries(source.document.hooks ?? {})) {
+    groups.forEach((group, groupIndex) => group.hooks.forEach((hook, hookIndex) => {
+      const diagnostics = [{
+        category: 'trust', severity: 'info', code: 'trust-independent',
+        message: 'Static audit findings do not establish Claude permission or managed-policy state',
+      }];
+      if (verified && typeof hook.timeout === 'number' && hook.timeout > 600) diagnostics.push({
+        category: 'performance', severity: 'warning', code: 'probable-timeout-unit-mismatch',
+        message: `Claude hook timeout ${hook.timeout}s is unusually high; confirm it was not authored as milliseconds`,
+      });
+      if (verified && event === 'SessionEnd' && !source.kind.startsWith('plugin-cache') && hook.timeout > 60) diagnostics.push({
+        category: 'compatibility', severity: 'warning', code: 'sessionend-timeout-clamped',
+        message: `Claude SessionEnd timeout ${hook.timeout}s exceeds the 60s settings budget and is effectively clamped`,
+      });
+      if (verified && event === 'SessionEnd' && source.kind.startsWith('plugin-cache') && hook.timeout > 1.5) diagnostics.push({
+        category: 'compatibility', severity: 'warning', code: 'plugin-sessionend-budget-not-raised',
+        message: 'A plugin SessionEnd timeout does not raise Claude\'s 1.5s default session budget; effective runtime depends on a settings-level budget or environment override',
+      });
+      records.push(normalizedOccurrence({
+        host: 'claude', event, matcher: group.matcher ?? '', type: hook.type, handler: hook,
+        indices: { group: groupIndex, hook: hookIndex }, timeout: timeoutFor(hook, verified, event, source.kind), diagnostics,
+        selected: source.selected ?? null,
+        source: {
+          file: source.file, digest: source.digest, sourceKind: source.kind,
+          authority: source.authority, generatedStatus: source.generatedStatus,
+          owner: source.pluginRef ?? (source.kind === 'managed' ? 'administrator' : source.kind === 'project' ? 'project-owner' : 'user'),
+          baseDir: source.baseDir ?? path.dirname(source.file),
+          pluginRef: source.pluginRef ?? null, pluginVersion: source.pluginVersion ?? null,
+        },
+      }));
+    }));
+  }
+  return records;
+}
+
+function remediation(records) {
+  return records.filter((record) => record.diagnostics.some((item) => [
+    'probable-timeout-unit-mismatch', 'sessionend-timeout-clamped', 'plugin-sessionend-budget-not-raised',
+  ].includes(item.code))).map((record) => ({
+    id: `claude-timeout-review-${record.behaviorFingerprint.slice(0, 16)}`,
+    host: 'claude', diagnostic: 'probable-timeout-unit-mismatch', target: record.source.file,
+    classification: record.source.generatedStatus === 'generated' ? 'upstream-required' : 'approval-required',
+    reason: 'Timeout units require source-owner confirmation; changing the definition can change behavior and trust state',
+    trustImpact: 'definition changes require the host to re-evaluate trust or managed policy',
+  }));
+}
+
+export function auditClaudeHooks({
+  claudeRoot = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude'),
+  projectRoots = [process.cwd()],
+  managedSettingsFile = MANAGED[process.platform] ?? null,
+  claudeVersion = 'unknown',
+} = {}) {
+  const sources = [];
+  const global = readSettings(path.join(claudeRoot, 'settings.json'), {
+    kind: 'global', authority: 'user-owned', generatedStatus: 'direct', baseDir: claudeRoot,
+  }, claudeRoot);
+  if (global) sources.push(global);
+  if (managedSettingsFile) {
+    const managed = readSettings(managedSettingsFile, {
+      kind: 'managed', authority: 'administrator-managed', generatedStatus: 'direct', baseDir: path.dirname(managedSettingsFile), selected: true,
+    }, path.dirname(managedSettingsFile));
+    if (managed) sources.push(managed);
+  }
+  for (const root of [...new Set(projectRoots.map((item) => path.resolve(item)))].sort()) {
+    for (const name of ['settings.json', 'settings.local.json']) {
+      const source = readSettings(path.join(root, '.claude', name), {
+        kind: 'project', authority: 'project-or-user-owned', generatedStatus: 'unknown', baseDir: root,
+      }, root);
+      if (source) sources.push(source);
+    }
+  }
+  const plugins = pluginSources(claudeRoot);
+  if (plugins.registry) sources.push(plugins.registry);
+  sources.push(...plugins.sources);
+  const records = sources.flatMap((source) => recordsFrom(source, claudeVersion)).sort((a, b) => a.source.file.localeCompare(b.source.file) || a.event.localeCompare(b.event));
+  const plan = remediation(records);
+  const gaps = [
+    'Claude runtime selection, organization policy, and trust decisions are not inferred from static files',
+    'Skill, subagent, and session-defined hooks outside settings/plugin manifests are reported only when declared through an inspected plugin hook document',
+  ];
+  const coverage = { status: 'partial', gaps };
+  return {
+    schemaVersion: 2, host: 'claude', mode: 'read-only',
+    hostSchema: { ...SCHEMA, confidence: SCHEMA.verifiedVersions.includes(claudeVersion) ? 'verified' : 'syntax-only' },
+    sources: sources.map(publicSource), records, plan, issues: [], coverage,
+    summary: summarizeHostReport({ sources, records, plan, coverage: coverage.status }),
+  };
+}

--- a/src/lib/hook-audit/providers/external.mjs
+++ b/src/lib/hook-audit/providers/external.mjs
@@ -1,0 +1,110 @@
+import path from 'node:path';
+
+import { validateAdapterManifest } from '../../adapters/manifest.mjs';
+import { hashAdapterContent, baseDirForSource } from '../../adapters/integrity.mjs';
+import {
+  normalizedOccurrence, publicSource, readJsonSource, summarizeHostReport,
+} from '../common.mjs';
+
+function isRemote(source) {
+  return /^https?:\/\//.test(source) || source.startsWith('npm:');
+}
+
+function hookEntries(manifest) {
+  const entries = [];
+  for (const [verb, definition] of Object.entries(manifest.lifecycle ?? {})) {
+    if (definition?.hook) entries.push({ event: `lifecycle.${verb}`, hook: definition.hook });
+  }
+  if (manifest.execution?.run?.hook) entries.push({ event: 'execution.run', hook: manifest.execution.run.hook });
+  if (manifest.aqe?.provider?.hook) entries.push({ event: 'aqe.provider', hook: manifest.aqe.provider.hook });
+  return entries;
+}
+
+function recordsFrom(source, manifest, integrity) {
+  return hookEntries(manifest).map(({ event, hook }, index) => normalizedOccurrence({
+    host: manifest.host.id, event, type: 'argv-subprocess', handler: { command: hook.command },
+    indices: { hook: index }, selected: null,
+    timeout: {
+      declared: hook.timeoutMs ?? null, units: 'milliseconds', effective: hook.timeoutMs ?? null,
+      default: null, maximum: null, status: 'manifest-validated',
+    },
+    source: {
+      file: source.file, digest: source.digest, sourceKind: 'external-adapter-manifest',
+      authority: 'operator-configured-unadmitted-for-audit', generatedStatus: 'direct',
+      owner: manifest.host.id, baseDir: source.baseDir, adapterVersion: manifest.version,
+      contentHash: integrity.hash, hookFiles: integrity.hookFiles,
+    },
+    diagnostics: [{
+      category: 'authority', severity: 'review', code: 'consent-and-grants-not-inferred',
+      message: 'Manifest validity and content identity do not prove consent, capability grants, runtime reachability, or target-host compatibility',
+    }],
+  }));
+}
+
+/** @param {{config?:any,cwd?:string}} options */
+export function auditExternalHooks({ config = {}, cwd = process.cwd() } = /** @type {any} */ ({})) {
+  const sources = [];
+  const records = [];
+  const issues = [];
+  for (const entry of Array.isArray(config.hostAdapters) ? config.hostAdapters : []) {
+    const name = typeof entry?.name === 'string' ? entry.name : '(unknown)';
+    const declared = typeof entry?.source === 'string' ? entry.source : '';
+    if (!declared) {
+      issues.push(`${name}: adapter source is missing`);
+      continue;
+    }
+    if (isRemote(declared)) {
+      sources.push({
+        kind: 'external-adapter-manifest', file: declared, status: 'opaque', digest: null,
+        authority: 'operator-configured', generatedStatus: 'remote',
+        error: 'remote sources are not fetched by a default-safe offline audit',
+      });
+      continue;
+    }
+    const file = path.resolve(cwd, declared);
+    const root = path.dirname(file);
+    const source = readJsonSource(file, root, {
+      kind: 'external-adapter-manifest', authority: 'operator-configured', generatedStatus: 'direct', baseDir: root,
+    });
+    if (!source) {
+      sources.push({ kind: 'external-adapter-manifest', file, status: 'invalid', error: 'configured manifest is absent' });
+      continue;
+    }
+    sources.push(source);
+    if (source.status !== 'valid') continue;
+    try {
+      const manifest = validateAdapterManifest(source.document);
+      const baseDir = baseDirForSource(file);
+      const integrity = hashAdapterContent(manifest, { baseDir });
+      records.push(...recordsFrom({ ...source, baseDir }, manifest, integrity));
+      if (entry.contract !== undefined && entry.contract !== manifest.contract) {
+        issues.push(`${name}: configured contract ${entry.contract} does not match manifest contract ${manifest.contract}`);
+      }
+    } catch (error) {
+      source.status = 'invalid';
+      source.error = error?.message ?? String(error);
+    }
+  }
+  records.sort((a, b) => a.host.localeCompare(b.host) || a.event.localeCompare(b.event));
+  const plan = records.map((record) => ({
+    id: `external-review-${record.behaviorFingerprint.slice(0, 16)}`,
+    host: record.host, diagnostic: 'target-host-compatibility-unproven', target: record.source.file,
+    classification: 'approval-required',
+    reason: 'An operator must verify host/version compatibility, consent, grants, and the pinned hook-file identity before activation',
+    trustImpact: 'no admission, consent, grant, or execution state was changed',
+  }));
+  const gaps = [
+    'Remote HTTPS and npm adapter sources are reported but never fetched during the default offline audit',
+    'Adapter consent, grants, reachability, and executable target versions remain independent evidence dimensions',
+    'The current adapter contract has no target host-version compatibility range; every external hook therefore requires human verification',
+  ];
+  const coverage = { status: 'partial', gaps };
+  return {
+    schemaVersion: 2, host: 'external', mode: 'read-only', hostSchema: {
+      id: 'agentic-kit-host-adapter-v1', confidence: 'manifest-validated',
+      evidence: 'docs/adr/0031-capability-graduation-and-upstream-requests.md', verifiedAt: '2026-09-01',
+    },
+    sources: sources.map(publicSource), records, plan, issues, coverage,
+    summary: summarizeHostReport({ sources, records, plan, issues, coverage: coverage.status }),
+  };
+}

--- a/src/lib/hook-audit/providers/opencode.mjs
+++ b/src/lib/hook-audit/providers/opencode.mjs
@@ -1,0 +1,141 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  normalizedOccurrence, publicSource, readBoundedFile, readJsonSource,
+  summarizeHostReport,
+} from '../common.mjs';
+
+const SCHEMA = Object.freeze({
+  id: 'opencode-plugins-1.18.25',
+  verifiedVersions: ['1.18.25'],
+  evidence: 'https://opencode.ai/docs/plugins/',
+  verifiedAt: '2026-09-01',
+});
+
+const KNOWN_EVENTS = [
+  'command.executed', 'file.edited', 'file.watcher.updated', 'installation.updated',
+  'lsp.client.diagnostics', 'lsp.updated', 'message.part.removed', 'message.part.updated',
+  'message.removed', 'message.updated', 'permission.replied', 'permission.updated',
+  'server.connected', 'session.compacted', 'session.created', 'session.deleted',
+  'session.diff', 'session.error', 'session.idle', 'session.status', 'session.updated',
+  'todo.updated', 'tool.execute.after', 'tool.execute.before', 'tui.prompt.append',
+  'tui.command.execute', 'tui.toast.show',
+];
+
+function readConfig(file, root, metadata) {
+  if (file.endsWith('.jsonc')) {
+    const read = readBoundedFile(file, root);
+    if (read.status === 'absent') return null;
+    return {
+      ...metadata, file, digest: read.digest ?? null,
+      status: read.status === 'valid' ? 'opaque' : read.status,
+      error: read.status === 'valid' ? 'JSONC is valid OpenCode input but is not normalized by the read-only auditor' : read.error,
+    };
+  }
+  return readJsonSource(file, root, metadata);
+}
+
+function pluginFiles(directory, root, metadata) {
+  let entries;
+  try {
+    entries = fs.readdirSync(directory, { withFileTypes: true });
+  } catch (error) {
+    return error?.code === 'ENOENT' ? [] : [{ ...metadata, file: directory, status: 'invalid', error: error.message }];
+  }
+  return entries.filter((entry) => entry.isFile() && /\.(?:js|mjs|cjs|ts)$/.test(entry.name)).sort((a, b) => a.name.localeCompare(b.name)).map((entry) => {
+    const file = path.join(directory, entry.name);
+    const read = readBoundedFile(file, root);
+    if (read.status !== 'valid') return { ...metadata, file, ...read };
+    const events = KNOWN_EVENTS.filter((event) => read.text.includes(event));
+    return { ...metadata, file, status: 'opaque', digest: read.digest, detectedEvents: events, baseDir: root };
+  });
+}
+
+function configRecords(source) {
+  if (source.status !== 'valid') return [];
+  const plugins = Array.isArray(source.document?.plugin) ? source.document.plugin : [];
+  return plugins.filter((plugin) => typeof plugin === 'string').map((plugin, index) => normalizedOccurrence({
+    host: 'opencode', event: 'PluginLoad', type: 'package-plugin', handler: { input: { plugin } },
+    indices: { plugin: index }, selected: null,
+    source: {
+      file: source.file, digest: source.digest, sourceKind: source.kind,
+      authority: source.authority, generatedStatus: source.generatedStatus,
+      owner: source.kind === 'project' ? 'project-owner' : 'user', baseDir: source.baseDir,
+    },
+    diagnostics: [{
+      category: 'security', severity: 'review', code: 'full-process-plugin',
+      message: 'OpenCode plugins execute in the host process; package source, install version, and permissions require review',
+    }],
+  }));
+}
+
+function moduleRecords(source) {
+  if (source.status !== 'opaque') return [];
+  const events = source.detectedEvents?.length ? source.detectedEvents : ['PluginRuntime'];
+  return events.map((event, index) => normalizedOccurrence({
+    host: 'opencode', event, type: 'module-plugin', handler: { input: { moduleDigest: source.digest } },
+    indices: { event: index }, selected: null,
+    source: {
+      file: source.file, digest: source.digest, sourceKind: source.kind,
+      authority: source.authority, generatedStatus: source.generatedStatus,
+      owner: source.owner, baseDir: source.baseDir,
+    },
+    diagnostics: [{
+      category: 'security', severity: 'review', code: 'opaque-full-process-plugin',
+      message: 'Static event-name discovery cannot prove plugin behavior; inspect and trust the complete module',
+    }],
+  }));
+}
+
+export function auditOpenCodeHooks({
+  opencodeRoot = path.join(process.env.XDG_CONFIG_HOME || path.join(os.homedir(), '.config'), 'opencode'),
+  projectRoots = [process.cwd()],
+  opencodeVersion = 'unknown',
+  ownership = null,
+} = {}) {
+  const sources = [];
+  for (const name of ['opencode.json', 'opencode.jsonc']) {
+    const source = readConfig(path.join(opencodeRoot, name), opencodeRoot, {
+      kind: 'global', authority: ownership?.mcp === 'ak' ? 'mixed-receipt-owned' : 'user-owned',
+      generatedStatus: ownership?.mcp === 'ak' ? 'partially-generated' : 'direct', baseDir: opencodeRoot,
+    });
+    if (source) sources.push(source);
+  }
+  sources.push(...pluginFiles(path.join(opencodeRoot, 'plugins'), opencodeRoot, {
+    kind: 'global-plugin', authority: 'user-or-receipt-owned', generatedStatus: 'unknown', owner: 'unknown',
+  }));
+  for (const root of [...new Set(projectRoots.map((item) => path.resolve(item)))].sort()) {
+    for (const name of ['opencode.json', 'opencode.jsonc']) {
+      const source = readConfig(path.join(root, name), root, {
+        kind: 'project', authority: 'project-owned', generatedStatus: 'direct', baseDir: root,
+      });
+      if (source) sources.push(source);
+    }
+    sources.push(...pluginFiles(path.join(root, '.opencode', 'plugins'), root, {
+      kind: 'project-plugin', authority: 'project-owned', generatedStatus: 'direct', owner: 'project-owner',
+    }));
+  }
+  const records = sources.flatMap((source) => [...configRecords(source), ...moduleRecords(source)])
+    .sort((a, b) => a.source.file.localeCompare(b.source.file) || a.event.localeCompare(b.event));
+  const plan = records.map((record) => ({
+    id: `opencode-review-${record.behaviorFingerprint.slice(0, 16)}`,
+    host: 'opencode', diagnostic: record.diagnostics[0]?.code ?? 'plugin-review', target: record.source.file,
+    classification: record.source.generatedStatus === 'partially-generated' ? 'approval-required' : 'approval-required',
+    reason: 'OpenCode plugins execute with host-process authority; remediation requires source-owner review and a restart',
+    trustImpact: 'OpenCode does not expose a Codex-style hook trust hash; OS and OpenCode permissions remain separate controls',
+  }));
+  const gaps = [
+    'JSONC is detected but not normalized, so later JSONC layers make effective selection unknown',
+    'Plugin modules are never imported or executed; event discovery is intentionally conservative and behavior remains opaque',
+    'Organization-supplied configuration and environment overrides are not proven by static local discovery',
+  ];
+  const coverage = { status: 'partial', gaps };
+  return {
+    schemaVersion: 2, host: 'opencode', mode: 'read-only',
+    hostSchema: { ...SCHEMA, confidence: SCHEMA.verifiedVersions.includes(opencodeVersion) ? 'verified' : 'syntax-only' },
+    sources: sources.map(publicSource), records, plan, issues: [], coverage,
+    summary: summarizeHostReport({ sources, records, plan, coverage: coverage.status }),
+  };
+}

--- a/src/lib/hook-audit/upstream.mjs
+++ b/src/lib/hook-audit/upstream.mjs
@@ -1,0 +1,31 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { publicSource, readJsonSource } from './common.mjs';
+
+const defaultFile = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..', 'config', 'agentic-dependency-constraints.json');
+
+export function loadUpstreamConstraints({ file = defaultFile } = {}) {
+  const source = readJsonSource(file, path.dirname(file), { kind: 'upstream-constraints' });
+  if (!source || source.status !== 'valid') {
+    return { status: source?.status ?? 'absent', source: source ? publicSource(source) : { file, status: 'absent' }, constraints: [], errors: [source?.error ?? 'constraint registry is absent'] };
+  }
+  const document = source.document;
+  const errors = [];
+  if (document?.schemaVersion !== 1) errors.push('unsupported upstream constraint schema');
+  if (!Array.isArray(document?.constraints)) errors.push('constraints must be an array');
+  const constraints = Array.isArray(document?.constraints) ? document.constraints.filter((entry, index) => {
+    const valid = entry && typeof entry === 'object'
+      && typeof entry.dependency === 'string' && typeof entry.kind === 'string'
+      && Array.isArray(entry.affected) && typeof entry.strategy === 'string'
+      && typeof entry.sunsetWhen === 'string';
+    if (!valid) errors.push(`constraint ${index} is invalid`);
+    return valid;
+  }) : [];
+  return {
+    status: errors.length ? 'invalid' : 'valid', source: publicSource(source),
+    lastVerifiedAt: document?.lastVerifiedAt ?? null,
+    recheckPolicy: document?.recheckPolicy ?? null,
+    constraints, errors,
+  };
+}

--- a/src/lib/live/claude-provider.mjs
+++ b/src/lib/live/claude-provider.mjs
@@ -17,7 +17,7 @@ import { readJson } from '../settings.mjs';
 const MANAGED_SETTINGS = {
   darwin: '/Library/Application Support/ClaudeCode/managed-settings.json',
   linux: '/etc/claude-code/managed-settings.json',
-  win32: 'C:\\ProgramData\\ClaudeCode\\managed-settings.json',
+  win32: 'C:\\Program Files\\ClaudeCode\\managed-settings.json',
 };
 
 const plainEnv = (value) => value && typeof value === 'object' && !Array.isArray(value)

--- a/src/lib/mcp.mjs
+++ b/src/lib/mcp.mjs
@@ -8,6 +8,7 @@ import path from 'node:path';
 import { rufloNodeModules, claudeUserMcpPath, claudeSettingsPath, repoRoot } from './paths.mjs';
 import { run } from './exec.mjs';
 import { readJson, addDenyRules, removeDenyRules } from './settings.mjs';
+import { writeFileWithBackup } from './file-write.mjs';
 
 /** Enumerate MCP tool names from the installed package's mcp-tools modules,
  *  grouped by name prefix (family). Returns Map<family, string[]>. */
@@ -119,6 +120,65 @@ export function codexMcpTopology({ cwd = process.cwd(), home = os.homedir() } = 
     rufloRegistrations,
     duplicateRuflo: rufloRegistrations.length > 1,
   };
+}
+
+/** Return the user-owned Codex MCP entries that ak can repair safely after an
+ * explicit sync confirmation. The canonical workspace-aware `ruflo` entry is
+ * deliberately never included. */
+export function codexMcpRepairPlan(topology) {
+  const targets = [];
+  const seen = new Set();
+  const add = (entry, reason) => {
+    const key = `${entry.file}\0${entry.scope}\0${entry.name}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    targets.push({ ...entry, reason });
+  };
+  for (const entry of topology.selfRegistrations) {
+    add(entry, 'recursively launches Codex through the deprecated mcp-server transport');
+  }
+  for (const entry of topology.rufloRegistrations) {
+    if (entry.name !== 'ruflo') {
+      add(entry, 'duplicates the canonical workspace-aware [mcp_servers.ruflo] registration');
+    }
+  }
+  return targets;
+}
+
+/** Apply a previously disclosed repair plan through Codex's supported command,
+ * then verify every target disappeared from the effective topology. */
+export async function repairCodexMcpTopology(targets, cwd = process.cwd(), {
+  runner = run, inspect = codexMcpTopology,
+} = {}) {
+  const backedUp = new Set();
+  for (const target of targets) {
+    if (!backedUp.has(target.file)) {
+      try {
+        writeFileWithBackup(target.file, fs.readFileSync(target.file, 'utf8'));
+        backedUp.add(target.file);
+      } catch (error) {
+        return { ok: false, changed: false, detail: `could not back up ${target.file}: ${error.message}` };
+      }
+    }
+    const result = await runner('codex', ['mcp', 'remove', target.name], { cwd });
+    if (result.code !== 0) {
+      return {
+        ok: false,
+        changed: false,
+        detail: `could not remove [mcp_servers.${target.name}] from ${target.file}: ${(result.stderr || result.stdout || `exit ${result.code}`).split('\n')[0].slice(0, 160)}`,
+      };
+    }
+  }
+  const remaining = inspect({ cwd }).registrations.filter((entry) =>
+    targets.some((target) => target.file === entry.file && target.scope === entry.scope && target.name === entry.name));
+  if (remaining.length) {
+    return {
+      ok: false,
+      changed: targets.length > 0,
+      detail: `Codex MCP repair could not be verified; remaining entries: ${remaining.map((entry) => `[mcp_servers.${entry.name}]`).join(', ')}`,
+    };
+  }
+  return { ok: true, changed: targets.length > 0, detail: `removed ${targets.map((target) => `[mcp_servers.${target.name}]`).join(', ')}` };
 }
 
 /**

--- a/src/lib/paths.mjs
+++ b/src/lib/paths.mjs
@@ -24,14 +24,14 @@ export const observabilityWorkspacePath = () =>
 export const legacyKitConfigPath = () => path.join(legacyConfigDir(), 'kit.json');
 
 /** Claude Code user-level locations (same shape on all platforms). */
-export const claudeDir = () => path.join(home, '.claude');
+export const claudeDir = () => process.env.CLAUDE_CONFIG_DIR || path.join(home, '.claude');
 export const claudeMdPath = () => path.join(claudeDir(), 'CLAUDE.md');
 export const claudeSettingsPath = () => path.join(claudeDir(), 'settings.json');
 /** Claude Code's machine-managed policy file, when the platform defines one. */
 export const claudeManagedSettingsPath = (platform = process.platform) => ({
   darwin: '/Library/Application Support/ClaudeCode/managed-settings.json',
   linux: '/etc/claude-code/managed-settings.json',
-  win32: 'C:\\ProgramData\\ClaudeCode\\managed-settings.json',
+  win32: 'C:\\Program Files\\ClaudeCode\\managed-settings.json',
 })[platform] ?? null;
 export const claudeUserMcpPath = () => path.join(home, '.claude.json');
 export const claudeSkillsDir = () => path.join(claudeDir(), 'skills');

--- a/src/lib/ruvnet-brain.mjs
+++ b/src/lib/ruvnet-brain.mjs
@@ -15,6 +15,11 @@ import { cmpVersions } from './versions.mjs';
 import { loadKitConfig, saveKitConfig } from './config.mjs';
 
 export const REPO = 'stuinfla/ruvnet-brain';
+// The published installer resolves this exact Release asset name. A newer tag
+// without this asset is an announcement, not an installable Brain update: the
+// installer's conventional fallback URL points at the same absent asset and
+// returns 404. Keep the release probe aligned with that executable contract.
+export const RELEASE_ASSET = 'ruvnet-brain.zip';
 /** npx spec + flags. The PUBLISHED npm installer, not `github:` — a github: spec
  *  runs the default-branch HEAD (an unreleased -dev installer, audited live
  *  2026-07-17: HEAD was 3.4.5-dev while releases/latest was v3.3.1), which is
@@ -93,24 +98,43 @@ export function installedReleaseOnDisk() {
   return null;
 }
 
-/** Latest release tag from GitHub, best-effort (null on any failure or rate
- *  limit — callers must treat null as "unknown", never as "up to date"). */
-export async function latestVersion({ timeout = 8000 } = {}) {
+/** Reduce GitHub's latest-release payload to the two facts ak needs. Pure so
+ *  missing-asset behavior is testable without a network dependency. */
+export function releaseMetadata(payload) {
+  const tag = payload?.tag_name;
+  if (!tag) return null;
+  const asset = Array.isArray(payload.assets)
+    ? payload.assets.find((candidate) => candidate?.name === RELEASE_ASSET
+      && candidate?.browser_download_url)
+    : null;
+  return {
+    version: String(tag).replace(/^v/, ''),
+    releaseAssetAvailable: !!asset,
+  };
+}
+
+/** Latest release metadata from GitHub, best-effort (null on any failure or
+ *  rate limit — callers must treat null as "unknown", never as "up to date"). */
+export async function latestRelease({ timeout = 8000, fetchImpl = fetch } = {}) {
   const ctl = new AbortController();
   const t = setTimeout(() => ctl.abort(), timeout);
   try {
-    const res = await fetch(
+    const res = await fetchImpl(
       `https://api.github.com/repos/${REPO}/releases/latest`,
       { headers: { 'User-Agent': 'agentic-kit', Accept: 'application/vnd.github+json' },
         signal: ctl.signal });
     if (!res.ok) return null;
-    const tag = (await res.json())?.tag_name;
-    return tag ? String(tag).replace(/^v/, '') : null;
+    return releaseMetadata(await res.json());
   } catch {
     return null;
   } finally {
     clearTimeout(t);
   }
+}
+
+/** Compatibility helper for callers that only need the release tag. */
+export async function latestVersion(options) {
+  return (await latestRelease(options))?.version ?? null;
 }
 
 /** Record the release tag ak just pulled, so future drift compares like-for-like.
@@ -150,17 +174,27 @@ export async function drift({ force = false } = {}) {
   const cfg = loadKitConfig();
   const ttlMs = (cfg.versionCheck?.ttlHours ?? 24) * 3600_000;
   const cached = cfg.versionCheck?.ruvnetBrain ?? {};
+  // Do not invalidate a pre-asset-probe cache here: `ak sync --dry-run` reaches
+  // this collector and is forbidden to write. A real sync force-refreshes this
+  // metadata before collection; ordinary status waits for the normal TTL.
   const fresh = !force && cached.last && Date.now() - cached.last < ttlMs;
   let latest = fresh ? cached.latest ?? null : null;
+  let releaseAssetAvailable = fresh ? cached.releaseAssetAvailable ?? null : null;
   if (!fresh) {
-    latest = await latestVersion();
+    const release = await latestRelease();
+    latest = release?.version ?? null;
+    releaseAssetAvailable = release?.releaseAssetAvailable ?? null;
     // Preserve installedRelease across the cache write.
-    cfg.versionCheck = { ...cfg.versionCheck, ruvnetBrain: { ...cached, last: Date.now(), latest } };
+    cfg.versionCheck = {
+      ...cfg.versionCheck,
+      ruvnetBrain: { ...cached, last: Date.now(), latest, releaseAssetAvailable },
+    };
     try { saveKitConfig(cfg); } catch { /* read-only envs: next call re-fetches */ }
   }
   const installedRelease = installedReleaseOnDisk() ?? cached.installedRelease ?? null;
   return {
     ...classifyDrift({ present: present(), installedRelease, latest }),
+    releaseAssetAvailable,
     pluginVersion: installedVersion(),
   };
 }

--- a/tests/dashboard.test.cjs
+++ b/tests/dashboard.test.cjs
@@ -422,12 +422,23 @@ async function main() {
   const npmDrift = [{ pkg: 'ruflo', installed: '4.0.0', latest: '4.1.0', outdated: true }];
 
   await test('foldBrainDrift appends an outdated brain in renderDrift shape', async () => {
-    const out = foldBrainDrift(npmDrift, { present: true, installedRelease: '3.3.1', latest: '3.4.0', outdated: true });
+    const out = foldBrainDrift(npmDrift, {
+      present: true, installedRelease: '3.3.1', latest: '3.4.0', outdated: true,
+      releaseAssetAvailable: true,
+    });
     assert(out.length === 2, 'brain entry must be appended');
     const b = out[1];
     assert(b.pkg === 'ruvnet-brain' && b.installed === '3.3.1' && b.latest === '3.4.0' && b.outdated === true,
       'entry must carry {pkg, installed, latest, outdated}: ' + JSON.stringify(b));
     assert(out[0] === npmDrift[0], 'npm entries pass through untouched');
+  });
+
+  await test('foldBrainDrift does not advertise an update whose bundle asset is absent', async () => {
+    const out = foldBrainDrift([], {
+      present: true, installedRelease: '4.2.2-dev', latest: '4.3.1', outdated: true,
+      releaseAssetAvailable: false,
+    });
+    assert(out[0].outdated === false, 'an un-downloadable release must not become an update banner');
   });
 
   await test('foldBrainDrift: absent brain → array unchanged; null drift → brain-only array', async () => {
@@ -2075,7 +2086,7 @@ async function main() {
   // is the suite where it matters most — the traversal-guard and credential-
   // leak tests live here and were the reviewer's cited example of a block
   // that could silently vanish with the old harness never noticing.
-  const EXPECTED = 82;
+  const EXPECTED = 83;
   if (passed + failed !== EXPECTED) {
     console.error(`\nPLAN MISMATCH: expected ${EXPECTED} tests, ran ${passed + failed}`);
     process.exit(1);

--- a/tests/kit/codex-mcp.test.mjs
+++ b/tests/kit/codex-mcp.test.mjs
@@ -3,7 +3,9 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { codexMcpStatus, codexMcpTopology } from '../../src/lib/mcp.mjs';
+import {
+  codexMcpStatus, codexMcpTopology, codexMcpRepairPlan, repairCodexMcpTopology,
+} from '../../src/lib/mcp.mjs';
 
 // A tmp dir with a .git marker → repoRoot() resolves to it, so codexMcpStatus reads
 // the .mcp.json we write here (not the real repo's).
@@ -114,5 +116,39 @@ test('Codex MCP topology treats absent and malformed files as empty', () => {
       rufloRegistrations: [],
       duplicateRuflo: false,
     });
+  } finally { rm(dir); rm(home); }
+});
+
+test('Codex MCP repair plans only remove recursive and legacy duplicate entries', async () => {
+  const dir = tmpProject();
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'kit-codexmcp-home-'));
+  try {
+    fs.mkdirSync(path.join(home, '.codex'), { recursive: true });
+    fs.writeFileSync(path.join(home, '.codex', 'config.toml'), [
+      '[mcp_servers.codex]', 'command = "codex"', 'args = ["mcp-server"]', '',
+      '[mcp_servers.claude-flow]', 'command = "ruflo"', 'args = ["mcp", "start"]', '',
+      '[mcp_servers.ruflo]', 'command = "ak"', 'args = ["x", "ruflo-mcp"]',
+    ].join('\n'));
+    const topology = codexMcpTopology({ cwd: dir, home });
+    const plan = codexMcpRepairPlan(topology);
+    assert.deepEqual(plan.map(({ name, reason }) => ({ name, reason })), [
+      { name: 'codex', reason: 'recursively launches Codex through the deprecated mcp-server transport' },
+      { name: 'claude-flow', reason: 'duplicates the canonical workspace-aware [mcp_servers.ruflo] registration' },
+    ]);
+    const calls = [];
+    const result = await repairCodexMcpTopology(plan, dir, {
+      runner: async (command, args, options) => {
+        calls.push({ command, args, options });
+        return { code: 0, stdout: '', stderr: '' };
+      },
+      inspect: () => ({ registrations: [] }),
+    });
+    assert.equal(result.ok, true);
+    assert.ok(fs.existsSync(path.join(home, '.codex', 'config.toml.bak')),
+      'repair must preserve a recovery copy before changing user-owned config');
+    assert.deepEqual(calls.map(({ command, args }) => [command, args]), [
+      ['codex', ['mcp', 'remove', 'codex']],
+      ['codex', ['mcp', 'remove', 'claude-flow']],
+    ]);
   } finally { rm(dir); rm(home); }
 });

--- a/tests/kit/codex-plugins.test.mjs
+++ b/tests/kit/codex-plugins.test.mjs
@@ -100,6 +100,19 @@ test('a manifest hook override wins over an incompatible conventional file', () 
   assert.match(result.plugins[0].hookFiles[0], /codex-hooks\.json$/);
 });
 
+test('an explicit empty Codex manifest hook object disables conventional hooks', () => {
+  fs.rmSync(cacheDir, { recursive: true, force: true });
+  fs.writeFileSync(configFile, '[plugins."skills-only@local"]\nenabled = true\n');
+  const root = seedPlugin({
+    marketplace: 'local', plugin: 'skills-only', version: '1.0.0', manifest: { hooks: {} },
+  });
+  fs.mkdirSync(path.join(root, 'hooks'), { recursive: true });
+  fs.writeFileSync(path.join(root, 'hooks', 'hooks.json'), JSON.stringify({ hooks: { Stop: [] } }));
+  const result = inspect();
+  assert.deepEqual(result.hookIssues, []);
+  assert.deepEqual(result.plugins[0].hookFiles, []);
+});
+
 test('missing cache and unsafe manifest paths produce actionable facts', () => {
   fs.rmSync(cacheDir, { recursive: true, force: true });
   fs.writeFileSync(configFile, '[plugins."missing@market"]\nenabled = true\n');
@@ -115,6 +128,36 @@ test('missing cache and unsafe manifest paths produce actionable facts', () => {
   assert.match(inspect().issues[0], /must start with "\.\/"/);
 });
 
+test('plugin cache discovery rejects traversal refs and symlinked marketplace escapes', (t) => {
+  fs.rmSync(cacheDir, { recursive: true, force: true });
+  fs.writeFileSync(configFile, '[plugins."p@../../outside-market"]\nenabled = true\n');
+  const traversalRoot = path.resolve(cacheDir, '..', '..', 'outside-market', 'p', '1.0.0');
+  fs.mkdirSync(path.join(traversalRoot, '.codex-plugin'), { recursive: true });
+  fs.writeFileSync(path.join(traversalRoot, '.codex-plugin', 'plugin.json'), JSON.stringify({ name: 'p', version: '1.0.0' }));
+  assert.match(inspect().hookIssues[0], /invalid plugin reference/);
+
+  fs.rmSync(cacheDir, { recursive: true, force: true });
+  const outside = fs.mkdtempSync(path.join(os.tmpdir(), 'ak-plugin-outside-'));
+  try {
+    seedPlugin({ marketplace: 'linked', plugin: 'p', version: '1.0.0' });
+    const seeded = path.join(cacheDir, 'linked');
+    fs.cpSync(seeded, outside, { recursive: true });
+    fs.rmSync(seeded, { recursive: true, force: true });
+    try {
+      fs.symlinkSync(outside, seeded, 'dir');
+    } catch (error) {
+      if (error.code === 'EPERM') { t.skip('directory symlinks unavailable'); return; }
+      throw error;
+    }
+    fs.writeFileSync(configFile, '[plugins."p@linked"]\nenabled = true\n');
+    const result = inspect();
+    assert.match(result.hookIssues[0], /escapes.*cache/i);
+    assert.deepEqual(result.plugins[0].hookFiles, []);
+  } finally {
+    fs.rmSync(outside, { recursive: true, force: true });
+  }
+});
+
 test('skills without portable YAML frontmatter are reported', () => {
   fs.rmSync(cacheDir, { recursive: true, force: true });
   fs.writeFileSync(configFile, '[plugins."spring-m11n@market"]\nenabled = true\n');
@@ -128,6 +171,8 @@ test('skills without portable YAML frontmatter are reported', () => {
   const result = inspect();
   assert.equal(result.plugins[0].skillFiles.length, 2);
   assert.equal(result.issues.length, 1);
+  assert.deepEqual(result.hookIssues, []);
+  assert.equal(result.skillIssues.length, 1);
   assert.match(result.issues[0], /missing-frontmatter[\\/]SKILL\.md: missing YAML frontmatter/);
 });
 

--- a/tests/kit/heal-natives.test.mjs
+++ b/tests/kit/heal-natives.test.mjs
@@ -317,7 +317,7 @@ test('brain installer exit failure is failed even when an old or partial KB is p
   let stamped = false;
   const r = await installRuvnetBrain({
     runner: async () => ({ code: 1, stdout: '', stderr: 'installer failed after partial copy\n' }),
-    latestVersion: async () => '4.0.12',
+    latestRelease: async () => ({ version: '4.0.12', releaseAssetAvailable: true }),
     present: () => true,
     recordRelease: () => { stamped = true; },
   });
@@ -332,12 +332,40 @@ test('brain installer stamps only a zero-exit installation', async () => {
   let stamped = null;
   const r = await installRuvnetBrain({
     runner: async () => ({ code: 0, stdout: '', stderr: '' }),
-    latestVersion: async () => '4.0.12',
+    latestRelease: async () => ({ version: '4.0.12', releaseAssetAvailable: true }),
     present: () => false,
     recordRelease: (version) => { stamped = version; },
   });
   assert.equal(r.status, 'ok');
   assert.equal(stamped, '4.0.12');
+});
+
+test('brain installer refuses a release tag whose required bundle asset is absent', async () => {
+  let ran = false;
+  const r = await installRuvnetBrain({
+    runner: async () => { ran = true; return { code: 0, stdout: '', stderr: '' }; },
+    latestRelease: async () => ({ version: '4.3.1', releaseAssetAvailable: false }),
+    present: () => true,
+  });
+  assert.equal(r.ok, false);
+  assert.equal(r.usable, true);
+  assert.equal(ran, false, 'a release known to lack ruvnet-brain.zip must never launch npx');
+  assert.match(r.detail, /v4\.3\.1 is missing ruvnet-brain\.zip/);
+  assert.match(r.detail, /existing Brain was left unchanged/);
+});
+
+test('brain installer failure selects the causal updater error across stdout and stderr', async () => {
+  const r = await installRuvnetBrain({
+    runner: async () => ({
+      code: 1,
+      stdout: '[forge-update] ERROR: v4.3.1 has no matching .zip asset\n',
+      stderr: "Nothing is left half-installed — fix the above and re-run.\n",
+    }),
+    latestRelease: async () => ({ version: '4.3.1', releaseAssetAvailable: true }),
+    present: () => true,
+  });
+  assert.match(r.detail, /no matching \.zip asset/);
+  assert.doesNotMatch(r.detail, /Nothing is left half-installed/);
 });
 
 test('AQE solver: the unpublished native is never install-attempted and the TS fallback is reported as the implementation (#135)', async () => {

--- a/tests/kit/hook-audit-hosts.test.mjs
+++ b/tests/kit/hook-audit-hosts.test.mjs
@@ -1,0 +1,285 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { run as runAuditCommand } from '../../src/commands/audit.mjs';
+import { auditCodexHooks } from '../../src/lib/hook-audit/index.mjs';
+import { auditHooks } from '../../src/lib/hook-audit/orchestrator.mjs';
+import { readBoundedFile } from '../../src/lib/hook-audit/common.mjs';
+
+function write(file, value) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, typeof value === 'string' ? value : `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function fixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ak-host-hooks-'));
+  return {
+    root,
+    project: path.join(root, 'project'),
+    codex: path.join(root, 'codex'),
+    claude: path.join(root, 'claude'),
+    opencode: path.join(root, 'opencode'),
+  };
+}
+
+function externalManifest() {
+  return {
+    name: 'hermes', version: '1.0.0', contract: 1,
+    host: {
+      id: 'hermes', label: 'Hermes',
+      install: { bin: 'hermes', externalInstallPolicy: 'detect-never-overwrite' },
+      capabilities: {
+        canDriveSession: true, canBePrimary: false, canRouteActivities: true,
+        commandStatusline: false, transcripts: true, usage: false,
+        nativeMcpConfig: false, nativeGuidance: false,
+      },
+      trust: { approvalPolicy: 'unchanged', changes: [] }, enabledByDefault: false,
+      configProjection: 'ruflo', observability: [],
+    },
+    detection: { bin: 'hermes', versionArgs: ['--version'], versionPattern: '\\d+\\.\\d+\\.\\d+' },
+    driving: { surfaces: ['acp'] },
+    trust: { changes: [{
+      id: 'hermes-hooks', kind: 'third-party-adapter', scope: 'project', owner: 'hermes',
+      value: 'subprocess hooks', effect: 'run consented lifecycle hooks',
+    }] },
+    lifecycle: { detect: { hook: { command: ['hermes', 'detect'], timeoutMs: 5000 } } },
+  };
+}
+
+test('host-neutral audit reports each provider and never proposes automatic trust or execution', () => {
+  const fx = fixture();
+  try {
+    write(path.join(fx.codex, 'hooks.json'), { hooks: { Stop: [{ hooks: [{ type: 'command', command: 'node stop.cjs' }] }] } });
+    write(path.join(fx.claude, 'settings.json'), { hooks: { Stop: [{ hooks: [{ type: 'command', command: 'node stop.cjs', timeout: 3000 }] }] } });
+    write(path.join(fx.opencode, 'opencode.json'), { plugin: ['example-plugin@1.0.0'] });
+    write(path.join(fx.opencode, 'plugins', 'local.js'), 'export const Local = async () => ({ "tool.execute.before": async () => {} });\n');
+    const manifest = path.join(fx.root, 'hermes.json');
+    write(manifest, externalManifest());
+
+    const report = auditHooks({
+      hosts: ['all'], projectRoots: [fx.project],
+      versions: { codex: '0.151.0', claude: '2.1.258', opencode: '1.18.25' },
+      config: { hostAdapters: [{ name: 'hermes', source: manifest, contract: 1 }] },
+      codex: { codexHome: fx.codex, pluginCacheDir: path.join(fx.codex, 'plugins', 'cache') },
+      claude: { claudeRoot: fx.claude, managedSettingsFile: null },
+      opencode: { opencodeRoot: fx.opencode },
+    });
+
+    assert.deepEqual(report.hosts, ['codex', 'claude', 'opencode', 'external']);
+    assert.equal(report.reports.codex.records.length, 1);
+    assert.equal(report.reports.claude.records.length, 1);
+    assert.equal(report.reports.opencode.records.length, 2);
+    assert.equal(report.reports.external.records.length, 1);
+    assert.equal(report.summary.automaticActions, 0);
+    assert.ok(Object.values(report.reports).every((host) => host.mode === 'read-only'));
+    assert.ok(Object.values(report.reports).flatMap((host) => host.records).every((record) => record.trust.observedState === 'unknown'));
+    assert.equal(report.upstream.status, 'valid');
+  } finally {
+    fs.rmSync(fx.root, { recursive: true, force: true });
+  }
+});
+
+test('Codex discovers inline TOML and preserves MCP handler identity', () => {
+  const fx = fixture();
+  try {
+    write(path.join(fx.codex, 'config.toml'), `[[hooks.PostToolUse]]
+matcher = "^apply_patch$"
+
+[[hooks.PostToolUse.hooks]]
+type = "mcp_tool"
+server = "scanner"
+tool = "scan_patch"
+input = {"path":"\${tool_input.file_path}"}
+timeout = 30
+statusMessage = "Scanning"
+`);
+    const report = auditCodexHooks({
+      codexHome: fx.codex, projectRoots: [], pluginCacheDir: path.join(fx.codex, 'plugins', 'cache'), codexVersion: '0.151.0',
+    });
+    assert.equal(report.records.length, 1);
+    assert.equal(report.records[0].type, 'mcp_tool');
+    assert.equal(report.records[0].timeout.effective, 30);
+    assert.match(report.records[0].source.file, /config\.toml/);
+  } finally {
+    fs.rmSync(fx.root, { recursive: true, force: true });
+  }
+});
+
+test('Codex inventories valid inline plugin hooks and refuses symlinked manifests', (t) => {
+  const fx = fixture();
+  try {
+    write(path.join(fx.codex, 'config.toml'), '[plugins."inline@test"]\nenabled = true\n');
+    const plugin = path.join(fx.codex, 'plugins', 'cache', 'test', 'inline', '1.0.0');
+    write(path.join(plugin, '.codex-plugin', 'plugin.json'), {
+      name: 'inline', version: '1.0.0', hooks: { hooks: { Stop: [{ hooks: [{ type: 'command', command: 'node inline.cjs' }] }] } },
+    });
+    let report = auditCodexHooks({ codexHome: fx.codex, projectRoots: [], pluginCacheDir: path.join(fx.codex, 'plugins', 'cache'), codexVersion: '0.151.0' });
+    assert.equal(report.records.length, 1);
+    assert.equal(report.records[0].scope.kind, 'plugin-cache-inline');
+
+    const manifest = path.join(plugin, '.codex-plugin', 'plugin.json');
+    const actual = path.join(fx.root, 'manifest.json');
+    fs.renameSync(manifest, actual);
+    try { fs.symlinkSync(actual, manifest); } catch (error) {
+      if (error.code === 'EPERM') { t.skip('file symlinks unavailable'); return; }
+      throw error;
+    }
+    report = auditCodexHooks({ codexHome: fx.codex, projectRoots: [], pluginCacheDir: path.join(fx.codex, 'plugins', 'cache'), codexVersion: '0.151.0' });
+    assert.equal(report.records.length, 0);
+    assert.match(report.pluginIssues[0], /non-symlink/);
+  } finally {
+    fs.rmSync(fx.root, { recursive: true, force: true });
+  }
+});
+
+test('public command text redacts credential assignments while fingerprints remain deterministic', () => {
+  const fx = fixture();
+  try {
+    write(path.join(fx.codex, 'hooks.json'), { hooks: { Stop: [{ hooks: [{ type: 'command', command: 'API_TOKEN=super-secret node stop.cjs' }] }] } });
+    const options = { codexHome: fx.codex, projectRoots: [], pluginCacheDir: path.join(fx.codex, 'plugins', 'cache'), codexVersion: '0.151.0' };
+    const first = auditCodexHooks(options);
+    const second = auditCodexHooks(options);
+    assert.doesNotMatch(JSON.stringify(first), /super-secret/);
+    assert.equal(first.records[0].behaviorFingerprint, second.records[0].behaviorFingerprint);
+  } finally {
+    fs.rmSync(fx.root, { recursive: true, force: true });
+  }
+});
+
+test('unverified newer Codex versions do not inherit the 0.151 timeout profile', () => {
+  const fx = fixture();
+  try {
+    write(path.join(fx.codex, 'hooks.json'), { hooks: { SessionEnd: [{ hooks: [{ type: 'command', command: 'node end.cjs', timeout: 5 }] }] } });
+    const report = auditCodexHooks({ codexHome: fx.codex, projectRoots: [], pluginCacheDir: path.join(fx.codex, 'plugins', 'cache'), codexVersion: '0.152.0' });
+    assert.equal(report.hostSchema.confidence, 'unknown');
+    assert.equal(report.records[0].timeout.effective, null);
+    assert.equal(report.plan.length, 0);
+  } finally {
+    fs.rmSync(fx.root, { recursive: true, force: true });
+  }
+});
+
+test('bounded reads reject a source replaced between inspection and open', () => {
+  const fx = fixture();
+  const file = path.join(fx.root, 'hooks.json');
+  const replacement = path.join(fx.root, 'replacement.json');
+  write(file, { hooks: {} });
+  write(replacement, { hooks: { Stop: [] } });
+  const originalOpen = fs.openSync;
+  let replaced = false;
+  fs.openSync = function replaceBeforeOpen(target, ...args) {
+    if (!replaced && target === file) {
+      replaced = true;
+      fs.renameSync(replacement, file);
+    }
+    return originalOpen.call(fs, target, ...args);
+  };
+  try {
+    const result = readBoundedFile(file, fx.root);
+    assert.equal(result.status, 'refused');
+    assert.match(result.error, /identity changed/);
+  } finally {
+    fs.openSync = originalOpen;
+    fs.rmSync(fx.root, { recursive: true, force: true });
+  }
+});
+
+test('Codex-only command isolates version and config probes to the selected provider', async () => {
+  const binaries = [];
+  const originalLog = console.log;
+  const originalError = console.error;
+  console.log = () => {};
+  console.error = () => {};
+  try {
+    const status = await runAuditCommand({
+      flags: { host: ['codex'], project: [] },
+      positionals: ['hooks'],
+      detectVersionFn(binary) { binaries.push(binary); return 'unknown'; },
+      loadConfigFn() { throw new Error('unrelated kit config must not be loaded'); },
+    });
+    assert.notEqual(status, 2);
+    assert.deepEqual(binaries, ['codex']);
+  } finally {
+    console.log = originalLog;
+    console.error = originalError;
+  }
+});
+
+test('external audit loads adapter configuration without probing unrelated host binaries', async () => {
+  const binaries = [];
+  let configLoads = 0;
+  const originalLog = console.log;
+  const originalError = console.error;
+  console.log = () => {};
+  console.error = () => {};
+  try {
+    const status = await runAuditCommand({
+      flags: { host: ['external'], project: [] },
+      positionals: ['hooks'],
+      detectVersionFn(binary) { binaries.push(binary); return 'unknown'; },
+      loadConfigFn() { configLoads += 1; return { hostAdapters: [] }; },
+    });
+    assert.equal(status, 0);
+    assert.deepEqual(binaries, []);
+    assert.equal(configLoads, 1);
+  } finally {
+    console.log = originalLog;
+    console.error = originalError;
+  }
+});
+
+test('Claude plugin discovery preserves registry provenance and honors manifest-free default hooks', () => {
+  const fx = fixture();
+  try {
+    const plugin = path.join(fx.claude, 'plugins', 'cache', 'market', 'demo', '1.0.0');
+    write(path.join(fx.claude, 'plugins', 'installed_plugins.json'), {
+      plugins: { 'demo@market': [{ installPath: plugin, version: '1.0.0' }] },
+    });
+    write(path.join(plugin, 'hooks', 'hooks.json'), {
+      hooks: { Stop: [{ hooks: [{ type: 'command', command: 'node stop.cjs' }] }] },
+    });
+    const report = auditHooks({
+      hosts: ['claude'], projectRoots: [], versions: { claude: '2.1.258' },
+      claude: { claudeRoot: fx.claude, managedSettingsFile: null },
+    });
+    assert.deepEqual(report.reports.claude.sources.map((source) => source.kind), ['plugin-registry', 'plugin-cache']);
+    assert.equal(report.reports.claude.records.length, 1);
+    assert.equal(report.reports.claude.records[0].source.pluginRef, 'demo@market');
+  } finally {
+    fs.rmSync(fx.root, { recursive: true, force: true });
+  }
+});
+
+test('Claude SessionEnd reports settings clamping and plugin budget dependence separately', () => {
+  const fx = fixture();
+  try {
+    write(path.join(fx.claude, 'settings.json'), {
+      hooks: { SessionEnd: [{ hooks: [{ type: 'command', command: 'node user.cjs', timeout: 120 }] }] },
+    });
+    const plugin = path.join(fx.claude, 'plugins', 'cache', 'market', 'demo', '1.0.0');
+    write(path.join(fx.claude, 'plugins', 'installed_plugins.json'), {
+      plugins: { 'demo@market': [{ installPath: plugin, version: '1.0.0' }] },
+    });
+    write(path.join(plugin, 'hooks', 'hooks.json'), {
+      hooks: { SessionEnd: [{ hooks: [{ type: 'command', command: 'node plugin.cjs', timeout: 10 }] }] },
+    });
+    const report = auditHooks({
+      hosts: ['claude'], projectRoots: [], versions: { claude: '2.1.258' },
+      claude: { claudeRoot: fx.claude, managedSettingsFile: null },
+    }).reports.claude;
+    const settingsHook = report.records.find((record) => record.source.sourceKind === 'global');
+    const pluginHook = report.records.find((record) => record.source.sourceKind === 'plugin-cache');
+    assert.equal(settingsHook.timeout.effective, 60);
+    assert.equal(settingsHook.timeout.maximum, 60);
+    assert.ok(settingsHook.diagnostics.some((item) => item.code === 'sessionend-timeout-clamped'));
+    assert.equal(pluginHook.timeout.effective, null);
+    assert.equal(pluginHook.timeout.status, 'plugin-session-budget-dependent');
+    assert.ok(pluginHook.diagnostics.some((item) => item.code === 'plugin-sessionend-budget-not-raised'));
+    assert.equal(report.plan.length, 2);
+  } finally {
+    fs.rmSync(fx.root, { recursive: true, force: true });
+  }
+});

--- a/tests/kit/hook-audit.test.mjs
+++ b/tests/kit/hook-audit.test.mjs
@@ -1,0 +1,416 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+import { auditCodexHooks } from '../../src/lib/hook-audit/index.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+function writeJson(file, value) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function fixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ak-hook-audit-'));
+  const codexHome = path.join(root, 'codex');
+  const project = path.join(root, 'project');
+  const cache = path.join(codexHome, 'plugins', 'cache');
+  fs.mkdirSync(project, { recursive: true });
+  return { root, codexHome, project, cache };
+}
+
+test('audit keeps SessionEnd compatibility separate from trust and never proposes an automatic cache edit', () => {
+  const fx = fixture();
+  try {
+    writeJson(path.join(fx.project, '.codex', 'hooks.json'), {
+      hooks: { SessionEnd: [{ hooks: [{ type: 'command', command: 'node local.cjs', timeout: 10000 }] }] },
+    });
+    fs.mkdirSync(fx.codexHome, { recursive: true });
+    fs.writeFileSync(path.join(fx.codexHome, 'config.toml'), '[plugins."companion@test"]\nenabled = true\n');
+    const pluginRoot = path.join(fx.cache, 'test', 'companion', '1.0.0');
+    writeJson(path.join(pluginRoot, '.codex-plugin', 'plugin.json'), {
+      name: 'companion', version: '1.0.0', hooks: './hooks/hooks.json',
+    });
+    writeJson(path.join(pluginRoot, 'hooks', 'hooks.json'), {
+      hooks: { SessionEnd: [{ hooks: [{ type: 'command', command: 'node plugin.cjs', timeout: 5 }] }] },
+    });
+
+    const report = auditCodexHooks({
+      codexHome: fx.codexHome,
+      projectRoots: [fx.project],
+      pluginCacheDir: fx.cache,
+      codexVersion: '0.151.0',
+    });
+
+    assert.equal(report.summary.hookOccurrences, 2);
+    assert.equal(report.summary.compatibilityWarnings, 2);
+    assert.equal(report.summary.automaticActions, 0);
+    assert.deepEqual(new Set(report.records.map((record) => record.timeout.effective)), new Set([3]));
+    assert.ok(report.records.every((record) => record.trust.observedState === 'unknown'));
+    assert.ok(report.records.every((record) => record.diagnostics.some((d) => d.category === 'compatibility')));
+    assert.ok(report.plan.every((action) => action.classification === 'never-automatic'));
+    assert.ok(report.records.every((record) => typeof record.implementationTarget === 'string'));
+    assert.ok(report.records.every((record) => Array.isArray(record.sideEffects)));
+    assert.ok(report.records.every((record) => record.duplicateGroupId === record.behaviorFingerprint));
+  } finally {
+    fs.rmSync(fx.root, { recursive: true, force: true });
+  }
+});
+
+test('audit keeps cwd-sensitive occurrences behaviorally distinct', () => {
+  const fx = fixture();
+  try {
+    for (const name of ['a', 'b']) {
+      const project = path.join(fx.root, name);
+      writeJson(path.join(project, '.codex', 'hooks.json'), {
+        hooks: { PreToolUse: [{ matcher: '^Bash$', hooks: [{ type: 'command', command: 'node guard.cjs' }] }] },
+      });
+    }
+
+    const report = auditCodexHooks({
+      codexHome: fx.codexHome,
+      projectRoots: [path.join(fx.root, 'a'), path.join(fx.root, 'b')],
+      pluginCacheDir: fx.cache,
+      codexVersion: '0.151.0',
+    });
+
+    assert.equal(report.records.length, 2);
+    assert.equal(report.summary.uniqueBehaviors, 2);
+    assert.notEqual(report.records[0].behaviorFingerprint, report.records[1].behaviorFingerprint);
+    assert.notEqual(report.records[0].source.file, report.records[1].source.file);
+  } finally {
+    fs.rmSync(fx.root, { recursive: true, force: true });
+  }
+});
+
+test('audit JSON is deterministic across no-op runs', async () => {
+  const fx = fixture();
+  try {
+    writeJson(path.join(fx.project, '.codex', 'hooks.json'), {
+      hooks: { Stop: [{ hooks: [{ type: 'command', command: 'node stop.cjs' }] }] },
+    });
+    const options = {
+      codexHome: fx.codexHome,
+      projectRoots: [fx.project],
+      pluginCacheDir: fx.cache,
+      codexVersion: '0.151.0',
+    };
+    const first = auditCodexHooks(options);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    const second = auditCodexHooks(options);
+    assert.deepEqual(second, first);
+  } finally {
+    fs.rmSync(fx.root, { recursive: true, force: true });
+  }
+});
+
+test('unknown Codex versions receive syntax-only validation and no timeout rewrite plan', () => {
+  const fx = fixture();
+  try {
+    writeJson(path.join(fx.project, '.codex', 'hooks.json'), {
+      hooks: { SessionEnd: [{ hooks: [{ type: 'command', command: 'node end.cjs', timeout: 10000 }] }] },
+    });
+    const report = auditCodexHooks({
+      codexHome: fx.codexHome,
+      projectRoots: [fx.project],
+      pluginCacheDir: fx.cache,
+      codexVersion: 'unknown',
+    });
+    assert.equal(report.hostSchema.confidence, 'unknown');
+    assert.equal(report.summary.compatibilityWarnings, 0);
+    assert.equal(report.plan.length, 0);
+    assert.equal(report.records[0].timeout.effective, null);
+  } finally {
+    fs.rmSync(fx.root, { recursive: true, force: true });
+  }
+});
+
+test('plugin hook discovery refuses a symlinked parent that escapes the plugin root', (t) => {
+  const fx = fixture();
+  try {
+    fs.mkdirSync(fx.codexHome, { recursive: true });
+    fs.writeFileSync(path.join(fx.codexHome, 'config.toml'), '[plugins."escape@test"]\nenabled = true\n');
+    const pluginRoot = path.join(fx.cache, 'test', 'escape', '1.0.0');
+    writeJson(path.join(pluginRoot, '.codex-plugin', 'plugin.json'), {
+      name: 'escape', version: '1.0.0', hooks: './hooks/hooks.json',
+    });
+    const outside = path.join(fx.root, 'outside');
+    writeJson(path.join(outside, 'hooks.json'), {
+      hooks: { Stop: [{ hooks: [{ type: 'command', command: 'node outside.cjs' }] }] },
+    });
+    try {
+      fs.symlinkSync(outside, path.join(pluginRoot, 'hooks'), 'dir');
+    } catch (error) {
+      if (error.code === 'EPERM') { t.skip('directory symlinks unavailable'); return; }
+      throw error;
+    }
+
+    const report = auditCodexHooks({
+      codexHome: fx.codexHome,
+      projectRoots: [],
+      pluginCacheDir: fx.cache,
+      codexVersion: '0.151.0',
+    });
+    assert.equal(report.records.length, 0);
+    assert.equal(report.sources[0].status, 'refused');
+    assert.match(report.sources[0].error, /escapes/);
+  } finally {
+    fs.rmSync(fx.root, { recursive: true, force: true });
+  }
+});
+
+test('an expected hook path that is itself a broken symlink is refused, not ignored', (t) => {
+  const fx = fixture();
+  try {
+    const hookFile = path.join(fx.project, '.codex', 'hooks.json');
+    fs.mkdirSync(path.dirname(hookFile), { recursive: true });
+    try {
+      fs.symlinkSync(path.join(fx.root, 'missing-hooks.json'), hookFile);
+    } catch (error) {
+      if (error.code === 'EPERM') { t.skip('file symlinks unavailable'); return; }
+      throw error;
+    }
+    const report = auditCodexHooks({
+      codexHome: fx.codexHome,
+      projectRoots: [fx.project],
+      pluginCacheDir: fx.cache,
+      codexVersion: '0.151.0',
+    });
+    assert.equal(report.summary.invalidSources, 1);
+    assert.equal(report.sources[0].status, 'refused');
+    assert.match(report.sources[0].error, /non-symlink/);
+  } finally {
+    fs.rmSync(fx.root, { recursive: true, force: true });
+  }
+});
+
+test('a conventional plugin hook path that is a broken symlink is refused, not ignored', (t) => {
+  const fx = fixture();
+  try {
+    fs.mkdirSync(fx.codexHome, { recursive: true });
+    fs.writeFileSync(path.join(fx.codexHome, 'config.toml'), '[plugins."broken@test"]\nenabled = true\n');
+    const pluginRoot = path.join(fx.cache, 'test', 'broken', '1.0.0');
+    writeJson(path.join(pluginRoot, '.codex-plugin', 'plugin.json'), {
+      name: 'broken', version: '1.0.0',
+    });
+    const hookFile = path.join(pluginRoot, 'hooks', 'hooks.json');
+    fs.mkdirSync(path.dirname(hookFile), { recursive: true });
+    try {
+      fs.symlinkSync(path.join(fx.root, 'missing-plugin-hooks.json'), hookFile);
+    } catch (error) {
+      if (error.code === 'EPERM') { t.skip('file symlinks unavailable'); return; }
+      throw error;
+    }
+    const report = auditCodexHooks({
+      codexHome: fx.codexHome,
+      projectRoots: [],
+      pluginCacheDir: fx.cache,
+      codexVersion: '0.151.0',
+    });
+    assert.equal(report.summary.invalidSources, 1);
+    assert.equal(report.summary.configurationIssues, 1);
+    assert.equal(report.sources[0].status, 'refused');
+  } finally {
+    fs.rmSync(fx.root, { recursive: true, force: true });
+  }
+});
+
+test('behavior fingerprints preserve material whitespace inside quoted arguments', () => {
+  const fx = fixture();
+  try {
+    writeJson(path.join(fx.project, '.codex', 'hooks.json'), {
+      hooks: { Stop: [
+        { hooks: [{ type: 'command', command: 'node stop.cjs --label "a  b"' }] },
+        { hooks: [{ type: 'command', command: 'node stop.cjs --label "a b"' }] },
+      ] },
+    });
+    const report = auditCodexHooks({
+      codexHome: fx.codexHome,
+      projectRoots: [fx.project],
+      pluginCacheDir: fx.cache,
+      codexVersion: '0.151.0',
+    });
+    assert.equal(report.summary.uniqueBehaviors, 2);
+  } finally {
+    fs.rmSync(fx.root, { recursive: true, force: true });
+  }
+});
+
+test('malformed nested hook schema invalidates the source instead of silently skipping it', () => {
+  const fx = fixture();
+  try {
+    writeJson(path.join(fx.project, '.codex', 'hooks.json'), {
+      hooks: { Stop: { hooks: [] } },
+    });
+    const report = auditCodexHooks({
+      codexHome: fx.codexHome,
+      projectRoots: [fx.project],
+      pluginCacheDir: fx.cache,
+      codexVersion: '0.151.0',
+    });
+    assert.equal(report.summary.invalidSources, 1);
+    assert.equal(report.records.length, 0);
+    assert.match(report.sources[0].error, /Stop.*array/);
+  } finally {
+    fs.rmSync(fx.root, { recursive: true, force: true });
+  }
+});
+
+test('malformed matcher and timeout values invalidate the source', () => {
+  const fx = fixture();
+  try {
+    writeJson(path.join(fx.project, '.codex', 'hooks.json'), {
+      hooks: { SessionEnd: [{ matcher: 42, hooks: [
+        { type: 'command', command: 'node end.cjs', timeout: '10000' },
+      ] }] },
+    });
+    const report = auditCodexHooks({
+      codexHome: fx.codexHome,
+      projectRoots: [fx.project],
+      pluginCacheDir: fx.cache,
+      codexVersion: '0.151.0',
+    });
+    assert.equal(report.summary.invalidSources, 1);
+    assert.equal(report.records.length, 0);
+    assert.match(report.sources[0].error, /matcher.*string/);
+  } finally {
+    fs.rmSync(fx.root, { recursive: true, force: true });
+  }
+});
+
+test('remediation action ids stay unique for duplicate occurrences in one source', () => {
+  const fx = fixture();
+  try {
+    writeJson(path.join(fx.project, '.codex', 'hooks.json'), {
+      hooks: { SessionEnd: [{ hooks: [
+        { type: 'command', command: 'node end.cjs', timeout: 5 },
+        { type: 'command', command: 'node end.cjs', timeout: 5 },
+      ] }] },
+    });
+    const report = auditCodexHooks({
+      codexHome: fx.codexHome,
+      projectRoots: [fx.project],
+      pluginCacheDir: fx.cache,
+      codexVersion: '0.151.0',
+    });
+    assert.equal(new Set(report.plan.map((action) => action.id)).size, 2);
+  } finally {
+    fs.rmSync(fx.root, { recursive: true, force: true });
+  }
+});
+
+test('enabled-plugin discovery failures are counted and make CLI JSON exit nonzero', () => {
+  const fx = fixture();
+  try {
+    fs.mkdirSync(fx.codexHome, { recursive: true });
+    fs.writeFileSync(path.join(fx.codexHome, 'config.toml'), '[plugins."missing@test"]\nenabled = true\n');
+    const report = auditCodexHooks({
+      codexHome: fx.codexHome,
+      projectRoots: [fx.project],
+      pluginCacheDir: fx.cache,
+      codexVersion: '0.151.0',
+    });
+    assert.equal(report.summary.configurationIssues, 1);
+
+    const result = spawnSync(process.execPath, [path.join(repoRoot, 'bin', 'agentic-kit.mjs'), 'audit', 'hooks', '--json'], {
+      cwd: fx.project,
+      env: { ...process.env, CODEX_HOME: fx.codexHome },
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 1, result.stderr || result.stdout);
+    assert.equal(JSON.parse(result.stdout).summary.configurationIssues, 1);
+  } finally {
+    fs.rmSync(fx.root, { recursive: true, force: true });
+  }
+});
+
+test('non-hook plugin skill findings do not make the hook audit fail', () => {
+  const fx = fixture();
+  try {
+    fs.mkdirSync(fx.codexHome, { recursive: true });
+    fs.writeFileSync(path.join(fx.codexHome, 'config.toml'), '[plugins."skills@test"]\nenabled = true\n');
+    const pluginRoot = path.join(fx.cache, 'test', 'skills', '1.0.0');
+    writeJson(path.join(pluginRoot, '.codex-plugin', 'plugin.json'), {
+      name: 'skills', version: '1.0.0', hooks: './hooks/hooks.json',
+    });
+    writeJson(path.join(pluginRoot, 'hooks', 'hooks.json'), { hooks: { Stop: [] } });
+    fs.mkdirSync(path.join(pluginRoot, 'skills', 'BadName'), { recursive: true });
+    fs.writeFileSync(path.join(pluginRoot, 'skills', 'BadName', 'SKILL.md'), '# no frontmatter\n');
+
+    const report = auditCodexHooks({
+      codexHome: fx.codexHome,
+      projectRoots: [],
+      pluginCacheDir: fx.cache,
+      codexVersion: '0.151.0',
+    });
+    assert.equal(report.summary.configurationIssues, 0);
+    assert.deepEqual(report.pluginIssues, []);
+  } finally {
+    fs.rmSync(fx.root, { recursive: true, force: true });
+  }
+});
+
+test('audit reports malformed hook documents and remains read-only', () => {
+  const fx = fixture();
+  try {
+    const hookFile = path.join(fx.project, '.codex', 'hooks.json');
+    fs.mkdirSync(path.dirname(hookFile), { recursive: true });
+    fs.writeFileSync(hookFile, '{not-json\n');
+    const before = fs.statSync(hookFile);
+    const bytes = fs.readFileSync(hookFile);
+
+    const report = auditCodexHooks({
+      codexHome: fx.codexHome,
+      projectRoots: [fx.project],
+      pluginCacheDir: fx.cache,
+      codexVersion: '0.151.0',
+    });
+
+    assert.equal(report.records.length, 0);
+    assert.equal(report.sources[0].status, 'invalid');
+    assert.match(report.sources[0].error, /JSON/);
+    assert.deepEqual(fs.readFileSync(hookFile), bytes);
+    assert.equal(fs.statSync(hookFile).mtimeMs, before.mtimeMs);
+  } finally {
+    fs.rmSync(fx.root, { recursive: true, force: true });
+  }
+});
+
+test('ak audit hooks exposes the read-only audit as a porcelain command', () => {
+  const fx = fixture();
+  try {
+    const result = spawnSync(process.execPath, [path.join(repoRoot, 'bin', 'agentic-kit.mjs'), 'audit', 'hooks', '--json'], {
+      cwd: fx.project,
+      env: { ...process.env, CODEX_HOME: fx.codexHome },
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    const report = JSON.parse(result.stdout);
+    assert.equal(report.mode, 'read-only');
+    assert.equal(report.summary.automaticActions, 0);
+  } finally {
+    fs.rmSync(fx.root, { recursive: true, force: true });
+  }
+});
+
+test('ak audit hooks human output is not followed by the generic network drift nudge', () => {
+  const fx = fixture();
+  try {
+    const result = spawnSync(process.execPath, [path.join(repoRoot, 'bin', 'agentic-kit.mjs'), 'audit', 'hooks'], {
+      cwd: fx.project,
+      env: { ...process.env, CODEX_HOME: fx.codexHome },
+      encoding: 'utf8',
+      timeout: 3_000,
+    });
+    assert.equal(result.error, undefined, result.error?.message);
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /trust: unchanged/);
+  } finally {
+    fs.rmSync(fx.root, { recursive: true, force: true });
+  }
+});

--- a/tests/kit/ruvnet-brain.test.mjs
+++ b/tests/kit/ruvnet-brain.test.mjs
@@ -5,8 +5,10 @@ import os from 'node:os';
 import path from 'node:path';
 import {
   kbDir, present, installedVersion, installedReleaseOnDisk, classifyDrift,
-  INSTALL_SPEC, INSTALL_ARGS, REPO, NIGHTLY_LABEL, nightlyAgentPlist, nightlyAgentPresent,
+  INSTALL_SPEC, INSTALL_ARGS, REPO, RELEASE_ASSET, releaseMetadata,
+  NIGHTLY_LABEL, nightlyAgentPlist, nightlyAgentPresent,
 } from '../../src/lib/ruvnet-brain.mjs';
+import { brainReleaseRow } from '../../src/commands/status/sections/ruvnet-brain.mjs';
 import { BUILTIN_BLOCKS, detect } from '../../src/lib/blocks.mjs';
 import { loadKitConfig, saveKitConfig } from '../../src/lib/config.mjs';
 
@@ -38,12 +40,45 @@ test('install spec/args stay pinned to the PUBLISHED installer with the four sup
   //   optional offer, silently enabling the 03:47 self-update LaunchAgent (macOS)
   //   and telemetry consent. ak owns updates, so these MUST persist.
   assert.equal(REPO, 'stuinfla/ruvnet-brain');
+  assert.equal(RELEASE_ASSET, 'ruvnet-brain.zip');
   assert.equal(INSTALL_SPEC, 'ruvnet-brain@latest');
   assert.ok(INSTALL_ARGS.includes('--no-stack'));
   assert.ok(INSTALL_ARGS.includes('--no-enhance'));
   assert.ok(INSTALL_ARGS.includes('--no-nightly-prompt'));
   assert.ok(INSTALL_ARGS.includes('--no-telemetry'));
   assert.ok(INSTALL_ARGS.includes('--yes'));
+});
+
+test('release metadata requires the exact bundle asset consumed by the installer', () => {
+  assert.deepEqual(releaseMetadata({
+    tag_name: 'v4.3.2',
+    assets: [{ name: 'ruvnet-brain.zip', browser_download_url: 'https://example.test/brain.zip' }],
+  }), { version: '4.3.2', releaseAssetAvailable: true });
+  assert.deepEqual(releaseMetadata({ tag_name: 'v4.3.1', assets: [] }), {
+    version: '4.3.1', releaseAssetAvailable: false,
+  });
+  assert.deepEqual(releaseMetadata({
+    tag_name: 'v4.3.1',
+    assets: [{ name: 'source.zip', browser_download_url: 'https://example.test/source.zip' }],
+  }), { version: '4.3.1', releaseAssetAvailable: false });
+  assert.equal(releaseMetadata({ assets: [] }), null);
+});
+
+test('an announced release without a bundle stays visible but is not an ak sync action', () => {
+  const retained = brainReleaseRow({
+    present: true, outdated: true, installedRelease: '4.2.2-dev', latest: '4.3.1',
+    releaseAssetAvailable: false,
+  });
+  assert.equal(retained.level, 'info');
+  assert.equal(retained.fix, null, 'sync must not prescribe a download known to return 404');
+  assert.match(retained.message, /release v4\.2\.2-dev retained/);
+  assert.match(retained.message, /update deferred upstream/);
+
+  const actionable = brainReleaseRow({
+    present: true, outdated: true, installedRelease: '4.2.2-dev', latest: '4.3.2',
+    releaseAssetAvailable: true,
+  });
+  assert.equal(actionable.fix, 'sync refreshes the KB');
 });
 
 test('installedReleaseOnDisk reads SOURCE.json releaseTag — validated, v-stripped, null-safe', () => {

--- a/tests/kit/sync-command.test.mjs
+++ b/tests/kit/sync-command.test.mjs
@@ -24,7 +24,7 @@ assertSandboxed(paths, HOME);
 
 const PKG_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
 const PROJECT = sandboxProject('ak-sync');
-const FLAGS = (over = {}) => ({ 'dry-run': false, 'no-upgrade': false, json: false, ...over });
+const FLAGS = (over = {}) => ({ 'dry-run': false, 'no-upgrade': false, yes: false, json: false, ...over });
 
 function seedHome(cfg = offlineKitConfig(), pkgs = {}) {
   rmrf(paths.claudeDir(), paths.configDir(), path.join(HOME, '.config', 'opencode'));
@@ -330,10 +330,45 @@ test('an oversized RVF store is planned as a quarantine', async () => {
 });
 
 test('every documented flag is declared in the parser options', () => {
-  for (const flag of ['dry-run', 'no-upgrade', 'json']) {
+  for (const flag of ['dry-run', 'no-upgrade', 'yes', 'json']) {
     assert.ok(flag in sync.options, `--${flag} is documented in help but not parseable`);
     assert.match(sync.help, new RegExp(`--${flag}\\b`), `--${flag} is parseable but undocumented`);
   }
+});
+
+test('a noninteractive Codex repair is disclosed but not applied without --yes', async () => {
+  seedHome(offlineKitConfig({
+    integrations: {
+      version: 2, hosts: { claude: true, codex: true, opencode: false }, bindings: [], ownership: {},
+    },
+  }));
+  fs.mkdirSync(paths.codexDir(), { recursive: true });
+  fs.writeFileSync(paths.codexConfigPath(), [
+    '[mcp_servers.codex]', 'command = "codex"', 'args = ["mcp-server"]',
+  ].join('\n'));
+  const before = snapshot(HOME);
+  const prior = process.cwd();
+  process.chdir(PROJECT);
+  let result;
+  try {
+    result = await captureLog(() => sync.run({
+      flags: FLAGS({ 'no-upgrade': true }), pkgRoot: PKG_ROOT,
+      collectFn: async () => [{
+        subsystem: 'codex-mcp', level: 'fail', message: 'recursive Codex registration',
+        fix: 'remove the recursive Codex MCP registration',
+      }],
+    }));
+  } finally { process.chdir(prior); }
+  assert.equal(result.result, 1);
+  assert.match(result.out, /Codex repairs need confirmation/);
+  assertUnchanged(before, HOME, 'unapproved Codex repair must not mutate the sandbox');
+});
+
+test('failed heal results are retained for the final convergence proof', () => {
+  const state = { applyFailures: [] };
+  sync.recordApplyFailure(state, 'ruvnet-brain', { ok: false, status: 'failed', detail: 'network unavailable' });
+  sync.recordApplyFailure(state, 'natives', { ok: true, detail: 'healthy' });
+  assert.deepEqual(state.applyFailures, [{ name: 'ruvnet-brain', detail: 'network unavailable' }]);
 });
 
 // ── opencode convergence through a REAL sync ─────────────────────────────────


### PR DESCRIPTION
## Summary

- add a read-only, host-neutral `ak audit hooks` registry for Codex, Claude Code, OpenCode, and declarative external adapters
- normalize provenance, behavior identity, compatibility, coverage gaps, trust separation, and four-class remediation authority
- add exact-version schema profiles, upstream dependency constraints, ADR-0040/0041, a DDD boundary, audit artifacts, and release-check fixtures
- preserve the prior audited runtime-drift repairs in separate commits

## Safety properties

- never executes hook or plugin code
- never changes host trust, consent, grants, or project review state
- refuses unsafe, oversized, symlinked, escaped, or identity-raced sources
- never edits generated/plugin cache files and exposes no apply flag
- unknown host versions fall back to syntax-only validation

## Brutal-honesty / Agentic-QE review

The post-implementation review found and remediated four substantive issues: a source identity race, incomplete Claude plugin provenance/default discovery, incorrect Claude `SessionEnd` budget semantics, and provider-unscoped CLI probes. Agentic-QE coverage/security analysis was cross-checked against measured Node coverage; its lexical security findings were false positives. Service-bound QE operations that would disclose nonpublic source/history were not retried after policy refusal.

## Verification

- complete `npm test` suite: pass
- typecheck, ESLint hard ceiling, Markdown lint, build/package check: pass
- focused hook audit tests: 35/35 pass
- measured hook-audit line coverage: 83.64–99.29%; core parser/reader paths: 96.87%+
- two consecutive `ak audit hooks --host all --json` runs: byte-identical
- live read-only audit: 37 sources, 100 occurrences, 96 unique behaviors, 0 invalid sources, 0 configuration issues, 0 automatic actions

## Known limits

- every provider reports explicit partial coverage where static files cannot prove runtime/organization state
- OpenCode JSONC and module behavior remain opaque; modules are never imported
- remote external manifests are not fetched by the default offline audit
- transactional healing and trust-aware approval remain deferred behind a separate decision
