### PR TITLE
feat(models): add Claude Fable 5.1 / Mythos 5.1 support

### DIFF
--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -524,7 +524,7 @@ a user-pinned route is reported, never rewritten (still routed to the replacemen
 merely no longer the default, which `ak status` reports as routing *divergence*: a trade for you to
 weigh, cleared with `ak x host refresh` if you want the newer default.
 
-**Known-good model choices** (verified 2026-08; any model your host CLI accepts also works):
+**Known-good model choices** (verified 2026-09; any model your host CLI accepts also works):
 
 > **Per-token price ≠ per-task cost.** A model that needs more agentic turns costs more
 > per task at the same per-token price. On subscription (`claude-code` oauth) billing the
@@ -535,9 +535,10 @@ weigh, cleared with `ak x host refresh` if you want the newer default.
 |---|---|---|
 | claude | `claude-opus-5` | top Opus — the deepest reasoning, at ~2–3× the agentic turns of a balanced model on routine work; earns it at the hard end |
 | claude | `claude-sonnet-5` | near-Opus capability at a lower per-token price — review, spec, release |
-| claude | `claude-fable-5` | top capability (Mythos-class, above Opus 5) — hardest problems |
+| claude | `claude-fable-5-1` | top capability (Mythos-class, above Opus 5) — successor to Fable 5 at the same per-token price — hardest problems |
 | claude | `claude-haiku-4-5-20251001` | cheap/fast — high-volume mechanical work |
 | claude | `claude-opus-4-8` | prior Opus generation — same per-token price as Opus 5, roughly half the agentic turns on routine work |
+| claude | `claude-fable-5` | prior Fable generation — same per-token price as Fable 5.1, superseded as the flagship pick |
 | codex | `gpt-5.6-sol` | flagship 5.6 — strongest on complex coding, computer use and security work; first-class max reasoning effort |
 | codex | `gpt-5.6-terra` | balanced 5.6 — everyday implementation and testing at a materially lower per-token price than sol; the gpt-5.4 replacement |
 | codex | `gpt-5.6-luna` | fastest/cheapest 5.6 — mechanical implementation, docs and packaging; the gpt-5.4-mini replacement |
@@ -546,11 +547,12 @@ weigh, cleared with `ak x host refresh` if you want the newer default.
 > same $5/$25 per-Mtok pricing as Opus 4.8 with roughly double the Frontier-Bench
 > performance, which is why it is the reasoning-tier default. That parity is **per token**:
 > measured end-to-end it takes 2–3.4× the agentic turns on routine work, so per task it is
-> the more expensive arm there and 4.8 remains a defensible pin. It is **not** Mythos-class: `claude-fable-5`
+> the more expensive arm there and 4.8 remains a defensible pin. It is **not** Mythos-class: `claude-fable-5-1`
 > remains the flagship tier. Opus 5 lands within ~0.5% of Fable on coding/agentic
 > benchmarks at about half the cost per task, but stays behind the Mythos-class models on
 > frontier domains. Rule of thumb: `claude-opus-5` is the premium default;
-> `claude-fable-5` is the escalation ceiling.
+> `claude-fable-5-1` is the escalation ceiling. `claude-fable-5` remains pinnable at the
+> same per-token price but is no longer the default flagship pick.
 
 `ak host pick --help` prints this list too. Tuning is per-route and reversible: hand-edit
 `kit.json` `routing.routes`, pass `--route`, or use `ak host off` to clear it entirely.

--- a/docs/USAGE-SCORECARD-METRICS.md
+++ b/docs/USAGE-SCORECARD-METRICS.md
@@ -487,7 +487,7 @@ cost = (inputUnits × rate_in + output × rate_out) / 1,000,000
 Mythos 5.1, which resolve to 0.025 (§13.1). Summed across every row in the
 window.
 
-**Source:** `costOf()`, `src/lib/pricing.mjs:294-301`, reproduced verbatim:
+**Source:** `costOf()`, `src/lib/pricing.mjs:298-305`, reproduced verbatim:
 
 ```js
 export function costOf(usage) {
@@ -502,19 +502,19 @@ export function costOf(usage) {
 
 `CACHE_READ_MULTIPLIER = 0.1` is the default `cacheReadMultiplier` `priceFor`
 resolves for a matched entry; `CACHE_WRITE_MULTIPLIER = 1.25` is applied
-uniformly, no per-model override (`pricing.mjs:189-190`) — see §13 for why
+uniformly, no per-model override (`pricing.mjs:193-194`) — see §13 for why
 these two numbers are correct for **both** Anthropic and OpenAI (excepting
 the one documented cache-read exception), which is why `costOf` needs no
 per-provider branch on either multiplier (only on the base
-`rate_in`/`rate_out`, resolved by `priceFor`, `pricing.mjs:254-269`).
+`rate_in`/`rate_out`, resolved by `priceFor`, `pricing.mjs:258-273`).
 
 Rate resolution is **longest-prefix match** (`isPrefixOf`, `KEYS_BY_LENGTH`)
-on a normalized model id (`pricing.mjs:198-207`), so a dated release
+on a normalized model id (`pricing.mjs:202-211`), so a dated release
 (`claude-haiku-4-5-20251001`)
 resolves to the same entry as its bare alias, and a more specific entry
 (`gpt-5.6-sol`) is never shadowed by a shorter one (`gpt-5.6`). An id matching
 nothing gets `FALLBACK_PRICE` — Sonnet-class rate, `$3`/`$15`
-(`pricing.mjs:186`) — rather than `$0`, so an unrecognized model can never be
+(`pricing.mjs:190`) — rather than `$0`, so an unrecognized model can never be
 silently free; `matched: false` travels with the result so a maintainer can
 find fallback-priced rows if the table needs a new entry.
 
@@ -524,7 +524,7 @@ Each table entry is a **schedule** — an ordered list of periods, each with the
 day it takes effect. Nearly every entry has exactly one period that has always
 applied (`anthropic(5, 25)` builds that shape); an entry whose rate the vendor
 has *published* a change to carries more than one (`schedule`,
-`pricing.mjs:44-63`). `periodOn` (`pricing.mjs:222`) picks the last period
+`pricing.mjs:44-67`). `periodOn` (`pricing.mjs:226`) picks the last period
 already in effect on the given day, comparing ISO date strings
 lexicographically so no `Date` parsing is involved and the module stays
 clock-free.
@@ -552,7 +552,7 @@ Two rules bound the mechanism:
   Codex promo would be a one-line edit rather than new machinery. Rates that
   vary by *how* a request was served — regional uplift, large-prompt surcharge,
   service tiers — are a different axis, are deliberately **not** expressible
-  here, and remain in `UNMODELLED_PRICING_FACTORS` (`pricing.mjs:177-179`)
+  here, and remain in `UNMODELLED_PRICING_FACTORS` (`pricing.mjs:181-183`)
   because a transcript does not record the endpoint or tier.
 
 A `priceFor` call with no day prices as of `PRICES_AS_OF`, the table's
@@ -1099,14 +1099,14 @@ path, opt-in or otherwise, anywhere in this codebase.
 
 ## 13. Provider pricing tables — verified rates
 
-Every rate lives in the `PRICES` table (`src/lib/pricing.mjs:74-145`) and carries
+Every rate lives in the `PRICES` table (`src/lib/pricing.mjs:78-149`) and carries
 the table's own last-verified date, `PRICES_AS_OF = '2026-08-25'`
-(`pricing.mjs:18`). Each subsection below dates its own source check separately.
+(`pricing.mjs:21`). Each subsection below dates its own source check separately.
 
 **The code is the authority for a rate; this section is a reading of it.** The
-Anthropic transcription in §13.1 matches `pricing.mjs:75-109` value for value.
+Anthropic transcription in §13.1 matches `pricing.mjs:79-113` value for value.
 The OpenAI transcription in §13.2 does **not** currently match
-`pricing.mjs:132-144`, and the sourcing note there is likewise out of step with
+`pricing.mjs:136-148`, and the sourcing note there is likewise out of step with
 the file's own comment. Price a row from `pricing.mjs`, not from §13.2's table,
 until the two are reconciled.
 
@@ -1130,7 +1130,7 @@ own published table, not a transcription from a secondary source:
 input — every other current Anthropic model uses 0.1×. Verified 2026-09-02
 against **[C1]**'s live pricing page.
 
-Every value in `pricing.mjs`'s Anthropic entries (`pricing.mjs:75-109`) matches
+Every value in `pricing.mjs`'s Anthropic entries (`pricing.mjs:79-113`) matches
 this table's Base-input and Output columns exactly. Note that the two Sonnet
 5 rows above are not a documentation convenience — they are exactly what the
 code encodes, as the two periods of that entry's schedule (§3a), so the table
@@ -1139,14 +1139,14 @@ cache-read *columns* in this table are provider-published absolute rates; the
 kit's `pricing.mjs` instead stores **multipliers** — 1.25× for a 5-minute cache
 write (uniform, no published per-model exception) and, for cache reads, 0.1×
 for every model *except* Fable 5.1 / Mythos 5.1, which carry their own
-0.025× cache-read override on that catalog entry (`pricing.mjs:85-86`)
+0.025× cache-read override on that catalog entry (`pricing.mjs:89-90`)
 instead of the module-wide default multiplier.
 
-`priceFor()` (`pricing.mjs:254-269`) is what resolves that: it returns a
+`priceFor()` (`pricing.mjs:258-273`) is what resolves that: it returns a
 `cacheReadMultiplier` field taken from the matched entry, falling back to
-`CACHE_READ_MULTIPLIER` (`pricing.mjs:189-190`) when the entry carries none.
+`CACHE_READ_MULTIPLIER` (`pricing.mjs:193-194`) when the entry carries none.
 
-`costOf()` (`pricing.mjs:294-301`) then multiplies cache-read tokens by
+`costOf()` (`pricing.mjs:298-305`) then multiplies cache-read tokens by
 that resolved value rather than a hardcoded constant.
 
 5-minute TTL only: the kit does not currently distinguish 5-minute from 1-hour cache TTL,
@@ -1163,11 +1163,11 @@ Anthropic's own prompt-caching documentation **[C2]** states the multipliers
 in prose, independent of the pricing table: *"5-minute cache write tokens are
 1.25 times the base input tokens price... Cache read tokens are 0.1 times the
 base input tokens price."* This is the second, independent confirmation of
-`CACHE_READ_MULTIPLIER`/`CACHE_WRITE_MULTIPLIER` (`pricing.mjs:189-190`).
+`CACHE_READ_MULTIPLIER`/`CACHE_WRITE_MULTIPLIER` (`pricing.mjs:193-194`).
 
 ### 13.2 OpenAI (Codex) — hand-maintained, no canonical machine-readable source
 
-`pricing.mjs`'s own comment (`pricing.mjs:111-114`) records that
+`pricing.mjs`'s own comment (`pricing.mjs:115-118`) records that
 `~/.codex/models_cache.json` was checked directly and contains **zero**
 price-related keys — Codex CLI does not ship pricing data locally, unlike
 Anthropic which publishes a fetchable pricing document. OpenAI's rates in
@@ -1212,8 +1212,8 @@ hand-maintained and drift-prone, not vendor-confirmed via automated fetch.
 
 ### 13.3 What the pricing table deliberately does not model
 
-Recorded verbatim from `pricing.mjs:148-176` (`UNMODELLED_PRICING_FACTORS`,
-`pricing.mjs:177-179`) because listing known gaps is what makes the
+Recorded verbatim from `pricing.mjs:152-180` (`UNMODELLED_PRICING_FACTORS`,
+`pricing.mjs:181-183`) because listing known gaps is what makes the
 *modelled* factors credible:
 
 - **Regional-processing uplift.** OpenAI charges +10% on data-residency

--- a/docs/USAGE-SCORECARD-METRICS.md
+++ b/docs/USAGE-SCORECARD-METRICS.md
@@ -479,38 +479,42 @@ price · not plan billing`.
 **Formula**, per `(session, day, model)` usage row:
 
 ```text
-inputUnits = input + cacheWrite × 1.25 + cacheRead × 0.1
+inputUnits = input + cacheWrite × 1.25 + cacheRead × cacheReadMultiplier
 cost = (inputUnits × rate_in + output × rate_out) / 1,000,000
 ```
 
-summed across every row in the window.
+`cacheReadMultiplier` is 0.1 for every model except Claude Fable 5.1 / Claude
+Mythos 5.1, which resolve to 0.025 (§13.1). Summed across every row in the
+window.
 
-**Source:** `costOf()`, `src/lib/pricing.mjs:262-268`, reproduced verbatim:
+**Source:** `costOf()`, `src/lib/pricing.mjs:294-301`, reproduced verbatim:
 
 ```js
 export function costOf(usage) {
   const { model, provider, input, output, cacheRead, cacheWrite, day } = usage ?? {};
-  const { in: rin, out: rout } = priceFor(model, provider, day);
+  const { in: rin, out: rout, cacheReadMultiplier } = priceFor(model, provider, day);
   const inputUnits = tokens(input)
     + tokens(cacheWrite) * CACHE_WRITE_MULTIPLIER
-    + tokens(cacheRead) * CACHE_READ_MULTIPLIER;
+    + tokens(cacheRead) * cacheReadMultiplier;
   return (inputUnits * rin + tokens(output) * rout) / 1e6;
 }
 ```
 
-`CACHE_READ_MULTIPLIER = 0.1`, `CACHE_WRITE_MULTIPLIER = 1.25`
-(`pricing.mjs:169-170`) — see §13 for why these two numbers are correct for
-**both** Anthropic and OpenAI, which is why `costOf` needs no per-provider
-branch on the multiplier (only on the base `rate_in`/`rate_out`, resolved by
-`priceFor`, `pricing.mjs:229-242`).
+`CACHE_READ_MULTIPLIER = 0.1` is the default `cacheReadMultiplier` `priceFor`
+resolves for a matched entry; `CACHE_WRITE_MULTIPLIER = 1.25` is applied
+uniformly, no per-model override (`pricing.mjs:189-190`) — see §13 for why
+these two numbers are correct for **both** Anthropic and OpenAI (excepting
+the one documented cache-read exception), which is why `costOf` needs no
+per-provider branch on either multiplier (only on the base
+`rate_in`/`rate_out`, resolved by `priceFor`, `pricing.mjs:254-269`).
 
 Rate resolution is **longest-prefix match** (`isPrefixOf`, `KEYS_BY_LENGTH`)
-on a normalized model id (`pricing.mjs:178-187`), so a dated release
+on a normalized model id (`pricing.mjs:198-207`), so a dated release
 (`claude-haiku-4-5-20251001`)
 resolves to the same entry as its bare alias, and a more specific entry
 (`gpt-5.6-sol`) is never shadowed by a shorter one (`gpt-5.6`). An id matching
 nothing gets `FALLBACK_PRICE` — Sonnet-class rate, `$3`/`$15`
-(`pricing.mjs:166`) — rather than `$0`, so an unrecognized model can never be
+(`pricing.mjs:186`) — rather than `$0`, so an unrecognized model can never be
 silently free; `matched: false` travels with the result so a maintainer can
 find fallback-priced rows if the table needs a new entry.
 
@@ -520,7 +524,7 @@ Each table entry is a **schedule** — an ordered list of periods, each with the
 day it takes effect. Nearly every entry has exactly one period that has always
 applied (`anthropic(5, 25)` builds that shape); an entry whose rate the vendor
 has *published* a change to carries more than one (`schedule`,
-`pricing.mjs:41-55`). `periodOn` (`pricing.mjs:202`) picks the last period
+`pricing.mjs:44-63`). `periodOn` (`pricing.mjs:222`) picks the last period
 already in effect on the given day, comparing ISO date strings
 lexicographically so no `Date` parsing is involved and the module stays
 clock-free.
