### PR TITLE
feat(hooks): add host-neutral healing workflow

### DIFF
--- a/MAINTAINER.md
+++ b/MAINTAINER.md
@@ -92,7 +92,7 @@ docs/
 ```
 
 **Published tarball** = the `files` whitelist in `package.json`:
-`bin/agentic-kit.mjs`, `src/`, `claude/`, `docs/DEJA-VU.md`, `docs/HOST-SUPPORT.md`,
+`bin/agentic-kit.mjs`, `src/`, `claude/`, `docs/DEJA-VU.md`, `docs/HOST-SUPPORT.md`, `docs/HOOKS.md`,
 `docs/INSTALLATION.md`, `docs/MODELS.md`, `docs/PROVIDERS.md`, `docs/SETUP.md`,
 `docs/TROUBLESHOOTING.md`, `docs/UPGRADING.md`, `docs/CODEX-STATUSLINE.md`,
 `docs/adr/0015-managed-codex-native-statusline.md`,

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ ak models       inspect model lifecycle evidence and swap impact
                 status | refresh | diff | explain | plan
 ak host         manage execution hosts, routing, and provider bindings
                 status | pick | refresh | off
+ak audit hooks  read-only hook inventory across Codex, Claude, OpenCode, and adapters
+ak heal hooks   deterministic dry-run repair plan; explicit apply, verify, undo, recover
 ak run          execute a host-neutral activity pipeline (including explicit OpenCode routes)
                 <template> "<task>"  [--dry-run] [--route ...] [--max-concurrent N] [--timeout ms] [--json]
 ak uninstall    leave cleanly                [--dry-run] [--this-project] [--remove-ruflo]
@@ -118,6 +120,10 @@ independent package/data removal scopes.
 `ak` is the daily-driver alias; the full `agentic-kit` command is identical.
 (Heads-up if you also use AutoKitteh: its CLI is also named `ak` — the full
 command always works.)
+
+Hook healing never edits trust state, plugin caches, generated runtime copies, opaque
+OpenCode modules, or unsupported schemas. See the [hook assurance runbook](docs/HOOKS.md)
+for the preview/authorize/apply/verify/undo journey and current platform limits.
 
 <details>
 <summary>What the verbs cover</summary>

--- a/bin/agentic-kit.mjs
+++ b/bin/agentic-kit.mjs
@@ -26,6 +26,7 @@ const PORCELAIN = Object.assign(Object.create(null), {
   system: () => import('../src/commands/system.mjs'),
   about: () => import('../src/commands/about.mjs'),
   audit: () => import('../src/commands/audit.mjs'),
+  heal: () => import('../src/commands/heal.mjs'),
   run: () => import('../src/commands/run.mjs'),
   host: () => import('../src/commands/x/host.mjs'),
   uninstall: () => import('../src/commands/uninstall.mjs'),
@@ -59,6 +60,7 @@ Usage (ak = alias of agentic-kit):
   ak system          what this stack occupies on your machine   [--deep] [--json]
   ak about           what agentic-kit installs and configures, and why  [--category N]
   ak audit hooks     read-only host-neutral hook inventory + remediation plan [--host HOST] [--json]
+  ak heal hooks      dry-run hook healing plan; explicit apply/verify/undo     [--host HOST] [--json]
   ak run             execute a host-neutral activity pipeline  [template "task"] [--dry-run]
   ak host            manage agent hosts, routing, and provider bindings  [status|pick|refresh|off]
   ak uninstall       leave cleanly                                      [--this-project] [--purge]
@@ -202,7 +204,7 @@ async function main() {
   // setup and host own complete mutation/reporting flows. Running the generic
   // nudge after a declined trust preflight could write version-cache state and
   // violate their "before any changes" boundary.
-  if (!values.json && !values['dry-run'] && !['sync', 'usage', 'models', 'setup', 'host', 'audit', 'ruflo-mcp', 'aqe-provider'].includes(cmd)) {
+  if (!values.json && !values['dry-run'] && !['sync', 'usage', 'models', 'setup', 'host', 'audit', 'heal', 'ruflo-mcp', 'aqe-provider'].includes(cmd)) {
     try {
       const { driftReport } = await import('../src/lib/versions.mjs');
       for (const r of await driftReport()) {

--- a/config/agentic-dependency-constraints.json
+++ b/config/agentic-dependency-constraints.json
@@ -1,38 +1,114 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "lastVerifiedAt": "2026-09-01",
   "recheckPolicy": {
     "cadence": "weekly-and-before-upgrade",
     "staleAfterDays": 14,
-    "requirePrimarySource": true
+    "requirePrimarySource": true,
+    "onObservedRelease": true,
+    "beforeManagedUpgrade": true
   },
+  "dependencyPolicies": [
+    {
+      "dependency": "ruflo",
+      "owner": "ruvnet",
+      "issuePublication": "explicit-user-approval-required",
+      "evidenceRequired": ["installed-version", "affected-range", "minimal-reproduction", "expected-versus-observed", "artifact-digest"],
+      "workaroundPolicy": "bounded, receipt-owned, version-gated, and never applied to generated runtime caches",
+      "retestPolicy": "weekly, on observed release, and before managed upgrade",
+      "removalProof": "released artifact passes the host-neutral hook and lifecycle conformance suite"
+    },
+    {
+      "dependency": "agentic-qe",
+      "owner": "proffesor-for-testing",
+      "issuePublication": "explicit-user-approval-required",
+      "evidenceRequired": ["installed-version", "affected-range", "minimal-reproduction", "expected-versus-observed", "test-receipt"],
+      "workaroundPolicy": "qualify evidence honestly; no simulated QE verdict and no provider-backed fallback without authorization",
+      "retestPolicy": "weekly, on observed release, and before managed upgrade",
+      "removalProof": "released host-neutral runner passes participant and provider conformance"
+    },
+    {
+      "dependency": "ruvnet-brain",
+      "owner": "ruvnet",
+      "issuePublication": "explicit-user-approval-required",
+      "evidenceRequired": ["installed-version", "brain-version", "doctor-output", "source-reference", "artifact-digest"],
+      "workaroundPolicy": "retain source-grounded read-only evidence; never patch versioned cache copies as authoritative source",
+      "retestPolicy": "on brain update, observed release, and before managed upgrade",
+      "removalProof": "updated brain passes doctor plus exact source-reference conformance"
+    },
+    {
+      "dependency": "ruvector",
+      "owner": "ruvnet",
+      "issuePublication": "explicit-user-approval-required",
+      "evidenceRequired": ["installed-version", "store-format", "minimal-reproduction", "artifact-digest"],
+      "workaroundPolicy": "use isolated state and bounded migration gates; never reinterpret store health as authorization",
+      "retestPolicy": "on store migration, observed release, and before managed upgrade",
+      "removalProof": "released artifact passes store integrity and migration conformance"
+    },
+    {
+      "dependency": "agentic-flow",
+      "owner": "ruvnet",
+      "issuePublication": "explicit-user-approval-required",
+      "evidenceRequired": ["installed-version", "routing-input", "selected-provider", "authorization-boundary"],
+      "workaroundPolicy": "subscription execution stays default; separately billed provider routing requires explicit opt-in",
+      "retestPolicy": "on routing-policy change, observed release, and before managed upgrade",
+      "removalProof": "released router passes authorization and routing conformance"
+    }
+  ],
   "constraints": [
     {
+      "id": "ruflo-3.38.17-3.38.18-block",
       "dependency": "ruflo",
       "kind": "blocked-version",
       "affected": ["3.38.17", "3.38.18"],
       "issue": "https://github.com/ruvnet/ruflo/issues/2885",
       "issueState": "open-at-last-verification",
+      "primaryEvidence": "upstream issue plus local host conformance failure",
       "strategy": "retain the last proven version and re-run host conformance before removing the block",
-      "sunsetWhen": "an upstream release closes the issue and passes agentic-kit's host-neutral hook and lifecycle conformance suite"
+      "versionGate": "apply only when the installed version exactly matches an affected entry",
+      "expiryPolicy": "retest within 14 days; do not silently extend stale evidence",
+      "nextRetestAt": "2026-09-08",
+      "sunsetWhen": "an upstream release closes the issue and passes agentic-kit's host-neutral hook and lifecycle conformance suite",
+      "notification": {
+        "status": "draft-only",
+        "requiredFields": ["minimalReproduction", "expected", "observed", "hostVersions", "dependencyVersion", "evidenceDigests", "boundedWorkaround", "expiry", "removalProof"]
+      }
     },
     {
+      "id": "ruflo-3x-capability-gap",
       "dependency": "ruflo",
       "kind": "upstream-capability-gap",
       "affected": ["3.x"],
       "issue": "https://github.com/ruvnet/ruflo/issues/3046",
       "issueState": "open-at-last-verification",
+      "primaryEvidence": "upstream issue plus local capability evidence",
       "strategy": "keep agentic-kit detection read-only and treat registration, health, reachability, and authorization as separate facts",
-      "sunsetWhen": "upstream exposes the required evidence and agentic-kit verifies it against a released artifact"
+      "versionGate": "treat every 3.x version as observation-only until independently verified",
+      "expiryPolicy": "retest within 14 days; do not silently extend stale evidence",
+      "nextRetestAt": "2026-09-08",
+      "sunsetWhen": "upstream exposes the required evidence and agentic-kit verifies it against a released artifact",
+      "notification": {
+        "status": "draft-only",
+        "requiredFields": ["minimalReproduction", "expected", "observed", "hostVersions", "dependencyVersion", "evidenceDigests", "boundedWorkaround", "expiry", "removalProof"]
+      }
     },
     {
+      "id": "agentic-qe-3x-host-neutral-runner-gap",
       "dependency": "agentic-qe",
       "kind": "upstream-capability-gap",
       "affected": ["3.x"],
       "issue": "https://github.com/ruvnet/agentic-qe/issues/628",
       "issueState": "open-at-last-verification",
+      "primaryEvidence": "upstream issue plus live participant/provider transport tests",
       "strategy": "qualify external-provider and cross-host results as transport evidence rather than a host-neutral QE verdict",
-      "sunsetWhen": "a released host-neutral runner passes the live participant and provider conformance tests"
+      "versionGate": "applies to 3.x until a released host-neutral runner is proven",
+      "expiryPolicy": "retest within 14 days; do not silently extend stale evidence",
+      "nextRetestAt": "2026-09-08",
+      "sunsetWhen": "a released host-neutral runner passes the live participant and provider conformance tests",
+      "notification": {
+        "status": "draft-only",
+        "requiredFields": ["minimalReproduction", "expected", "observed", "hostVersions", "dependencyVersion", "evidenceDigests", "boundedWorkaround", "expiry", "removalProof"]
+      }
     }
   ]
 }

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -1,0 +1,87 @@
+# Hook configuration assurance
+
+`ak audit hooks` inventories hook definitions without executing them. `ak heal hooks`
+turns the same evidence into a deterministic repair plan. Both commands keep host
+compatibility separate from trust, consent, grants, reachability, and organization policy.
+
+## Operator journey
+
+1. Discover and explain ownership:
+
+   ```bash
+   ak audit hooks --host all
+   ak heal hooks --host all --json
+   ```
+
+   The plan names each source, canonical owner evidence, authority class, behavior and
+   trust impact, exact host profile, proposed diff, verification method, and rollback.
+   Dry-run is the default and creates no transaction directory.
+
+2. Apply only the actions you reviewed:
+
+   ```bash
+   ak heal hooks \
+     --action <ACTION_ID> \
+     --plan-digest <PLAN_SHA256> \
+     --apply --yes
+   ```
+
+   Every action ID and the plan digest must come from the current preview. The command
+   performs a fresh audit and refuses version, profile, source, owner, parent, mode, or
+   content drift before it writes a target.
+
+3. Verify and retain the receipt. A successful apply already performs an exact-profile
+   re-audit, confirms the targeted finding cleared, rebuilds a no-action plan, and proves
+   a repeat audit/plan did not change bytes, mode, or modification time.
+
+4. Preview and perform rollback when needed:
+
+   ```bash
+   ak heal hooks --undo <RECEIPT_ID>
+   ak heal hooks --undo <RECEIPT_ID> --apply --yes
+   ```
+
+5. If a process or machine stopped mid-transaction, normal apply is blocked. Preview and
+   explicitly recover the named unfinished receipt:
+
+   ```bash
+   ak heal hooks --recover <RECEIPT_ID>
+   ak heal hooks --recover <RECEIPT_ID> --apply --yes
+   ```
+
+   Recovery validates all target and backup digests before restoring anything. It
+   refuses user drift instead of guessing.
+
+## Authority classes
+
+- `safe-automatic`: exact, semantics-preserving and canonically owned. Selection is still
+  explicit at this CLI boundary.
+- `approval-required`: a user/project source or a change requiring explicit review.
+- `upstream-required`: the authoritative repair belongs in the producing dependency.
+- `never-automatic`: generated/cache targets, opaque modules, trust bypasses, unsupported
+  schemas, unsafe files, or unproven ownership.
+
+The initial executable recipes cover only canonical user-owned JSON for exact Codex CLI
+`0.151.0` and Claude Code `2.1.258` `SessionEnd` timeout normalization. OpenCode,
+external adapters, JSONC, plugin caches, generated copies, unknown versions, and remote
+sources remain observable but non-executable. Windows receives the full plan but no
+mutation until atomic replace-existing behavior has a proven platform port.
+
+## Transactions and receipts
+
+The default transaction store is private user state. A custom `--transactions-root` must
+already be a current-user private directory; the command never changes its permissions.
+Backups and receipts are transaction-specific. Writes use bounded regular files,
+real-path containment, exclusive temporary files, file and directory synchronization,
+same-directory replacement, and immediate verification.
+
+The receipt digest detects accidental corruption or editing without resealing. It is not
+a signature and does not authenticate against the same operating-system user. Trust,
+consent, capability grants, and host permission state are never inferred or mutated.
+
+## Upstream work
+
+The audit reports registry validity, evidence freshness, and installed-version
+applicability separately. Notification payloads are drafts only. Opening or updating an
+upstream issue always requires explicit user approval, and a workaround is retired only
+after a released artifact passes the relevant conformance suite.

--- a/docs/adr/0041-host-neutral-hook-configuration-assurance.md
+++ b/docs/adr/0041-host-neutral-hook-configuration-assurance.md
@@ -1,7 +1,8 @@
 # ADR-0041 — Host-neutral hook configuration assurance
 
-- **Status:** Accepted; read-only implementation complete
+- **Status:** Accepted; transactional Wave 2 implemented
 - **Date:** 2026-09-01
+- **Updated:** 2026-09-02
 - **Deciders:** agentic-kit maintainers
 - **Extends:** [ADR-0040](0040-codex-hook-audit-and-conservative-remediation.md)
 - **Related:** [ADR-0016](0016-capability-driven-integration-adapters.md),
@@ -71,24 +72,47 @@ The initial profiles are Codex CLI `0.151.0`, Claude Code `2.1.258` and OpenCode
 fixtures agree. Host releases trigger the conformance suite before widening a range or
 adding a new exact profile.
 
-### 5. Remediation authority has four classes
+### 5. Remediation authority has four classes and an explicit writer
 
-- `automatic-eligible`: proven agentic-kit ownership, exact schema, semantics-preserving
-  change and matching preimage; still only a proposal in this read-only wave.
+- `safe-automatic`: proven agentic-kit ownership, exact schema, semantics-preserving
+  change and matching preimage.
 - `approval-required`: user/project sources or any behavioral change.
-- `prohibited`: trust bypasses, generated/cache targets, unsafe files, unknown schemas or
-  unproven canonical ownership.
 - `upstream-required`: generated dependency behavior whose authoritative repair belongs
   in the producing project.
+- `never-automatic`: trust bypasses, generated/cache targets, unsafe files, unknown
+  schemas, opaque modules or unproven canonical ownership.
 
-The implemented command has no apply flag. A future writer must satisfy ADR-0040's
-backup, preimage, rollback, receipt and idempotency contract. It may never programmatically
-approve or bypass host trust.
+`ak heal hooks` is dry-run by default. Apply requires the exact displayed action IDs,
+the exact plan digest, `--apply`, and `--yes`. Only compiled `safe-automatic` and
+`approval-required` recipes can reach the mutation port. The first recipes normalize
+the already-clamped `SessionEnd` timeout in canonical user-owned JSON for exact Codex
+`0.151.0` and Claude Code `2.1.258` profiles. The writer never approves or bypasses
+host trust.
+
+### 5a. The mutation port is transactional and recovery is explicit
+
+Before writing, the engine re-audits, rebuilds the plan, verifies exact versions and
+profiles, and checks digest, size, mode, owner, special bits, parent inode and containment
+for every selected target. It creates private transaction-specific backups, persists a
+state journal, uses same-directory atomic replacement, re-audits the result, and proves a
+second plan plus third no-op pass. A multi-target failure conditionally restores only
+targets whose bytes still equal the recorded postimage.
+
+`--undo RECEIPT` is for committed transactions. `--recover RECEIPT` is a separate,
+explicit path for interrupted journals; both are dry-run first and validate every target
+and backup before writing. Receipt hashes detect accidental corruption and unsealed
+editing, but they are not signatures or an authenticity boundary against the same user.
+Filesystem durability requires file and directory `fsync`; a failure is reported rather
+than silently called committed. Mutation is currently supported on POSIX. Windows retains
+the complete audit and plan, but replacement stays non-executable until replace-existing
+atomicity has a proven platform port.
 
 ### 6. External adapters stay declarative and independently authorized
 
 Local external manifests are validated through the existing adapter contract and their
-declared hook files are content-hashed. The audit does not import adapter code, admit the
+declared hook files are content-hashed through bounded descriptor reads with real-path,
+inode and path rechecks. Contract pins, host identity and built-in shadowing are refused
+before a normalized occurrence exists. The audit does not import adapter code, admit the
 adapter, grant capabilities or run a hook. Because the current contract does not declare
 a target host-version compatibility range, every external hook carries an explicit
 human-review proposal until a later contract version adds and validates that evidence.
@@ -99,7 +123,8 @@ human-review proposal until a later contract version adds and validates that evi
 primary issue, independently tracked issue state, bounded strategy, verification date
 and an objective sunset condition. It is not a grant store and never authorizes a patch.
 
-Constraints are rechecked weekly, before a managed upgrade, and when host/dependency
+Registry validity, evidence freshness and installed-version applicability are distinct
+fields. Constraints are rechecked weekly, before a managed upgrade, and when host/dependency
 release automation observes a new version. A workaround is removed only after a released
 artifact passes the relevant host-neutral audit and conformance tests. Issue closure alone
 does not prove a fix; an open issue does not by itself prove the installed version is
@@ -122,6 +147,8 @@ affected.
 - Exact profiles require maintenance when hosts release.
 - External adapter compatibility cannot be complete until its versioned contract grows a
   target-host range.
+- A same-user receipt digest is integrity evidence, not third-party authenticity.
+- Windows healing remains a visible non-executable plan until atomic replacement is proven.
 
 ## Implementation status
 
@@ -137,10 +164,15 @@ Implemented in this decision:
 - adversarial cross-host fixtures and read-only tests.
 - post-open inode/path verification for every bounded source read;
 - Claude optional-manifest plugin provenance and host-specific `SessionEnd` budget rules.
+- deterministic public plans with content-bound private candidates;
+- explicit `ak heal hooks` apply, undo and interrupted-transaction recovery;
+- private backups, strict durability ordering, atomic replacement, guarded rollback,
+  re-audit and idempotency proof;
+- plan and receipt schemas plus tamper, drift, partial-failure and platform refusal tests;
+- bounded real-path-confined external adapter hook-file hashing.
 
-Deferred behind a separate decision and explicit approval design:
+Still deferred:
 
-- transactional apply/rollback;
 - host trust inspection or mutation;
 - JSONC normalization;
 - network retrieval of remote adapter manifests;

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -48,7 +48,7 @@ Consequences**, and cites the grounded source it rests on where relevant.
 | [0038](0038-consistent-cross-host-session-metrics.md) | Consistent cross-host session metrics | Accepted |
 | [0039](0039-prompts-intelligence.md) | Prompts intelligence: fingerprints, coaching, and layer-3 enrichment | Accepted |
 | [0040](0040-codex-hook-audit-and-conservative-remediation.md) | Codex hook audit and conservative remediation | Implemented (Codex Wave 1) |
-| [0041](0041-host-neutral-hook-configuration-assurance.md) | Host-neutral hook configuration assurance | Accepted; read-only implementation complete |
+| [0041](0041-host-neutral-hook-configuration-assurance.md) | Host-neutral hook configuration assurance | Accepted; transactional Wave 2 implemented |
 
 Theme: ADRs **0001–0006** define **dual-host LLM routing and leadership** — how `ak` lets ruflo route
 each development activity (architecture, implementation, testing, review, …) to the right host (Claude

--- a/docs/audits/host-neutral-hook-healing-2026-09-02.md
+++ b/docs/audits/host-neutral-hook-healing-2026-09-02.md
@@ -1,0 +1,103 @@
+# Host-neutral hook healing validation — 2026-09-02
+
+## Outcome
+
+The host-neutral hook audit now has a deliberately narrow healing companion. `ak heal
+hooks` is dry-run by default and can mutate only an exact, previewed, content-bound action
+after the operator repeats the action id and plan digest with `--apply --yes`. The same
+authorization model applies to undo and interrupted-transaction recovery.
+
+Executable healing is limited to verified Codex 0.151.0 and Claude Code 2.1.258
+user-owned canonical JSON `SessionEnd` timeout normalization on POSIX. OpenCode 1.18.25,
+external adapters, unknown or future versions, generated/plugin caches, JSONC, TOML,
+noncanonical JSON, Windows replacement, trust state and executable plugin modules remain
+observable but non-executable. No cache edit, trust bypass or optimistic future-version
+inheritance is permitted.
+
+## Assurance boundary
+
+Each preview binds the selected action to the source bytes, metadata, provider profile and
+complete deterministic plan. Apply repeats the audit and plan, checks exact equality,
+validates the target and parent identity, creates a private durable transaction journal,
+writes and syncs exact backups, uses same-directory atomic replacement, re-audits the
+result and records a committed receipt. A later mismatch stops before mutation.
+
+Rollback is conditional: undo refuses to overwrite later user changes, and explicit
+recovery first validates every target and backup before restoring any target. A missing,
+malformed or unfinished journal blocks a new apply as recovery-required. Multi-target
+apply uses compensating rollback; it is not presented as globally atomic.
+
+The receipt digest detects accidental or unsophisticated tampering but is not a signature
+or an authenticity claim. User-space realpath and inode checks narrow path races but cannot
+eliminate a malicious same-user directory race without native directory-fd operations.
+
+## Mechanical verification
+
+- `npm run typecheck`: pass.
+- `npm run lint`: pass with warnings only; no errors.
+- `npm run lint:cc`: pass; the two reported file-length warnings predate this change.
+- `npm run lint:md`: pass across 80 Markdown files.
+- `npm run build`: pass, including syntax checks for 266 shipped files and a 300-file
+  package inspection.
+- `npm test`: pass with exit code 0 in the repository's loopback-enabled test environment.
+- Focused Node suite: 90 tests passed, 0 failed.
+- Measured focused coverage for the new remediation boundary: `engine.mjs` 87.22% line,
+  `fs-port.mjs` 88.39%, `planner.mjs` 98.36% and `store.mjs` 86.85%. The same run measured
+  `hook-audit` files from 85.96% to 100% line coverage and `integrity.mjs` at 83.81%.
+- `git diff --check`: pass.
+
+The adversarial fixtures exercise stale plans, action substitution, duplicate actions,
+candidate tampering, source replacement, profile drift, noncanonical JSON, special/symlink
+paths, transaction-root permissions, missing and corrupt journals, backup tampering,
+partial failure, conditional undo, interrupted recovery, exact metadata restoration,
+Windows non-executability and a second-run no-op proof.
+
+## Agentic-QE review
+
+The real Agentic-QE fleet was used after implementation:
+
+- Defect prediction found no file above its defect threshold (`riskScore: 0`).
+- Narrow SAST scans found zero findings in `hook-remediation`, `adapters/integrity.mjs`
+  and `adapters/admission.mjs`.
+- The hook-audit scan produced three lexical false positives: `RegExp.exec()` was labeled
+  dynamic execution, and two static `../` import specifiers were labeled runtime path
+  traversal. Inspection confirmed that none is an executable evaluation or user-controlled
+  traversal site.
+- The repository-wide scan also matched longstanding command names, test fixtures and
+  secret-detector test strings. It is retained as triage input, not asserted as 813 real
+  vulnerabilities.
+- AQE coverage analysis explicitly reported `static-estimation`, `measured: false` and
+  confidence 0.2. Its approximately 20% estimate was therefore rejected as coverage
+  evidence in favor of Node's instrumented results above.
+- AQE's aggregate quality gate returned 18/block because it consumed the same static
+  estimate and repository-wide complexity. This is recorded as an unresolved aggregate
+  gate, not silently relabeled as a pass; the focused mechanical oracle is green.
+- AI-enhanced test generation was denied because it could transmit private source to an
+  external model service. No workaround or indirect export was attempted.
+- AQE's parallel test executor returned per-file `failed` statuses while simultaneously
+  reporting `failed: 0`; that contradictory synthetic receipt is excluded from acceptance
+  evidence. The directly executed Node suite is the test oracle.
+
+## Upstream lifecycle
+
+`config/agentic-dependency-constraints.json` is schema-versioned and separates registry
+validity, evidence freshness and installed-version applicability. Entries require unique
+ids, valid dependency references, semantic verification dates and canonical GitHub issue
+URLs; future verification dates are invalid rather than fresh.
+
+Issue payloads remain drafts. No upstream issue was published because publication is an
+external side effect and no separate approval was granted. Workarounds have objective
+sunset evidence and remain local until a released upstream artifact is independently
+verified.
+
+## Review limitations
+
+The Ruflo swarm completed architecture, compatibility and QE-design reviews. Claude Code
+was unavailable because the local host required login, so the cross-host participant check
+is degraded and must not be described as independent dual-host acceptance. OpenCode
+ownership evidence remains conservative at document level, which can over-prohibit a
+repair but cannot authorize an unsafe one.
+
+See [the operator guide](../HOOKS.md),
+[ADR-0041](../adr/0041-host-neutral-hook-configuration-assurance.md) and the
+[DDD boundary](../ddd/hook-configuration-assurance.md) for the lasting contracts.

--- a/docs/ddd/hook-configuration-assurance.md
+++ b/docs/ddd/hook-configuration-assurance.md
@@ -2,12 +2,13 @@
 
 ## Purpose
 
-Answer four questions without running hook code or changing trust:
+Answer five questions without running hook code or changing trust:
 
 1. Which lifecycle behaviors can each host discover?
 2. Which exact source and owner produced every occurrence?
 3. Which compatibility, security, ownership and duplication findings are proven?
 4. Which remediation authority class applies, if any?
+5. Can an explicitly selected, exact-profile repair be applied and reversed safely?
 
 ## Boundary
 
@@ -17,9 +18,10 @@ consent, capability grant or trust decision.
 
 ```text
 Project Census ────────┐
-Integration Management ├──> Hook Configuration Assurance ──> audit report / proposal
-Host binaries + files ─┘                 │
-                                        └──> no execution, no trust, no write
+Integration Management ├──> Hook Configuration Assurance ──> audit / deterministic plan
+Host binaries + files ─┘                 │                         │
+                                        │                         └──> explicit mutation port
+                                        └──> no hook execution, trust, consent, or grants
 ```
 
 ## Aggregate and value objects
@@ -38,6 +40,10 @@ host set plus source digests and exact version facts.
 - `Diagnostic`: category, severity, stable code, evidence and message.
 - `RemediationProposal`: target, expected source digest, authority class, rationale,
   behavior impact and trust impact.
+- `HealingPlan`: exact audit identity, runtime profiles, selected source preimages,
+  candidate postimages and stable action identities.
+- `HealingTransaction`: private backups, explicit authorization, action journal,
+  verification evidence and guarded rollback state.
 - `UpstreamConstraint`: dependency range, issue state, local strategy and sunset proof.
 
 ## Provider contract
@@ -67,7 +73,12 @@ manifests, not imported implementation modules.
    diagnostic dimensions.
 8. Plugin caches and generated projections are never direct healing targets.
 9. Audit results never confer trust, consent, grants, reachability or health.
-10. The read-only wave has no mutation port.
+10. Only exact action IDs bound to an exact plan digest can reach the mutation port.
+11. Every selected target passes a complete preflight and live re-audit before the first
+    backup or target write.
+12. Mutation cannot change trust, consent, grants, generated copies, caches, opaque
+    modules, JSONC, unsupported schemas or Windows targets.
+13. Receipt digests prove internal consistency, not authenticity against the same user.
 
 ## Host anti-corruption layers
 
@@ -96,8 +107,16 @@ Translates validated manifest lifecycle, execution and Agentic-QE provider subpr
 hooks. Content identity includes declared hook files. Admission, consent and grants stay
 owned by Integration Management.
 
-## Future remediation process
+## Remediation process
 
-A future command may add `plan -> apply -> verify -> undo` only through a separate
-mutation port with exact preimages, backups, atomic replacement, receipts and guarded
-rollback. The domain rejects trust bypasses and cache writes before the port is reached.
+`ak heal hooks` implements `audit -> plan -> authorize -> preflight -> backup -> apply ->
+verify -> commit`, with dry-run as the default. Undo and interrupted recovery are separate
+explicit flows. The mutation port requires exact preimages, private backups, strict
+file/directory durability, atomic same-directory replacement, per-action journal updates,
+guarded rollback, an exact-profile second audit and a byte/mode/mtime no-op proof. The
+domain rejects trust bypasses and cache writes before the port is reached.
+
+Transactions use `prepared`, `applying`, `verifying`, `committed`, `undoing`,
+`rolled-back`, and explicit failure/recovery states. A new apply refuses while an
+unfinished transaction exists. Recovery never guesses: each target must equal its
+recorded preimage or postimage, and every backup must match the receipt.

--- a/docs/schemas/agentic-dependency-constraints.schema.json
+++ b/docs/schemas/agentic-dependency-constraints.schema.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/pacphi/agentic-kit/docs/schemas/agentic-dependency-constraints.schema.json",
+  "title": "agentic-kit upstream dependency constraints",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "lastVerifiedAt", "recheckPolicy", "dependencyPolicies", "constraints"],
+  "properties": {
+    "schemaVersion": { "const": 2 },
+    "lastVerifiedAt": { "type": "string", "format": "date" },
+    "recheckPolicy": {
+      "type": "object",
+      "required": ["cadence", "staleAfterDays", "requirePrimarySource", "onObservedRelease", "beforeManagedUpgrade"],
+      "properties": {
+        "cadence": { "type": "string" },
+        "staleAfterDays": { "type": "integer", "minimum": 1 },
+        "requirePrimarySource": { "const": true },
+        "onObservedRelease": { "type": "boolean" },
+        "beforeManagedUpgrade": { "type": "boolean" }
+      }
+    },
+    "dependencyPolicies": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["dependency", "owner", "issuePublication", "evidenceRequired", "workaroundPolicy", "retestPolicy", "removalProof"],
+        "properties": {
+          "dependency": { "type": "string" },
+          "owner": { "type": "string" },
+          "issuePublication": { "const": "explicit-user-approval-required" },
+          "evidenceRequired": { "type": "array", "minItems": 1, "uniqueItems": true, "items": { "type": "string" } },
+          "workaroundPolicy": { "type": "string" },
+          "retestPolicy": { "type": "string" },
+          "removalProof": { "type": "string" }
+        }
+      }
+    },
+    "constraints": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "dependency", "kind", "affected", "issue", "issueState", "primaryEvidence", "strategy", "versionGate", "expiryPolicy", "nextRetestAt", "sunsetWhen", "notification"],
+        "properties": {
+          "id": { "type": "string" },
+          "dependency": { "type": "string" },
+          "kind": { "type": "string" },
+          "affected": { "type": "array", "minItems": 1, "uniqueItems": true, "items": { "type": "string" } },
+          "issue": { "type": "string", "pattern": "^https://github\\.com/[^/]+/[^/]+/issues/[0-9]+$" },
+          "issueState": { "enum": ["open-at-last-verification", "closed-at-last-verification"] },
+          "primaryEvidence": { "type": "string" },
+          "strategy": { "type": "string" },
+          "versionGate": { "type": "string" },
+          "expiryPolicy": { "type": "string" },
+          "nextRetestAt": { "type": "string", "format": "date" },
+          "sunsetWhen": { "type": "string" },
+          "notification": {
+            "type": "object",
+            "required": ["status", "requiredFields"],
+            "properties": {
+              "status": { "const": "draft-only" },
+              "requiredFields": { "type": "array", "minItems": 1, "uniqueItems": true, "items": { "type": "string" } }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/schemas/hook-healing-plan.schema.json
+++ b/docs/schemas/hook-healing-plan.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/pacphi/agentic-kit/docs/schemas/hook-healing-plan.schema.json",
+  "title": "agentic-kit public hook healing plan",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "auditId", "planDigest", "hosts", "runtimeVersions", "actions", "summary", "upstream"],
+  "properties": {
+    "schemaVersion": { "const": "hook-heal-plan/v1" },
+    "auditId": { "type": "string", "minLength": 1 },
+    "planDigest": { "$ref": "#/$defs/sha256" },
+    "hosts": { "type": "array", "uniqueItems": true, "items": { "enum": ["codex", "claude", "opencode", "external"] } },
+    "runtimeVersions": { "type": "object", "additionalProperties": { "type": "string" } },
+    "actions": { "type": "array", "items": { "$ref": "#/$defs/action" } },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["total", "executable", "safeAutomatic", "approvalRequired", "upstreamRequired", "neverAutomatic"],
+      "properties": {
+        "total": { "type": "integer", "minimum": 0 },
+        "executable": { "type": "integer", "minimum": 0 },
+        "safeAutomatic": { "type": "integer", "minimum": 0 },
+        "approvalRequired": { "type": "integer", "minimum": 0 },
+        "upstreamRequired": { "type": "integer", "minimum": 0 },
+        "neverAutomatic": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "upstream": { "type": "object" },
+    "unfinishedTransactions": { "type": "array", "items": { "type": "object" } }
+  },
+  "$defs": {
+    "sha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+    "image": {
+      "type": "object",
+      "required": ["sha256", "size", "mode", "modeSupported"],
+      "properties": {
+        "sha256": { "$ref": "#/$defs/sha256" },
+        "size": { "type": "integer", "minimum": 0 },
+        "mode": { "type": ["integer", "null"], "minimum": 0, "maximum": 511 },
+        "modeSupported": { "type": "boolean" }
+      }
+    },
+    "action": {
+      "type": "object",
+      "required": ["id", "host", "hostVersion", "classification", "executable", "canonicalOwnership", "behaviorImpact", "trustImpact"],
+      "properties": {
+        "id": { "type": "string", "pattern": "^hook-(heal|review)-[a-f0-9]{24}$" },
+        "host": { "type": "string", "minLength": 1 },
+        "hostVersion": { "type": "string", "minLength": 1 },
+        "classification": { "enum": ["safe-automatic", "approval-required", "upstream-required", "never-automatic"] },
+        "executable": { "type": "boolean" },
+        "canonicalOwnership": { "type": "object" },
+        "behaviorImpact": { "type": "string" },
+        "trustImpact": { "type": "string" },
+        "expectedPreimage": { "$ref": "#/$defs/image" },
+        "desiredPostimage": { "$ref": "#/$defs/image" },
+        "diff": { "type": ["string", "null"] },
+        "rollback": { "type": ["string", "null"] }
+      },
+      "allOf": [{
+        "if": { "properties": { "executable": { "const": true } }, "required": ["executable"] },
+        "then": { "required": ["recipeId", "exactProfileId", "canonicalTarget", "expectedPreimage", "desiredPostimage", "verification", "rollback", "diff"] }
+      }]
+    }
+  }
+}

--- a/docs/schemas/hook-healing-receipt.schema.json
+++ b/docs/schemas/hook-healing-receipt.schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/pacphi/agentic-kit/docs/schemas/hook-healing-receipt.schema.json",
+  "title": "agentic-kit hook healing transaction receipt",
+  "type": "object",
+  "required": ["schemaVersion", "id", "createdAt", "status", "planDigest", "auditId", "authorization", "actions", "receiptDigest"],
+  "properties": {
+    "schemaVersion": { "const": "hook-heal-receipt/v1" },
+    "id": { "type": "string", "pattern": "^tx-[0-9TZ.-]+-[a-f0-9]{16}$" },
+    "createdAt": { "type": "string", "format": "date-time" },
+    "status": { "enum": ["prepared", "applying", "verifying", "committed", "undoing", "rolled-back", "failed", "failed-before-write", "failed-before-prepared-receipt", "partial", "partial-recovery-required"] },
+    "planDigest": { "$ref": "#/$defs/sha256" },
+    "auditId": { "type": "string", "minLength": 1 },
+    "authorization": {
+      "type": "object",
+      "required": ["actionIds"],
+      "properties": { "actionIds": { "type": "array", "uniqueItems": true, "items": { "type": "string" } } }
+    },
+    "actions": { "type": "array", "items": { "$ref": "#/$defs/action" } },
+    "verification": { "type": ["object", "null"] },
+    "receiptDigest": { "$ref": "#/$defs/sha256" }
+  },
+  "$defs": {
+    "sha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+    "image": {
+      "type": "object",
+      "required": ["sha256", "size", "mode", "modeSupported"],
+      "properties": {
+        "sha256": { "$ref": "#/$defs/sha256" },
+        "size": { "type": "integer", "minimum": 0 },
+        "mode": { "type": ["integer", "null"], "minimum": 0, "maximum": 511 },
+        "modeSupported": { "type": "boolean" }
+      }
+    },
+    "action": {
+      "type": "object",
+      "required": ["id", "host", "hostVersion", "recipeId", "target", "containmentRoot", "classification", "profileId", "preimage", "postimage", "backup", "state"],
+      "properties": {
+        "id": { "type": "string" },
+        "host": { "type": "string" },
+        "hostVersion": { "type": "string" },
+        "recipeId": { "type": "string" },
+        "target": { "type": "string" },
+        "containmentRoot": { "type": "string" },
+        "classification": { "enum": ["safe-automatic", "approval-required"] },
+        "profileId": { "type": "string" },
+        "preimage": { "$ref": "#/$defs/image" },
+        "postimage": { "$ref": "#/$defs/image" },
+        "backup": {
+          "type": "object",
+          "required": ["relative", "sha256", "size"],
+          "properties": {
+            "relative": { "type": "string", "pattern": "^backups[/\\\\][0-9]{4}\\.bin$" },
+            "sha256": { "$ref": "#/$defs/sha256" },
+            "size": { "type": "integer", "minimum": 0 }
+          }
+        },
+        "state": { "enum": ["prepared", "applied", "verified", "rolled-back", "rollback-drift-refused", "rollback-failed"] }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "!claude/**/.claude-flow/**",
     "docs/DEJA-VU.md",
     "docs/HOST-SUPPORT.md",
+    "docs/HOOKS.md",
     "docs/INSTALLATION.md",
     "docs/MODELS.md",
     "docs/PROVIDERS.md",

--- a/src/commands/audit.mjs
+++ b/src/commands/audit.mjs
@@ -6,6 +6,7 @@ import path from 'node:path';
 import { auditHooks, BUILTIN_HOOK_AUDIT_HOSTS } from '../lib/hook-audit/orchestrator.mjs';
 import { loadKitConfig } from '../lib/config.mjs';
 import { projectCensus, projectsInScope } from '../lib/project-census.mjs';
+import { installedVersion } from '../lib/versions.mjs';
 
 export const options = {
   json: { type: 'boolean', default: false },
@@ -33,7 +34,7 @@ Examples:
   ak audit hooks --host all --project ../another-repo --json
   ak audit hooks --all-projects --json`;
 