@@ -548,7 +552,7 @@ Two rules bound the mechanism:
   Codex promo would be a one-line edit rather than new machinery. Rates that
   vary by *how* a request was served — regional uplift, large-prompt surcharge,
   service tiers — are a different axis, are deliberately **not** expressible
-  here, and remain in `UNMODELLED_PRICING_FACTORS` (`pricing.mjs:157-159`)
+  here, and remain in `UNMODELLED_PRICING_FACTORS` (`pricing.mjs:177-179`)
   because a transcript does not record the endpoint or tier.
 
 A `priceFor` call with no day prices as of `PRICES_AS_OF`, the table's
@@ -666,7 +670,7 @@ t.tokens)`), rendered `dashboard/client.mjs`.
 **Why this number matters more than it looks like it should.** On the
 reference corpus, 96.3% of tokens were cache reads — pricing them as fresh
 input (rather than at the 0.1× multiplier) would overstate cost by roughly
-10× (`pricing.mjs:8-9`). A cache-read share this high is not an anomaly to be
+10× (`pricing.mjs:7-10`). A cache-read share this high is not an anomaly to be
 suspicious of on its own — it is the expected steady state for any
 long-running agentic session that resends a large, mostly-unchanged system
 prompt and tool-result history on every turn, which both Claude Code and
@@ -1095,14 +1099,14 @@ path, opt-in or otherwise, anywhere in this codebase.
 
 ## 13. Provider pricing tables — verified rates
 
-Every rate lives in the `PRICES` table (`src/lib/pricing.mjs:65-125`) and carries
+Every rate lives in the `PRICES` table (`src/lib/pricing.mjs:74-145`) and carries
 the table's own last-verified date, `PRICES_AS_OF = '2026-08-25'`
 (`pricing.mjs:18`). Each subsection below dates its own source check separately.
 
 **The code is the authority for a rate; this section is a reading of it.** The
-Anthropic transcription in §13.1 matches `pricing.mjs:67-89` value for value.
+Anthropic transcription in §13.1 matches `pricing.mjs:75-109` value for value.
 The OpenAI transcription in §13.2 does **not** currently match
-`pricing.mjs:112-124`, and the sourcing note there is likewise out of step with
+`pricing.mjs:132-144`, and the sourcing note there is likewise out of step with
 the file's own comment. Price a row from `pricing.mjs`, not from §13.2's table,
 until the two are reconciled.
 
@@ -1113,6 +1117,7 @@ own published table, not a transcription from a secondary source:
 
 | Model | Base input | 5m cache write | 1h cache write | Cache read (hit) | Output |
 |---|---|---|---|---|---|
+| Claude Fable 5.1 / Mythos 5.1 | $10/MTok | $12.50/MTok | $20/MTok | $0.25/MTok¹ | $50/MTok |
 | Claude Fable 5 / Mythos 5 | $10/MTok | $12.50/MTok | $20/MTok | $1/MTok | $50/MTok |
 | Claude Opus 5 | $5/MTok | $6.25/MTok | $10/MTok | $0.50/MTok | $25/MTok |
 | Claude Opus 4.8 / 4.7 / 4.6 / 4.5 | $5/MTok | $6.25/MTok | $10/MTok | $0.50/MTok | $25/MTok |
@@ -1121,32 +1126,48 @@ own published table, not a transcription from a secondary source:
 | Claude Sonnet 4.6 / 4.5 | $3/MTok | $3.75/MTok | $6/MTok | $0.30/MTok | $15/MTok |
 | Claude Haiku 4.5 | $1/MTok | $1.25/MTok | $2/MTok | $0.10/MTok | $5/MTok |
 
-Every value in `pricing.mjs`'s Anthropic entries (`pricing.mjs:67-89`) matches
+¹ Cache hits on Claude Fable 5.1 and Claude Mythos 5.1 price at **0.025×** base
+input — every other current Anthropic model uses 0.1×. Verified 2026-09-02
+against **[C1]**'s live pricing page.
+
+Every value in `pricing.mjs`'s Anthropic entries (`pricing.mjs:75-109`) matches
 this table's Base-input and Output columns exactly. Note that the two Sonnet
 5 rows above are not a documentation convenience — they are exactly what the
 code encodes, as the two periods of that entry's schedule (§3a), so the table
 and the implementation state the same published change in the same shape. The cache-write and
 cache-read *columns* in this table are provider-published absolute rates; the
-kit's `pricing.mjs` instead stores the two **multipliers** (0.1× and 1.25×,
-5-minute TTL only — the kit does not currently distinguish 5-minute from
-1-hour cache TTL, since Claude Code transcripts do not record which TTL a
-given cache write used) and applies them to the base input rate at cost-compute
-time (`costOf()`, §3). Cross-checking one row: Opus 5's published $6.25
-5-minute cache-write rate is exactly *$5 × 1.25*; its published $0.50 cache-read
-rate is exactly *$5 × 0.1*. Every row in Anthropic's own table satisfies
-`cache_write_5m = input × 1.25` and `cache_read = input × 0.1` — confirming
-the multiplier approach is arithmetically identical to using the provider's
-published absolute cache rates directly, for every current Anthropic model.
+kit's `pricing.mjs` instead stores **multipliers** — 1.25× for a 5-minute cache
+write (uniform, no published per-model exception) and, for cache reads, 0.1×
+for every model *except* Fable 5.1 / Mythos 5.1, which carry their own
+0.025× cache-read override on that catalog entry (`pricing.mjs:85-86`)
+instead of the module-wide default multiplier.
+
+`priceFor()` (`pricing.mjs:254-269`) is what resolves that: it returns a
+`cacheReadMultiplier` field taken from the matched entry, falling back to
+`CACHE_READ_MULTIPLIER` (`pricing.mjs:189-190`) when the entry carries none.
+
+`costOf()` (`pricing.mjs:294-301`) then multiplies cache-read tokens by
+that resolved value rather than a hardcoded constant.
+
+5-minute TTL only: the kit does not currently distinguish 5-minute from 1-hour cache TTL,
+since Claude Code transcripts do not record which TTL a given cache write
+used. Cross-checking one row: Opus 5's published $6.25 5-minute cache-write
+rate is exactly *$5 × 1.25*; its published $0.50 cache-read rate is exactly
+*$5 × 0.1*. Every row in Anthropic's own table satisfies
+`cache_write_5m = input × 1.25` and, except for the Fable 5.1 / Mythos 5.1
+row noted above, `cache_read = input × 0.1` — confirming the multiplier
+approach is arithmetically identical to using the provider's published
+absolute cache rates directly.
 
 Anthropic's own prompt-caching documentation **[C2]** states the multipliers
 in prose, independent of the pricing table: *"5-minute cache write tokens are
 1.25 times the base input tokens price... Cache read tokens are 0.1 times the
 base input tokens price."* This is the second, independent confirmation of
-`CACHE_READ_MULTIPLIER`/`CACHE_WRITE_MULTIPLIER` (`pricing.mjs:169-170`).
+`CACHE_READ_MULTIPLIER`/`CACHE_WRITE_MULTIPLIER` (`pricing.mjs:189-190`).
 
 ### 13.2 OpenAI (Codex) — hand-maintained, no canonical machine-readable source
 
-`pricing.mjs`'s own comment (`pricing.mjs:91-94`) records that
+`pricing.mjs`'s own comment (`pricing.mjs:111-114`) records that
 `~/.codex/models_cache.json` was checked directly and contains **zero**
 price-related keys — Codex CLI does not ship pricing data locally, unlike
 Anthropic which publishes a fetchable pricing document. OpenAI's rates in
@@ -1191,8 +1212,8 @@ hand-maintained and drift-prone, not vendor-confirmed via automated fetch.
 
 ### 13.3 What the pricing table deliberately does not model
 
-Recorded verbatim from `pricing.mjs:127-156` (`UNMODELLED_PRICING_FACTORS`,
-`pricing.mjs:157-159`) because listing known gaps is what makes the
+Recorded verbatim from `pricing.mjs:148-176` (`UNMODELLED_PRICING_FACTORS`,
+`pricing.mjs:177-179`) because listing known gaps is what makes the
 *modelled* factors credible:
 
 - **Regional-processing uplift.** OpenAI charges +10% on data-residency

--- a/src/lib/model-inventory/discovery/anthropic-catalog.mjs
+++ b/src/lib/model-inventory/discovery/anthropic-catalog.mjs
@@ -1,7 +1,7 @@
 import { PRICES_AS_OF, priceFor } from '../../pricing.mjs';
 import { modelRecord, sourceRecord } from './index.mjs';
 
-export const ANTHROPIC_PUBLIC_CATALOG_AS_OF = '2026-08-25';
+export const ANTHROPIC_PUBLIC_CATALOG_AS_OF = '2026-09-02';
 export const ANTHROPIC_MODELS_URL =
   'https://platform.claude.com/docs/en/about-claude/models/overview';
 export const ANTHROPIC_LIFECYCLE_URL =
@@ -49,6 +49,12 @@ const removed = (id, displayName, retiredAt, replacement, aliases = []) => ({
  * @type {readonly AnthropicPublicModel[]}
  */
 export const ANTHROPIC_PUBLIC_MODELS = Object.freeze([
+  active('claude-fable-5-1', 'Claude Fable 5.1', {
+    contextLimit: 1_000_000, outputLimit: 128_000, retirementNotBefore: '2027-09-01',
+  }),
+  active('claude-mythos-5-1', 'Claude Mythos 5.1', {
+    contextLimit: 1_000_000, outputLimit: 128_000, availability: 'limited',
+  }),
   active('claude-fable-5', 'Claude Fable 5', {
     contextLimit: 1_000_000, outputLimit: 128_000, retirementNotBefore: '2027-06-09',
   }),

--- a/src/lib/pricing.mjs
+++ b/src/lib/pricing.mjs
@@ -5,8 +5,11 @@
 // as such and never as plan billing.
 //
 // The cache multipliers are the whole point of this module. On a real corpus
-// ~96% of tokens are cache reads, which bill at 0.1× input; pricing them as
-// fresh input overstates cost by roughly 10×. Cache writes bill at 1.25×.
+// ~96% of tokens are cache reads, which bill at 0.1× input for nearly every
+// model (0.025× on Fable 5.1 / Mythos 5.1 — a per-entry override, see below);
+// pricing them as fresh input overstates cost by roughly 10×, or 40× on those
+// two. Cache writes bill at 1.25× uniformly (no published per-model exception
+// as of this writing).
 //
 // Rates drift and are maintained BY HAND (OpenAI publishes nothing
 // machine-readable in ~/.codex/models_cache.json, verified). PRICES_AS_OF is
@@ -41,14 +44,20 @@ export const PRICES_AS_OF = '2026-08-25';
 const schedule = (provider) => {
   // `from` absent on the first period = "has always applied". Periods are kept
   // sorted so selection is a scan for the last one already in effect.
-  const build = (periods) => ({
+  //
+  // `cacheReadMultiplier` is a per-MODEL override, not per-period — it lives
+  // on the built entry itself, not inside `periods`. Every entry defaults to
+  // the module-wide CACHE_READ_MULTIPLIER; Fable 5.1 / Mythos 5.1 are, as of
+  // this writing, the only published exception (§ PRICES).
+  const build = (periods, { cacheReadMultiplier } = {}) => ({
     provider,
     asOf: PRICES_AS_OF,
     periods: [...periods]
       .map((p) => ({ from: p.from ?? null, in: p.in, out: p.out }))
       .sort((a, b) => String(a.from ?? '').localeCompare(String(b.from ?? ''))),
+    ...(cacheReadMultiplier !== undefined ? { cacheReadMultiplier } : {}),
   });
-  const make = (i, o) => build([{ in: i, out: o }]);
+  const make = (i, o, extra) => build([{ in: i, out: o }], extra);
   make.dated = build;
   return make;
 };
@@ -64,6 +73,17 @@ const openai = schedule('openai');
  */
 export const PRICES = {
   // Anthropic — flagship (Fable/Mythos class)
+  // Fable 5.1 / Mythos 5.1 launched at the same base $10/$50 rate as 5 — an
+  // explicit entry (rather than relying on the longest-prefix matcher falling
+  // through to 'claude-fable-5' on the '-1' token boundary) so a future
+  // divergence in Anthropic's published rate is a one-line diff, not a silent
+  // mis-price. They DO already diverge on one axis: Anthropic prices cache
+  // reads on these two at 0.025x base input, not the standard 0.1x every
+  // other current model uses (platform.claude.com/docs/en/about-claude/pricing,
+  // verified 2026-09-02) — hence the per-entry override below rather than
+  // relying on the module-wide default.
+  'claude-fable-5-1': anthropic(10, 50, { cacheReadMultiplier: 0.025 }),
+  'claude-mythos-5-1': anthropic(10, 50, { cacheReadMultiplier: 0.025 }),
   'claude-fable-5': anthropic(10, 50),
   'claude-mythos-5': anthropic(10, 50),
   // Anthropic — Opus line (5 and the prior generations share a price)
@@ -211,13 +231,18 @@ function periodOn(periods, day) {
 }
 
 /**
- * Resolve a model id to its rates: `{ in, out, provider, key, matched }`.
+ * Resolve a model id to its rates:
+ * `{ in, out, provider, key, matched, cacheReadMultiplier }`.
  *
  * Longest-prefix match over `PRICES`. `provider` is a HINT used only to break a
  * tie between equally-specific entries — it never vetoes an unambiguous id match,
  * because the id is the stronger signal. An unrecognised (or absent, or
  * non-string) model yields `FALLBACK_PRICE` with `matched:false`; this function
  * never throws.
+ *
+ * `cacheReadMultiplier` defaults to the module-wide `CACHE_READ_MULTIPLIER`
+ * unless the matched entry carries its own (Fable 5.1 / Mythos 5.1 today) —
+ * see the `schedule()` comment in the table above.
  *
  * `day` (ISO `YYYY-MM-DD`) selects the rate IN EFFECT ON THAT DAY. Cost
  * attribution is historical: tokens spent in August were metered at August's
@@ -234,10 +259,13 @@ export function priceFor(model, provider, day) {
       const best = (provider && hits.find(({ key }) => PRICES[key].provider === provider)) || hits[0];
       const p = PRICES[best.key];
       const r = periodOn(p.periods, day);
-      return { in: r.in, out: r.out, provider: p.provider, key: best.key, matched: true };
+      return {
+        in: r.in, out: r.out, provider: p.provider, key: best.key, matched: true,
+        cacheReadMultiplier: p.cacheReadMultiplier ?? CACHE_READ_MULTIPLIER,
+      };
     }
   }
-  return { ...FALLBACK_PRICE, key: null, matched: false };
+  return { ...FALLBACK_PRICE, key: null, matched: false, cacheReadMultiplier: CACHE_READ_MULTIPLIER };
 }
 
 // ── Cost ─────────────────────────────────────────────────────────────────────
@@ -248,7 +276,11 @@ const tokens = (v) => (Number.isFinite(v) && v > 0 ? v : 0);
 /**
  * API-equivalent cost in USD for one model's token usage:
  *
- *   (input·in + cacheWrite·in·1.25 + cacheRead·in·0.1 + output·out) / 1e6
+ *   (input·in + cacheWrite·in·1.25 + cacheRead·in·cacheReadMultiplier + output·out) / 1e6
+ *
+ * `cacheReadMultiplier` is 0.1 for nearly every model but is resolved per-model
+ * via `priceFor` (Fable 5.1 / Mythos 5.1 price cache reads at 0.025x — see the
+ * `PRICES` table comment), so this is never hardcoded here.
  *
  * All counters are optional and default to 0, so all-zero usage returns exactly
  * `0`. An unknown model is priced at the fallback rate rather than zeroed, and
@@ -261,9 +293,9 @@ const tokens = (v) => (Number.isFinite(v) && v > 0 ? v : 0);
  */
 export function costOf(usage) {
   const { model, provider, input, output, cacheRead, cacheWrite, day } = usage ?? {};
-  const { in: rin, out: rout } = priceFor(model, provider, day);
+  const { in: rin, out: rout, cacheReadMultiplier } = priceFor(model, provider, day);
   const inputUnits = tokens(input)
     + tokens(cacheWrite) * CACHE_WRITE_MULTIPLIER
-    + tokens(cacheRead) * CACHE_READ_MULTIPLIER;
+    + tokens(cacheRead) * cacheReadMultiplier;
   return (inputUnits * rin + tokens(output) * rout) / 1e6;
 }

--- a/src/lib/pricing.mjs
+++ b/src/lib/pricing.mjs
@@ -49,6 +49,10 @@ const schedule = (provider) => {
   // on the built entry itself, not inside `periods`. Every entry defaults to
   // the module-wide CACHE_READ_MULTIPLIER; Fable 5.1 / Mythos 5.1 are, as of
   // this writing, the only published exception (§ PRICES).
+  /**
+   * @param {{in: number, out: number, from?: string}[]} periods
+   * @param {{cacheReadMultiplier?: number}} [extra]
+   */
   const build = (periods, { cacheReadMultiplier } = {}) => ({
     provider,
     asOf: PRICES_AS_OF,

--- a/src/lib/routing.mjs
+++ b/src/lib/routing.mjs
@@ -77,7 +77,7 @@ export const SUBSCRIPTION_PROVIDERS = new Set(['claude-code', 'codex', 'ollama',
 // WITHOUT saying "per-token" gets read as cost-per-task, which is the axis users
 // actually pay on (a model needing 2-3x the agentic turns costs more per task at
 // identical per-token price). Measured end-to-end in pacphi/retort versions-blog.
-export const MODEL_CATALOG_VERIFIED = '2026-08-07';
+export const MODEL_CATALOG_VERIFIED = '2026-09-02';
 export const COST_AXIS_NOTE = 'per-token price ≠ per-task cost — a model that needs more agentic turns costs more per task at the same per-token price';
 // Tier names are the pairing key for swapHostModel(): a codex tier only mirrors
 // to a claude model (and back) when BOTH catalogs use the same tier string.
@@ -87,12 +87,13 @@ export const MODEL_CATALOG = {
   claude: [
     { id: 'claude-opus-5', tier: 'reasoning', note: 'top Opus — the deepest reasoning, at ~2–3× the agentic turns of a balanced model on routine work; earns it at the hard end' },
     { id: 'claude-sonnet-5', tier: 'balanced', note: 'near-Opus capability at a lower per-token price — review, spec, release' },
-    { id: 'claude-fable-5', tier: 'flagship', note: 'top capability (Mythos-class, above Opus 5) — hardest problems' },
+    { id: 'claude-fable-5-1', tier: 'flagship', note: 'top capability (Mythos-class, above Opus 5) — successor to Fable 5 at the same per-token price — hardest problems' },
     { id: 'claude-haiku-4-5-20251001', tier: 'fast', note: 'cheap/fast — high-volume mechanical work' },
     // Still current (no deprecation notice) and still pinnable — it is simply no
     // longer what ak routes to by default. Kept listed so divergedRoutes can name
     // its cost-per-task trade when a policy is still pointing at it.
     { id: 'claude-opus-4-8', tier: 'prior', note: 'prior Opus generation — same per-token price as Opus 5, roughly half the agentic turns on routine work' },
+    { id: 'claude-fable-5', tier: 'prior', note: 'prior Fable generation — same per-token price as Fable 5.1, superseded as the flagship pick' },
   ],
   codex: [
     { id: 'gpt-5.6-sol', tier: 'flagship', note: 'flagship 5.6 — strongest on complex coding, computer use and security work; first-class max reasoning effort' },

--- a/tests/kit/model-discovery-claude-codex.test.mjs
+++ b/tests/kit/model-discovery-claude-codex.test.mjs
@@ -54,11 +54,11 @@ test('Claude keeps the 1M selector as a variant instead of a duplicate base mode
 
 test('Claude public facts retain first-party lifecycle, discovery, limits, and scope', () => {
   const result = discoverAnthropicPublicCatalog({
-    capturedAt: '2026-08-25T13:00:00.000Z', scope: { profile: 'default' }, scopeKey: SCOPE_KEY,
+    capturedAt: '2026-09-02T13:00:00.000Z', scope: { profile: 'default' }, scopeKey: SCOPE_KEY,
   });
   assert.equal(result.source.id, 'anthropic-docs');
   assert.equal(result.source.ownerType, 'provider');
-  assert.equal(result.source.sourceVersion, '2026-08-25');
+  assert.equal(result.source.sourceVersion, '2026-09-02');
   assert.equal(result.models.length, ANTHROPIC_PUBLIC_MODELS.length);
 
   const fable = result.models.find((model) => model.identity.modelId === 'claude-fable-5');
@@ -97,9 +97,33 @@ test('Claude public facts retain first-party lifecycle, discovery, limits, and s
   assert.doesNotThrow(() => normalizeSourceResult(result.source));
 });
 
+test('Claude public facts include Fable 5.1 and Mythos 5.1 as active, priced entries', () => {
+  const result = discoverAnthropicPublicCatalog({
+    capturedAt: '2026-09-02T13:00:00.000Z', scopeKey: SCOPE_KEY,
+  });
+  const fable51 = result.models.find((model) => model.identity.modelId === 'claude-fable-5-1');
+  assert.equal(fable51.lifecycle.state, 'active');
+  assert.equal(fable51.dimensions.discoverable.value, true);
+  assert.equal(fable51.capabilities.contextLimit, 1_000_000);
+  assert.equal(fable51.capabilities.outputLimit, 128_000);
+  assert.equal(fable51.pricing.basis, 'per-million-tokens');
+  assert.equal(fable51.pricing.input, 10);
+  assert.equal(fable51.pricing.output, 50);
+  assert.equal(fable51.pricing.currency, 'USD');
+
+  const mythos51 = result.models.find((model) => model.identity.modelId === 'claude-mythos-5-1');
+  assert.equal(mythos51.lifecycle.state, 'active');
+  assert.equal(mythos51.variant.availability, 'limited');
+  assert.equal(mythos51.capabilities.contextLimit, 1_000_000);
+
+  // Fable 5 stays a distinct, still-active entry — 5.1 is additive, not a rename.
+  const fable5 = result.models.find((model) => model.identity.modelId === 'claude-fable-5');
+  assert.equal(fable5.lifecycle.state, 'active');
+});
+
 test('Claude bundled public facts become explicitly stale instead of silently aging', () => {
   const result = discoverAnthropicPublicCatalog({
-    capturedAt: '2026-12-01T00:00:00.000Z', scopeKey: SCOPE_KEY,
+    capturedAt: '2026-12-09T00:00:00.000Z', scopeKey: SCOPE_KEY,
   });
   assert.equal(result.source.status, 'stale');
   assert.equal(result.models[0].evidence.every(({ freshness }) => freshness === 'stale'), true);

--- a/tests/kit/pricing.test.mjs
+++ b/tests/kit/pricing.test.mjs
@@ -38,6 +38,9 @@ test('every PRICES entry carries finite in/out rates, a provider, and asOf', () 
 });
 
 test('the table carries the ADR-0009 §3 rates for each Anthropic tier', () => {
+  assert.deepEqual([priceFor('claude-fable-5-1').in, priceFor('claude-fable-5-1').out], [10, 50]);
+  assert.equal(priceFor('claude-fable-5-1').key, 'claude-fable-5-1', 'resolves to its own explicit row, not a prefix fallthrough');
+  assert.deepEqual([priceFor('claude-mythos-5-1').in, priceFor('claude-mythos-5-1').out], [10, 50]);
   assert.deepEqual([priceFor('claude-fable-5').in, priceFor('claude-fable-5').out], [10, 50]);
   assert.deepEqual([priceFor('claude-opus-5').in, priceFor('claude-opus-5').out], [5, 25]);
   assert.deepEqual([priceFor('claude-opus-4-8').in, priceFor('claude-opus-4-8').out], [5, 25]);
@@ -91,6 +94,38 @@ test('provider disambiguates when given, and is reported back', () => {
   assert.equal(priceFor('gpt-5.5', 'openai').matched, true);
   // A provider that contradicts the only match does not veto it — the id wins.
   assert.equal(priceFor('claude-opus-5', 'openai').in, 5);
+});
+
+// ── priceFor / costOf: per-model cacheReadMultiplier override ───────────────
+// Anthropic prices cache-read hits on Fable 5.1 / Mythos 5.1 at 0.025x base
+// input — every other current model (Anthropic and OpenAI) uses 0.1x. Before
+// the per-entry override existed, costOf() applied the global 0.1x uniformly,
+// which would have overstated Fable 5.1's cache-read-heavy cost by 4x.
+
+test('cacheReadMultiplier defaults to 0.1 for models with no published exception', () => {
+  assert.equal(priceFor('claude-opus-5').cacheReadMultiplier, 0.1);
+  assert.equal(priceFor('claude-fable-5').cacheReadMultiplier, 0.1);
+  assert.equal(priceFor('gpt-5.6-sol').cacheReadMultiplier, 0.1);
+  assert.equal(priceFor('an-unknown-model').cacheReadMultiplier, 0.1, 'fallback also defaults to 0.1');
+});
+
+test('Fable 5.1 and Mythos 5.1 override cacheReadMultiplier to 0.025', () => {
+  assert.equal(priceFor('claude-fable-5-1').cacheReadMultiplier, 0.025);
+  assert.equal(priceFor('claude-mythos-5-1').cacheReadMultiplier, 0.025);
+  // The override travels through a dated id too, same as the base rate does.
+  assert.equal(priceFor('claude-fable-5-1-20260901').cacheReadMultiplier, 0.025);
+});
+
+test('costOf actually applies the override — a cache-read-heavy Fable 5.1 row costs 1/4 of the default-multiplier price', () => {
+  const usage = { model: 'claude-fable-5-1', cacheRead: 1_000_000 };
+  const withOverride = costOf(usage);
+  const withDefaultMultiplier = (1_000_000 * 0.1 * 10) / 1e6; // what the old, pre-fix behavior computed
+  assert.equal(withOverride, (1_000_000 * 0.025 * 10) / 1e6);
+  assert.equal(withOverride, 0.25);
+  assert.equal(withOverride * 4, withDefaultMultiplier, 'the bug this override fixes was a flat 4x overstatement');
+  // Fable 5 (no override) still prices the same cache-read volume at the
+  // default 0.1x, so the two models diverge only on this one axis.
+  assert.equal(costOf({ model: 'claude-fable-5', cacheRead: 1_000_000 }), 1);
 });
 
 // ── priceFor: unknown models never throw ─────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds Claude Fable 5.1 / Mythos 5.1 (`claude-fable-5-1` / `claude-mythos-5-1`) across the three source-of-truth files that track Anthropic model data, plus their doc mirrors and test coverage.

- **Catalog** (`anthropic-catalog.mjs`): both added as active, discoverable entries (1M context / 128K output). Fable 5.1's retirement commitment was verified live against `platform.claude.com`.
- **Pricing** (`pricing.mjs`): explicit `$10/$50` rows added (previously only reachable via an undocumented prefix-match fallthrough to `claude-fable-5`). More importantly: Anthropic prices **cache-read hits on these two models at 0.025x base input, not the 0.1x every other current model uses** — verified live against Anthropic's pricing page. `priceFor()`/`costOf()` previously applied a single module-wide cache-read multiplier to every model; that would have overstated Fable 5.1's cache-read-heavy cost by **4x**. Fixed by resolving a per-entry `cacheReadMultiplier` instead.
- **Routing catalog** (`routing.mjs`): `claude-fable-5-1` promoted to the `'flagship'` pick (Anthropic's own top recommendation for demanding/long-horizon work); `claude-fable-5` moved to `'prior'`, mirroring how Opus 5 superseded Opus 4.8 in the same catalog.
- **Docs**: `PROVIDERS.md` and `USAGE-SCORECARD-METRICS.md` updated to match (both are hand-maintained mirrors of the code, one enforced by an existing test). Also corrected a pricing-table figure I initially got wrong (copied Fable 5's cache-read rate instead of the actual $0.25/MTok), and fixed every `file:line` citation that drifted as `pricing.mjs` grew.
- **Tests**: new coverage for the catalog entries, the explicit pricing row, and — most importantly — the cache-read override, including a test that demonstrates the exact 4x overstatement bug it fixes.

## Test plan

- [x] `npm test` — 2776 tests, 0 failures
- [x] `eslint` clean on all touched source/test files
- [x] `markdownlint-cli2` clean on both touched docs
- [x] `tests/kit/doc-citations.test.mjs` — verifies every `file:line` citation in `USAGE-SCORECARD-METRICS.md` still points at its actual subject
- [x] `tests/kit/routing-divergence.test.mjs` — verifies `PROVIDERS.md` renders `MODEL_CATALOG`'s notes verbatim
- [x] Manually verified Fable 5.1 / Mythos 5.1 model IDs, specs, and pricing against Anthropic's live docs (`platform.claude.com/docs/en/about-claude/models/overview` and `.../pricing`) rather than relying solely on a potentially-stale cached reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gf6hzEr2YRLoWs8p7Zx5Qj