-function detectedVersion(binary, pattern = /(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)/) {
+export function detectedVersion(binary, pattern = /(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)/) {
   try {
     const result = spawnSync(binary, ['--version'], {
       encoding: 'utf8', timeout: 3_000, stdio: ['ignore', 'pipe', 'ignore'],
@@ -44,7 +45,7 @@ function detectedVersion(binary, pattern = /(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)/
   }
 }
 
-function selectedHosts(flags) {
+export function selectedHosts(flags) {
   const hosts = flags.host?.length ? flags.host : ['codex'];
   const unknown = hosts.filter((host) => host !== 'all' && !BUILTIN_HOOK_AUDIT_HOSTS.includes(host));
   if (unknown.length) throw new TypeError(`unknown --host value(s): ${unknown.join(', ')}`);
@@ -55,7 +56,7 @@ function includesHost(hosts, host) {
   return hosts.includes('all') || hosts.includes(host);
 }
 
-function projectRoots(flags) {
+export function projectRoots(flags) {
   const roots = new Set([process.cwd()]);
   for (const project of flags.project ?? []) roots.add(path.resolve(project));
   if (flags['all-projects']) {
@@ -64,12 +65,30 @@ function projectRoots(flags) {
   return [...roots].sort();
 }
 
-export async function run({
+export function collectHookAudit({
   flags,
-  positionals,
   detectVersionFn = detectedVersion,
   loadConfigFn = loadKitConfig,
+  dependencyVersionFn = installedVersion,
 }) {
+  const hosts = selectedHosts(flags);
+  return auditHooks({
+    hosts,
+    projectRoots: projectRoots(flags),
+    versions: {
+      ...(includesHost(hosts, 'codex') ? { codex: detectVersionFn('codex') } : {}),
+      ...(includesHost(hosts, 'claude') ? { claude: detectVersionFn('claude') } : {}),
+      ...(includesHost(hosts, 'opencode') ? { opencode: detectVersionFn('opencode') } : {}),
+    },
+    config: includesHost(hosts, 'external') ? loadConfigFn() : {},
+    upstream: { observedVersions: Object.fromEntries([
+      ['ruflo', 'ruflo'], ['agentic-qe', 'agentic-qe'], ['ruvnet-brain', 'ruvnet-brain'],
+      ['ruvector', 'ruvector'], ['agentic-flow', 'agentic-flow'],
+    ].map(([dependency, pkg]) => [dependency, dependencyVersionFn(pkg) ?? 'unknown'])) },
+  });
+}
+
+export async function run({ flags, positionals, detectVersionFn = detectedVersion, loadConfigFn = loadKitConfig }) {
   if (positionals.length !== 1 || positionals[0] !== 'hooks') {
     console.error('ak audit requires the hooks subcommand');
     console.log(help);
@@ -77,17 +96,7 @@ export async function run({
   }
   let report;
   try {
-    const hosts = selectedHosts(flags);
-    report = auditHooks({
-      hosts,
-      projectRoots: projectRoots(flags),
-      versions: {
-        ...(includesHost(hosts, 'codex') ? { codex: detectVersionFn('codex') } : {}),
-        ...(includesHost(hosts, 'claude') ? { claude: detectVersionFn('claude') } : {}),
-        ...(includesHost(hosts, 'opencode') ? { opencode: detectVersionFn('opencode') } : {}),
-      },
-      config: includesHost(hosts, 'external') ? loadConfigFn() : {},
-    });
+    report = collectHookAudit({ flags, detectVersionFn, loadConfigFn });
   } catch (error) {
     console.error(`hook audit failed: ${error.message}`);
     return 2;

--- a/src/commands/heal.mjs
+++ b/src/commands/heal.mjs
@@ -1,0 +1,166 @@
+import path from 'node:path';
+
+import { collectHookAudit } from './audit.mjs';
+import {
+  buildHookHealingPlan, publicHookHealingPlan,
+} from '../lib/hook-remediation/planner.mjs';
+import {
+  applyHookHealingPlan, previewHookHealingRecovery, previewHookHealingUndo,
+  recoverHookHealing, undoHookHealing,
+} from '../lib/hook-remediation/engine.mjs';
+import { hookHealingTransactionsDir } from '../lib/paths.mjs';
+import { unfinishedHookReceipts } from '../lib/hook-remediation/store.mjs';
+
+export const options = {
+  json: { type: 'boolean', default: false },
+  project: { type: 'string', multiple: true },
+  host: { type: 'string', multiple: true },
+  'all-projects': { type: 'boolean', default: false },
+  apply: { type: 'boolean', default: false },
+  yes: { type: 'boolean', default: false },
+  'dry-run': { type: 'boolean', default: false },
+  action: { type: 'string', multiple: true },
+  'plan-digest': { type: 'string' },
+  undo: { type: 'string' },
+  recover: { type: 'string' },
+  'transactions-root': { type: 'string' },
+};
+
+export const help = `ak heal hooks — preview, explicitly apply, verify, or undo bounded hook repairs
+
+The default is a read-only deterministic plan. Applying requires every exact action ID,
+the displayed plan digest, --apply, and --yes. Trust, consent, grants, plugin caches,
+generated runtime copies, OpenCode modules, and unsupported host schemas are never changed.
+
+Usage:
+  ak heal hooks [--host HOST] [--project PATH] [--json]
+  ak heal hooks --action ID... --plan-digest SHA --apply --yes
+  ak heal hooks --undo RECEIPT_ID [--apply --yes]
+  ak heal hooks --recover RECEIPT_ID [--apply --yes]
+
+Options:
+  --host HOST            codex, claude, opencode, external, or all (repeatable)
+  --project PATH         add an explicit project (repeatable)
+  --all-projects         include bounded project census roots
+  --action ID            select an exact executable action (repeatable)
+  --plan-digest SHA      bind apply to the exact previewed plan
+  --apply --yes          explicitly perform the selected apply or undo
+  --undo RECEIPT_ID      preview rollback; add --apply --yes to perform it
+  --recover RECEIPT_ID   preview guarded recovery of an unfinished transaction
+  --transactions-root P override the private transaction store (testing/recovery)
+  --dry-run              assert preview-only behavior (also the default)
+  --json                 emit machine-readable output
+
+Examples:
+  ak heal hooks --host all --json
+  ak heal hooks --action <ID> --plan-digest <SHA> --apply --yes
+  ak heal hooks --undo <RECEIPT_ID>
+  ak heal hooks --undo <RECEIPT_ID> --apply --yes
+  ak heal hooks --recover <RECEIPT_ID> --apply --yes`;
+
+function transactionRoot(flags) {
+  return path.resolve(flags['transactions-root'] ?? hookHealingTransactionsDir());
+}
+
+function printPlan(plan) {
+  console.log(`ak heal hooks (dry-run: ${plan.hosts.join(', ')})`);
+  console.log(`  audit: ${plan.auditId}`);
+  console.log(`  plan digest: ${plan.planDigest}`);
+  console.log(`  actions: ${plan.summary.total} (${plan.summary.executable} executable)`);
+  for (const transaction of plan.unfinishedTransactions ?? []) {
+    console.log(`  recovery required: ${transaction.id} [${transaction.status}]`);
+  }
+  for (const action of plan.actions) {
+    const target = action.canonicalTarget?.file ?? action.target;
+    console.log(`  - ${action.id} [${action.classification}] ${action.host}: ${target}`);
+    console.log(`    owner: ${action.canonicalOwnership?.status ?? 'unproven'}; executable: ${action.executable ? 'yes' : 'no'}`);
+    if (action.reason) console.log(`    why: ${action.reason}`);
+    if (action.behaviorImpact) console.log(`    behavior: ${action.behaviorImpact}`);
+    if (action.trustImpact) console.log(`    trust: ${action.trustImpact}`);
+    if (action.diff) console.log(action.diff.split('\n').map((line) => `    ${line}`).join('\n'));
+    if (action.rollback) console.log(`    rollback: ${action.rollback}`);
+  }
+  console.log('  no files changed; apply requires exact --action IDs, --plan-digest, --apply, and --yes');
+}
+
+function printResult(result, json) {
+  if (json) console.log(JSON.stringify(result, null, 2));
+  else {
+    console.log(`ak heal hooks: ${result.status}`);
+    if (result.receiptId) console.log(`  receipt: ${result.receiptId}`);
+    if (result.error) console.error(`  ${result.error}`);
+  }
+  return result.ok ? 0 : 1;
+}
+
+function validateMode(flags) {
+  if (flags.apply && flags['dry-run']) throw new TypeError('--apply and --dry-run are mutually exclusive');
+  if (flags.yes && !flags.apply) throw new TypeError('--yes requires --apply');
+  if (flags.apply && !flags.yes) throw new TypeError('--apply requires --yes');
+}
+
+export async function run({ flags, positionals, detectVersionFn, loadConfigFn }) {
+  if (positionals.length !== 1 || positionals[0] !== 'hooks') {
+    console.error('ak heal requires the hooks subcommand');
+    console.log(help);
+    return 2;
+  }
+  try { validateMode(flags); } catch (error) {
+    console.error(`hook healing refused: ${error.message}`);
+    return 2;
+  }
+  const transactionsRoot = transactionRoot(flags);
+  if (flags.undo && flags.recover) {
+    console.error('hook healing refused: --undo and --recover are mutually exclusive');
+    return 2;
+  }
+  if (flags.undo || flags.recover) {
+    if ((flags.action?.length ?? 0) || flags['plan-digest']) {
+      console.error('hook healing refused: rollback/recovery cannot be combined with plan action flags');
+      return 2;
+    }
+    const result = flags.recover
+      ? (flags.apply
+        ? recoverHookHealing({ transactionsRoot, receiptId: flags.recover })
+        : previewHookHealingRecovery({ transactionsRoot, receiptId: flags.recover }))
+      : (flags.apply
+        ? undoHookHealing({ transactionsRoot, receiptId: flags.undo })
+        : previewHookHealingUndo({ transactionsRoot, receiptId: flags.undo }));
+    return printResult(result, flags.json);
+  }
+
+  let audit;
+  let plan;
+  try {
+    const collect = () => collectHookAudit({ flags, detectVersionFn, loadConfigFn });
+    audit = collect();
+    plan = buildHookHealingPlan({ report: audit });
+    const unfinishedTransactions = unfinishedHookReceipts(transactionsRoot).map((receipt) => ({
+      id: receipt.id, status: receipt.status, createdAt: receipt.createdAt,
+    }));
+    if (!flags.apply) {
+      const publicPlan = { ...publicHookHealingPlan(plan), unfinishedTransactions };
+      if (flags.json) console.log(JSON.stringify(publicPlan, null, 2));
+      else printPlan(publicPlan);
+      return audit.summary.invalidSources || audit.summary.configurationIssues ? 1 : 0;
+    }
+    if (!flags.action?.length || !flags['plan-digest']) {
+      console.error('hook healing refused: apply requires --action and --plan-digest from a preview');
+      return 2;
+    }
+    if (unfinishedTransactions.length) {
+      throw new Error(`unfinished hook transaction(s) require --recover first: ${unfinishedTransactions.map((item) => item.id).join(', ')}`);
+    }
+    const result = applyHookHealingPlan({
+      plan,
+      actionIds: flags.action,
+      expectedPlanDigest: flags['plan-digest'],
+      transactionsRoot,
+      auditFn: collect,
+    });
+    return printResult(result, flags.json);
+  } catch (error) {
+    console.error(`hook healing failed: ${error.message}`);
+    return 2;
+  }
+}

--- a/src/lib/adapters/admission.mjs
+++ b/src/lib/adapters/admission.mjs
@@ -81,6 +81,19 @@ function checkHostIdentity(name, manifest, builtins) {
   return null;
 }
 
+/** Pure pre-consent validation shared by admission and read-only audit. */
+export function validateAdapterEntryForInspection(entry, raw, { builtins = builtinIds() } = {}) {
+  const shapeFailure = validateEntryShape(entry);
+  if (shapeFailure) return { ok: false, failure: shapeFailure };
+  const contractPinFailure = checkContractPin(entry.name, entry, raw);
+  if (contractPinFailure) return { ok: false, failure: contractPinFailure };
+  const manifestParsed = parseEntryManifest(entry.name, raw);
+  if (!manifestParsed.ok) return manifestParsed;
+  const identityFailure = checkHostIdentity(entry.name, manifestParsed.manifest, builtins);
+  if (identityFailure) return { ok: false, failure: identityFailure };
+  return { ok: true, manifest: manifestParsed.manifest };
+}
+
 function computeEntryIntegrity(name, manifest, source) {
   try {
     return { ok: true, integrity: hashAdapterContent(manifest, { baseDir: baseDirForSource(source) }) };
@@ -123,15 +136,9 @@ async function admitOne(entry, { readManifest, consent, builtins }) {
   if (!manifestRead.ok) return manifestRead.failure;
   const { raw } = manifestRead;
 
-  const contractPinFailure = checkContractPin(name, entry, raw);
-  if (contractPinFailure) return contractPinFailure;
-
-  const manifestParsed = parseEntryManifest(name, raw);
-  if (!manifestParsed.ok) return manifestParsed.failure;
-  const { manifest } = manifestParsed;
-
-  const identityFailure = checkHostIdentity(name, manifest, builtins);
-  if (identityFailure) return identityFailure;
+  const inspected = validateAdapterEntryForInspection(entry, raw, { builtins });
+  if (!inspected.ok) return inspected.failure;
+  const { manifest } = inspected;
 
   const integrityComputed = computeEntryIntegrity(name, manifest, entry.source);
   if (!integrityComputed.ok) return integrityComputed.failure;

--- a/src/lib/adapters/integrity.mjs
+++ b/src/lib/adapters/integrity.mjs
@@ -11,6 +11,8 @@ import path from 'node:path';
 
 const SCRIPT_LIKE_RE = /\.(?:mjs|cjs|js|ts|py|rb|sh|pl|exe|bat|cmd|com|ps1)$/i;
 const SCRIPT_SOURCE_RE = /\.(?:mjs|cjs|js|ts|py|rb|sh|pl|ps1)$/i;
+export const MAX_ADAPTER_HOOK_FILE_BYTES = 2 * 1024 * 1024;
+export const MAX_ADAPTER_HOOK_BUNDLE_BYTES = 8 * 1024 * 1024;
 
 export class AdapterIntegrityError extends Error {
   constructor(reason, detail) {
@@ -151,28 +153,72 @@ function adapterFilePath(baseDir, relative) {
   return candidate;
 }
 
-function digestFile(baseDir, relative) {
+function isContained(root, file) {
+  const relative = path.relative(root, file);
+  return relative === '' || (!relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative));
+}
+
+function digestFile(baseDir, relative, { fsImpl, maxFileBytes }) {
   const filename = adapterFilePath(baseDir, relative);
   let stat;
+  let realRoot;
+  let realFile;
   try {
-    stat = fs.lstatSync(filename);
+    stat = fsImpl.lstatSync(filename);
+    realRoot = fsImpl.realpathSync(baseDir);
+    realFile = fsImpl.realpathSync(filename);
   } catch (error) {
     throw new AdapterIntegrityError('hook-file-unreadable', `'${relative}' could not be read: ${error?.message ?? String(error)}`);
   }
-  if (!stat.isFile()) {
+  if (!stat.isFile() || stat.isSymbolicLink()) {
     throw new AdapterIntegrityError('hook-file-not-regular', `'${relative}' is not a regular file`);
   }
+  if (!isContained(realRoot, realFile)) {
+    throw new AdapterIntegrityError('invalid-hook-file', `'${relative}' escapes the real adapter directory`);
+  }
+  if (stat.size > maxFileBytes) {
+    throw new AdapterIntegrityError('hook-file-too-large', `'${relative}' exceeds the ${maxFileBytes} byte limit`);
+  }
+  let descriptor;
   try {
-    const bytes = fs.readFileSync(filename);
-    return createHash('sha256').update(bytes).digest('hex');
+    descriptor = fsImpl.openSync(filename, fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW ?? 0));
+    const opened = fsImpl.fstatSync(descriptor);
+    if (!opened.isFile() || opened.size > maxFileBytes) {
+      throw new AdapterIntegrityError('hook-file-not-regular', `'${relative}' is not a bounded regular file`);
+    }
+    if (opened.dev !== stat.dev || opened.ino !== stat.ino) {
+      throw new AdapterIntegrityError('hook-file-changed', `'${relative}' changed between inspection and open`);
+    }
+    if (fsImpl.realpathSync(filename) !== realFile) {
+      throw new AdapterIntegrityError('hook-file-changed', `'${relative}' changed path between inspection and open`);
+    }
+    const bytes = Buffer.alloc(opened.size);
+    let offset = 0;
+    while (offset < bytes.length) {
+      const count = fsImpl.readSync(descriptor, bytes, offset, bytes.length - offset, offset);
+      if (count === 0) break;
+      offset += count;
+    }
+    const after = fsImpl.fstatSync(descriptor);
+    if (offset !== bytes.length || after.size !== opened.size || after.dev !== opened.dev
+        || after.ino !== opened.ino || after.mtimeMs !== opened.mtimeMs) {
+      throw new AdapterIntegrityError('hook-file-changed', `'${relative}' changed while it was read`);
+    }
+    return { sha256: createHash('sha256').update(bytes).digest('hex'), size: bytes.length };
   } catch (error) {
+    if (error instanceof AdapterIntegrityError) throw error;
     throw new AdapterIntegrityError('hook-file-unreadable', `'${relative}' could not be read: ${error?.message ?? String(error)}`);
+  } finally {
+    if (descriptor !== undefined) fsImpl.closeSync(descriptor);
   }
 }
 
 /** Compute the content identity used by consent and grants. */
-/** @param {any} manifest @param {{baseDir?: string|null}} [options] */
-export function hashAdapterContent(manifest, { baseDir } = {}) {
+/** @param {any} manifest @param {{baseDir?: string|null,fsImpl?:typeof fs,maxFileBytes?:number,maxTotalBytes?:number}} [options] */
+export function hashAdapterContent(manifest, {
+  baseDir, fsImpl = fs, maxFileBytes = MAX_ADAPTER_HOOK_FILE_BYTES,
+  maxTotalBytes = MAX_ADAPTER_HOOK_BUNDLE_BYTES,
+} = {}) {
   const manifestHash = hashManifest(manifest);
   const files = declaredHookFiles(manifest);
   const commandFiles = commandFileTokens(manifest, baseDir);
@@ -195,9 +241,19 @@ export function hashAdapterContent(manifest, { baseDir } = {}) {
     }
   }
 
-  const hookFiles = files.map((relative) => ({ path: relative, sha256: digestFile(baseDir, relative) }));
+  let totalBytes = 0;
+  const hookFiles = files.map((relative) => {
+    const digest = digestFile(baseDir, relative, { fsImpl, maxFileBytes });
+    totalBytes += digest.size;
+    if (totalBytes > maxTotalBytes) {
+      throw new AdapterIntegrityError('hook-bundle-too-large', `declared hook files exceed the ${maxTotalBytes} byte bundle limit`);
+    }
+    return { path: relative, sha256: digest.sha256, size: digest.size };
+  });
   const hash = hookFiles.length
-    ? hashManifest({ manifest, hookFiles })
+    // Preserve the v1 consent identity. Size is enforcement evidence, not a
+    // hash-shape migration that would silently invalidate existing consent.
+    ? hashManifest({ manifest, hookFiles: hookFiles.map(({ path: file, sha256 }) => ({ path: file, sha256 })) })
     : manifestHash;
   return { hash, manifestHash, hookFiles };
 }

--- a/src/lib/hook-audit/common.mjs
+++ b/src/lib/hook-audit/common.mjs
@@ -84,19 +84,26 @@ export function redactCommand(value) {
 }
 
 export function commandFacts(command) {
-  const normalized = typeof command === 'string' ? command.trim() : '';
-  const redacted = redactCommand(normalized);
+  const argv = Array.isArray(command) ? command.map((value) => String(value)) : null;
+  const normalized = argv ? stableJson(argv) : typeof command === 'string' ? command.trim() : '';
+  const redacted = argv
+    ? stableJson(argv.map((value) => redactCommand(value)))
+    : redactCommand(normalized);
+  const scanText = argv ? argv.join(' ') : normalized;
   return {
     normalized: redacted,
     digest: sha256(normalized),
-    shell: /(?:^|[\s/])(?:env\s+)?(?:sh|bash|zsh|fish|cmd(?:\.exe)?|powershell|pwsh)(?:\s|$)|(?:&&|\|\||[|;<>`])/i.test(normalized),
-    projectDirReferences: [...new Set(normalized.match(/\$\{?[A-Z][A-Z0-9_]+/g) ?? [])].sort(),
+    kind: argv ? 'argv' : 'string',
+    shell: /(?:^|[\s/])(?:env\s+)?(?:sh|bash|zsh|fish|cmd(?:\.exe)?|powershell|pwsh)(?:\s|$)|(?:&&|\|\||[|;<>`])/i.test(scanText),
+    projectDirReferences: [...new Set(scanText.match(/\$\{?[A-Z][A-Z0-9_]+/g) ?? [])].sort(),
     redacted: redacted !== normalized,
   };
 }
 
 export function sideEffectHints(command) {
-  const normalized = typeof command === 'string' ? command.trim() : '';
+  const normalized = Array.isArray(command)
+    ? command.map((value) => String(value)).join(' ')
+    : typeof command === 'string' ? command.trim() : '';
   const hints = [];
   if (/\bnpx\b/.test(normalized)) hints.push('package-resolution-or-network-possible');
   if (/\b(?:gh|curl|wget)\b/.test(normalized)) hints.push('network-possible');
@@ -128,8 +135,10 @@ export function summarizeHostReport({ sources, records, plan, issues = [], cover
 }
 
 function materialHandler(handler, command, source) {
+  const commandIdentity = commandFacts(command);
   return stableValue({
-    commandDigest: command ? sha256(command) : null,
+    commandDigest: commandIdentity.digest,
+    commandKind: commandIdentity.kind,
     commandWindowsDigest: handler.commandWindows ? sha256(handler.commandWindows) : null,
     server: handler.server ?? null,
     tool: handler.tool ?? null,
@@ -161,13 +170,19 @@ export function normalizedOccurrence({
   host, event, matcher = '', type = 'command', handler = {}, source, indices = {},
   timeout = null, diagnostics = [], selected = null, risk = 'HUMAN REVIEW REQUIRED',
 } = /** @type {any} */ ({})) {
-  const command = Array.isArray(handler.command) ? handler.command.join(' ') : handler.command ?? '';
+  const command = handler.command ?? '';
   const material = {
     host, event, matcher, type,
     handler: materialHandler(handler, command, source),
     timeout,
   };
   const behaviorFingerprint = sha256(stableJson(material));
+  const rawFingerprint = sha256(stableJson(handler));
+  const occurrenceId = sha256(stableJson({
+    host, event, matcher, type, indices,
+    source: { file: source.file, digest: source.digest ?? null },
+    rawFingerprint,
+  }));
   return {
     schemaVersion: 2,
     host,
@@ -187,9 +202,10 @@ export function normalizedOccurrence({
       recommendation: 'HUMAN REVIEW REQUIRED',
       evidence: 'Audit evidence never establishes host trust or approval state',
     },
-    rawFingerprint: sha256(stableJson(handler)),
+    rawFingerprint,
     behaviorFingerprint,
     duplicateGroupId: behaviorFingerprint,
+    occurrenceId,
     diagnostics,
   };
 }

--- a/src/lib/hook-audit/index.mjs
+++ b/src/lib/hook-audit/index.mjs
@@ -18,7 +18,7 @@ const SCHEMA = Object.freeze({
   confidence: 'verified',
 });
 
-const VERIFIED_CODEX_VERSION = /^0\.151(?:\.|$)/;
+const VERIFIED_CODEX_VERSION = '0.151.0';
 const CODEX_EVENTS = new Set([
   'PreToolUse', 'PermissionRequest', 'PostToolUse', 'PreCompact', 'PostCompact',
   'UserPromptSubmit', 'SubagentStop', 'Stop', 'SessionStart', 'SubagentStart', 'SessionEnd',
@@ -29,14 +29,14 @@ const sha256 = (value) => createHash('sha256').update(value).digest('hex');
 const pointerPart = (value) => String(value).replaceAll('~', '~0').replaceAll('/', '~1');
 
 function schemaFor(codexVersion) {
-  if (VERIFIED_CODEX_VERSION.test(codexVersion)) return SCHEMA;
+  if (codexVersion === VERIFIED_CODEX_VERSION) return SCHEMA;
   return Object.freeze({
     id: 'codex-hooks-syntax-only',
     timeoutUnits: 'unknown',
     sessionEnd: { default: null, maximum: null },
     evidence: SCHEMA.evidence,
     verifiedAt: SCHEMA.verifiedAt,
-    confidence: 'unknown',
+    confidence: 'syntax-only',
   });
 }
 
@@ -61,61 +61,65 @@ function validateCommonHookFields(hook, location) {
   return null;
 }
 
-function validateHook(hook, event, groupIndex, hookIndex) {
+function validateHook(hook, event, groupIndex, hookIndex, strictProfile) {
   const location = `${event} hook ${groupIndex}/${hookIndex}`;
   if (!isRecord(hook)) return `${location} must be an object`;
   if (hook.type !== undefined && typeof hook.type !== 'string') {
     return `${location} type must be a string`;
   }
   const type = hook.type ?? 'command';
-  if (!CODEX_HANDLER_TYPES.has(type)) return `${location} has unsupported type ${type}`;
+  if (strictProfile && !CODEX_HANDLER_TYPES.has(type)) return `${location} has unsupported type ${type}`;
   if (hook.timeout !== undefined
       && (typeof hook.timeout !== 'number' || !Number.isFinite(hook.timeout) || hook.timeout < 0)) {
     return `${location} timeout must be a finite nonnegative number`;
   }
+  if (!strictProfile) return null;
   if (type === 'command'
       && (typeof hook.command !== 'string' || hook.command.trim() === '')) {
     return `${event} command hook ${groupIndex}/${hookIndex} requires a non-empty command`;
   }
-  if (type === 'mcp_tool') return validateMcpHook(hook, event, location);
+  if (type === 'mcp_tool') {
+    const mcpError = validateMcpHook(hook, event, location);
+    if (mcpError) return mcpError;
+  }
   return validateCommonHookFields(hook, location);
 }
 
-function validateHookGroup(group, event, groupIndex) {
+function validateHookGroup(group, event, groupIndex, strictProfile) {
   if (!isRecord(group)) return `${event} hook group ${groupIndex} must be an object`;
   if (group.matcher !== undefined && typeof group.matcher !== 'string') {
     return `${event} hook group ${groupIndex} matcher must be a string`;
   }
   if (!Array.isArray(group.hooks)) return `${event} hook group ${groupIndex} hooks must be an array`;
   for (const [hookIndex, hook] of group.hooks.entries()) {
-    const error = validateHook(hook, event, groupIndex, hookIndex);
+    const error = validateHook(hook, event, groupIndex, hookIndex, strictProfile);
     if (error) return error;
   }
   return null;
 }
 
-function validateHookDocument(document) {
+function validateHookDocument(document, schema) {
   if (!isRecord(document) || !isRecord(document.hooks)) {
     return 'hook JSON requires a top-level hooks object';
   }
   for (const [event, groups] of Object.entries(document.hooks)) {
-    if (!CODEX_EVENTS.has(event)) return `unsupported Codex hook event ${event}`;
+    if (schema.confidence === 'verified' && !CODEX_EVENTS.has(event)) return `unsupported Codex hook event ${event}`;
     if (!Array.isArray(groups)) return `${event} hook groups must be an array`;
     for (const [groupIndex, group] of groups.entries()) {
-      const error = validateHookGroup(group, event, groupIndex);
+      const error = validateHookGroup(group, event, groupIndex, schema.confidence === 'verified');
       if (error) return error;
     }
   }
   return null;
 }
 
-function readHookSource(file, metadata, containmentRoot) {
+function readHookSource(file, metadata, containmentRoot, schema) {
   const read = readBoundedFile(file, containmentRoot);
   if (read.status === 'absent') return null;
   if (read.status !== 'valid') return { ...metadata, file, ...read };
   try {
     const document = JSON.parse(read.text);
-    const schemaError = validateHookDocument(document);
+    const schemaError = validateHookDocument(document, schema);
     if (schemaError) return { ...metadata, file, status: 'invalid', digest: read.digest, error: `hook schema failed: ${schemaError}` };
     return { ...metadata, file, status: 'valid', digest: read.digest, document };
   } catch (error) {
@@ -254,8 +258,14 @@ function recordsFromSource(source, codexVersion, schema) {
           timeout: typeof hook.timeout === 'number' ? hook.timeout : null,
           cwd: source.baseDir ?? source.projectPath ?? path.dirname(source.file),
         });
+        const rawFingerprint = sha256(stableJson(hook));
+        const occurrenceId = sha256(stableJson({
+          host: 'codex', event, matcher, type: hook.type ?? 'command',
+          indices: { group: groupIndex, hook: hookIndex },
+          source: { file: source.file, digest: source.digest ?? null }, rawFingerprint,
+        }));
         records.push({
-          schemaVersion: 1,
+          schemaVersion: 2,
           host: 'codex',
           scope: {
             kind: source.kind,
@@ -279,6 +289,7 @@ function recordsFromSource(source, codexVersion, schema) {
             owner: posture.owner,
             authority: posture.authority,
             generatedStatus: posture.generatedStatus,
+            baseDir: source.baseDir ?? source.projectPath ?? path.dirname(source.file),
             provenanceConfidence: source.kind === 'global' || source.kind === 'global-inline' ? 'high' : source.kind.startsWith('plugin-cache') ? 'high' : 'low',
           },
           runtime: { codexCliVersion: codexVersion },
@@ -289,9 +300,10 @@ function recordsFromSource(source, codexVersion, schema) {
             recommendation: 'HUMAN REVIEW REQUIRED',
             evidence: 'Trust hashes are intentionally not inferred from project trust or compatibility state',
           },
-          rawFingerprint: sha256(JSON.stringify(hook)),
+          rawFingerprint,
           behaviorFingerprint: sha256(behaviorInput),
           duplicateGroupId: sha256(behaviorInput),
+          occurrenceId,
           diagnostics: diagnosticsFor(event, hook, source, rawCommand, schema),
         });
       });
@@ -328,23 +340,25 @@ export function auditCodexHooks({
 } = {}) {
   const schema = schemaFor(codexVersion);
   const sources = [];
-  const globalSource = readHookSource(path.join(codexHome, 'hooks.json'), { kind: 'global' }, codexHome);
+  const globalSource = readHookSource(path.join(codexHome, 'hooks.json'), {
+    kind: 'global', authority: 'user-owned', generatedStatus: 'direct', baseDir: codexHome,
+  }, codexHome, schema);
   if (globalSource) sources.push(globalSource);
   const globalInline = readCodexInlineHooks(path.join(codexHome, 'config.toml'), codexHome, {
     kind: 'global-inline', authority: 'user-owned', generatedStatus: 'direct', baseDir: codexHome,
   });
   if (globalInline) {
-    const error = globalInline.status === 'valid' ? validateHookDocument(globalInline.document) : null;
+    const error = globalInline.status === 'valid' ? validateHookDocument(globalInline.document, schema) : null;
     sources.push(error ? { ...globalInline, status: 'invalid', error: `hook schema failed: ${error}` } : globalInline);
   }
   for (const projectPath of [...new Set(projectRoots.map((root) => path.resolve(root)))].sort()) {
-    const source = readHookSource(path.join(projectPath, '.codex', 'hooks.json'), { kind: 'project', projectPath }, projectPath);
+    const source = readHookSource(path.join(projectPath, '.codex', 'hooks.json'), { kind: 'project', projectPath }, projectPath, schema);
     if (source) sources.push(source);
     const inline = readCodexInlineHooks(path.join(projectPath, '.codex', 'config.toml'), projectPath, {
       kind: 'project-inline', projectPath, authority: 'project-owned', generatedStatus: 'unknown', baseDir: projectPath,
     });
     if (inline) {
-      const error = inline.status === 'valid' ? validateHookDocument(inline.document) : null;
+      const error = inline.status === 'valid' ? validateHookDocument(inline.document, schema) : null;
       sources.push(error ? { ...inline, status: 'invalid', error: `hook schema failed: ${error}` } : inline);
     }
   }
@@ -356,11 +370,11 @@ export function auditCodexHooks({
     for (const file of plugin.hookFiles) {
       const source = readHookSource(file, {
         kind: 'plugin-cache', pluginRef: plugin.ref, pluginVersion: plugin.version,
-      }, plugin.root);
+      }, plugin.root, schema);
       if (source) sources.push(source);
     }
     for (const [index, document] of (plugin.inlineHookDocuments ?? []).entries()) {
-      const schemaError = validateHookDocument(document);
+      const schemaError = validateHookDocument(document, schema);
       sources.push(schemaError ? {
         kind: 'plugin-cache-inline', pluginRef: plugin.ref, pluginVersion: plugin.version,
         file: `${plugin.manifestFile ?? `${plugin.root}/.codex-plugin/plugin.json`}#hooks/${index}`, status: 'invalid', error: schemaError,
@@ -386,8 +400,9 @@ export function auditCodexHooks({
     return result;
   });
   return {
-    schemaVersion: 1,
+    schemaVersion: 2,
     mode: 'read-only',
+    observedVersion: codexVersion,
     hostSchema: schema,
     sources: publicSources,
     records,

--- a/src/lib/hook-audit/orchestrator.mjs
+++ b/src/lib/hook-audit/orchestrator.mjs
@@ -3,6 +3,7 @@ import { auditClaudeHooks } from './providers/claude.mjs';
 import { auditOpenCodeHooks } from './providers/opencode.mjs';
 import { auditExternalHooks } from './providers/external.mjs';
 import { loadUpstreamConstraints } from './upstream.mjs';
+import { sha256, stableJson, stableValue } from './common.mjs';
 
 export const BUILTIN_HOOK_AUDIT_HOSTS = Object.freeze(['codex', 'claude', 'opencode', 'external']);
 
@@ -55,6 +56,9 @@ export function auditHooks({
   });
   if (selected.includes('external')) reports.external = auditExternalHooks({ ...external, config });
   const constraints = loadUpstreamConstraints(upstream);
+  const runtimeVersions = stableValue(Object.fromEntries(selected.map((host) => [
+    host, reports[host]?.observedVersion ?? versions[host] ?? 'unknown',
+  ])));
   const totals = Object.values(reports).reduce((summary, report) => ({
     sources: summary.sources + report.summary.sources,
     invalidSources: summary.invalidSources + report.summary.invalidSources,
@@ -70,13 +74,27 @@ export function auditHooks({
     uniqueBehaviors: 0, automaticActions: 0, approvalRequiredActions: 0,
     neverAutomaticActions: 0, upstreamRequiredActions: 0,
   });
+  const auditId = `hook-audit-${sha256(stableJson({
+    hosts: selected,
+    runtimeVersions,
+    reports: Object.fromEntries(Object.entries(reports).map(([host, report]) => [host, {
+      hostSchema: report.hostSchema,
+      sources: report.sources,
+      records: report.records,
+      plan: report.plan,
+      issues: report.issues,
+      coverage: report.coverage,
+    }])),
+    upstream: constraints,
+  })).slice(0, 32)}`;
   return {
     schemaVersion: 2, mode: 'read-only', hosts: selected, reports,
+    auditId, runtimeVersions,
     upstream: constraints,
     maintenance: {
       schemaStrategy: 'exact-version evidence profiles; unknown versions receive syntax-only validation and no automatic healing',
       releaseStrategy: 're-audit on host or dependency release, weekly for open constraints, and before every managed upgrade',
-      notificationStrategy: 'open or refresh upstream issues with minimal reproductions; retain bounded workarounds until a released artifact passes conformance',
+      notificationStrategy: 'prepare minimal upstream issue payloads; publish only after explicit user approval; retain bounded workarounds until a released artifact passes conformance',
     },
     summary: totals,
   };

--- a/src/lib/hook-audit/providers/claude.mjs
+++ b/src/lib/hook-audit/providers/claude.mjs
@@ -20,20 +20,20 @@ const MANAGED = Object.freeze({
   win32: 'C:\\Program Files\\ClaudeCode\\managed-settings.json',
 });
 
-function validateDocument(document) {
+function validateDocument(document, { strict = true } = {}) {
   if (!isRecord(document)) return 'settings must be an object';
   if (document.hooks !== undefined && !isRecord(document.hooks)) return 'settings hooks must be an object';
   for (const [event, groups] of Object.entries(document.hooks ?? {})) {
     if (!Array.isArray(groups)) return `${event} hook groups must be an array`;
     for (const [groupIndex, group] of groups.entries()) {
       if (!isRecord(group) || !Array.isArray(group.hooks)) return `${event} hook group ${groupIndex} requires a hooks array`;
-      if (group.matcher !== undefined && typeof group.matcher !== 'string') return `${event} hook group ${groupIndex} matcher must be a string`;
+      if (strict && group.matcher !== undefined && typeof group.matcher !== 'string') return `${event} hook group ${groupIndex} matcher must be a string`;
       for (const [hookIndex, hook] of group.hooks.entries()) {
-        if (!isRecord(hook) || typeof hook.type !== 'string') return `${event} hook ${groupIndex}/${hookIndex} requires a type`;
-        if (hook.timeout !== undefined && (!Number.isFinite(hook.timeout) || hook.timeout < 0)) {
+        if (!isRecord(hook) || (strict && typeof hook.type !== 'string')) return `${event} hook ${groupIndex}/${hookIndex} requires an object${strict ? ' with a type' : ''}`;
+        if (strict && hook.timeout !== undefined && (!Number.isFinite(hook.timeout) || hook.timeout < 0)) {
           return `${event} hook ${groupIndex}/${hookIndex} timeout must be a nonnegative number`;
         }
-        if (hook.type === 'command' && (typeof hook.command !== 'string' || !hook.command.trim())) {
+        if (strict && hook.type === 'command' && (typeof hook.command !== 'string' || !hook.command.trim())) {
           return `${event} command hook ${groupIndex}/${hookIndex} requires a command`;
         }
       }
@@ -42,14 +42,14 @@ function validateDocument(document) {
   return null;
 }
 
-function readSettings(file, metadata, root) {
+function readSettings(file, metadata, root, strict = true) {
   const source = readJsonSource(file, root, metadata);
   if (!source || source.status !== 'valid') return source;
-  const error = validateDocument(source.document);
+  const error = validateDocument(source.document, { strict });
   return error ? { ...source, status: 'invalid', error: `hook schema failed: ${error}` } : source;
 }
 
-function sourcesForPluginInstall(ref, install) {
+function sourcesForPluginInstall(ref, install, strict) {
   const sources = [];
   if (!isRecord(install) || typeof install.installPath !== 'string') return sources;
   const root = path.resolve(install.installPath);
@@ -69,10 +69,10 @@ function sourcesForPluginInstall(ref, install) {
     for (const value of declared) {
       if (typeof value === 'string' && value.startsWith('./')) targets.push(path.resolve(root, value));
       else if (isRecord(value)) {
-        const error = validateDocument(value);
+        const error = validateDocument(value, { strict });
         sources.push(error
-          ? { kind: 'plugin-cache-inline', pluginRef: ref, pluginVersion: install.version ?? null, file: `${manifest.file}#hooks`, status: 'invalid', error }
-          : { kind: 'plugin-cache-inline', pluginRef: ref, pluginVersion: install.version ?? null, file: `${manifest.file}#hooks`, status: 'valid', digest: sha256(stableJson(value)), document: value, baseDir: root });
+          ? { kind: 'plugin-cache-inline', pluginRef: ref, pluginVersion: install.version ?? null, authority: 'generated-runtime-copy', generatedStatus: 'generated', file: `${manifest.file}#hooks`, status: 'invalid', error }
+          : { kind: 'plugin-cache-inline', pluginRef: ref, pluginVersion: install.version ?? null, authority: 'generated-runtime-copy', generatedStatus: 'generated', file: `${manifest.file}#hooks`, status: 'valid', digest: sha256(stableJson(value)), document: value, baseDir: root });
       }
     }
   } else {
@@ -84,13 +84,13 @@ function sourcesForPluginInstall(ref, install) {
     const source = readSettings(file, {
       kind: 'plugin-cache', pluginRef: ref, pluginVersion: install.version ?? null,
       authority: 'generated-runtime-copy', generatedStatus: 'generated', baseDir: root,
-    }, root);
+    }, root, strict);
     if (source) sources.push(source);
   }
   return sources;
 }
 
-function pluginSources(claudeRoot) {
+function pluginSources(claudeRoot, strict) {
   let registry = readJsonSource(path.join(claudeRoot, 'plugins', 'installed_plugins.json'), claudeRoot, {
     kind: 'plugin-registry', authority: 'claude-managed-registry', generatedStatus: 'generated',
   });
@@ -101,7 +101,7 @@ function pluginSources(claudeRoot) {
   const sources = [];
   for (const [ref, installs] of Object.entries(registry.document.plugins)) {
     if (!Array.isArray(installs)) continue;
-    for (const install of installs) sources.push(...sourcesForPluginInstall(ref, install));
+    for (const install of installs) sources.push(...sourcesForPluginInstall(ref, install, strict));
   }
   return { registry, sources };
 }
@@ -182,15 +182,19 @@ function recordsFrom(source, version) {
 }
 
 function remediation(records) {
-  return records.filter((record) => record.diagnostics.some((item) => [
-    'probable-timeout-unit-mismatch', 'sessionend-timeout-clamped', 'plugin-sessionend-budget-not-raised',
-  ].includes(item.code))).map((record) => ({
-    id: `claude-timeout-review-${record.behaviorFingerprint.slice(0, 16)}`,
-    host: 'claude', diagnostic: 'probable-timeout-unit-mismatch', target: record.source.file,
+  return records.flatMap((record) => {
+    const diagnostic = record.diagnostics.find((item) => [
+      'probable-timeout-unit-mismatch', 'sessionend-timeout-clamped', 'plugin-sessionend-budget-not-raised',
+    ].includes(item.code));
+    if (!diagnostic) return [];
+    return [{
+    id: `claude-timeout-review-${record.occurrenceId.slice(0, 16)}`,
+    host: 'claude', diagnostic: diagnostic.code, target: record.source.file,
     classification: record.source.generatedStatus === 'generated' ? 'upstream-required' : 'approval-required',
     reason: 'Timeout units require source-owner confirmation; changing the definition can change behavior and trust state',
     trustImpact: 'definition changes require the host to re-evaluate trust or managed policy',
-  }));
+    }];
+  });
 }
 
 export function auditClaudeHooks({
@@ -199,26 +203,27 @@ export function auditClaudeHooks({
   managedSettingsFile = MANAGED[process.platform] ?? null,
   claudeVersion = 'unknown',
 } = {}) {
+  const verified = SCHEMA.verifiedVersions.includes(claudeVersion);
   const sources = [];
   const global = readSettings(path.join(claudeRoot, 'settings.json'), {
     kind: 'global', authority: 'user-owned', generatedStatus: 'direct', baseDir: claudeRoot,
-  }, claudeRoot);
+  }, claudeRoot, verified);
   if (global) sources.push(global);
   if (managedSettingsFile) {
     const managed = readSettings(managedSettingsFile, {
       kind: 'managed', authority: 'administrator-managed', generatedStatus: 'direct', baseDir: path.dirname(managedSettingsFile), selected: true,
-    }, path.dirname(managedSettingsFile));
+    }, path.dirname(managedSettingsFile), verified);
     if (managed) sources.push(managed);
   }
   for (const root of [...new Set(projectRoots.map((item) => path.resolve(item)))].sort()) {
     for (const name of ['settings.json', 'settings.local.json']) {
       const source = readSettings(path.join(root, '.claude', name), {
         kind: 'project', authority: 'project-or-user-owned', generatedStatus: 'unknown', baseDir: root,
-      }, root);
+      }, root, verified);
       if (source) sources.push(source);
     }
   }
-  const plugins = pluginSources(claudeRoot);
+  const plugins = pluginSources(claudeRoot, verified);
   if (plugins.registry) sources.push(plugins.registry);
   sources.push(...plugins.sources);
   const records = sources.flatMap((source) => recordsFrom(source, claudeVersion)).sort((a, b) => a.source.file.localeCompare(b.source.file) || a.event.localeCompare(b.event));
@@ -229,8 +234,8 @@ export function auditClaudeHooks({
   ];
   const coverage = { status: 'partial', gaps };
   return {
-    schemaVersion: 2, host: 'claude', mode: 'read-only',
-    hostSchema: { ...SCHEMA, confidence: SCHEMA.verifiedVersions.includes(claudeVersion) ? 'verified' : 'syntax-only' },
+    schemaVersion: 2, host: 'claude', mode: 'read-only', observedVersion: claudeVersion,
+    hostSchema: { ...SCHEMA, confidence: verified ? 'verified' : 'syntax-only' },
     sources: sources.map(publicSource), records, plan, issues: [], coverage,
     summary: summarizeHostReport({ sources, records, plan, coverage: coverage.status }),
   };

--- a/src/lib/hook-audit/providers/external.mjs
+++ b/src/lib/hook-audit/providers/external.mjs
@@ -1,6 +1,6 @@
 import path from 'node:path';
 
-import { validateAdapterManifest } from '../../adapters/manifest.mjs';
+import { SUPPORTED_CONTRACT, validateAdapterEntryForInspection } from '../../adapters/admission.mjs';
 import { hashAdapterContent, baseDirForSource } from '../../adapters/integrity.mjs';
 import {
   normalizedOccurrence, publicSource, readJsonSource, summarizeHostReport,
@@ -73,13 +73,17 @@ export function auditExternalHooks({ config = {}, cwd = process.cwd() } = /** @t
     sources.push(source);
     if (source.status !== 'valid') continue;
     try {
-      const manifest = validateAdapterManifest(source.document);
+      const inspected = validateAdapterEntryForInspection(entry, source.document);
+      if (!inspected.ok) {
+        source.status = 'inadmissible';
+        source.error = `${inspected.failure.reason}: ${inspected.failure.detail}`;
+        issues.push(`${name}: ${source.error}`);
+        continue;
+      }
+      const { manifest } = inspected;
       const baseDir = baseDirForSource(file);
       const integrity = hashAdapterContent(manifest, { baseDir });
       records.push(...recordsFrom({ ...source, baseDir }, manifest, integrity));
-      if (entry.contract !== undefined && entry.contract !== manifest.contract) {
-        issues.push(`${name}: configured contract ${entry.contract} does not match manifest contract ${manifest.contract}`);
-      }
     } catch (error) {
       source.status = 'invalid';
       source.error = error?.message ?? String(error);
@@ -87,11 +91,11 @@ export function auditExternalHooks({ config = {}, cwd = process.cwd() } = /** @t
   }
   records.sort((a, b) => a.host.localeCompare(b.host) || a.event.localeCompare(b.event));
   const plan = records.map((record) => ({
-    id: `external-review-${record.behaviorFingerprint.slice(0, 16)}`,
+    id: `external-review-${record.occurrenceId.slice(0, 16)}`,
     host: record.host, diagnostic: 'target-host-compatibility-unproven', target: record.source.file,
     classification: 'approval-required',
     reason: 'An operator must verify host/version compatibility, consent, grants, and the pinned hook-file identity before activation',
-    trustImpact: 'no admission, consent, grant, or execution state was changed',
+    trustImpact: 'Any manifest or declared-hook-file change would produce a new content hash and require fresh admission, consent, and grants; this audit changed none of those states',
   }));
   const gaps = [
     'Remote HTTPS and npm adapter sources are reported but never fetched during the default offline audit',
@@ -100,7 +104,7 @@ export function auditExternalHooks({ config = {}, cwd = process.cwd() } = /** @t
   ];
   const coverage = { status: 'partial', gaps };
   return {
-    schemaVersion: 2, host: 'external', mode: 'read-only', hostSchema: {
+    schemaVersion: 2, host: 'external', mode: 'read-only', observedVersion: `contract-${SUPPORTED_CONTRACT}`, hostSchema: {
       id: 'agentic-kit-host-adapter-v1', confidence: 'manifest-validated',
       evidence: 'docs/adr/0031-capability-graduation-and-upstream-requests.md', verifiedAt: '2026-09-01',
     },

--- a/src/lib/hook-audit/providers/opencode.mjs
+++ b/src/lib/hook-audit/providers/opencode.mjs
@@ -98,7 +98,7 @@ export function auditOpenCodeHooks({
   const sources = [];
   for (const name of ['opencode.json', 'opencode.jsonc']) {
     const source = readConfig(path.join(opencodeRoot, name), opencodeRoot, {
-      kind: 'global', authority: ownership?.mcp === 'ak' ? 'mixed-receipt-owned' : 'user-owned',
+      kind: 'global', authority: ownership?.mcp === 'ak' ? 'mixed-user-and-receipt-evidence' : 'user-owned',
       generatedStatus: ownership?.mcp === 'ak' ? 'partially-generated' : 'direct', baseDir: opencodeRoot,
     });
     if (source) sources.push(source);
@@ -120,9 +120,10 @@ export function auditOpenCodeHooks({
   const records = sources.flatMap((source) => [...configRecords(source), ...moduleRecords(source)])
     .sort((a, b) => a.source.file.localeCompare(b.source.file) || a.event.localeCompare(b.event));
   const plan = records.map((record) => ({
-    id: `opencode-review-${record.behaviorFingerprint.slice(0, 16)}`,
+    id: `opencode-review-${record.occurrenceId.slice(0, 16)}`,
     host: 'opencode', diagnostic: record.diagnostics[0]?.code ?? 'plugin-review', target: record.source.file,
-    classification: record.source.generatedStatus === 'partially-generated' ? 'approval-required' : 'approval-required',
+    classification: record.type === 'module-plugin' || record.source.generatedStatus === 'partially-generated'
+      ? 'prohibited' : 'approval-required',
     reason: 'OpenCode plugins execute with host-process authority; remediation requires source-owner review and a restart',
     trustImpact: 'OpenCode does not expose a Codex-style hook trust hash; OS and OpenCode permissions remain separate controls',
   }));
@@ -133,7 +134,7 @@ export function auditOpenCodeHooks({
   ];
   const coverage = { status: 'partial', gaps };
   return {
-    schemaVersion: 2, host: 'opencode', mode: 'read-only',
+    schemaVersion: 2, host: 'opencode', mode: 'read-only', observedVersion: opencodeVersion,
     hostSchema: { ...SCHEMA, confidence: SCHEMA.verifiedVersions.includes(opencodeVersion) ? 'verified' : 'syntax-only' },
     sources: sources.map(publicSource), records, plan, issues: [], coverage,
     summary: summarizeHostReport({ sources, records, plan, coverage: coverage.status }),

--- a/src/lib/hook-audit/upstream.mjs
+++ b/src/lib/hook-audit/upstream.mjs
@@ -4,28 +4,109 @@ import { fileURLToPath } from 'node:url';
 import { publicSource, readJsonSource } from './common.mjs';
 
 const defaultFile = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..', 'config', 'agentic-dependency-constraints.json');
+const ISSUE_STATES = new Set(['open-at-last-verification', 'closed-at-last-verification']);
 
-export function loadUpstreamConstraints({ file = defaultFile } = {}) {
+function validDate(value) {
+  return typeof value === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(value)
+    && Number.isFinite(Date.parse(`${value}T00:00:00Z`))
+    && new Date(`${value}T00:00:00Z`).toISOString().slice(0, 10) === value;
+}
+
+function affectedBy(version, ranges) {
+  if (typeof version !== 'string' || !version || version === 'unknown') return null;
+  return ranges.some((range) => range === version
+    || (/^\d+\.x$/.test(range) && version.startsWith(`${range.slice(0, -1)}`)));
+}
+
+export function loadUpstreamConstraints({
+  file = defaultFile, observedVersions = {}, now = () => new Date(),
+} = {}) {
   const source = readJsonSource(file, path.dirname(file), { kind: 'upstream-constraints' });
   if (!source || source.status !== 'valid') {
     return { status: source?.status ?? 'absent', source: source ? publicSource(source) : { file, status: 'absent' }, constraints: [], errors: [source?.error ?? 'constraint registry is absent'] };
   }
   const document = source.document;
   const errors = [];
-  if (document?.schemaVersion !== 1) errors.push('unsupported upstream constraint schema');
+  const asOf = now();
+  if (document?.schemaVersion !== 2) errors.push('unsupported upstream constraint schema');
   if (!Array.isArray(document?.constraints)) errors.push('constraints must be an array');
+  if (!Array.isArray(document?.dependencyPolicies)) errors.push('dependencyPolicies must be an array');
+  if (!validDate(document?.lastVerifiedAt)) errors.push('lastVerifiedAt must be an ISO date');
+  if (validDate(document?.lastVerifiedAt)
+      && Date.parse(`${document.lastVerifiedAt}T00:00:00Z`) > asOf.getTime()) {
+    errors.push('lastVerifiedAt cannot be in the future');
+  }
+  if (!Number.isInteger(document?.recheckPolicy?.staleAfterDays) || document.recheckPolicy.staleAfterDays <= 0) {
+    errors.push('recheckPolicy.staleAfterDays must be a positive integer');
+  }
+  const policyNames = new Set();
+  const dependencyPolicies = Array.isArray(document?.dependencyPolicies)
+    ? document.dependencyPolicies.filter((entry, index) => {
+      const valid = entry && typeof entry === 'object'
+        && typeof entry.dependency === 'string' && typeof entry.owner === 'string'
+        && entry.issuePublication === 'explicit-user-approval-required'
+        && Array.isArray(entry.evidenceRequired)
+        && typeof entry.workaroundPolicy === 'string'
+        && typeof entry.retestPolicy === 'string'
+        && typeof entry.removalProof === 'string';
+      if (valid && policyNames.has(entry.dependency)) errors.push(`dependency policy ${index} duplicates ${entry.dependency}`);
+      if (valid) policyNames.add(entry.dependency);
+      if (!valid) errors.push(`dependency policy ${index} is invalid`);
+      return valid;
+    }) : [];
+  const constraintIds = new Set();
   const constraints = Array.isArray(document?.constraints) ? document.constraints.filter((entry, index) => {
     const valid = entry && typeof entry === 'object'
-      && typeof entry.dependency === 'string' && typeof entry.kind === 'string'
+      && typeof entry.id === 'string' && typeof entry.dependency === 'string' && typeof entry.kind === 'string'
       && Array.isArray(entry.affected) && typeof entry.strategy === 'string'
-      && typeof entry.sunsetWhen === 'string';
+      && typeof entry.primaryEvidence === 'string' && typeof entry.versionGate === 'string'
+      && typeof entry.issue === 'string' && /^https:\/\/github\.com\/[^/]+\/[^/]+\/issues\/\d+$/.test(entry.issue)
+      && ISSUE_STATES.has(entry.issueState)
+      && typeof entry.expiryPolicy === 'string' && validDate(entry.nextRetestAt)
+      && typeof entry.sunsetWhen === 'string'
+      && entry.notification?.status === 'draft-only'
+      && Array.isArray(entry.notification?.requiredFields);
+    if (valid && constraintIds.has(entry.id)) errors.push(`constraint ${index} duplicates ${entry.id}`);
+    if (valid) constraintIds.add(entry.id);
+    if (valid && !policyNames.has(entry.dependency)) errors.push(`constraint ${index} has no dependency policy for ${entry.dependency}`);
+    if (valid && validDate(document?.lastVerifiedAt)
+        && Date.parse(`${entry.nextRetestAt}T00:00:00Z`) < Date.parse(`${document.lastVerifiedAt}T00:00:00Z`)) {
+      errors.push(`constraint ${index} nextRetestAt precedes lastVerifiedAt`);
+    }
     if (!valid) errors.push(`constraint ${index} is invalid`);
     return valid;
   }) : [];
+  const lastVerified = validDate(document?.lastVerifiedAt) ? Date.parse(`${document.lastVerifiedAt}T00:00:00Z`) : NaN;
+  const staleAfterMs = Number(document?.recheckPolicy?.staleAfterDays) * 86_400_000;
+  const registryStale = Number.isFinite(lastVerified) && Number.isFinite(staleAfterMs)
+    ? asOf.getTime() - lastVerified > staleAfterMs : true;
+  const projected = constraints.map((entry) => {
+    const observedVersion = observedVersions[entry.dependency] ?? null;
+    const applicability = affectedBy(observedVersion, entry.affected);
+    const retestOverdue = asOf.getTime() > Date.parse(`${entry.nextRetestAt}T23:59:59Z`);
+    return {
+      ...entry,
+      evidence: {
+        status: retestOverdue || registryStale ? 'stale' : 'current',
+        observedVersion,
+        applicability: applicability === null ? 'unresolved' : applicability ? 'affected' : 'not-affected',
+        reason: applicability === null
+          ? 'No installed dependency version was supplied; registry shape is not applicability proof.'
+          : 'Applicability is bound to the supplied installed version and the declared affected range.',
+      },
+      notificationDraft: {
+        status: 'draft-only', approvalRequired: true, dependency: entry.dependency,
+        constraintId: entry.id, requiredFields: entry.notification.requiredFields,
+      },
+    };
+  });
+  const evidenceStatus = projected.some((entry) => entry.evidence.status === 'stale') ? 'stale' : 'current';
   return {
-    status: errors.length ? 'invalid' : 'valid', source: publicSource(source),
+    status: errors.length ? 'invalid' : evidenceStatus === 'stale' ? 'stale' : 'valid',
+    registryStatus: errors.length ? 'invalid' : 'valid', evidenceStatus,
+    source: publicSource(source),
     lastVerifiedAt: document?.lastVerifiedAt ?? null,
     recheckPolicy: document?.recheckPolicy ?? null,
-    constraints, errors,
+    dependencyPolicies, constraints: projected, errors,
   };
 }

--- a/src/lib/hook-remediation/engine.mjs
+++ b/src/lib/hook-remediation/engine.mjs
@@ -1,0 +1,446 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import {
+  assertHookHealingPlanIntegrity, buildHookHealingPlan,
+} from './planner.mjs';
+import {
+  atomicReplaceHookTarget, inspectHookTarget, writeHookBackup,
+} from './fs-port.mjs';
+import {
+  backupFileForReceiptAction, createHookTransactionDir,
+  HOOK_HEAL_RECEIPT_SCHEMA, lastHookReceiptId, readHookReceipt,
+  writeHookReceipt,
+} from './store.mjs';
+
+function actionById(plan, id) {
+  return plan.actions.find((action) => action.id === id);
+}
+
+function sameMode(snapshot, expected) {
+  return snapshot.modeSupported === expected.modeSupported
+    && (!snapshot.modeSupported || snapshot.mode === expected.mode);
+}
+
+function sameOwnerAndParent(snapshot, expected) {
+  return snapshot.uid === (expected.uid ?? snapshot.uid)
+    && snapshot.gid === (expected.gid ?? snapshot.gid)
+    && snapshot.specialMode === (expected.specialMode ?? 0)
+    && snapshot.parent.realPath === (expected.parent?.realPath ?? snapshot.parent.realPath)
+    && snapshot.parent.dev === (expected.parent?.dev ?? snapshot.parent.dev)
+    && snapshot.parent.ino === (expected.parent?.ino ?? snapshot.parent.ino);
+}
+
+function preflight(plan, actionIds, expectedPlanDigest, options) {
+  assertHookHealingPlanIntegrity(plan);
+  if (expectedPlanDigest !== plan.planDigest) throw new Error('stale or mismatched plan digest');
+  if (!Array.isArray(actionIds) || !actionIds.length) throw new Error('at least one exact action id is required');
+  if (new Set(actionIds).size !== actionIds.length) throw new Error('duplicate action ids are not allowed');
+  const selected = [...actionIds].sort().map((id) => {
+    const action = actionById(plan, id);
+    if (!action) throw new Error(`action is not present in this plan: ${id}`);
+    if (!action.executable || !['safe-automatic', 'approval-required'].includes(action.classification)) {
+      throw new Error(`action is not executable: ${id}`);
+    }
+    return action;
+  });
+  const targets = new Set();
+  return selected.map((action) => {
+    const target = action.canonicalTarget.file;
+    if (targets.has(target)) throw new Error(`multiple selected actions target the same file: ${target}`);
+    targets.add(target);
+    const snapshot = inspectHookTarget(target, action.canonicalTarget.containmentRoot, options);
+    if (snapshot.sha256 !== action.expectedPreimage.sha256
+        || snapshot.size !== action.expectedPreimage.size) {
+      throw new Error(`preimage changed for ${target}`);
+    }
+    if (!sameMode(snapshot, action.expectedPreimage)) throw new Error(`mode changed for ${target}`);
+    if (!sameOwnerAndParent(snapshot, action.expectedPreimage)) throw new Error(`owner or parent changed for ${target}`);
+    return { action, snapshot };
+  });
+}
+
+function findingCleared(report, action) {
+  const hostReport = report.reports?.[action.host];
+  if (!hostReport
+      || hostReport.observedVersion !== action.hostVersion
+      || hostReport.hostSchema?.confidence !== 'verified'
+      || hostReport.hostSchema?.id !== action.exactProfileId) return false;
+  const source = hostReport.sources?.find((candidate) => (
+    path.resolve(candidate.file) === path.resolve(action.verification.sourceFile)
+  ));
+  if (!source || source.status !== 'valid' || source.digest !== action.desiredPostimage.sha256) return false;
+  return !hostReport.records.some((record) => (
+    path.resolve(record.source?.file ?? '') === path.resolve(action.verification.sourceFile)
+    && record.diagnostics?.some((diagnostic) => action.verification.diagnosticCodes.includes(diagnostic.code))
+  ));
+}
+
+function receiptAction(action, snapshot, backup) {
+  return {
+    id: action.id,
+    host: action.host,
+    hostVersion: action.hostVersion,
+    recipeId: action.recipeId,
+    target: action.canonicalTarget.file,
+    containmentRoot: action.canonicalTarget.containmentRoot,
+    classification: action.classification,
+    profileId: action.exactProfileId,
+    preimage: {
+      sha256: snapshot.sha256, size: snapshot.size,
+      mode: snapshot.mode, modeSupported: snapshot.modeSupported,
+      uid: snapshot.uid, gid: snapshot.gid, specialMode: snapshot.specialMode,
+      parent: snapshot.parent,
+    },
+    postimage: action.desiredPostimage,
+    backup,
+    state: 'prepared',
+  };
+}
+
+function rollbackApplied(receipt, transactionDir, receiptFile, prepared, options) {
+  let incomplete = false;
+  let journalFailure = null;
+  const journal = () => {
+    try { receipt = writeHookReceipt(receiptFile, receipt, { fsImpl: options.fsImpl }); }
+    catch (error) {
+      journalFailure = error?.message ?? String(error);
+      incomplete = true;
+    }
+  };
+  receipt.status = 'partial';
+  journal();
+  for (const item of [...prepared].reverse()) {
+    const entry = receipt.actions.find((candidate) => candidate.id === item.action.id);
+    if (!entry) { incomplete = true; continue; }
+    try {
+      const current = inspectHookTarget(item.snapshot.file, item.snapshot.containmentRoot, options);
+      const expectedMode = current.sha256 === entry.preimage.sha256 ? entry.preimage : entry.postimage;
+      if (!sameOwnerAndParent(current, entry.preimage) || !sameMode(current, expectedMode)) {
+        entry.state = 'rollback-drift-refused';
+        incomplete = true;
+        journal();
+        continue;
+      }
+      if (current.sha256 === entry.preimage.sha256) {
+        entry.state = 'rolled-back';
+        journal();
+        continue;
+      }
+      if (current.sha256 !== entry.postimage.sha256) {
+        entry.state = 'rollback-drift-refused';
+        incomplete = true;
+        journal();
+        continue;
+      }
+      const backupFile = backupFileForReceiptAction(transactionDir, entry);
+      const backup = inspectHookTarget(backupFile, transactionDir, options);
+      if (backup.sha256 !== entry.preimage.sha256 || backup.size !== entry.preimage.size) {
+        throw new Error('backup digest or size mismatch');
+      }
+      const restored = atomicReplaceHookTarget(current, backup.bytes, entry.preimage.mode, options);
+      if (restored.sha256 !== entry.preimage.sha256) throw new Error('rollback verification failed');
+      entry.state = 'rolled-back';
+    } catch (error) {
+      entry.state = 'rollback-failed';
+      entry.error = error?.message ?? String(error);
+      incomplete = true;
+    }
+    journal();
+  }
+  receipt.status = incomplete ? 'partial-recovery-required' : 'rolled-back';
+  journal();
+  return { receipt, status: journalFailure ? 'recovery-state-write-failed' : receipt.status, journalFailure };
+}
+
+export function applyHookHealingPlan({
+  plan, actionIds, expectedPlanDigest, transactionsRoot, auditFn,
+  replanFn = (report) => buildHookHealingPlan({ report }), fsImpl = fs,
+  platform = process.platform, faults = {}, now = () => new Date(),
+} = /** @type {any} */ ({})) {
+  const options = { fsImpl, platform };
+  let prepared;
+  try {
+    prepared = preflight(plan, actionIds, expectedPlanDigest, options);
+    if (typeof auditFn !== 'function') throw new Error('a read-only audit function is required for apply');
+    const liveAudit = auditFn();
+    const livePlan = replanFn(liveAudit);
+    assertHookHealingPlanIntegrity(livePlan);
+    if (livePlan.planDigest !== plan.planDigest
+        || !prepared.every((item) => livePlan.actions.some((action) => action.id === item.action.id))) {
+      throw new Error('audit or exact host profile changed after preview');
+    }
+  } catch (error) {
+    return { ok: false, status: 'preflight-refused', error: error?.message ?? String(error) };
+  }
+
+  let transaction;
+  let receipt;
+  try {
+    faults.beforeTransaction?.();
+    transaction = createHookTransactionDir(transactionsRoot, { fsImpl, now });
+    const receiptActions = [];
+    for (const [index, item] of prepared.entries()) {
+      faults.beforeBackup?.(item.action, index);
+      const backup = writeHookBackup(transaction.dir, index, item.snapshot, { fsImpl });
+      receiptActions.push(receiptAction(item.action, item.snapshot, backup));
+    }
+    receipt = {
+      schemaVersion: HOOK_HEAL_RECEIPT_SCHEMA,
+      id: transaction.id,
+      createdAt: now().toISOString(),
+      status: 'prepared',
+      planDigest: plan.planDigest,
+      auditId: plan.auditId,
+      runtimeVersions: plan.runtimeVersions,
+      authorization: {
+        mechanism: 'explicit-action-selection',
+        actionIds: prepared.map((item) => item.action.id).sort(),
+        trustMutationAuthorized: false,
+      },
+      actions: receiptActions,
+      verification: null,
+    };
+    faults.beforeReceipt?.('prepared');
+    receipt = writeHookReceipt(transaction.receiptFile, receipt, { fsImpl });
+    receipt.status = 'applying';
+    receipt = writeHookReceipt(transaction.receiptFile, receipt, { fsImpl });
+
+    for (const [index, item] of prepared.entries()) {
+      faults.beforeReplace?.(item.action, index);
+      const written = atomicReplaceHookTarget(
+        item.snapshot, item.action.candidateBytes, item.action.desiredPostimage.mode, options,
+      );
+      if (written.sha256 !== item.action.desiredPostimage.sha256) {
+        throw new Error(`postimage verification failed for ${item.snapshot.file}`);
+      }
+      const entry = receipt.actions.find((candidate) => candidate.id === item.action.id);
+      entry.state = 'applied';
+      receipt = writeHookReceipt(transaction.receiptFile, receipt, { fsImpl });
+      faults.afterReplace?.(item.action, index);
+    }
+
+    receipt.status = 'verifying';
+    receipt = writeHookReceipt(transaction.receiptFile, receipt, { fsImpl });
+    const secondAudit = auditFn();
+    if (!prepared.every((item) => findingCleared(secondAudit, item.action))) {
+      throw new Error('second audit did not prove every targeted finding cleared');
+    }
+    const secondPlan = replanFn(secondAudit);
+    if (secondPlan.actions.some((action) => prepared.some((item) => (
+      action.executable && action.canonicalTarget?.file === item.action.canonicalTarget.file
+    )))) throw new Error('second plan still contains a targeted executable action');
+    const beforeThird = prepared.map((item) => (
+      inspectHookTarget(item.snapshot.file, item.snapshot.containmentRoot, options)
+    ));
+    const thirdAudit = auditFn();
+    replanFn(thirdAudit);
+    const afterThird = prepared.map((item) => (
+      inspectHookTarget(item.snapshot.file, item.snapshot.containmentRoot, options)
+    ));
+    const idempotentNoop = beforeThird.every((before, index) => (
+      before.sha256 === afterThird[index].sha256
+      && before.size === afterThird[index].size
+      && before.mtimeMs === afterThird[index].mtimeMs
+      && sameMode(afterThird[index], before)
+    ));
+    if (!idempotentNoop) throw new Error('repeat audit/plan changed target bytes, mode, or mtime');
+    for (const entry of receipt.actions) entry.state = 'verified';
+    receipt.status = 'committed';
+    receipt.verification = {
+      targetedFindingsCleared: true,
+      exactProfilesReverified: true,
+      idempotentNoop: true,
+      trustMutationPerformed: false,
+    };
+    faults.beforeReceipt?.('committed');
+    receipt = writeHookReceipt(transaction.receiptFile, receipt, { fsImpl });
+    return {
+      ok: true, status: 'committed', receiptId: receipt.id,
+      receiptFile: transaction.receiptFile, receipt,
+    };
+  } catch (error) {
+    if (!transaction) return { ok: false, status: 'backup-refused', error: error?.message ?? String(error) };
+    if (!receipt) {
+      const failure = {
+        schemaVersion: HOOK_HEAL_RECEIPT_SCHEMA, id: transaction.id, createdAt: now().toISOString(),
+        status: 'failed-before-write', planDigest: plan.planDigest, auditId: plan.auditId,
+        runtimeVersions: plan.runtimeVersions,
+        authorization: { actionIds: [], requestedActionIds: [...actionIds].sort() },
+        actions: [], verification: null, error: error?.message ?? String(error),
+      };
+      try {
+        const saved = writeHookReceipt(transaction.receiptFile, failure, { fsImpl });
+        return {
+          ok: false, status: saved.status, error: saved.error,
+          receiptId: saved.id, receiptFile: transaction.receiptFile,
+        };
+      } catch (receiptError) {
+        return {
+          ok: false, status: 'failure-receipt-write-failed',
+          error: `${failure.error}; recovery receipt failed: ${receiptError?.message ?? String(receiptError)}`,
+          receiptId: transaction.id, receiptFile: transaction.receiptFile,
+        };
+      }
+    }
+    receipt.error = error?.message ?? String(error);
+    const rollback = rollbackApplied(receipt, transaction.dir, transaction.receiptFile, prepared, options);
+    receipt = rollback.receipt;
+    return {
+      ok: false, status: rollback.status,
+      error: rollback.journalFailure ? `${receipt.error}; recovery journal failed: ${rollback.journalFailure}` : receipt.error,
+      receiptId: receipt.id, receiptFile: transaction.receiptFile,
+    };
+  }
+}
+
+function selectedReceipt(transactionsRoot, receiptId, last, fsImpl) {
+  const selectedId = last ? lastHookReceiptId(transactionsRoot, { fsImpl }) : receiptId;
+  if (!selectedId) throw new Error('no hook receipt found');
+  return { selectedId, ...readHookReceipt(transactionsRoot, selectedId, { fsImpl }) };
+}
+
+export function undoHookHealing({
+  transactionsRoot, receiptId, last = false, fsImpl = fs, platform = process.platform,
+  now = () => new Date(),
+} = /** @type {any} */ ({})) {
+  let loaded;
+  try { loaded = selectedReceipt(transactionsRoot, receiptId, last, fsImpl); } catch (error) {
+    return { ok: false, status: 'receipt-refused', error: error?.message ?? String(error) };
+  }
+  return performReceiptRollback(loaded, {
+    allowedStatuses: ['committed', 'rolled-back'], mode: 'undo', fsImpl, platform, now,
+  });
+}
+
+function preflightReceiptRollback(receipt, dir, options) {
+  return receipt.actions.map((action) => {
+    const current = inspectHookTarget(action.target, action.containmentRoot, options);
+    const backupFile = backupFileForReceiptAction(dir, action);
+    const backup = inspectHookTarget(backupFile, dir, options);
+    if (backup.sha256 !== action.preimage.sha256 || backup.size !== action.preimage.size) {
+      throw new Error(`backup integrity failed for ${action.target}`);
+    }
+    if (!sameOwnerAndParent(current, action.preimage)) throw new Error(`owner or parent drift at ${action.target}`);
+    if (current.sha256 === action.preimage.sha256) {
+      if (!sameMode(current, action.preimage)) throw new Error(`preimage mode drift at ${action.target}`);
+      return { action, current, backup, status: 'already-restored' };
+    }
+    if (current.sha256 !== action.postimage.sha256 || !sameMode(current, action.postimage)) {
+      throw new Error(`postimage drift at ${action.target}`);
+    }
+    return { action, current, backup, status: 'ready' };
+  });
+}
+
+function performReceiptRollback(loaded, {
+  allowedStatuses, mode, fsImpl, platform, now,
+}) {
+  const { receipt, dir, file, selectedId } = loaded;
+  if (!allowedStatuses.includes(receipt.status)) {
+    return { ok: false, status: 'receipt-refused', error: `receipt status is not eligible for ${mode}: ${receipt.status}` };
+  }
+  if (receipt.status === 'rolled-back') return { ok: true, status: 'already-rolled-back', receiptId: selectedId };
+  const options = { fsImpl, platform };
+  let restorations;
+  try {
+    restorations = preflightReceiptRollback(receipt, dir, options);
+  } catch (error) {
+    return { ok: false, status: 'drift-refused', error: error?.message ?? String(error) };
+  }
+  receipt.status = 'undoing';
+  receipt.recovery = { mode, startedAt: now().toISOString(), guardedByImageDigests: true };
+  try { writeHookReceipt(file, receipt, { fsImpl }); } catch (error) {
+    return { ok: false, status: 'recovery-state-write-failed', error: error?.message ?? String(error), receiptId: selectedId };
+  }
+  try {
+    for (const restoration of restorations) {
+      const { action, current, backup } = restoration;
+      if (restoration.status === 'ready') {
+        const rechecked = inspectHookTarget(action.target, action.containmentRoot, options);
+        if (rechecked.sha256 !== current.sha256 || !sameMode(rechecked, current)
+            || !sameOwnerAndParent(rechecked, current)) {
+          throw new Error(`postimage changed before restore: ${action.target}`);
+        }
+        const restored = atomicReplaceHookTarget(rechecked, backup.bytes, action.preimage.mode, options);
+        if (restored.sha256 !== action.preimage.sha256 || !sameMode(restored, action.preimage)) {
+          throw new Error(`restore verification failed for ${action.target}`);
+        }
+      }
+      action.state = 'rolled-back';
+      writeHookReceipt(file, receipt, { fsImpl });
+    }
+    receipt.status = 'rolled-back';
+    receipt.recovery.completedAt = now().toISOString();
+    if (mode === 'undo') receipt.undo = { completedAt: receipt.recovery.completedAt, guardedByPostimage: true };
+    writeHookReceipt(file, receipt, { fsImpl });
+    return { ok: true, status: 'rolled-back', receiptId: selectedId, receiptFile: file };
+  } catch (error) {
+    receipt.status = 'partial-recovery-required';
+    receipt.recovery.error = error?.message ?? String(error);
+    try { writeHookReceipt(file, receipt, { fsImpl }); } catch (writeError) {
+      return {
+        ok: false, status: 'recovery-state-write-failed', receiptId: selectedId,
+        error: `${receipt.recovery.error}; recovery journal failed: ${writeError?.message ?? String(writeError)}`,
+      };
+    }
+    return { ok: false, status: 'partial-recovery-required', error: receipt.recovery.error, receiptId: selectedId };
+  }
+}
+
+const RECOVERABLE_STATUSES = [
+  'prepared', 'applying', 'verifying', 'undoing', 'failed', 'failed-before-write',
+  'failed-before-prepared-receipt', 'partial', 'partial-recovery-required',
+];
+
+function previewReceiptRollback(loaded, { allowedStatuses, fsImpl, platform, mode }) {
+  if (!allowedStatuses.includes(loaded.receipt.status)) {
+    return { ok: false, status: 'receipt-refused', error: `receipt status is not eligible for ${mode}: ${loaded.receipt.status}` };
+  }
+  try {
+    const actions = preflightReceiptRollback(loaded.receipt, loaded.dir, { fsImpl, platform }).map((item) => ({
+      id: item.action.id, target: item.action.target, status: item.status,
+      backupVerified: true, expectedPostimage: item.action.postimage.sha256,
+      restorePreimage: item.action.preimage.sha256,
+    }));
+    return { ok: true, status: 'dry-run', mode, receiptId: loaded.selectedId, actions };
+  } catch (error) {
+    return { ok: false, status: 'drift-refused', error: error?.message ?? String(error) };
+  }
+}
+
+export function previewHookHealingUndo({
+  transactionsRoot, receiptId, last = false, fsImpl = fs, platform = process.platform,
+} = /** @type {any} */ ({})) {
+  let loaded;
+  try { loaded = selectedReceipt(transactionsRoot, receiptId, last, fsImpl); } catch (error) {
+    return { ok: false, status: 'receipt-refused', error: error?.message ?? String(error) };
+  }
+  return previewReceiptRollback(loaded, {
+    allowedStatuses: ['committed', 'rolled-back'], fsImpl, platform, mode: 'undo',
+  });
+}
+
+export function recoverHookHealing({
+  transactionsRoot, receiptId, fsImpl = fs, platform = process.platform, now = () => new Date(),
+} = /** @type {any} */ ({})) {
+  let loaded;
+  try { loaded = selectedReceipt(transactionsRoot, receiptId, false, fsImpl); } catch (error) {
+    return { ok: false, status: 'receipt-refused', error: error?.message ?? String(error) };
+  }
+  return performReceiptRollback(loaded, {
+    allowedStatuses: RECOVERABLE_STATUSES, mode: 'interrupted-transaction-recovery', fsImpl, platform, now,
+  });
+}
+
+export function previewHookHealingRecovery({
+  transactionsRoot, receiptId, fsImpl = fs, platform = process.platform,
+} = /** @type {any} */ ({})) {
+  let loaded;
+  try { loaded = selectedReceipt(transactionsRoot, receiptId, false, fsImpl); } catch (error) {
+    return { ok: false, status: 'receipt-refused', error: error?.message ?? String(error) };
+  }
+  return previewReceiptRollback(loaded, {
+    allowedStatuses: RECOVERABLE_STATUSES, fsImpl, platform, mode: 'interrupted-transaction-recovery',
+  });
+}

--- a/src/lib/hook-remediation/fs-port.mjs
+++ b/src/lib/hook-remediation/fs-port.mjs
@@ -1,0 +1,155 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { randomBytes } from 'node:crypto';
+
+import { MAX_AUDIT_SOURCE_BYTES, sha256 } from '../hook-audit/common.mjs';
+
+export const MAX_HOOK_TARGET_BYTES = MAX_AUDIT_SOURCE_BYTES;
+
+function normalizedForPlatform(value, platform) {
+  return platform === 'win32' ? value.toLowerCase() : value;
+}
+
+function contained(root, file, platform = process.platform) {
+  const normalizedRoot = normalizedForPlatform(root, platform);
+  const normalizedFile = normalizedForPlatform(file, platform);
+  const relative = path.relative(normalizedRoot, normalizedFile);
+  return relative === '' || (!relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative));
+}
+
+function readDescriptor(fsImpl, descriptor, size) {
+  const bytes = Buffer.alloc(size);
+  let offset = 0;
+  while (offset < size) {
+    const count = fsImpl.readSync(descriptor, bytes, offset, size - offset, offset);
+    if (count === 0) break;
+    offset += count;
+  }
+  if (offset !== size) throw new Error('target changed while it was read');
+  return bytes;
+}
+
+export function inspectHookTarget(file, containmentRoot, {
+  fsImpl = fs, platform = process.platform, maxBytes = MAX_HOOK_TARGET_BYTES,
+} = {}) {
+  if (!path.isAbsolute(file) || !path.isAbsolute(containmentRoot)) {
+    throw new TypeError('hook target and containment root must be absolute paths');
+  }
+  let descriptor;
+  try {
+    const stat = fsImpl.lstatSync(file);
+    if (!stat.isFile() || stat.isSymbolicLink()) throw new Error('target must be a regular non-symlink file');
+    if (stat.size > maxBytes) throw new Error(`target exceeds ${maxBytes} byte limit`);
+    const realRoot = fsImpl.realpathSync(containmentRoot);
+    const realFile = fsImpl.realpathSync(file);
+    if (!contained(realRoot, realFile, platform)) throw new Error('target escapes its containment root');
+    descriptor = fsImpl.openSync(file, fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW ?? 0));
+    const opened = fsImpl.fstatSync(descriptor);
+    if (!opened.isFile() || opened.size > maxBytes) throw new Error('opened target is not a bounded regular file');
+    if (opened.dev !== stat.dev || opened.ino !== stat.ino) {
+      throw new Error('target identity changed between inspection and open');
+    }
+    const reopened = fsImpl.realpathSync(file);
+    if (reopened !== realFile || !contained(realRoot, reopened, platform)) {
+      throw new Error('target path changed between inspection and open');
+    }
+    const bytes = readDescriptor(fsImpl, descriptor, opened.size);
+    const parent = path.dirname(realFile);
+    const parentStat = fsImpl.statSync(parent);
+    return {
+      file: path.resolve(file), containmentRoot: path.resolve(containmentRoot),
+      realFile, realRoot, bytes, sha256: sha256(bytes), size: bytes.length,
+      mode: platform === 'win32' ? null : opened.mode & 0o777,
+      modeSupported: platform !== 'win32', mtimeMs: opened.mtimeMs,
+      uid: typeof opened.uid === 'number' ? opened.uid : null,
+      gid: typeof opened.gid === 'number' ? opened.gid : null,
+      specialMode: platform === 'win32' ? 0 : opened.mode & 0o7000,
+      parent: { realPath: parent, dev: parentStat.dev, ino: parentStat.ino },
+    };
+  } finally {
+    if (descriptor !== undefined) fsImpl.closeSync(descriptor);
+  }
+}
+
+function exclusiveWrite(file, bytes, mode, fsImpl) {
+  let descriptor;
+  try {
+    descriptor = fsImpl.openSync(file, 'wx', mode);
+    fsImpl.writeFileSync(descriptor, bytes);
+    if (typeof fsImpl.fsyncSync === 'function') fsImpl.fsyncSync(descriptor);
+  } finally {
+    if (descriptor !== undefined) fsImpl.closeSync(descriptor);
+  }
+}
+
+function fsyncDirectory(directory, fsImpl) {
+  if (typeof fsImpl.fsyncSync !== 'function') throw new Error('durable hook mutation requires directory fsync support');
+  let descriptor;
+  try {
+    descriptor = fsImpl.openSync(directory, fs.constants.O_RDONLY);
+    fsImpl.fsyncSync(descriptor);
+  } finally {
+    if (descriptor !== undefined) fsImpl.closeSync(descriptor);
+  }
+}
+
+export function writeHookBackup(transactionDir, index, snapshot, { fsImpl = fs } = {}) {
+  const backupsDir = path.join(transactionDir, 'backups');
+  try {
+    const existing = fsImpl.lstatSync(backupsDir);
+    if (!existing.isDirectory() || existing.isSymbolicLink()) {
+      throw new Error('backup directory must be a non-symlink directory');
+    }
+  } catch (error) {
+    if (error?.code !== 'ENOENT') throw error;
+    fsImpl.mkdirSync(backupsDir, { mode: 0o700 });
+  }
+  const backupDirectory = fsImpl.lstatSync(backupsDir);
+  if (!backupDirectory.isDirectory() || backupDirectory.isSymbolicLink()) {
+    throw new Error('backup directory became unsafe');
+  }
+  fsyncDirectory(transactionDir, fsImpl);
+  const relative = path.join('backups', `${String(index).padStart(4, '0')}.bin`);
+  const file = path.join(transactionDir, relative);
+  exclusiveWrite(file, snapshot.bytes, 0o600, fsImpl);
+  fsyncDirectory(backupsDir, fsImpl);
+  const saved = inspectHookTarget(file, transactionDir, { fsImpl });
+  if (saved.sha256 !== snapshot.sha256) throw new Error(`backup verification failed for ${snapshot.file}`);
+  return { relative, sha256: saved.sha256, size: saved.size };
+}
+
+export function atomicReplaceHookTarget(snapshot, bytes, desiredMode = snapshot.mode, {
+  fsImpl = fs, platform = process.platform,
+} = {}) {
+  if (platform === 'win32') {
+    throw new Error('hook mutation is unsupported on Windows until replace-existing atomicity is proven');
+  }
+  const current = inspectHookTarget(snapshot.file, snapshot.containmentRoot, { fsImpl, platform });
+  if (current.sha256 !== snapshot.sha256
+      || current.modeSupported !== snapshot.modeSupported
+      || (current.modeSupported && current.mode !== snapshot.mode)
+      || current.uid !== snapshot.uid || current.gid !== snapshot.gid
+      || current.specialMode !== snapshot.specialMode) {
+    throw new Error(`target changed immediately before replacement: ${snapshot.file}`);
+  }
+  const currentParent = fsImpl.statSync(path.dirname(current.realFile));
+  if (current.parent.realPath !== snapshot.parent.realPath
+      || currentParent.dev !== snapshot.parent.dev || currentParent.ino !== snapshot.parent.ino) {
+    throw new Error(`target parent changed immediately before replacement: ${snapshot.file}`);
+  }
+  const suffix = randomBytes(12).toString('hex');
+  const temporary = path.join(path.dirname(snapshot.file), `.${path.basename(snapshot.file)}.${suffix}.tmp`);
+  let renamed = false;
+  try {
+    exclusiveWrite(temporary, bytes, snapshot.modeSupported ? desiredMode : 0o600, fsImpl);
+    if (snapshot.modeSupported) fsImpl.chmodSync(temporary, desiredMode);
+    fsImpl.renameSync(temporary, snapshot.file);
+    renamed = true;
+    fsyncDirectory(path.dirname(snapshot.file), fsImpl);
+  } finally {
+    if (!renamed) {
+      try { fsImpl.rmSync(temporary, { force: true }); } catch { /* cleanup must not mask the failure */ }
+    }
+  }
+  return inspectHookTarget(snapshot.file, snapshot.containmentRoot, { fsImpl, platform });
+}

--- a/src/lib/hook-remediation/planner.mjs
+++ b/src/lib/hook-remediation/planner.mjs
@@ -1,0 +1,305 @@
+// Pure remediation planning. Provider policies may transform bytes in memory,
+// but this module never creates directories, receipts, backups, or target files.
+import path from 'node:path';
+
+import { sha256, stableJson, stableValue } from '../hook-audit/common.mjs';
+import { inspectHookTarget } from './fs-port.mjs';
+
+export const HOOK_HEAL_PLAN_SCHEMA = 'hook-heal-plan/v1';
+export const HOOK_HEAL_CLASSES = Object.freeze([
+  'safe-automatic', 'approval-required', 'upstream-required', 'never-automatic',
+]);
+
+const PROVIDER_POLICIES = Object.freeze({
+  codex: Object.freeze({
+    version: '0.151.0', sourceKind: 'global', authority: 'user-owned',
+    diagnostic: 'session-end-timeout-clamped', maximum: 3,
+    recipeId: 'codex/global-json/session-end-timeout/v1', activation: 'new-session',
+    behaviorImpact: 'No effective runtime change: Codex already clamps each selected SessionEnd timeout to 3 seconds under the exact verified profile.',
+    trustImpact: 'Codex definition review remains user-owned and may be required after the bytes change.',
+  }),
+  claude: Object.freeze({
+    version: '2.1.258', sourceKind: 'global', authority: 'user-owned',
+    diagnostic: 'sessionend-timeout-clamped', maximum: 60,
+    recipeId: 'claude/global-json/session-end-timeout/v1', activation: 'new-session',
+    behaviorImpact: 'No effective runtime change: Claude already clamps the selected settings-level SessionEnd timeout to 60 seconds under the exact verified profile.',
+    trustImpact: 'Claude permission, managed-policy, and review state remain separate and may require user review after the bytes change.',
+  }),
+  opencode: Object.freeze({ version: '1.18.25', executableRecipes: false }),
+  external: Object.freeze({ executableRecipes: false }),
+});
+
+function publicAction(action) {
+  const result = { ...action };
+  delete result.candidateBytes;
+  return stableValue(result);
+}
+
+function actionIdentity(action) {
+  const result = publicAction(action);
+  delete result.id;
+  return result;
+}
+
+function actionIdFor(action) {
+  const prefix = action.executable ? 'hook-heal' : 'hook-review';
+  return `${prefix}-${sha256(stableJson(actionIdentity(action))).slice(0, 24)}`;
+}
+
+function withActionId(action) {
+  return { ...action, id: actionIdFor(action) };
+}
+
+function planIdentity(plan) {
+  return stableValue({
+    schemaVersion: plan.schemaVersion,
+    auditId: plan.auditId,
+    hosts: plan.hosts,
+    runtimeVersions: plan.runtimeVersions,
+    actions: plan.actions.map(publicAction),
+    summary: plan.summary,
+    upstream: plan.upstream,
+  });
+}
+
+function jsonPointerFor(record) {
+  return record.source.jsonPointer
+    ?? `/hooks/${record.event}/${record.indices.group}/hooks/${record.indices.hook}`;
+}
+
+function recordsForPolicy(hostReport, policy) {
+  if (hostReport.hostSchema?.confidence !== 'verified') return [];
+  if (hostReport.observedVersion !== policy.version) return [];
+  return hostReport.records.filter((record) => (
+    record.source?.sourceKind === policy.sourceKind
+    && record.source?.authority === policy.authority
+    && record.source?.generatedStatus === 'direct'
+    && record.diagnostics?.some((diagnostic) => diagnostic.code === policy.diagnostic)
+    && record.timeout?.status === 'clamped'
+  ));
+}
+
+function compileJsonTimeoutAction(host, hostReport, records, policy, options) {
+  if (options.platform === 'win32') return null;
+  const first = records[0];
+  const target = path.resolve(first.source.file);
+  const source = hostReport.sources.find((candidate) => path.resolve(candidate.file) === target);
+  if (!source || source.status !== 'valid' || path.extname(target).toLowerCase() !== '.json') return null;
+  if (!records.every((record) => record.source.digest === first.source.digest)) return null;
+  const containmentRoot = path.resolve(first.source.baseDir ?? source.baseDir ?? path.dirname(target));
+  let snapshot;
+  try { snapshot = inspectHookTarget(target, containmentRoot, options); } catch { return null; }
+  if (snapshot.sha256 !== first.source.digest) return null;
+  let document;
+  try { document = JSON.parse(snapshot.bytes.toString('utf8')); } catch { return null; }
+  const changes = [];
+  for (const record of records) {
+    const hook = document?.hooks?.[record.event]?.[record.indices.group]?.hooks?.[record.indices.hook];
+    if (!hook || typeof hook.timeout !== 'number' || record.timeout.maximum !== policy.maximum) return null;
+    changes.push({ pointer: jsonPointerFor(record), before: hook.timeout, after: policy.maximum });
+    hook.timeout = policy.maximum;
+  }
+  const candidateBytes = Buffer.from(`${JSON.stringify(document, null, 2)}\n`);
+  const canonicalPreimage = Buffer.from(`${JSON.stringify(JSON.parse(snapshot.bytes.toString('utf8')), null, 2)}\n`);
+  if (!snapshot.bytes.equals(canonicalPreimage)) return null;
+  if (snapshot.sha256 === sha256(candidateBytes)) return null;
+  const providerActions = hostReport.plan.filter((proposal) => (
+    path.resolve(proposal.target) === target && proposal.diagnostic === policy.diagnostic
+  )).map((proposal) => proposal.id).sort();
+  const ownershipProven = snapshot.specialMode === 0
+    && (typeof process.getuid !== 'function' || snapshot.uid === process.getuid());
+  if (!ownershipProven) return null;
+  const findingKeys = records.map((record) => sha256(stableJson({
+    host, diagnostic: policy.diagnostic, target, pointer: jsonPointerFor(record),
+  }))).sort();
+  return withActionId({
+    host,
+    recipeId: policy.recipeId,
+    exactProfileId: hostReport.hostSchema.id,
+    hostVersion: hostReport.observedVersion,
+    classification: 'approval-required',
+    executable: true,
+    canonicalOwnership: {
+      status: 'proven',
+      ownerId: 'current-user', evidence: 'direct-user-source-and-filesystem-owner',
+    },
+    consumedProviderActionIds: providerActions,
+    observedProjection: {
+      file: target, sourceKind: first.source.sourceKind,
+      occurrenceIds: records.map((record) => record.occurrenceId ?? record.rawFingerprint).sort(),
+      pointers: changes.map((change) => change.pointer).sort(),
+    },
+    canonicalTarget: { file: target, containmentRoot },
+    expectedPreimage: {
+      sha256: snapshot.sha256, size: snapshot.size,
+      mode: snapshot.mode, modeSupported: snapshot.modeSupported,
+      uid: snapshot.uid, gid: snapshot.gid, specialMode: snapshot.specialMode,
+      parent: snapshot.parent,
+    },
+    desiredPostimage: {
+      sha256: sha256(candidateBytes), size: candidateBytes.length,
+      mode: snapshot.mode, modeSupported: snapshot.modeSupported,
+    },
+    behaviorImpact: policy.behaviorImpact,
+    trustImpact: policy.trustImpact,
+    activation: { restart: policy.activation, evidence: hostReport.hostSchema.evidence },
+    rollback: 'Restore the transaction-specific exact preimage only while the current digest still equals this action postimage.',
+    verification: {
+      provider: host, diagnosticCodes: [policy.diagnostic], sourceFile: target,
+      findingKeys,
+      method: 'exact-profile re-audit, second-plan no-op, then byte/mtime-stable repeat',
+      trustState: 'not-mutated-by-agentic-kit; resulting host trust state is unobserved',
+    },
+    diff: [
+      `--- ${target}`, `+++ ${target}`,
+      ...changes.flatMap((change) => [
+        `@@ ${change.pointer}/timeout @@`, `-${change.before}`, `+${change.after}`,
+      ]),
+    ].join('\n'),
+    candidateBytes,
+  });
+}
+
+function compileProvider(host, hostReport, options) {
+  const policy = PROVIDER_POLICIES[host];
+  if (!policy || policy.executableRecipes === false) return [];
+  const eligible = recordsForPolicy(hostReport, policy);
+  const groups = new Map();
+  for (const record of eligible) {
+    const key = record.source.file;
+    groups.set(key, [...(groups.get(key) ?? []), record]);
+  }
+  return [...groups.values()]
+    .map((records) => compileJsonTimeoutAction(host, hostReport, records, policy, options))
+    .filter(Boolean);
+}
+
+function healingClassification(classification) {
+  if (['automatic', 'automatic-eligible', 'safe-automatic'].includes(classification)) return 'safe-automatic';
+  if (classification === 'approval-required') return 'approval-required';
+  if (classification === 'upstream-required') return 'upstream-required';
+  return 'never-automatic';
+}
+
+function fallbackActions(report, compiled) {
+  const consumed = new Set(compiled.flatMap((action) => action.consumedProviderActionIds ?? []));
+  const actions = [];
+  for (const [host, hostReport] of Object.entries(report.reports ?? {})) {
+    for (const proposal of hostReport.plan ?? []) {
+      if (consumed.has(proposal.id)) continue;
+      const draft = {
+        host,
+        hostVersion: hostReport.observedVersion ?? 'unknown',
+        providerActionId: proposal.id,
+        classification: healingClassification(proposal.classification),
+        executable: false,
+        target: proposal.target,
+        exactProfileId: hostReport.hostSchema?.confidence === 'verified' ? hostReport.hostSchema.id : null,
+        schemaConfidence: hostReport.hostSchema?.confidence ?? 'unknown',
+        canonicalOwnership: { status: 'unproven' },
+        findingKey: sha256(stableJson({
+          host, diagnostic: proposal.diagnostic ?? 'unknown',
+          target: proposal.target, providerActionId: proposal.id,
+        })),
+        reason: proposal.reason,
+        behaviorImpact: proposal.behaviorImpact ?? 'unknown; no bounded mutation recipe was compiled',
+        trustImpact: proposal.trustImpact ?? 'unknown; no trust state is inferred or changed',
+        rollback: null,
+        diff: null,
+      };
+      actions.push(withActionId(draft));
+    }
+  }
+  return actions;
+}
+
+function summarize(actions) {
+  const count = (classification) => actions.filter((action) => action.classification === classification).length;
+  return {
+    total: actions.length,
+    executable: actions.filter((action) => action.executable).length,
+    safeAutomatic: count('safe-automatic'),
+    approvalRequired: count('approval-required'),
+    upstreamRequired: count('upstream-required'),
+    neverAutomatic: count('never-automatic'),
+  };
+}
+
+function publicUpstream(upstream = {}) {
+  return stableValue({
+    status: upstream.status ?? 'absent',
+    registryStatus: upstream.registryStatus ?? null,
+    evidenceStatus: upstream.evidenceStatus ?? null,
+    lastVerifiedAt: upstream.lastVerifiedAt ?? null,
+    recheckPolicy: upstream.recheckPolicy ?? null,
+    dependencyPolicies: upstream.dependencyPolicies ?? [],
+    constraints: upstream.constraints ?? [],
+    errors: upstream.errors ?? [],
+    issuePublication: 'payload-preparation-only; explicit user approval is required before opening or updating an issue',
+  });
+}
+
+export function recomputeHookHealingPlanDigest(plan) {
+  return sha256(stableJson(planIdentity(plan)));
+}
+
+export function assertHookHealingPlanIntegrity(plan) {
+  if (!plan || plan.schemaVersion !== HOOK_HEAL_PLAN_SCHEMA) throw new Error('unsupported hook healing plan schema');
+  if (!Array.isArray(plan.actions) || !Array.isArray(plan.hosts)) throw new Error('hook healing plan shape is invalid');
+  const ids = new Set();
+  for (const action of plan.actions) {
+    if (!HOOK_HEAL_CLASSES.includes(action.classification)) throw new Error(`invalid action classification: ${action.classification}`);
+    if (action.id !== actionIdFor(action) || ids.has(action.id)) throw new Error(`action identity is invalid: ${action.id}`);
+    ids.add(action.id);
+    if (action.executable) {
+      if (!Buffer.isBuffer(action.candidateBytes)) throw new Error(`executable action has no private candidate bytes: ${action.id}`);
+      if (sha256(action.candidateBytes) !== action.desiredPostimage?.sha256) throw new Error(`candidate digest mismatch: ${action.id}`);
+      if (!path.isAbsolute(action.canonicalTarget?.file ?? '')
+          || !path.isAbsolute(action.canonicalTarget?.containmentRoot ?? '')) {
+        throw new Error(`executable action paths are invalid: ${action.id}`);
+      }
+      if (action.canonicalOwnership?.status !== 'proven'
+          || !action.exactProfileId || !action.hostVersion
+          || !action.expectedPreimage?.sha256 || !action.desiredPostimage?.sha256) {
+        throw new Error(`executable action evidence is incomplete: ${action.id}`);
+      }
+    }
+  }
+  const expected = recomputeHookHealingPlanDigest(plan);
+  if (plan.planDigest !== expected) throw new Error('hook healing plan digest is invalid');
+  return true;
+}
+
+export function buildHookHealingPlan({ report, fsImpl, platform = process.platform } = /** @type {any} */ ({})) {
+  if (!report || report.mode !== 'read-only') throw new TypeError('a read-only hook audit report is required');
+  const options = { fsImpl, platform };
+  const compiled = Object.entries(report.reports ?? {}).flatMap(([host, hostReport]) => (
+    compileProvider(host, hostReport, options)
+  ));
+  const actions = [...compiled, ...fallbackActions(report, compiled)].sort((a, b) => a.id.localeCompare(b.id));
+  const plan = {
+    schemaVersion: HOOK_HEAL_PLAN_SCHEMA,
+    auditId: report.auditId ?? sha256(stableJson({ hosts: report.hosts, reports: report.reports })),
+    hosts: [...report.hosts],
+    runtimeVersions: stableValue(report.runtimeVersions ?? {}),
+    actions,
+    summary: summarize(actions),
+    upstream: publicUpstream(report.upstream),
+  };
+  plan.planDigest = recomputeHookHealingPlanDigest(plan);
+  return plan;
+}
+
+export function publicHookHealingPlan(plan) {
+  assertHookHealingPlanIntegrity(plan);
+  return stableValue({
+    schemaVersion: plan.schemaVersion,
+    auditId: plan.auditId,
+    planDigest: plan.planDigest,
+    hosts: plan.hosts,
+    runtimeVersions: plan.runtimeVersions,
+    actions: plan.actions.map(publicAction),
+    summary: plan.summary,
+    upstream: plan.upstream,
+  });
+}

--- a/src/lib/hook-remediation/store.mjs
+++ b/src/lib/hook-remediation/store.mjs
@@ -48,14 +48,16 @@ function ensureTransactionsRoot(transactionsRoot, fsImpl) {
       try {
         const ancestor = fsImpl.lstatSync(cursor);
         if (!ancestor.isDirectory() || ancestor.isSymbolicLink()) {
-          throw new Error(`transactions root ancestor is unsafe: ${cursor}`);
+          throw new Error(`transactions root ancestor is unsafe: ${cursor}`, { cause: error });
         }
         break;
       } catch (ancestorError) {
         if (ancestorError?.code !== 'ENOENT') throw ancestorError;
         missing.push(cursor);
         const parent = path.dirname(cursor);
-        if (parent === cursor) throw new Error('could not find a safe transactions root ancestor');
+        if (parent === cursor) {
+          throw new Error('could not find a safe transactions root ancestor', { cause: ancestorError });
+        }
         cursor = parent;
       }
     }

--- a/src/lib/hook-remediation/store.mjs
+++ b/src/lib/hook-remediation/store.mjs
@@ -1,0 +1,327 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { randomBytes } from 'node:crypto';
+
+import { MAX_AUDIT_SOURCE_BYTES, sha256, stableJson } from '../hook-audit/common.mjs';
+
+export const HOOK_HEAL_RECEIPT_SCHEMA = 'hook-heal-receipt/v1';
+const RECEIPT_ID = /^tx-[0-9TZ.-]+-[a-f0-9]{16}$/;
+const BACKUP_RELATIVE = /^backups[/\\][0-9]{4}\.bin$/;
+const RECEIPT_STATUSES = new Set([
+  'prepared', 'applying', 'verifying', 'committed', 'rolled-back',
+  'undoing', 'failed', 'failed-before-write', 'failed-before-prepared-receipt',
+  'partial', 'partial-recovery-required',
+]);
+const SHA256 = /^[a-f0-9]{64}$/;
+const ACTION_CLASSES = new Set(['safe-automatic', 'approval-required']);
+const ACTION_STATES = new Set([
+  'prepared', 'applied', 'verified', 'rolled-back', 'rollback-drift-refused', 'rollback-failed',
+]);
+
+function receiptBody(receipt) {
+  const body = { ...receipt };
+  delete body.receiptDigest;
+  return body;
+}
+
+export function sealHookReceipt(receipt) {
+  const body = receiptBody(receipt);
+  return { ...body, receiptDigest: sha256(stableJson(body)) };
+}
+
+function ensureTransactionsRoot(transactionsRoot, fsImpl) {
+  if (!path.isAbsolute(transactionsRoot)) throw new TypeError('transactions root must be absolute');
+  if (path.resolve(transactionsRoot) === path.parse(path.resolve(transactionsRoot)).root) {
+    throw new Error('filesystem root cannot be used as the transactions root');
+  }
+  let created = false;
+  try {
+    const stat = fsImpl.lstatSync(transactionsRoot);
+    if (!stat.isDirectory() || stat.isSymbolicLink()) {
+      throw new Error('transactions root must be a non-symlink directory');
+    }
+  } catch (error) {
+    if (error?.code !== 'ENOENT') throw error;
+    const missing = [];
+    let cursor = transactionsRoot;
+    while (true) {
+      try {
+        const ancestor = fsImpl.lstatSync(cursor);
+        if (!ancestor.isDirectory() || ancestor.isSymbolicLink()) {
+          throw new Error(`transactions root ancestor is unsafe: ${cursor}`);
+        }
+        break;
+      } catch (ancestorError) {
+        if (ancestorError?.code !== 'ENOENT') throw ancestorError;
+        missing.push(cursor);
+        const parent = path.dirname(cursor);
+        if (parent === cursor) throw new Error('could not find a safe transactions root ancestor');
+        cursor = parent;
+      }
+    }
+    for (const directory of missing.reverse()) {
+      fsImpl.mkdirSync(directory, { mode: 0o700 });
+      fsyncDirectoryStrict(path.dirname(directory), fsImpl);
+      fsyncDirectoryStrict(directory, fsImpl);
+    }
+    created = true;
+  }
+  const final = fsImpl.lstatSync(transactionsRoot);
+  if (!final.isDirectory() || final.isSymbolicLink()) throw new Error('transactions root creation was unsafe');
+  if (process.platform !== 'win32' && (final.mode & 0o077) !== 0) {
+    throw new Error(`transactions root must already be private (mode 0700): ${transactionsRoot}`);
+  }
+  if (typeof process.getuid === 'function' && typeof final.uid === 'number' && final.uid !== process.getuid()) {
+    throw new Error(`transactions root must be owned by the current user: ${transactionsRoot}`);
+  }
+  return { created, stat: final, realPath: fsImpl.realpathSync(transactionsRoot) };
+}
+
+export function createHookTransactionDir(transactionsRoot, { fsImpl = fs, now = () => new Date() } = {}) {
+  ensureTransactionsRoot(transactionsRoot, fsImpl);
+  for (let attempt = 0; attempt < 16; attempt += 1) {
+    const stamp = now().toISOString().replaceAll(':', '-');
+    const id = `tx-${stamp}-${randomBytes(8).toString('hex')}`;
+    const dir = path.join(transactionsRoot, id);
+    try {
+      fsImpl.mkdirSync(dir, { mode: 0o700 });
+      fsyncDirectoryStrict(transactionsRoot, fsImpl);
+      return { id, dir, receiptFile: path.join(dir, 'receipt.json') };
+    } catch (error) {
+      if (error?.code !== 'EEXIST') throw error;
+    }
+  }
+  throw new Error('could not allocate a unique hook transaction directory');
+}
+
+function writeAll(fsImpl, descriptor, bytes) {
+  let offset = 0;
+  while (offset < bytes.length) {
+    const written = fsImpl.writeSync(descriptor, bytes, offset, bytes.length - offset, offset);
+    if (written <= 0) throw new Error('receipt write made no progress');
+    offset += written;
+  }
+}
+
+function fsyncDirectoryStrict(directory, fsImpl) {
+  if (typeof fsImpl.fsyncSync !== 'function') throw new Error('receipt durability requires fsync support');
+  let descriptor;
+  try {
+    descriptor = fsImpl.openSync(directory, fs.constants.O_RDONLY);
+    fsImpl.fsyncSync(descriptor);
+  } finally {
+    if (descriptor !== undefined) fsImpl.closeSync(descriptor);
+  }
+}
+
+function writeReceiptAtomic(receiptFile, bytes, fsImpl) {
+  if (!path.isAbsolute(receiptFile) || path.basename(receiptFile) !== 'receipt.json') {
+    throw new TypeError('receipt path must be an absolute transaction receipt.json path');
+  }
+  const directory = path.dirname(receiptFile);
+  const id = path.basename(directory);
+  if (!RECEIPT_ID.test(id)) throw new Error('receipt transaction directory name is invalid');
+  const directoryStat = fsImpl.lstatSync(directory);
+  if (!directoryStat.isDirectory() || directoryStat.isSymbolicLink()) throw new Error('receipt transaction directory is unsafe');
+  if (process.platform !== 'win32' && (directoryStat.mode & 0o077) !== 0) throw new Error('receipt transaction directory is not private');
+  const realDirectory = fsImpl.realpathSync(directory);
+  const realRoot = fsImpl.realpathSync(path.dirname(directory));
+  if (path.dirname(realDirectory) !== realRoot || path.basename(realDirectory) !== id) {
+    throw new Error('receipt transaction directory escapes its transactions root');
+  }
+  let prior = null;
+  try {
+    prior = fsImpl.lstatSync(receiptFile);
+    if (!prior.isFile() || prior.isSymbolicLink()) throw new Error('existing receipt is unsafe');
+  } catch (error) {
+    if (error?.code !== 'ENOENT') throw error;
+  }
+  const temporary = path.join(directory, `.receipt.${randomBytes(12).toString('hex')}.tmp`);
+  let descriptor;
+  let renamed = false;
+  try {
+    descriptor = fsImpl.openSync(temporary, fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL | (fs.constants.O_NOFOLLOW ?? 0), 0o600);
+    writeAll(fsImpl, descriptor, bytes);
+    if (typeof fsImpl.fsyncSync !== 'function') throw new Error('receipt durability requires fsync support');
+    fsImpl.fsyncSync(descriptor);
+    fsImpl.closeSync(descriptor);
+    descriptor = undefined;
+    const currentDirectory = fsImpl.lstatSync(directory);
+    if (currentDirectory.dev !== directoryStat.dev || currentDirectory.ino !== directoryStat.ino) {
+      throw new Error('receipt transaction directory changed before commit');
+    }
+    if (prior) {
+      const currentReceipt = fsImpl.lstatSync(receiptFile);
+      if (!currentReceipt.isFile() || currentReceipt.isSymbolicLink()
+          || currentReceipt.dev !== prior.dev || currentReceipt.ino !== prior.ino) {
+        throw new Error('receipt changed before commit');
+      }
+    }
+    fsImpl.renameSync(temporary, receiptFile);
+    renamed = true;
+    fsyncDirectoryStrict(directory, fsImpl);
+  } finally {
+    if (descriptor !== undefined) fsImpl.closeSync(descriptor);
+    if (!renamed) {
+      try { fsImpl.rmSync(temporary, { force: true }); } catch { /* cleanup must not mask the failure */ }
+    }
+  }
+}
+
+export function writeHookReceipt(receiptFile, receipt, { fsImpl = fs } = {}) {
+  const sealed = sealHookReceipt(receipt);
+  const bytes = Buffer.from(`${JSON.stringify(sealed, null, 2)}\n`);
+  if (bytes.length > MAX_AUDIT_SOURCE_BYTES) throw new Error('receipt exceeds the bounded receipt size limit');
+  writeReceiptAtomic(receiptFile, bytes, fsImpl);
+  return sealed;
+}
+
+export function backupFileForReceiptAction(transactionDir, action) {
+  if (!BACKUP_RELATIVE.test(action?.backup?.relative ?? '')) throw new Error('receipt backup path is invalid');
+  const file = path.resolve(transactionDir, action.backup.relative);
+  const relative = path.relative(path.resolve(transactionDir), file);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) throw new Error('receipt backup escapes its transaction');
+  return file;
+}
+
+function contained(root, file) {
+  const relative = path.relative(root, file);
+  return relative === '' || (!relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative));
+}
+
+function validImage(image, { preimage = false } = {}) {
+  return image && typeof image === 'object' && SHA256.test(image.sha256)
+    && Number.isSafeInteger(image.size) && image.size >= 0
+    && typeof image.modeSupported === 'boolean'
+    && (image.mode === null || (Number.isInteger(image.mode) && image.mode >= 0 && image.mode <= 0o777))
+    && (!preimage || (
+      (image.uid === null || Number.isInteger(image.uid))
+      && (image.gid === null || Number.isInteger(image.gid))
+      && Number.isInteger(image.specialMode) && image.specialMode >= 0 && image.specialMode <= 0o7000
+      && path.isAbsolute(image.parent?.realPath ?? '')
+      && Number.isInteger(image.parent?.dev) && Number.isInteger(image.parent?.ino)
+    ));
+}
+
+function validateReceipt(receipt, receiptId, transactionDir) {
+  if (receipt.schemaVersion !== HOOK_HEAL_RECEIPT_SCHEMA) throw new Error('unsupported hook receipt schema');
+  if (receipt.id !== receiptId || !Array.isArray(receipt.actions)) throw new Error('receipt identity is invalid');
+  if (!RECEIPT_STATUSES.has(receipt.status) || !Number.isFinite(Date.parse(receipt.createdAt))) throw new Error('receipt state is invalid');
+  if (!SHA256.test(receipt.planDigest ?? '') || typeof receipt.auditId !== 'string') throw new Error('receipt plan identity is invalid');
+  const ids = new Set();
+  const targets = new Set();
+  for (const action of receipt.actions) {
+    if (!action || typeof action !== 'object' || typeof action.id !== 'string' || ids.has(action.id)) throw new Error('receipt action identity is invalid');
+    ids.add(action.id);
+    if (!ACTION_CLASSES.has(action.classification) || typeof action.host !== 'string' || typeof action.hostVersion !== 'string'
+        || typeof action.recipeId !== 'string' || typeof action.profileId !== 'string'
+        || !ACTION_STATES.has(action.state)) throw new Error('receipt action policy is invalid');
+    if (!path.isAbsolute(action.target ?? '') || !path.isAbsolute(action.containmentRoot ?? '')) throw new Error('receipt action paths must be absolute');
+    const target = path.resolve(action.target);
+    const root = path.resolve(action.containmentRoot);
+    if (target !== action.target || root !== action.containmentRoot || root === path.parse(root).root || !contained(root, target)) throw new Error('receipt action target escapes its bounded root');
+    if (targets.has(target)) throw new Error('receipt contains duplicate targets');
+    targets.add(target);
+    if (!validImage(action.preimage, { preimage: true }) || !validImage(action.postimage)) throw new Error('receipt action image is invalid');
+    if (!action.backup || !SHA256.test(action.backup.sha256 ?? '') || action.backup.sha256 !== action.preimage.sha256
+        || action.backup.size !== action.preimage.size) throw new Error('receipt backup metadata is invalid');
+    backupFileForReceiptAction(transactionDir, action);
+  }
+  const authorized = receipt.authorization?.actionIds;
+  if (!Array.isArray(authorized) || new Set(authorized).size !== authorized.length
+      || authorized.some((id) => typeof id !== 'string')
+      || [...authorized].sort().join('\0') !== [...ids].sort().join('\0')) {
+    throw new Error('receipt authorization does not match its actions');
+  }
+  if (receipt.actions.length && (receipt.authorization.mechanism !== 'explicit-action-selection'
+      || receipt.authorization.trustMutationAuthorized !== false)) {
+    throw new Error('receipt authorization policy is invalid');
+  }
+}
+
+function readReceiptDescriptor(file, realRoot, fsImpl) {
+  const before = fsImpl.lstatSync(file);
+  if (!before.isFile() || before.isSymbolicLink() || before.size > MAX_AUDIT_SOURCE_BYTES) throw new Error('receipt must be a bounded regular non-symlink file');
+  const realFile = fsImpl.realpathSync(file);
+  if (!contained(realRoot, realFile)) throw new Error('receipt escapes its transaction root');
+  let descriptor;
+  try {
+    descriptor = fsImpl.openSync(file, fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW ?? 0));
+    const opened = fsImpl.fstatSync(descriptor);
+    if (!opened.isFile() || opened.size > MAX_AUDIT_SOURCE_BYTES || opened.dev !== before.dev || opened.ino !== before.ino) throw new Error('receipt identity changed while opening');
+    if (fsImpl.realpathSync(file) !== realFile) throw new Error('receipt path changed while opening');
+    const bytes = Buffer.alloc(opened.size);
+    let offset = 0;
+    while (offset < bytes.length) {
+      const count = fsImpl.readSync(descriptor, bytes, offset, bytes.length - offset, offset);
+      if (count === 0) break;
+      offset += count;
+    }
+    if (offset !== bytes.length) throw new Error('receipt changed while reading');
+    return JSON.parse(bytes.toString('utf8'));
+  } finally {
+    if (descriptor !== undefined) fsImpl.closeSync(descriptor);
+  }
+}
+
+export function readHookReceipt(transactionsRoot, receiptId, { fsImpl = fs } = {}) {
+  if (!path.isAbsolute(transactionsRoot)) throw new TypeError('transactions root must be absolute');
+  if (!RECEIPT_ID.test(receiptId)) throw new TypeError('invalid hook receipt id');
+  const rootStat = fsImpl.lstatSync(transactionsRoot);
+  if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) throw new Error('transactions root is unsafe');
+  if (process.platform !== 'win32' && (rootStat.mode & 0o077) !== 0) throw new Error('transactions root is not private');
+  if (typeof process.getuid === 'function' && typeof rootStat.uid === 'number' && rootStat.uid !== process.getuid()) {
+    throw new Error('transactions root is not owned by the current user');
+  }
+  const realRoot = fsImpl.realpathSync(transactionsRoot);
+  const dir = path.join(transactionsRoot, receiptId);
+  const file = path.join(dir, 'receipt.json');
+  const dirStat = fsImpl.lstatSync(dir);
+  if (!dirStat.isDirectory() || dirStat.isSymbolicLink()) throw new Error('transaction directory is unsafe');
+  const realDir = fsImpl.realpathSync(dir);
+  const relativeDir = path.relative(realRoot, realDir);
+  if (relativeDir.startsWith('..') || path.isAbsolute(relativeDir)) throw new Error('transaction escapes its root');
+  const receipt = readReceiptDescriptor(file, realRoot, fsImpl);
+  validateReceipt(receipt, receiptId, dir);
+  const expected = sha256(stableJson(receiptBody(receipt)));
+  if (receipt.receiptDigest !== expected) throw new Error('hook receipt integrity check failed');
+  return { dir, file, receipt };
+}
+
+export function lastHookReceiptId(transactionsRoot, { fsImpl = fs } = {}) {
+  let entries;
+  try { entries = fsImpl.readdirSync(transactionsRoot, { withFileTypes: true }); } catch (error) {
+    if (error?.code === 'ENOENT') return null;
+    throw error;
+  }
+  const candidates = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory() || !RECEIPT_ID.test(entry.name)) continue;
+    try {
+      const { receipt } = readHookReceipt(transactionsRoot, entry.name, { fsImpl });
+      candidates.push(receipt);
+    } catch { /* invalid receipts are not eligible for implicit --last */ }
+  }
+  candidates.sort((a, b) => String(a.createdAt).localeCompare(String(b.createdAt)) || a.id.localeCompare(b.id));
+  return candidates.at(-1)?.id ?? null;
+}
+
+export function unfinishedHookReceipts(transactionsRoot, { fsImpl = fs } = {}) {
+  let entries;
+  try { entries = fsImpl.readdirSync(transactionsRoot, { withFileTypes: true }); } catch (error) {
+    if (error?.code === 'ENOENT') return [];
+    throw error;
+  }
+  return entries.filter((entry) => entry.isDirectory() && RECEIPT_ID.test(entry.name)).flatMap((entry) => {
+    try {
+      const { receipt } = readHookReceipt(transactionsRoot, entry.name, { fsImpl });
+      return ['prepared', 'applying', 'verifying', 'undoing', 'partial', 'failed',
+        'failed-before-write', 'failed-before-prepared-receipt', 'partial-recovery-required'].includes(receipt.status) ? [receipt] : [];
+    } catch (error) {
+      return [{
+        id: entry.name, status: 'unknown-recovery-required', createdAt: null,
+        error: error?.message ?? String(error),
+      }];
+    }
+  }).sort((a, b) => a.id.localeCompare(b.id));
+}

--- a/src/lib/paths.mjs
+++ b/src/lib/paths.mjs
@@ -13,7 +13,12 @@ function configBase() {
   if (isWindows) return process.env.APPDATA || path.join(home, 'AppData', 'Roaming');
   return process.env.XDG_CONFIG_HOME || path.join(home, '.config');
 }
+function stateBase() {
+  if (isWindows) return process.env.LOCALAPPDATA || path.join(home, 'AppData', 'Local');
+  return process.env.XDG_STATE_HOME || path.join(home, '.local', 'state');
+}
 export const configDir = () => path.join(configBase(), 'agentic-kit');
+export const hookHealingTransactionsDir = () => path.join(stateBase(), 'agentic-kit', 'hook-healing');
 /** The ruflo-era config dir — read-fallback for kit.json migration and the
  *  target of uninstall's legacy shell-kit cleanup. */
 export const legacyConfigDir = () => path.join(configBase(), 'ruflo');

--- a/tests/kit/adapter-integrity.test.mjs
+++ b/tests/kit/adapter-integrity.test.mjs
@@ -62,6 +62,21 @@ test('hashAdapterContent combines the validated manifest with sorted per-file di
   }
 });
 
+test('v1 file-backed consent identity remains stable while read hardening evolves', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ak-adapter-integrity-'));
+  try {
+    fs.writeFileSync(path.join(dir, 'detect-hook.mjs'), 'process.stdout.write("one");\n');
+    const manifest = structuredClone(fileManifest());
+    manifest.lifecycle.detect.hook.command[0] = 'node';
+    assert.equal(
+      hashAdapterContent(manifest, { baseDir: dir }).hash,
+      'fb9e3a3e91d6f82ac7d90858ba54ed62fe0da38f91fca219ed68d4440ee54e37',
+    );
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test('path-backed hooks without an explicit inventory are refused before consent can admit them', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ak-adapter-integrity-'));
   try {
@@ -133,6 +148,41 @@ test('admission marks consent stale when only a declared hook file changes', asy
     });
     assert.equal(result[0].admitted, false);
     assert.equal(result[0].reason, 'consent-stale');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('declared hook files cannot escape through a symlinked ancestor', (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ak-adapter-integrity-'));
+  const outside = fs.mkdtempSync(path.join(os.tmpdir(), 'ak-adapter-outside-'));
+  try {
+    fs.writeFileSync(path.join(outside, 'hook.mjs'), 'process.stdout.write("outside");\n');
+    try { fs.symlinkSync(outside, path.join(dir, 'sub'), 'dir'); } catch (error) {
+      if (error.code === 'EPERM') { t.skip('directory symlinks unavailable'); return; }
+      throw error;
+    }
+    const raw = structuredClone(fileManifest());
+    raw.lifecycle.detect.hook.command = [process.execPath, 'sub/hook.mjs'];
+    raw.lifecycle.detect.hook.files = ['sub/hook.mjs'];
+    assert.throws(
+      () => hashAdapterContent(validateAdapterManifest(raw), { baseDir: dir }),
+      (error) => error.reason === 'invalid-hook-file' && /real adapter directory/.test(error.message),
+    );
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+    fs.rmSync(outside, { recursive: true, force: true });
+  }
+});
+
+test('declared hook files and bundles have explicit byte limits', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ak-adapter-integrity-'));
+  try {
+    fs.writeFileSync(path.join(dir, 'detect-hook.mjs'), '0123456789');
+    assert.throws(
+      () => hashAdapterContent(fileManifest(), { baseDir: dir, maxFileBytes: 4 }),
+      (error) => error.reason === 'hook-file-too-large',
+    );
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }

--- a/tests/kit/hook-audit-hosts.test.mjs
+++ b/tests/kit/hook-audit-hosts.test.mjs
@@ -7,7 +7,8 @@ import path from 'node:path';
 import { run as runAuditCommand } from '../../src/commands/audit.mjs';
 import { auditCodexHooks } from '../../src/lib/hook-audit/index.mjs';
 import { auditHooks } from '../../src/lib/hook-audit/orchestrator.mjs';
-import { readBoundedFile } from '../../src/lib/hook-audit/common.mjs';
+import { normalizedOccurrence, readBoundedFile } from '../../src/lib/hook-audit/common.mjs';
+import { auditClaudeHooks } from '../../src/lib/hook-audit/providers/claude.mjs';
 
 function write(file, value) {
   fs.mkdirSync(path.dirname(file), { recursive: true });
@@ -154,9 +155,88 @@ test('unverified newer Codex versions do not inherit the 0.151 timeout profile',
   try {
     write(path.join(fx.codex, 'hooks.json'), { hooks: { SessionEnd: [{ hooks: [{ type: 'command', command: 'node end.cjs', timeout: 5 }] }] } });
     const report = auditCodexHooks({ codexHome: fx.codex, projectRoots: [], pluginCacheDir: path.join(fx.codex, 'plugins', 'cache'), codexVersion: '0.152.0' });
-    assert.equal(report.hostSchema.confidence, 'unknown');
+    assert.equal(report.hostSchema.confidence, 'syntax-only');
     assert.equal(report.records[0].timeout.effective, null);
     assert.equal(report.plan.length, 0);
+  } finally {
+    fs.rmSync(fx.root, { recursive: true, force: true });
+  }
+});
+
+test('Codex profiles are exact and future syntax remains observable without optimistic validation', () => {
+  const fx = fixture();
+  try {
+    write(path.join(fx.codex, 'hooks.json'), {
+      hooks: {
+        FutureEvent: [{ hooks: [{ type: 'future_handler', futureField: true }] }],
+        SessionEnd: [{ hooks: [{ type: 'command', command: 'node end.cjs', timeout: 5 }] }],
+      },
+    });
+    const report = auditCodexHooks({
+      codexHome: fx.codex,
+      projectRoots: [],
+      pluginCacheDir: path.join(fx.codex, 'plugins', 'cache'),
+      codexVersion: '0.151.999',
+    });
+    assert.equal(report.hostSchema.confidence, 'syntax-only');
+    assert.equal(report.summary.invalidSources, 0);
+    assert.equal(report.records.length, 2);
+    assert.equal(report.plan.length, 0);
+    assert.ok(report.records.every((record) => record.timeout.effective === null));
+  } finally {
+    fs.rmSync(fx.root, { recursive: true, force: true });
+  }
+});
+
+test('structured argv boundaries remain material to occurrence identity', () => {
+  const source = {
+    file: '/fixture/adapter.json', digest: 'a'.repeat(64), sourceKind: 'external-adapter-manifest',
+    authority: 'operator-configured', generatedStatus: 'direct', owner: 'fixture', baseDir: '/fixture',
+  };
+  const first = normalizedOccurrence({
+    host: 'fixture', event: 'execution.run', type: 'argv-subprocess',
+    handler: { command: ['node', 'a b'] }, source,
+  });
+  const second = normalizedOccurrence({
+    host: 'fixture', event: 'execution.run', type: 'argv-subprocess',
+    handler: { command: ['node a', 'b'] }, source,
+  });
+  assert.notEqual(first.behaviorFingerprint, second.behaviorFingerprint);
+  assert.notEqual(first.command.digest, second.command.digest);
+});
+
+test('duplicate Claude occurrences retain unique action ids and inline plugin ownership', () => {
+  const fx = fixture();
+  try {
+    const plugin = path.join(fx.root, 'plugin');
+    write(path.join(fx.claude, 'plugins', 'installed_plugins.json'), {
+      plugins: {
+        'fixture@test': [{ installPath: plugin, version: '1.0.0' }],
+      },
+    });
+    write(path.join(plugin, '.claude-plugin', 'plugin.json'), {
+      name: 'fixture',
+      version: '1.0.0',
+      hooks: {
+        hooks: {
+          SessionEnd: [{ hooks: [
+            { type: 'command', command: 'node end.cjs', timeout: 5 },
+            { type: 'command', command: 'node end.cjs', timeout: 5 },
+          ] }],
+        },
+      },
+    });
+    const report = auditClaudeHooks({
+      claudeRoot: fx.claude,
+      projectRoots: [],
+      managedSettingsFile: null,
+      claudeVersion: '2.1.258',
+    });
+    assert.equal(report.records.length, 2);
+    assert.equal(new Set(report.plan.map((action) => action.id)).size, 2);
+    assert.ok(report.records.every((record) => record.source.generatedStatus === 'generated'));
+    assert.ok(report.records.every((record) => record.source.authority === 'generated-runtime-copy'));
+    assert.ok(report.plan.every((action) => action.classification === 'upstream-required'));
   } finally {
     fs.rmSync(fx.root, { recursive: true, force: true });
   }
@@ -228,6 +308,56 @@ test('external audit loads adapter configuration without probing unrelated host 
   } finally {
     console.log = originalLog;
     console.error = originalError;
+  }
+});
+
+test('external audit refuses contract drift, name mismatch, and built-in shadowing before records', () => {
+  const fx = fixture();
+  try {
+    const contractFile = path.join(fx.root, 'contract.json');
+    const nameFile = path.join(fx.root, 'name.json');
+    const builtinFile = path.join(fx.root, 'builtin.json');
+    write(contractFile, externalManifest());
+    write(nameFile, externalManifest());
+    const builtin = externalManifest();
+    builtin.name = 'codex';
+    builtin.host.id = 'codex';
+    write(builtinFile, builtin);
+    const report = auditHooks({
+      hosts: ['external'], projectRoots: [],
+      config: { hostAdapters: [
+        { name: 'hermes', source: contractFile, contract: 2 },
+        { name: 'other', source: nameFile, contract: 1 },
+        { name: 'codex', source: builtinFile, contract: 1 },
+      ] },
+    }).reports.external;
+    assert.equal(report.records.length, 0);
+    assert.equal(report.plan.length, 0);
+    assert.equal(report.sources.filter((source) => source.status === 'inadmissible').length, 3);
+    assert.match(report.issues.join('\n'), /contract-mismatch/);
+    assert.match(report.issues.join('\n'), /name-mismatch/);
+    assert.match(report.issues.join('\n'), /builtin-shadow/);
+  } finally {
+    fs.rmSync(fx.root, { recursive: true, force: true });
+  }
+});
+
+test('unknown Claude versions use structural-only validation and never remediation semantics', () => {
+  const fx = fixture();
+  try {
+    write(path.join(fx.claude, 'settings.json'), {
+      hooks: { FutureEvent: [{ matcher: { future: true }, hooks: [
+        { futureShape: true }, { type: 'command', futureCommandField: ['future'] },
+      ] }] },
+    });
+    const report = auditClaudeHooks({
+      claudeRoot: fx.claude, projectRoots: [], managedSettingsFile: null, claudeVersion: '2.2.0',
+    });
+    assert.equal(report.hostSchema.confidence, 'syntax-only');
+    assert.equal(report.sources[0].status, 'valid');
+    assert.equal(report.plan.length, 0);
+  } finally {
+    fs.rmSync(fx.root, { recursive: true, force: true });
   }
 });
 

--- a/tests/kit/hook-audit.test.mjs
+++ b/tests/kit/hook-audit.test.mjs
@@ -121,7 +121,7 @@ test('unknown Codex versions receive syntax-only validation and no timeout rewri
       pluginCacheDir: fx.cache,
       codexVersion: 'unknown',
     });
-    assert.equal(report.hostSchema.confidence, 'unknown');
+    assert.equal(report.hostSchema.confidence, 'syntax-only');
     assert.equal(report.summary.compatibilityWarnings, 0);
     assert.equal(report.plan.length, 0);
     assert.equal(report.records[0].timeout.effective, null);

--- a/tests/kit/hook-remediation-cli.test.mjs
+++ b/tests/kit/hook-remediation-cli.test.mjs
@@ -1,0 +1,79 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { run } from '../../src/commands/heal.mjs';
+
+function captureConsole() {
+  const output = [];
+  const errors = [];
+  const originalLog = console.log;
+  const originalError = console.error;
+  console.log = (...values) => output.push(values.join(' '));
+  console.error = (...values) => errors.push(values.join(' '));
+  return {
+    output, errors,
+    restore() { console.log = originalLog; console.error = originalError; },
+  };
+}
+
+test('ak heal hooks requires exact preview authorization and supports previewed undo', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ak-hook-cli-'));
+  const codexHome = path.join(root, 'codex');
+  const target = path.join(codexHome, 'hooks.json');
+  const transactionsRoot = path.join(root, 'transactions');
+  const priorCodexHome = process.env.CODEX_HOME;
+  fs.mkdirSync(codexHome, { recursive: true });
+  fs.writeFileSync(target, `${JSON.stringify({
+    hooks: { SessionEnd: [{ hooks: [{ type: 'command', command: 'node end.cjs', timeout: 5 }] }] },
+  }, null, 2)}\n`, { mode: 0o640 });
+  process.env.CODEX_HOME = codexHome;
+  const invoke = async (flags) => {
+    const capture = captureConsole();
+    try {
+      const code = await run({
+        flags: { host: ['codex'], project: [], json: true, 'transactions-root': transactionsRoot, ...flags },
+        positionals: ['hooks'], detectVersionFn: () => '0.151.0',
+        loadConfigFn: () => { throw new Error('Codex-only healing must not load adapter config'); },
+      });
+      return { code, output: capture.output, errors: capture.errors };
+    } finally { capture.restore(); }
+  };
+  try {
+    const preview = await invoke({});
+    assert.equal(preview.code, 0);
+    const plan = JSON.parse(preview.output.join('\n'));
+    assert.equal(JSON.parse(fs.readFileSync(target, 'utf8')).hooks.SessionEnd[0].hooks[0].timeout, 5);
+    assert.equal(fs.existsSync(transactionsRoot), false);
+
+    const missingYes = await invoke({
+      apply: true, action: [plan.actions[0].id], 'plan-digest': plan.planDigest,
+    });
+    assert.equal(missingYes.code, 2);
+    assert.match(missingYes.errors.join('\n'), /--apply requires --yes/);
+
+    const applied = await invoke({
+      apply: true, yes: true, action: [plan.actions[0].id], 'plan-digest': plan.planDigest,
+    });
+    assert.equal(applied.code, 0);
+    const applyResult = JSON.parse(applied.output.join('\n'));
+    assert.equal(applyResult.status, 'committed');
+    assert.equal(JSON.parse(fs.readFileSync(target, 'utf8')).hooks.SessionEnd[0].hooks[0].timeout, 3);
+
+    const undoPreview = await invoke({ undo: applyResult.receiptId });
+    assert.equal(undoPreview.code, 0);
+    assert.equal(JSON.parse(undoPreview.output.join('\n')).actions[0].backupVerified, true);
+    assert.equal(JSON.parse(fs.readFileSync(target, 'utf8')).hooks.SessionEnd[0].hooks[0].timeout, 3);
+
+    const undone = await invoke({ undo: applyResult.receiptId, apply: true, yes: true });
+    assert.equal(undone.code, 0);
+    assert.equal(JSON.parse(undone.output.join('\n')).status, 'rolled-back');
+    assert.equal(JSON.parse(fs.readFileSync(target, 'utf8')).hooks.SessionEnd[0].hooks[0].timeout, 5);
+  } finally {
+    if (priorCodexHome === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = priorCodexHome;
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/tests/kit/hook-remediation-cli.test.mjs
+++ b/tests/kit/hook-remediation-cli.test.mjs
@@ -6,6 +6,10 @@ import path from 'node:path';
 
 import { run } from '../../src/commands/heal.mjs';
 
+const POSIX_MUTATION_ONLY = process.platform === 'win32'
+  ? { skip: 'executable hook healing is intentionally unavailable on Windows' }
+  : {};
+
 function captureConsole() {
   const output = [];
   const errors = [];
@@ -19,7 +23,7 @@ function captureConsole() {
   };
 }
 
-test('ak heal hooks requires exact preview authorization and supports previewed undo', async () => {
+test('ak heal hooks requires exact preview authorization and supports previewed undo', POSIX_MUTATION_ONLY, async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ak-hook-cli-'));
   const codexHome = path.join(root, 'codex');
   const target = path.join(codexHome, 'hooks.json');

--- a/tests/kit/hook-remediation.test.mjs
+++ b/tests/kit/hook-remediation.test.mjs
@@ -16,6 +16,10 @@ import {
   createHookTransactionDir, unfinishedHookReceipts, writeHookReceipt,
 } from '../../src/lib/hook-remediation/store.mjs';
 
+const POSIX_MUTATION_ONLY = process.platform === 'win32'
+  ? { skip: 'executable hook healing is intentionally unavailable on Windows' }
+  : {};
+
 function writeJson(file, value, mode = 0o640) {
   fs.mkdirSync(path.dirname(file), { recursive: true });
   fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`, { mode });
@@ -43,7 +47,7 @@ function fixture() {
   return { root, codexHome, transactionsRoot, target, audit, plan };
 }
 
-test('dry-run plan is deterministic, content-bound, redacted, and leaves no transaction state', () => {
+test('dry-run plan is deterministic, content-bound, redacted, and leaves no transaction state', POSIX_MUTATION_ONLY, () => {
   const fx = fixture();
   try {
     const before = fs.statSync(fx.target);
@@ -65,7 +69,7 @@ test('dry-run plan is deterministic, content-bound, redacted, and leaves no tran
   }
 });
 
-test('authorized heal changes only the selected target and commits one verified receipt', () => {
+test('authorized heal changes only the selected target and commits one verified receipt', POSIX_MUTATION_ONLY, () => {
   const fx = fixture();
   try {
     const plan = fx.plan();
@@ -95,7 +99,7 @@ test('authorized heal changes only the selected target and commits one verified 
   }
 });
 
-test('receipt undo restores exact bytes and mode while refusing later user drift', () => {
+test('receipt undo restores exact bytes and mode while refusing later user drift', POSIX_MUTATION_ONLY, () => {
   const fx = fixture();
   try {
     const original = fs.readFileSync(fx.target);
@@ -155,7 +159,7 @@ test('stale plan preimage is refused before the transaction directory or any tar
   }
 });
 
-test('plan and private candidate tampering are refused before transaction state', () => {
+test('plan and private candidate tampering are refused before transaction state', POSIX_MUTATION_ONLY, () => {
   const fx = fixture();
   try {
     const plan = fx.plan();
@@ -217,7 +221,7 @@ test('noncanonical JSON is observed but not rewritten behind a scalar-only diff'
   }
 });
 
-test('exact Claude settings repair stays distinct from plugin upstream work', () => {
+test('exact Claude settings repair stays distinct from plugin upstream work', POSIX_MUTATION_ONLY, () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ak-hook-claude-heal-'));
   try {
     const claudeRoot = path.join(root, 'claude');
@@ -266,7 +270,7 @@ test('host profile drift between preview and apply refuses before backups', () =
   }
 });
 
-test('second-target failure conditionally restores the first target', () => {
+test('second-target failure conditionally restores the first target', POSIX_MUTATION_ONLY, () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ak-hook-multi-heal-'));
   try {
     const codexHome = path.join(root, 'codex');
@@ -296,7 +300,7 @@ test('second-target failure conditionally restores the first target', () => {
   }
 });
 
-test('receipt tampering is detected before rollback touches the target', () => {
+test('receipt tampering is detected before rollback touches the target', POSIX_MUTATION_ONLY, () => {
   const fx = fixture();
   try {
     const plan = fx.plan();
@@ -316,7 +320,7 @@ test('receipt tampering is detected before rollback touches the target', () => {
   }
 });
 
-test('caller-supplied transaction roots are never silently re-permissioned', () => {
+test('caller-supplied transaction roots are never silently re-permissioned', POSIX_MUTATION_ONLY, () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ak-hook-root-'));
   try {
     fs.chmodSync(root, 0o755);
@@ -343,7 +347,7 @@ test('missing or corrupt transaction journals block new apply as recovery-requir
   }
 });
 
-test('undo preview verifies backup bytes before reporting ready', () => {
+test('undo preview verifies backup bytes before reporting ready', POSIX_MUTATION_ONLY, () => {
   const fx = fixture();
   try {
     const plan = fx.plan();
@@ -363,7 +367,7 @@ test('undo preview verifies backup bytes before reporting ready', () => {
   }
 });
 
-test('unfinished applied receipts require explicit previewed recovery and restore exact bytes', () => {
+test('unfinished applied receipts require explicit previewed recovery and restore exact bytes', POSIX_MUTATION_ONLY, () => {
   const fx = fixture();
   try {
     const original = fs.readFileSync(fx.target);

--- a/tests/kit/hook-remediation.test.mjs
+++ b/tests/kit/hook-remediation.test.mjs
@@ -1,0 +1,403 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { auditHooks } from '../../src/lib/hook-audit/orchestrator.mjs';
+import {
+  buildHookHealingPlan, publicHookHealingPlan,
+} from '../../src/lib/hook-remediation/planner.mjs';
+import {
+  applyHookHealingPlan, previewHookHealingRecovery, previewHookHealingUndo,
+  recoverHookHealing, undoHookHealing,
+} from '../../src/lib/hook-remediation/engine.mjs';
+import {
+  createHookTransactionDir, unfinishedHookReceipts, writeHookReceipt,
+} from '../../src/lib/hook-remediation/store.mjs';
+
+function writeJson(file, value, mode = 0o640) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`, { mode });
+}
+
+function fixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ak-hook-heal-'));
+  const codexHome = path.join(root, 'codex');
+  const transactionsRoot = path.join(root, 'transactions');
+  const target = path.join(codexHome, 'hooks.json');
+  writeJson(target, {
+    keep: { user: true },
+    hooks: {
+      SessionEnd: [{ hooks: [{ type: 'command', command: 'node end.cjs', timeout: 5 }] }],
+    },
+  });
+  const audit = () => auditHooks({
+    hosts: ['codex'],
+    versions: { codex: '0.151.0' },
+    projectRoots: [],
+    codex: { codexHome, pluginCacheDir: path.join(codexHome, 'plugins', 'cache') },
+    upstream: { file: path.join(root, 'missing-constraints.json') },
+  });
+  const plan = () => buildHookHealingPlan({ report: audit() });
+  return { root, codexHome, transactionsRoot, target, audit, plan };
+}
+
+test('dry-run plan is deterministic, content-bound, redacted, and leaves no transaction state', () => {
+  const fx = fixture();
+  try {
+    const before = fs.statSync(fx.target);
+    const first = fx.plan();
+    const second = fx.plan();
+    assert.deepEqual(publicHookHealingPlan(second), publicHookHealingPlan(first));
+    assert.match(first.planDigest, /^[a-f0-9]{64}$/);
+    assert.equal(first.actions.length, 1);
+    assert.equal(first.actions[0].classification, 'approval-required');
+    assert.equal(first.actions[0].executable, true);
+    assert.match(first.actions[0].diff, /^--- /m);
+    assert.doesNotMatch(JSON.stringify(publicHookHealingPlan(first)), /candidateBytes|node end\.cjs/);
+    assert.equal(fs.existsSync(fx.transactionsRoot), false);
+    const after = fs.statSync(fx.target);
+    assert.equal(after.mtimeMs, before.mtimeMs);
+    assert.equal(after.size, before.size);
+  } finally {
+    fs.rmSync(fx.root, { recursive: true, force: true });
+  }
+});
+
+test('authorized heal changes only the selected target and commits one verified receipt', () => {
+  const fx = fixture();
+  try {
+    const plan = fx.plan();
+    const action = plan.actions[0];
+    const result = applyHookHealingPlan({
+      plan,
+      actionIds: [action.id],
+      expectedPlanDigest: plan.planDigest,
+      transactionsRoot: fx.transactionsRoot,
+      auditFn: fx.audit,
+      replanFn: (report) => buildHookHealingPlan({ report }),
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.status, 'committed');
+    assert.equal(JSON.parse(fs.readFileSync(fx.target, 'utf8')).hooks.SessionEnd[0].hooks[0].timeout, 3);
+    assert.equal(fs.statSync(fx.target).mode & 0o777, 0o640);
+    const receipt = JSON.parse(fs.readFileSync(result.receiptFile, 'utf8'));
+    assert.equal(receipt.status, 'committed');
+    assert.equal(receipt.actions.length, 1);
+    assert.equal(receipt.actions[0].preimage.sha256, action.expectedPreimage.sha256);
+    assert.equal(receipt.actions[0].postimage.sha256, action.desiredPostimage.sha256);
+    assert.equal(receipt.verification.targetedFindingsCleared, true);
+    assert.equal(receipt.verification.idempotentNoop, true);
+    assert.match(receipt.receiptDigest, /^[a-f0-9]{64}$/);
+  } finally {
+    fs.rmSync(fx.root, { recursive: true, force: true });
+  }
+});
+
+test('receipt undo restores exact bytes and mode while refusing later user drift', () => {
+  const fx = fixture();
+  try {
+    const original = fs.readFileSync(fx.target);
+    const plan = fx.plan();
+    const applied = applyHookHealingPlan({
+      plan,
+      actionIds: [plan.actions[0].id],
+      expectedPlanDigest: plan.planDigest,
+      transactionsRoot: fx.transactionsRoot,
+      auditFn: fx.audit,
+      replanFn: (report) => buildHookHealingPlan({ report }),
+    });
+    fs.appendFileSync(fx.target, '\n');
+    const drifted = fs.readFileSync(fx.target);
+    const refused = undoHookHealing({
+      transactionsRoot: fx.transactionsRoot,
+      receiptId: applied.receiptId,
+    });
+    assert.equal(refused.ok, false);
+    assert.equal(refused.status, 'drift-refused');
+    assert.deepEqual(fs.readFileSync(fx.target), drifted);
+
+    fs.writeFileSync(fx.target, plan.actions[0].candidateBytes, { mode: 0o640 });
+    const undone = undoHookHealing({
+      transactionsRoot: fx.transactionsRoot,
+      receiptId: applied.receiptId,
+    });
+    assert.equal(undone.ok, true);
+    assert.equal(undone.status, 'rolled-back');
+    assert.deepEqual(fs.readFileSync(fx.target), original);
+    assert.equal(fs.statSync(fx.target).mode & 0o777, 0o640);
+  } finally {
+    fs.rmSync(fx.root, { recursive: true, force: true });
+  }
+});
+
+test('stale plan preimage is refused before the transaction directory or any target write', () => {
+  const fx = fixture();
+  try {
+    const plan = fx.plan();
+    fs.appendFileSync(fx.target, ' ');
+    const drifted = fs.readFileSync(fx.target);
+    const result = applyHookHealingPlan({
+      plan,
+      actionIds: [plan.actions[0].id],
+      expectedPlanDigest: plan.planDigest,
+      transactionsRoot: fx.transactionsRoot,
+      auditFn: fx.audit,
+      replanFn: (report) => buildHookHealingPlan({ report }),
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.status, 'preflight-refused');
+    assert.deepEqual(fs.readFileSync(fx.target), drifted);
+    assert.equal(fs.existsSync(fx.transactionsRoot), false);
+  } finally {
+    fs.rmSync(fx.root, { recursive: true, force: true });
+  }
+});
+
+test('plan and private candidate tampering are refused before transaction state', () => {
+  const fx = fixture();
+  try {
+    const plan = fx.plan();
+    plan.actions[0].trustImpact = 'mutated after preview';
+    let result = applyHookHealingPlan({
+      plan, actionIds: [plan.actions[0].id], expectedPlanDigest: plan.planDigest,
+      transactionsRoot: fx.transactionsRoot, auditFn: fx.audit,
+    });
+    assert.equal(result.status, 'preflight-refused');
+    assert.equal(fs.existsSync(fx.transactionsRoot), false);
+
+    const fresh = fx.plan();
+    fresh.actions[0].candidateBytes[0] ^= 1;
+    result = applyHookHealingPlan({
+      plan: fresh, actionIds: [fresh.actions[0].id], expectedPlanDigest: fresh.planDigest,
+      transactionsRoot: fx.transactionsRoot, auditFn: fx.audit,
+    });
+    assert.equal(result.status, 'preflight-refused');
+    assert.equal(fs.existsSync(fx.transactionsRoot), false);
+  } finally {
+    fs.rmSync(fx.root, { recursive: true, force: true });
+  }
+});
+
+test('duplicate, unknown, and non-executable action selections fail closed', () => {
+  const fx = fixture();
+  try {
+    const plan = fx.plan();
+    for (const actionIds of [[plan.actions[0].id, plan.actions[0].id], ['missing-action']]) {
+      const result = applyHookHealingPlan({
+        plan, actionIds, expectedPlanDigest: plan.planDigest,
+        transactionsRoot: fx.transactionsRoot, auditFn: fx.audit,
+      });
+      assert.equal(result.status, 'preflight-refused');
+      assert.equal(fs.existsSync(fx.transactionsRoot), false);
+    }
+    const report = auditHooks({
+      hosts: ['codex'], versions: { codex: 'future' }, projectRoots: [],
+      codex: { codexHome: fx.codexHome, pluginCacheDir: path.join(fx.codexHome, 'plugins', 'cache') },
+      upstream: { file: path.join(fx.root, 'missing.json') },
+    });
+    const closed = buildHookHealingPlan({ report });
+    assert.equal(closed.summary.executable, 0);
+    assert.ok(closed.actions.every((action) => !action.executable));
+  } finally {
+    fs.rmSync(fx.root, { recursive: true, force: true });
+  }
+});
+
+test('noncanonical JSON is observed but not rewritten behind a scalar-only diff', () => {
+  const fx = fixture();
+  try {
+    fs.writeFileSync(fx.target, '{"hooks":{"SessionEnd":[{"hooks":[{"type":"command","command":"node end.cjs","timeout":5}]}]},"keep":true}\n');
+    const plan = fx.plan();
+    assert.equal(plan.summary.executable, 0);
+    assert.ok(plan.actions.some((action) => action.classification === 'approval-required' && !action.executable));
+  } finally {
+    fs.rmSync(fx.root, { recursive: true, force: true });
+  }
+});
+
+test('exact Claude settings repair stays distinct from plugin upstream work', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ak-hook-claude-heal-'));
+  try {
+    const claudeRoot = path.join(root, 'claude');
+    const plugin = path.join(root, 'plugin');
+    writeJson(path.join(claudeRoot, 'settings.json'), {
+      hooks: { SessionEnd: [{ hooks: [{ type: 'command', command: 'node user.cjs', timeout: 120 }] }] },
+    });
+    writeJson(path.join(claudeRoot, 'plugins', 'installed_plugins.json'), {
+      plugins: { 'fixture@test': [{ installPath: plugin, version: '1.0.0' }] },
+    });
+    writeJson(path.join(plugin, 'hooks', 'hooks.json'), {
+      hooks: { SessionEnd: [{ hooks: [{ type: 'command', command: 'node plugin.cjs', timeout: 10 }] }] },
+    });
+    const report = auditHooks({
+      hosts: ['claude'], versions: { claude: '2.1.258' }, projectRoots: [],
+      claude: { claudeRoot, managedSettingsFile: null },
+      upstream: { file: path.join(root, 'missing.json') },
+    });
+    const plan = buildHookHealingPlan({ report });
+    assert.equal(plan.actions.filter((action) => action.executable).length, 1);
+    assert.equal(plan.actions.filter((action) => action.classification === 'upstream-required').length, 1);
+    assert.equal(plan.actions.filter((action) => action.providerActionId
+      && action.target === path.join(claudeRoot, 'settings.json')).length, 0);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('host profile drift between preview and apply refuses before backups', () => {
+  const fx = fixture();
+  try {
+    const plan = fx.plan();
+    const driftAudit = () => auditHooks({
+      hosts: ['codex'], versions: { codex: '0.152.0' }, projectRoots: [],
+      codex: { codexHome: fx.codexHome, pluginCacheDir: path.join(fx.codexHome, 'plugins', 'cache') },
+      upstream: { file: path.join(fx.root, 'missing.json') },
+    });
+    const result = applyHookHealingPlan({
+      plan, actionIds: [plan.actions[0].id], expectedPlanDigest: plan.planDigest,
+      transactionsRoot: fx.transactionsRoot, auditFn: driftAudit,
+    });
+    assert.equal(result.status, 'preflight-refused');
+    assert.equal(fs.existsSync(fx.transactionsRoot), false);
+  } finally {
+    fs.rmSync(fx.root, { recursive: true, force: true });
+  }
+});
+
+test('second-target failure conditionally restores the first target', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ak-hook-multi-heal-'));
+  try {
+    const codexHome = path.join(root, 'codex');
+    const claudeRoot = path.join(root, 'claude');
+    const codexTarget = path.join(codexHome, 'hooks.json');
+    const claudeTarget = path.join(claudeRoot, 'settings.json');
+    writeJson(codexTarget, { hooks: { SessionEnd: [{ hooks: [{ type: 'command', command: 'node c.cjs', timeout: 5 }] }] } });
+    writeJson(claudeTarget, { hooks: { SessionEnd: [{ hooks: [{ type: 'command', command: 'node d.cjs', timeout: 120 }] }] } });
+    const audit = () => auditHooks({
+      hosts: ['codex', 'claude'], versions: { codex: '0.151.0', claude: '2.1.258' }, projectRoots: [],
+      codex: { codexHome, pluginCacheDir: path.join(codexHome, 'plugins', 'cache') },
+      claude: { claudeRoot, managedSettingsFile: null }, upstream: { file: path.join(root, 'missing.json') },
+    });
+    const plan = buildHookHealingPlan({ report: audit() });
+    const originals = [fs.readFileSync(codexTarget), fs.readFileSync(claudeTarget)];
+    const result = applyHookHealingPlan({
+      plan, actionIds: plan.actions.filter((action) => action.executable).map((action) => action.id),
+      expectedPlanDigest: plan.planDigest, transactionsRoot: path.join(root, 'transactions'), auditFn: audit,
+      faults: { beforeReplace: (_action, index) => { if (index === 1) throw new Error('injected second write failure'); } },
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.status, 'rolled-back');
+    assert.deepEqual(fs.readFileSync(codexTarget), originals[0]);
+    assert.deepEqual(fs.readFileSync(claudeTarget), originals[1]);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('receipt tampering is detected before rollback touches the target', () => {
+  const fx = fixture();
+  try {
+    const plan = fx.plan();
+    const applied = applyHookHealingPlan({
+      plan, actionIds: [plan.actions[0].id], expectedPlanDigest: plan.planDigest,
+      transactionsRoot: fx.transactionsRoot, auditFn: fx.audit,
+    });
+    const changed = fs.readFileSync(fx.target);
+    const receipt = JSON.parse(fs.readFileSync(applied.receiptFile, 'utf8'));
+    receipt.actions[0].target = path.join(fx.root, 'other.json');
+    fs.writeFileSync(applied.receiptFile, `${JSON.stringify(receipt)}\n`);
+    const result = undoHookHealing({ transactionsRoot: fx.transactionsRoot, receiptId: applied.receiptId });
+    assert.equal(result.status, 'receipt-refused');
+    assert.deepEqual(fs.readFileSync(fx.target), changed);
+  } finally {
+    fs.rmSync(fx.root, { recursive: true, force: true });
+  }
+});
+
+test('caller-supplied transaction roots are never silently re-permissioned', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ak-hook-root-'));
+  try {
+    fs.chmodSync(root, 0o755);
+    assert.throws(() => createHookTransactionDir(root), /must already be private/);
+    assert.equal(fs.statSync(root).mode & 0o777, 0o755);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('missing or corrupt transaction journals block new apply as recovery-required', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ak-hook-root-'));
+  try {
+    const id = 'tx-2026-09-02T00-00-00.000Z-0123456789abcdef';
+    const dir = path.join(root, id);
+    fs.mkdirSync(dir, { mode: 0o700 });
+    fs.writeFileSync(path.join(dir, 'receipt.json'), '{broken', { mode: 0o600 });
+    const unfinished = unfinishedHookReceipts(root);
+    assert.equal(unfinished.length, 1);
+    assert.equal(unfinished[0].id, id);
+    assert.equal(unfinished[0].status, 'unknown-recovery-required');
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('undo preview verifies backup bytes before reporting ready', () => {
+  const fx = fixture();
+  try {
+    const plan = fx.plan();
+    const applied = applyHookHealingPlan({
+      plan, actionIds: [plan.actions[0].id], expectedPlanDigest: plan.planDigest,
+      transactionsRoot: fx.transactionsRoot, auditFn: fx.audit,
+      replanFn: (report) => buildHookHealingPlan({ report }),
+    });
+    const receipt = JSON.parse(fs.readFileSync(applied.receiptFile, 'utf8'));
+    fs.rmSync(path.join(path.dirname(applied.receiptFile), receipt.actions[0].backup.relative));
+    const preview = previewHookHealingUndo({ transactionsRoot: fx.transactionsRoot, receiptId: applied.receiptId });
+    assert.equal(preview.ok, false);
+    assert.equal(preview.status, 'drift-refused');
+    assert.match(preview.error, /ENOENT|could not|no such file/i);
+  } finally {
+    fs.rmSync(fx.root, { recursive: true, force: true });
+  }
+});
+
+test('unfinished applied receipts require explicit previewed recovery and restore exact bytes', () => {
+  const fx = fixture();
+  try {
+    const original = fs.readFileSync(fx.target);
+    const plan = fx.plan();
+    const applied = applyHookHealingPlan({
+      plan, actionIds: [plan.actions[0].id], expectedPlanDigest: plan.planDigest,
+      transactionsRoot: fx.transactionsRoot, auditFn: fx.audit,
+      replanFn: (report) => buildHookHealingPlan({ report }),
+    });
+    const receipt = JSON.parse(fs.readFileSync(applied.receiptFile, 'utf8'));
+    receipt.status = 'applying';
+    receipt.actions[0].state = 'applied';
+    writeHookReceipt(applied.receiptFile, receipt);
+    const preview = previewHookHealingRecovery({ transactionsRoot: fx.transactionsRoot, receiptId: applied.receiptId });
+    assert.equal(preview.ok, true);
+    assert.equal(preview.actions[0].status, 'ready');
+    assert.equal(preview.actions[0].backupVerified, true);
+    const recovered = recoverHookHealing({ transactionsRoot: fx.transactionsRoot, receiptId: applied.receiptId });
+    assert.equal(recovered.ok, true);
+    assert.equal(recovered.status, 'rolled-back');
+    assert.deepEqual(fs.readFileSync(fx.target), original);
+  } finally {
+    fs.rmSync(fx.root, { recursive: true, force: true });
+  }
+});
+
+test('Windows plans expose findings but compile no executable replacement action', () => {
+  const fx = fixture();
+  try {
+    const report = fx.audit();
+    const plan = buildHookHealingPlan({ report, platform: 'win32' });
+    assert.equal(plan.summary.executable, 0);
+    assert.ok(plan.actions.every((action) => action.executable === false));
+  } finally {
+    fs.rmSync(fx.root, { recursive: true, force: true });
+  }
+});

--- a/tests/kit/hook-upstream.test.mjs
+++ b/tests/kit/hook-upstream.test.mjs
@@ -1,0 +1,40 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { loadUpstreamConstraints } from '../../src/lib/hook-audit/upstream.mjs';
+
+const registryFile = path.resolve('config/agentic-dependency-constraints.json');
+const now = () => new Date('2026-09-02T12:00:00Z');
+
+test('upstream registry separates valid shape, current evidence, and version applicability', () => {
+  const result = loadUpstreamConstraints({
+    file: registryFile, now, observedVersions: { ruflo: '3.38.17', 'agentic-qe': '3.14.0' },
+  });
+  assert.equal(result.status, 'valid');
+  assert.equal(result.registryStatus, 'valid');
+  assert.equal(result.evidenceStatus, 'current');
+  const blocked = result.constraints.find((entry) => entry.id === 'ruflo-3.38.17-3.38.18-block');
+  assert.equal(blocked.evidence.observedVersion, '3.38.17');
+  assert.equal(blocked.evidence.applicability, 'affected');
+  const brain = result.constraints.find((entry) => entry.dependency === 'ruvnet-brain');
+  assert.equal(brain, undefined);
+});
+
+test('future verification dates are invalid rather than falsely current', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ak-upstream-'));
+  try {
+    const document = JSON.parse(fs.readFileSync(registryFile, 'utf8'));
+    document.lastVerifiedAt = '2099-01-01';
+    for (const constraint of document.constraints) constraint.nextRetestAt = '2099-01-02';
+    const file = path.join(root, 'constraints.json');
+    fs.writeFileSync(file, JSON.stringify(document));
+    const result = loadUpstreamConstraints({ file, now });
+    assert.equal(result.status, 'invalid');
+    assert.match(result.errors.join('\n'), /cannot be in the future/);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- add host-neutral `ak heal hooks` with deterministic dry-run and explicit content-bound apply authorization
- add durable backups, transaction journals, receipts, conditional undo, interrupted recovery, and no-op proof
- keep unknown/future schemas, OpenCode modules, external adapters, generated/plugin caches, trust state, JSONC/TOML, noncanonical JSON, and Windows replacement non-executable
- harden external adapter admission with bounded descriptor reads, containment and identity checks, byte limits, and v1 consent-hash compatibility
- version and validate the upstream dependency/workaround lifecycle; issue payloads remain drafts
- add operator guidance, ADR/DDD contracts, schemas, adversarial tests, and an evidence-bearing validation receipt

## Verification

- `npm run typecheck`
- `npm run lint` (warnings only, no errors)
- `npm run lint:cc`
- `npm run lint:md` (81 files, 0 issues)
- `npm run build`
- `npm test` (exit 0)
- focused Node suite: 90 passed, 0 failed
- measured focused line coverage: remediation modules 86.85–98.36%; hook-audit modules 85.96–100%; adapter integrity 83.81%
- `git diff --check`

## AQE and review disclosure

The real Agentic-QE fleet found no predicted defects and no narrowed SAST findings in the remediation or adapter admission/integrity boundary. The aggregate AQE quality gate remains `block` because it consumed an explicitly unmeasured static coverage estimate plus repository-wide complexity; this is disclosed rather than relabeled as a pass. Its repository scan matches longstanding fixtures and lexical patterns; the three changed-area hook-audit alerts were manually verified as `RegExp.exec()` and static relative imports. AI test generation was policy-denied because it could export private source, and no workaround was attempted.

Ruflo architecture, compatibility, and QE-design reviews completed. Claude Code required login, so independent dual-host participant acceptance is degraded and is not claimed.

## Remaining limits

- receipt digests provide integrity, not authenticity
- multi-target apply uses compensating rollback, not global atomicity
- native directory-fd operations would be needed to exclude a malicious same-user directory race more strongly
- upstream issue payloads are draft-only; this PR publishes no external issue

Full evidence: `docs/audits/host-neutral-hook-healing-2026-09-02.md`.
