### PR TITLE
feat: surface project skill pressure and read-only plans

### DIFF
--- a/bin/agentic-kit.mjs
+++ b/bin/agentic-kit.mjs
@@ -42,6 +42,7 @@ const PLUMBING = Object.assign(Object.create(null), {
   'host': () => import('../src/commands/x/host.mjs'),
   'reference': () => import('../src/commands/x/reference.mjs'),
   'ruflo-mcp': () => import('../src/commands/x/ruflo-mcp.mjs'),
+  'skills': () => import('../src/commands/x/skills.mjs'),
   'statusline': () => import('../src/commands/x/statusline.mjs'),
   'verify': () => import('../src/commands/x/verify.mjs'),
 });
@@ -85,6 +86,7 @@ Plumbing (power users) — each takes --help:
   ak x mcp [status|pick|off]   MCP registration + tool-family deny rules
   ak x host [status|pick|refresh|off]   manage hosts, routing, and provider bindings
   ak x reference [diff|sync]   CLAUDE.md managed-block inspection/reconcile
+  ak x skills plan             read-only project skill evidence + remediation plan
   ak x statusline [status|codex native|codex extended|codex off]   manage Codex's native user status line
   ak x verify [learning|security|aqe|providers|harvest|all]   deep proofs (slow, spawns real CLIs)
   ak x improvement-eval [...]  causal self-improvement eval (route Q-learner)`;

--- a/docs/DASHBOARD.md
+++ b/docs/DASHBOARD.md
@@ -52,7 +52,7 @@ permanent.
 | System | Sessions | `#system/sessions` | Sessions | The largest individual session files, the project each belongs to, and its share of that host's retained bytes |
 | System | Storage | `#system/storage` | Storage | Where the retained bytes are, by category and host — learning stores counted separately because they dwarf everything else — plus per-series growth |
 | System | Runtime | `#system/runtime` | Runtime | Live host processes, their CPU and memory, background daemons, and machine denominators — refreshed on the header's poll clock while open |
-| System | Catalog | `#system/catalog` | Catalog | Every deduplicated skill, agent, command, plugin and MCP server across user scope and all projects on disk, with a per-host presence matrix and kind/host filters |
+| System | Catalog | `#system/catalog` | Catalog | Summary-first project skill pressure with per-project host disclosure; standalone and plugin-qualified skills, agents, commands, plugins and MCP servers across user/project/plugin scope; provider/version and entrypoint-digest evidence; per-host matrix with kind/host/source filters |
 | System | Projects | `#system/projects` | Projects | Every repository with a remote that a host has recorded a session in — its approximate lines of code, language mix, total disk size and last activity. Worktrees, sub-folders and remote-less repositories are counted below the table, not listed |
 
 About is one scrolling page, so its hashes scroll to a section rather than swapping panels; `#about`
@@ -94,7 +94,10 @@ separate from Vibium's Agentic-QE-owned cache visibility in System.
 System's capability catalog counts both user/plugin surfaces and the project
 surfaces discovered by the host census. In particular, Codex project skills in
 `.agents/skills` are distinct evidence from user `~/.codex/skills` and enabled
-plugin caches; their presence matrix keeps the source visible after deduplication.
+plugin caches; their presence matrix keeps the source visible after deduplication. Full
+`plugin@marketplace` and version/state evidence stays attached to plugin contributions, and a
+standalone skill with the same logical name remains a distinct identity joined by an explicit
+name/digest relationship.
 
 Each card carries an icon, the component name with a state chip, a plain-language tagline, one
 short paragraph explaining what the thing does for you, and a row of link pills — source (GitHub),
@@ -484,9 +487,29 @@ you started is still running.
 
 The trade is stated rather than hidden. Deep-tier figures always render with when they were
 measured, and once a snapshot passes seven days the freshness label turns amber and reads
-`stale, rescan`. A scan writes one file — its own snapshot — and nothing else; the reclaimable-space
+`stale, rescan`. Catalog snapshots also retain bounded stat-only source probes; if a watched plugin,
+surface, or entrypoint changes first, the label immediately reads `catalog changed, rescan`.
+An unchanged probe is not full content validation, and says so in the JSON evidence.
+A scan writes one file — its own snapshot — and nothing else; the reclaimable-space
 rows are advisory, with their rationale and their path, and there is no delete button anywhere in
 this area.
+
+### Catalog evidence and project pressure
+
+Catalog starts with a project-by-host pressure table. Project, user, and enabled-plugin
+contributions are separate columns; exact skill-name and bounded entrypoint-body overlaps are
+separate evidence. The table always says that context inclusion and cutoff are host-owned and
+unknown. Filesystem presence must not be read as “loaded into this session.”
+
+The presence matrix can be filtered independently by kind, host, and source scope. Rows name their
+provider/version and body variants where known. Plugin inventory prefers the hosts' native list
+commands and labels manifest/config/cache fallback as partial; installed-disabled plugins stay in
+inventory without contributing enabled capabilities.
+
+The dashboard remains read-only. `ak x skills plan --project <path>` emits the corresponding
+receipt-aware classification, git state, affected paths, projected result, and stable plan ID; it
+writes nothing. Future remediation belongs to the [Maintenance capability](ddd/maintenance.md)
+tracked by issue #200.
 
 ### Largest consumers, and the project-trees toggle
 

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -5,6 +5,29 @@ latest capability is *two* motions, not one: get the newer code, then turn the f
 This page exists because those two are easy to conflate — and `ak sync`, despite its name,
 only does the first.
 
+## 2026-09-03: System Catalog snapshot v2
+
+Catalog identity now preserves full plugin marketplace/version provenance and separates
+standalone capability identities from plugin-contributed identities. The Footprint snapshot schema
+therefore advances from v1 to v2; an older snapshot is reported as unreadable-by-this-build until
+you run `ak system --deep`. It is not migrated or silently shown under the new semantics.
+
+JSON consumers should treat `catalog.items[].key` as an opaque canonical identifier. The additive
+fields `canonicalId`, `capabilityName`, `pluginRef`, `sourceScopes`, occurrence evidence,
+`overlaps`, `projects`, `pluginSources`, and `sourceStamps` provide relationships previously
+flattened into a display name. Skill/command entrypoint bodies remain absent; only bounded SHA-256
+evidence is emitted.
+
+For a read-only project review, run:
+
+```bash
+ak system --deep
+ak x skills plan --project /absolute/path/to/project
+```
+
+The plan does not remove anything. Mutating upgrade/cleanup remediation is tracked separately in
+issue #200.
+
 ## The one rule
 
 > **`ak sync` converges to the choices already recorded in `kit.json`.** It updates the

--- a/docs/adr/0025-machine-footprint-metrics.md
+++ b/docs/adr/0025-machine-footprint-metrics.md
@@ -11,6 +11,14 @@
   Install observes AQE-owned Vibium and both payloads; daemon cleanup gains an opt-in,
   identity-proven Ruflo MCP orphan path; Catalog covers the launching repository plus observed
   on-disk projects and attributes Codex `.agents/skills` separately
+- **Updated:** 2026-09-03 — CatalogInventory v2 preserves plugin marketplace/version relationships,
+  separates user/project/plugin occurrences, hashes bounded capability entrypoints, reports
+  project pressure and source-probe drift, and feeds a read-only skill maintenance plan. Mutating
+  remediation is explicitly deferred to issue #200.
+- **Updated:** 2026-09-03 — the Catalog leads with the host profile and a five-record cross-host
+  viewport, then gives Project skill pressure a full-width row; pressure groups one disclosure per
+  relevant project, keeps the launching project first, omits measured-zero project rows, and moves
+  per-host source evidence plus one deduplicated plan command behind progressive disclosure.
 - **Deciders:** agentic-kit maintainers
 - **Related:** [ADR-0005](0005-dashboard-in-page-routing-reveal.md),
   [ADR-0007](0007-maintainer-admin-local-telemetry.md),
@@ -19,6 +27,21 @@
   [ADR-0014](0014-dashboard-auth-and-remediation.md),
   [ADR-0023](0023-fail-closed-operations-and-explicit-degradation.md),
   [ADR-0024](0024-project-intelligence-telemetry.md)
+
+> **2026-09-03 amendment.** Catalog identity is no longer only `(kind, normalized name)`: a
+> standalone skill and a plugin-contributed skill with the same logical name are distinct catalog
+> identities joined by explicit exact-name and exact-entrypoint-digest relationships. Full
+> `plugin@marketplace` identity, installed version, enabled state, scope, and evidence authority are
+> retained per host occurrence. The deep snapshot schema advances to v2 so old flattened identities
+> cannot render as current. System remains read-only; `ak x skills plan` classifies and previews,
+> while [Maintenance](../ddd/maintenance.md) / issue #200 owns future mutation and receipts.
+> The pressure view is summary-first: it counts projects with local skills and projects carrying
+> same-name or matching-entrypoint relationships, then groups host evidence beneath one native
+> disclosure per project. Inventory completeness and model-context inclusion are separate facts;
+> hosts do not currently report the latter, so that caveat appears once rather than as a repeated
+> `complete · context unknown` row label. The all-kind detail remains in the Catalog matrix.
+
+<!-- amendment boundary -->
 
 > **2026-08-07 amendment.** Four changes, each recorded where it belongs:
 > project discovery moved to the shared census ([ADR-0027](0027-shared-project-census.md));

--- a/docs/ddd/context-map.md
+++ b/docs/ddd/context-map.md
@@ -29,6 +29,8 @@ Native Evidence ----> Evidence Acquisition ----> Canonical Evidence
                                                           ^
 Project State (.claude-flow/*) ----> Project Intelligence-+
 Local filesystem + process table ---> Machine Footprint --+
+                                           |
+                                           +----> Maintenance (proposed control plane)
 Curated editorial content ----------> Component Directory-+
 
 Maintainer Administration is a separate, deliberately-egressing context.
@@ -51,6 +53,16 @@ representations. A managed companion consumes enabled-host identity but gains no
 routing, observability, or curated-memory authority.
 
 See [Integration management](integration-management.md).
+
+### Maintenance
+
+Maintenance is the proposed human-guided control plane for upgrades, stale/unsupported resource
+cleanup, lifecycle remediation, verification, rollback, and receipts. It consumes observed facts
+from Machine Footprint and ownership/lifecycle facts from Integration Management. It does not own
+those facts and cannot promote disk presence, age, or digest equality into mutation authority.
+
+Issue #198 delivers the read-only catalog and planning seam. Mutating behavior remains proposed in
+issue #200 and is specified in [Maintenance](maintenance.md).
 
 ### Hook configuration assurance
 

--- a/docs/ddd/machine-footprint.md
+++ b/docs/ddd/machine-footprint.md
@@ -73,6 +73,8 @@ read not on this list is a defect, and adding one is an amendment to this docume
 | OpenCode's session store | `project-sources.mjs` | the `directory` column, read-only | every other column, and every message row |
 | A project's own manifests | `stack-detect.mjs` | dependency **keys** (and, for `path:`/`workspace:` entries, enough of the value to reject them) | manifest values, scripts, and anything executable |
 | A project's own source files | `stack-detect.mjs` | the count of `\n` bytes, and whether byte 0 of the first chunk region is NUL | the text — each 64 KB chunk is counted and immediately overwritten |
+| Skill/command entrypoints | `catalog.mjs` | SHA-256 of a regular, non-symlink file up to 1 MiB | descriptions or body text; only the digest leaves the read |
+| Host-native plugin inventory | `claude plugin list --json`, `codex plugin list --json` | whitelisted identity, version, scope, enabled state, install/cache location, lifecycle policy | MCP definitions, headers, credentials, arbitrary source documents, unknown fields |
 
 Three of those rows are new since the first draft of this document, and they are the reason this
 section exists rather than a one-line invariant.
@@ -142,8 +144,8 @@ FootprintSnapshot  { asOf, completeness, install, runtime, storage, catalog, pro
                                                                              persisted)
   storage:   StorageBreakdown     { nodes: category → host → project → session, growth, topN,
                                     reclaimables[], reclaimSummary: { tiers[], combined: null } }
-  catalog:   CatalogInventory     { skills[], agents[], commands[], plugins[], mcpServers[],
-                                    each with per-host presence }
+  catalog:   CatalogInventory v2  { items[], occurrences, scopes, providers/versions, overlaps,
+                                    project pressure, source stamps }
   projects:  ProjectFootprint[]   { path, label, remote?: {host, slug, webUrl}, stack: {languages,
                                     stack, unrecognized}, treeBytes, gitBytes, nodeModulesBytes,
                                     lastActivity }
@@ -404,24 +406,50 @@ promises less — never in the one that reads as free space.
 
 ### Catalog inventory
 
-Deduplicated `CatalogItem`s across hosts — skills, agents, commands, plugins, MCP servers —
-keyed by normalized name, each with a per-host presence matrix (which hosts carry it, from which
-surface it was observed). Counting is by manifest/directory-entry **names** on the host catalog
-surfaces Integration management already projects into; item file contents are not parsed beyond
-what naming requires. Scope is **user plus the launching repository plus every observed project
-still on disk**. The launching root is included explicitly because a fresh repository has no
-transcript yet; a skill defined in any observed repository is as deployed as one in `~/.claude`,
-and the question this inventory answers is what the machine carries. Deduplication by `(kind,
-name)` means a name defined in five projects is still one row, so the inventory grows with distinct
-names rather than with project count.
+`CatalogInventory v2` separates identity from relationship. Standalone artifacts still deduplicate
+by `(kind, normalized logical name)`, but a plugin contribution is keyed by kind, full
+`plugin@marketplace` producer identity, and logical name. Thus standalone `skill-creator` and
+`skill-creator@claude-plugins-official`'s contribution remain separate rows; explicit overlap
+groups report that their logical names or bounded entrypoint digests match.
 
-The presence matrix carries two independent multi-select filters — by kind and by host — with every
+Every occurrence retains host, surface, source scope (`user`, `project`, or `plugin`), project
+path, exact artifact path, plugin provider/version/enabled state, evidence authority, and bounded
+entrypoint digest status. Digest equality is evidence, not ownership: it says the entrypoint bytes
+match, not that supporting scripts/references match or that either copy is safe to delete.
+
+Scope is **user plus the launching repository plus every observed project still on disk**,
+including `~/.agents/skills`, project `.agents/skills`, and plugin
+`.codex-plugin/migrated-command-skills`. Native plugin inventory is authoritative when available;
+manifest/config/cache fallback stays visible as partial evidence. Installed-disabled plugins remain
+inventory rows but do not contribute enabled plugin capabilities.
+
+The project-pressure projection separates project, user, and enabled-plugin skill contributions
+per host and reports exact skill-name and matching-entrypoint relationships. Its summary groups
+one native disclosure per project, keeps the launching project first, and omits projects whose
+supported local skill surfaces measured zero. Expanding a project reveals the host breakdown and
+one deduplicated read-only plan command. Inventory completeness is distinct from model-context
+inclusion: hosts do not report the latter, so the dashboard states that limitation once instead of
+repeating a contradictory-looking `complete · context unknown` label.
+
+The presence matrix carries three independent multi-select filters — by kind, host, and source
+scope — with every
 option selected at first paint, so the default remains the whole inventory. The host filter matches
 **any** selected host rather than all of them: "carried by codex" is the question a reader is
 asking, and intersecting would answer a different one. A filtered view states how much it is
 hiding, and each row carries its own kind, because a filtered list must never leave a name
 unexplained. The config-surface row (managed CLAUDE.md/AGENTS.md block count, settings
 file sizes) lives here because it answers the same "what is deployed" question.
+
+A deep scan persists bounded stat stamps for active surfaces and entrypoints. The cheap tier
+re-probes them and marks `catalog changed, rescan` immediately when a watched path changes, rather
+than relying only on the seven-day age threshold. An unchanged probe is labelled
+`unchanged-at-probes`, never “fresh”: unobserved nested content still requires a deep rescan.
+
+`ak x skills plan --project <path>` consumes this inventory to classify project skills as current
+desired, receipt-owned-and-unchanged, exact known upstream, receipt-drifted/modified, unmeasured,
+or ambiguous/unreceipted. It reports git state, affected paths, projected counts, and a
+content-derived plan ID but performs no mutation. [Maintenance](maintenance.md) and issue #200 own
+future apply/verify/undo behavior.
 
 ### Project accounting
 
@@ -624,7 +652,9 @@ normative and this table restates it for readers of this document.
 | Ever seen / on disk | `everSeen` is every project any host ever recorded a session in, deletions included; `onDisk` is the measurable subset. Different questions, never one number |
 | Unresolved project | A transcript directory whose project path neither a declared `cwd` nor a filesystem-verified decode can name. Reported as such, never given a fabricated path; it makes `everSeen` a lower bound |
 | Stack detection | Per-project `languages` (which carry lines) and `stack` — frameworks, SDKs, tools — which carry presence only, plus the unrecognized tail of extensions and dependency names the registry could not name |
-| CatalogItem | A deduplicated deployed artifact (skill, agent, command, plugin, MCP server) with a per-host presence matrix; Codex project `.agents/skills` stays attributable separately from user/plugin surfaces |
+| CatalogItem | A canonical standalone or plugin-qualified identity with per-host/source occurrences and explicit name/digest relationships |
+| CatalogOccurrence | One host/source/project placement with provider/version/state, artifact path, and bounded digest evidence |
+| ProjectCapabilityPressure | Project/user/plugin contributions and exact overlap per project and host; context inclusion remains unknown |
 | ProjectFootprint | One project's size facts: approximate LOC by language, tree/`.git`/`node_modules` bytes, last activity, and an optional git-remote web link ("local only" when absent) |
 | Deep scan | The explicit, user-triggered, single-flight full measurement pass that produces a FootprintSnapshot |
 | Cheap tier | The per-request census + known-file stats + snapshot carry-forward served on every read |

--- a/docs/ddd/maintenance.md
+++ b/docs/ddd/maintenance.md
@@ -1,0 +1,76 @@
+# Maintenance Capability
+
+Maintenance is the proposed control-plane bounded context tracked by
+[GitHub issue #200](https://github.com/pacphi/agentic-kit/issues/200). It helps a human understand
+upgrade pressure and remove stale, unsupported, duplicated, or superseded resources without
+confusing observation with authority.
+
+## Boundary
+
+**System measures; Maintenance acts.** Machine Footprint owns observed local inventory, project
+pressure, source relationships, digest evidence, freshness, and read-only plans. Maintenance may
+consume those facts, but it may not reinterpret a filesystem observation as ownership or a safe
+delete decision.
+
+Maintenance will own explicit intent, policy, lifecycle checks, remediation transactions,
+verification, rollback, and durable receipts. Plugin or host-native lifecycle commands remain the
+preferred executor when they exist. Direct file removal is never the default substitute for a
+provider-owned uninstall or cache-prune operation.
+
+The first delivered seam is deliberately read-only:
+
+```text
+ak system --deep
+        |
+        v
+CatalogInventory v2
+  occurrences: host + source scope + project + provider/version + entrypoint digest
+  relationships: exact logical name + exact entrypoint digest
+  pressure: project / user / plugin contributions, with incomplete evidence explicit
+        |
+        v
+ak x skills plan --project <path>
+  classifies; reports git state; projects a possible result; writes nothing
+```
+
+Issue #198 owns that measurement-and-plan foundation. Issue #200 owns any future apply, upgrade,
+disable, uninstall, prune, rollback, or receipt-writing path.
+
+## Safety model
+
+A future action is eligible only when its authority and recovery path are explicit:
+
+- **receipt-owned and unchanged** — may become an automatically actionable candidate;
+- **exact known upstream revision** — useful evidence, but digest equality alone is not ownership;
+- **modified, ambiguous, unreceipted, unreadable, symlinked, or oversized** — preserve and ask for
+  review;
+- **provider-owned plugin or MCP resource** — use the provider lifecycle and verify the result;
+- **untracked project artifact** — require transaction backup before mutation;
+- **tracked project artifact** — record source state and require source-control recovery evidence.
+
+Every mutating operation must bind intent, exact inputs, affected paths, preconditions, executor,
+result, verification, rollback material, and a policy decision receipt. A plan identifier is not
+an authorization token.
+
+## Human workflow
+
+The dashboard should lead with explanation and evidence, then offer bounded actions only when the
+control plane exists:
+
+1. report upgrades, stale/unsupported resources, overlap, variants, and source drift;
+2. explain why each item is classified and what evidence is missing;
+3. preview the exact projected result and affected paths;
+4. require explicit confirmation for a mutation;
+5. verify the postcondition and retain a receipt/rollback path;
+6. show unresolved and preserved items rather than converting uncertainty into success.
+
+The proposed action vocabulary is `review`, `upgrade`, `disable`, `uninstall`, `prune`, `verify`,
+and `undo`. Bulk action is a later policy decision, not implied by the reporting UI.
+
+## Non-claims
+
+- Installed does not mean enabled; enabled does not mean loaded into a model context.
+- A source timestamp is not proof that nested content is unchanged.
+- Equal `SKILL.md` digests do not prove supporting scripts or references are equal.
+- Age alone does not prove that a cache, skill, MCP server, or plugin is stale or unsupported.
+- A machine-wide count is not a project-specific context budget.

--- a/docs/ddd/ubiquitous-language.md
+++ b/docs/ddd/ubiquitous-language.md
@@ -181,7 +181,12 @@ is what a user selects.
 | RuntimeCensus | The ephemeral point-in-time table of live host processes, daemons, and machine denominators |
 | StorageNode | One node in the category → host → project → session breakdown: bytes + file count |
 | ReclaimableCandidate | An advisory row naming reclaimable space, its path, and its rationale — never an action |
-| CatalogItem | A deduplicated deployed artifact (skill, agent, command, plugin, MCP server) with a per-host presence matrix |
+| CatalogItem | A canonical standalone or plugin-qualified capability identity with per-host/source occurrences; logical-name and entrypoint-digest overlap are relationships, not identity |
+| Catalog occurrence | One observed capability placement: host, source scope, project, artifact path, producer/version/state, digest status, and evidence authority |
+| Project capability pressure | Per-project/per-host inventory of project, user, and enabled-plugin contributions plus exact-name/body overlap; never a claim about host context inclusion |
+| Entrypoint digest | SHA-256 of one bounded regular capability entrypoint; equality proves only those bytes, not supporting files, ownership, safety, or context loading |
+| Maintenance plan | A content-derived, read-only classification and projected change set; it is evidence for a human decision, not authorization to mutate |
+| Maintenance receipt | Proposed durable evidence binding intent, authority, exact inputs, action, result, verification, and rollback for a Maintenance transaction |
 | ProjectFootprint | One project's size facts: approximate LOC by language, tree/`.git`/`node_modules` bytes, last activity, and an optional git-remote web link ("local only" when absent) |
 | Deep scan | The explicit, user-triggered, single-flight full measurement pass that produces a FootprintSnapshot |
 | Cheap tier | The per-request census + known-file stats + snapshot carry-forward served on every read |

--- a/src/commands/system.mjs
+++ b/src/commands/system.mjs
@@ -260,6 +260,43 @@ function renderStorage(storage) {
   }
 }
 
+function renderCatalogEvidence(catalog) {
+  const digestCoverage = catalog.overlaps?.digestCoverage;
+  if (digestCoverage) {
+    field('skill entrypoint evidence', `${fmtCount(digestCoverage.measured)} hashed · `
+      + `${fmtCount(digestCoverage.unknown)} unknown · `
+      + `${fmtCount(catalog.overlaps?.exactName?.length ?? 0)} exact-name overlap group(s)`);
+  }
+  for (const [host, source] of Object.entries(catalog.pluginSources ?? {})) {
+    field(`${host} plugin inventory`, `${source.status} · ${source.authority}${source.reason ? ` · ${source.reason}` : ''}`);
+  }
+}
+
+function renderCatalogPressure(catalog) {
+  const sink = reasonSink();
+  const pressureRows = [];
+  for (const project of catalog.projects ?? []) {
+    for (const host of catalog.hosts ?? []) {
+      const facts = project.byHost?.[host];
+      pressureRows.push([
+        project.label, host,
+        sink.cell(facts?.sources?.project?.skill),
+        sink.cell(facts?.sources?.user?.skill),
+        sink.cell(facts?.sources?.plugin?.skill),
+        sink.cell(facts?.overlaps?.skillNames),
+        sink.cell(facts?.overlaps?.skillDigests),
+      ]);
+    }
+  }
+  if (pressureRows.length) {
+    console.log('');
+    info(dim('project capability pressure (inventory only; context inclusion is host-owned and unknown)'));
+    table(['PROJECT', 'HOST', 'PROJECT SKILLS', 'USER SKILLS', 'PLUGIN SKILLS', 'NAME OVERLAP', 'BODY OVERLAP'], pressureRows);
+    sink.report();
+    info(dim('read-only remediation: ak x skills plan --project <path>'));
+  }
+}
+
 function renderCatalog(catalog) {
   deepHeading('Catalog', catalog);
   if (!catalog) {
@@ -275,6 +312,8 @@ function renderCatalog(catalog) {
     host, ...kinds.map((kind) => sink.cell(catalog.perHost?.[host]?.[kind])),
   ]));
   sink.report();
+  renderCatalogEvidence(catalog);
+  renderCatalogPressure(catalog);
   if (catalog.degraded?.length) info(dim(`unreadable surfaces: ${catalog.degraded.join(', ')}`));
   if (catalog.truncated?.length) {
     info(dim(`capped surfaces (counts are floors): ${catalog.truncated.join(', ')}`));

--- a/src/commands/x/skills.mjs
+++ b/src/commands/x/skills.mjs
@@ -1,0 +1,59 @@
+import path from 'node:path';
+
+import { collectCatalog } from '../../lib/footprint/catalog.mjs';
+import { buildSkillMaintenancePlan } from '../../lib/skill-maintenance-plan.mjs';
+import { loadKitConfig } from '../../lib/config.mjs';
+import { heading, info, warn, dim } from '../../lib/output.mjs';
+
+export const options = {
+  project: { type: 'string' },
+  json: { type: 'boolean', default: false },
+};
+
+export const help = `ak x skills plan — read-only project skill maintenance plan
+
+Classifies project skills using bounded digest, source, plugin, receipt, and git
+evidence. It never changes or deletes anything. Mutation belongs to issue #200.
+
+Usage: ak x skills plan [--project PATH] [--json]
+
+Options:
+  --project PATH   project to inspect (default: current working directory)
+  --json           emit the complete evidence and plan payload
+
+Examples:
+  ak x skills plan
+  ak x skills plan --project /absolute/path/to/project --json`;
+
+export async function run({ flags, positionals }) {
+  if ((positionals[0] ?? 'plan') !== 'plan' || positionals.length > 1) {
+    warn('usage: ak x skills plan [--project PATH] [--json]');
+    return 2;
+  }
+  const project = path.resolve(flags.project ?? process.cwd());
+  const cfg = loadKitConfig();
+  const catalog = /** @type {any} */ (collectCatalog({ cwd: project, projects: [project], cfg }));
+  const receipts = cfg.maintenance?.skillReceipts ?? [];
+  const plan = buildSkillMaintenancePlan({ catalog, project, receipts });
+  if (flags.json) {
+    console.log(JSON.stringify({ catalog: {
+      schemaVersion: catalog.schemaVersion, complete: catalog.complete,
+      pluginSources: catalog.pluginSources, overlaps: catalog.overlaps,
+      project: catalog.projects.find((row) => row.project === project) ?? null,
+    }, plan }, null, 2));
+    return 0;
+  }
+  heading('Project skill maintenance — read-only plan');
+  info(`${project}`);
+  info(`${plan.projection.currentProjectSkillPaths} project skill path(s) · `
+    + `${plan.projection.safePruneCandidates} receipt-proven safe-prune candidate(s)`);
+  for (const artifact of plan.artifacts) {
+    const evidence = artifact.git.tracked === true ? 'tracked'
+      : artifact.git.tracked === false ? 'untracked' : 'git unknown';
+    info(`${artifact.displayName}: ${artifact.classification} · ${evidence}`);
+    info(dim(`  ${artifact.path}`));
+  }
+  if (!plan.artifacts.length) info(dim('No project-scoped skills were observed.'));
+  info(dim('Nothing was changed. Mutating remediation is tracked in GitHub issue #200.'));
+  return 0;
+}

--- a/src/lib/dashboard/client/system-projects.mjs
+++ b/src/lib/dashboard/client/system-projects.mjs
@@ -368,11 +368,127 @@ import { fmtNum, fmtTok, limAge, pct } from './usage.mjs';
     countsEl.innerHTML='<div class="sy-tiles">'+tiles+"</div>";
   }
 
+  function pressureSkill(project,host,scope){
+    return project.byHost&&project.byHost[host]&&project.byHost[host].sources
+      &&project.byHost[host].sources[scope]&&project.byHost[host].sources[scope].skill;
+  }
+
+  function pressureSkillHtml(value){
+    var count=mval(value);
+    if(count==null)return '<span class="sy-unk">unknown</span><small class="sy-pressure-reason">'
+      +esc(value&&value.reason||"skill source was not measured")+'</small>';
+    return '<span class="sy-pressure-n">'+(value.partial?"at least ":"")+fmtNum(count)+"</span>";
+  }
+
+  function pressureRelationHtml(value){
+    var count=mval(value);
+    if(count==null)return '<span class="sy-unk">unknown</span><small class="sy-pressure-reason">'
+      +esc(value&&value.reason||"relationship was not measured")+'</small>';
+    return '<span class="sy-pressure-n">'+(value.partial?"at least ":"")+fmtNum(count)+"</span>";
+  }
+
+  function pressureHostIsRelevant(project,host){
+    var value=pressureSkill(project,host,"project"),count=mval(value),reason=value&&value.reason||"";
+    return count>0||(count==null&&!/not supported/.test(reason));
+  }
+
+  function pressureHosts(project,hosts){
+    return hosts.filter(function(host){return pressureHostIsRelevant(project,host);});
+  }
+
+  function pressureOverlap(project,hosts,key){
+    var highest=0,known=false;
+    for(var i=0;i<hosts.length;i++){
+      var value=project.byHost&&project.byHost[hosts[i]]&&project.byHost[hosts[i]].overlaps
+        &&project.byHost[hosts[i]].overlaps[key],count=mval(value);
+      if(count!=null){known=true;highest=Math.max(highest,count);}
+    }
+    return known?highest:null;
+  }
+
+  function pressurePath(project){
+    var parts=String(project.project||"").split(/[\\/]/).filter(Boolean);
+    return parts.slice(-3).join("/")||project.project||"unknown path";
+  }
+
+  function pressureProjectHtml(project,hosts){
+    var relevant=pressureHosts(project,hosts),rows="",chips="",i;
+    for(i=0;i<relevant.length;i++){
+      var host=relevant[i],view=project.byHost&&project.byHost[host],over=view&&view.overlaps;
+      rows+='<tr><th scope="row" class="mono">'+esc(host)+'</th>'
+        +'<td>'+pressureSkillHtml(pressureSkill(project,host,"project"))+'</td>'
+        +'<td>'+pressureSkillHtml(pressureSkill(project,host,"user"))+'</td>'
+        +'<td>'+pressureSkillHtml(pressureSkill(project,host,"plugin"))+'</td>'
+        +'<td>'+pressureRelationHtml(over&&over.skillNames)+'</td>'
+        +'<td>'+pressureRelationHtml(over&&over.skillDigests)+'</td></tr>';
+      var projectCount=mval(pressureSkill(project,host,"project"));
+      chips+='<span class="sy-pressure-chip"><b>'+esc(host)+'</b> '
+        +(projectCount==null?"unknown":fmtNum(projectCount))+' skills</span>';
+    }
+    var names=pressureOverlap(project,relevant,"skillNames");
+    var entries=pressureOverlap(project,relevant,"skillDigests");
+    var command=(project.guidance||[]).map(function(row){return row.nextCommand;}).filter(Boolean)[0]||null;
+    var status=project.complete
+      ?'<span class="sy-pressure-state sy-good">Inventory complete</span>'
+      :'<span class="sy-pressure-state sy-warn">Partial inventory</span>';
+    var signals=(names?'<span class="sy-pressure-state sy-warn">'+fmtNum(names)+' name overlap'+(names===1?"":"s")+'</span>':"")
+      +(entries?'<span class="sy-pressure-state">'+fmtNum(entries)+' matching entrypoint'+(entries===1?"":"s")+'</span>':"");
+    return '<details class="sy-pressure-project"'+(project.launching?' open data-launching="true"':"")+'>'
+      +'<summary><span class="sy-pressure-project-id"><span><b>'+esc(project.label)+'</b>'
+      +(project.launching?'<span class="sy-current">current project</span>':"")+'</span>'
+      +'<span class="sy-pressure-path" title="'+esc(project.project)+'">'+esc(pressurePath(project))+'</span></span>'
+      +'<span class="sy-pressure-meta">'+chips+status+signals+'</span></summary>'
+      +'<div class="sy-pressure-detail"><div class="sy-path">'+esc(project.project)+'</div>'
+      +'<div class="sy-tblwrap" tabindex="0" aria-label="'+esc(project.label)+' skill pressure by host">'
+      +'<table class="sy-table sy-pressure-t"><caption class="sr-only">Project, user, and plugin skill counts for '+esc(project.label)+'.</caption>'
+      +'<thead><tr><th scope="col">Host</th><th scope="col">Project skills</th><th scope="col">User skills</th>'
+      +'<th scope="col">Plugin skills</th><th scope="col">Name overlaps</th><th scope="col">Matching entrypoints</th></tr></thead>'
+      +'<tbody>'+rows+'</tbody></table></div>'
+      +(command?'<div class="sy-pressure-action"><span><b>Inspect safely</b><small>Read-only plan; changes nothing.</small></span>'
+        +'<code>'+esc(command)+'</code></div>':"")+'</div></details>';
+  }
+
+  function renderProjectPressure(c){
+    var el=document.getElementById("sys-pressure");
+    if(!el)return;
+    if(!c){el.innerHTML=sysEmpty(NOT_SCANNED);return;}
+    var all=c.projects||[],hosts=c.hosts||[];
+    var projects=all.filter(function(project){return pressureHosts(project,hosts).length;});
+    if(!projects.length){el.innerHTML=sysEmpty("no project-local skill surface was observed.");return;}
+    projects.sort(function(a,b){
+      if(Boolean(a.launching)!==Boolean(b.launching))return a.launching?-1:1;
+      var aOverlap=pressureOverlap(a,pressureHosts(a,hosts),"skillNames")||0;
+      var bOverlap=pressureOverlap(b,pressureHosts(b,hosts),"skillNames")||0;
+      if(aOverlap!==bOverlap)return bOverlap-aOverlap;
+      return String(a.label).localeCompare(String(b.label));
+    });
+    var nameProjects=0,entryProjects=0,partialProjects=0,html="";
+    for(var i=0;i<projects.length;i++){
+      var relevant=pressureHosts(projects[i],hosts);
+      if(pressureOverlap(projects[i],relevant,"skillNames"))nameProjects++;
+      if(pressureOverlap(projects[i],relevant,"skillDigests"))entryProjects++;
+      if(!projects[i].complete)partialProjects++;
+      html+=pressureProjectHtml(projects[i],hosts);
+    }
+    var omitted=all.length-projects.length;
+    el.innerHTML='<div class="sy-pressure-overview" aria-label="Project skill pressure summary">'
+      +'<span><b>'+fmtNum(projects.length)+'</b> project'+(projects.length===1?"":"s")+' with local skills</span>'
+      +'<span><b>'+fmtNum(nameProjects)+'</b> with same-name overlap</span>'
+      +'<span><b>'+fmtNum(entryProjects)+'</b> with matching entrypoints</span>'
+      +'<span><b>'+fmtNum(partialProjects)+'</b> partial</span></div>'
+      +'<div class="sy-pressure-context"><b>Inventory</b> reports installed or discoverable sources. '
+      +'<b>Context inclusion is not reported by these hosts.</b>'
+      +(omitted?' '+fmtNum(omitted)+' project'+(omitted===1?" has":"s have")+' no local skill contribution and '+(omitted===1?"is":"are")+' omitted.':"")+'</div>'
+      +'<div class="sy-pressure-list" tabindex="0" aria-label="Projects with local skill pressure">'+html+'</div>'
+      +'<div class="sy-pressure-foot"><b>System measures; Maintenance acts.</b> Expand one project for source counts and its read-only plan command.</div>';
+  }
+
   function renderSysCatalog(d){
     var c=d.catalog;
     var radar=document.getElementById("sys-radar");
     var countsEl=document.getElementById("sys-catcounts");
     var matrix=document.getElementById("sys-matrix");
+    renderProjectPressure(c);
     if(!c){
       if(radar)radar.innerHTML=sysEmpty(NOT_SCANNED);
       if(countsEl)countsEl.innerHTML="";
@@ -396,7 +512,7 @@ import { fmtNum, fmtTok, limAge, pct } from './usage.mjs';
   // so the default survives a payload that grows a new kind or host: an unknown
   // option is INCLUDED until the user has expressed an opinion, never silently
   // filtered out.
-  var catKinds=null,catHosts=null;
+  var catKinds=null,catHosts=null,catScopes=null;
 
   function catalogChip(group,value,label,on){
     return '<button class="chipf'+(on?" on":"")+'" type="button" data-cat-'+group+'="'+esc(value)
@@ -422,6 +538,14 @@ import { fmtNum, fmtTok, limAge, pct } from './usage.mjs';
       }
       hostsEl.innerHTML=html;
     }
+    var scopes=c.scopes||[],scopesEl=document.getElementById("sys-cat-scopes");
+    if(scopesEl){
+      html="";
+      for(i=0;i<scopes.length;i++){
+        html+=catalogChip("scope",scopes[i],scopes[i],!catScopes||catScopes.indexOf(scopes[i])>=0);
+      }
+      scopesEl.innerHTML=html;
+    }
   }
 
   function paintCatalogMatrix(c){
@@ -440,19 +564,31 @@ import { fmtNum, fmtTok, limAge, pct } from './usage.mjs';
         for(j=0;j<ih.length&&!carried;j++)if(catHosts.indexOf(ih[j])>=0)carried=true;
         if(!carried)continue;
       }
+      if(catScopes){
+        var scoped=false,itemScopes=it.sourceScopes||[];
+        for(j=0;j<itemScopes.length&&!scoped;j++)if(catScopes.indexOf(itemScopes[j])>=0)scoped=true;
+        if(!scoped)continue;
+      }
       items.push(it);
     }
     var head="",body="";
-    for(i=0;i<hosts.length;i++)head+='<th class="cell">'+esc(hosts[i])+"</th>";
+    for(i=0;i<hosts.length;i++)head+='<th class="cell" scope="col">'+esc(hosts[i])+"</th>";
     for(i=0;i<items.length;i++){
       // The kind rides on the row now that the heading rows are gone, so a
       // filtered view never leaves a name unexplained.
+      var provider=null,presences=items[i].presence||[];
+      for(j=0;j<presences.length&&!provider;j++)provider=presences[j].provider;
+      var meta=(items[i].sourceScopes||[]).join(" / ");
+      if(provider)meta+=" \u00b7 "+provider.ref+(provider.version?" v"+provider.version:"");
+      if(items[i].digestCoverage&&items[i].digestCoverage.unique>1)meta+=" \u00b7 "+items[i].digestCoverage.unique+" body variants";
       body+='<tr><td class="nm" title="'+esc(items[i].kind+" \u00b7 "+items[i].name)+'">'
-        +esc(items[i].name)+'<span class="sy-kindtag">'+esc(KIND_LABEL[items[i].kind]||items[i].kind)+"</span></td>";
+        +esc(items[i].name)+'<span class="sy-kindtag">'+esc(KIND_LABEL[items[i].kind]||items[i].kind)+'</span>'
+        +'<div class="sy-catmeta">'+esc(meta)+"</div></td>";
       for(j=0;j<hosts.length;j++){
         var on=(items[i].hosts||[]).indexOf(hosts[j])>=0;
         body+='<td class="cell"><i class="'+(on?"on":"off")+'" title="'
-          +esc(hosts[j]+(on?" carries":" does not carry")+" "+items[i].name)+'"></i></td>';
+          +esc(hosts[j]+(on?" carries":" does not carry")+" "+items[i].name)+'"></i>'
+          +'<span class="sr-only">'+esc(hosts[j]+(on?" carries ":" does not carry ")+items[i].name)+"</span></td>";
       }
       body+="</tr>";
     }
@@ -463,34 +599,38 @@ import { fmtNum, fmtTok, limAge, pct } from './usage.mjs';
       return;
     }
     var filtered=items.length!==all.length;
-    matrix.innerHTML='<div class="sy-tblwrap sy-catalog-scroll"><table class="sy-table sy-matrix-t">'
-      +"<thead><tr><th>Name</th>"+head+"</tr></thead><tbody>"+body+"</tbody></table></div>"
+    matrix.innerHTML='<div class="sy-tblwrap sy-catalog-scroll" tabindex="0" aria-label="Catalog presence matrix"><table class="sy-table sy-matrix-t">'
+      +'<caption class="sr-only">Capabilities and the hosts that carry them.</caption>'
+      +"<thead><tr><th scope=\"col\">Name and source</th>"+head+"</tr></thead><tbody>"+body+"</tbody></table></div>"
       +'<div class="sy-liner">'
       +(filtered
         ?esc(fmtNum(items.length))+" of "+esc(fmtNum(all.length))+" deduplicated items shown"
         :esc(fmtNum(all.length))+" deduplicated item"+(all.length===1?"":"s")
           +" across user scope and every project on disk")
-      +". A dot means that host carries the name.</div>";
+      +". A dot means that host carries this catalog identity. Inventory does not prove context inclusion.</div>";
+    var status=document.getElementById("sys-cat-status");
+    if(status)status.textContent=fmtNum(items.length)+" of "+fmtNum(all.length)+" catalog items shown";
   }
 
   export function wireCatalogFilters(){
     document.addEventListener("click",function(e){
       var t=e.target;
       if(!t||!t.closest)return;
-      var btn=t.closest("[data-cat-kind],[data-cat-host]");
+      var btn=t.closest("[data-cat-kind],[data-cat-host],[data-cat-scope]");
       if(!btn)return;
       var isKind=btn.hasAttribute("data-cat-kind");
-      var group=isKind?"kind":"host";
+      var isHost=btn.hasAttribute("data-cat-host");
+      var group=isKind?"kind":(isHost?"host":"scope");
       var value=btn.getAttribute("data-cat-"+group);
-      var all=(SYSTEM&&SYSTEM.catalog&&(isKind?SYSTEM.catalog.kinds:SYSTEM.catalog.hosts))||[];
-      var cur=(isKind?catKinds:catHosts)||all.slice();
+      var all=(SYSTEM&&SYSTEM.catalog&&(isKind?SYSTEM.catalog.kinds:(isHost?SYSTEM.catalog.hosts:SYSTEM.catalog.scopes)))||[];
+      var cur=(isKind?catKinds:(isHost?catHosts:catScopes))||all.slice();
       var at=cur.indexOf(value);
       if(at>=0)cur=cur.slice(0,at).concat(cur.slice(at+1));else cur=cur.concat([value]);
       // Turning the last one back on is "no filter", not "a filter that happens
       // to match everything" — so a later payload with a new option still
       // includes it.
       var next=cur.length===all.length?null:cur;
-      if(isKind)catKinds=next;else catHosts=next;
+      if(isKind)catKinds=next;else if(isHost)catHosts=next;else catScopes=next;
       if(SYSTEM&&SYSTEM.catalog){renderCatalogFilters(SYSTEM.catalog);paintCatalogMatrix(SYSTEM.catalog);}
     });
   }
@@ -746,11 +886,12 @@ import { fmtNum, fmtTok, limAge, pct } from './usage.mjs';
     // has to make "older than seven days" obvious. Reusing the Limits view's
     // formatter keeps one vocabulary for "how old is this figure".
     var age=limAge(Date.now()-Math.max(0,Number(snap.ageMs)||0));
-    el.textContent="deep scan \u00b7 "+age+(snap.stale?" \u00b7 stale, rescan":"")
+    var drift=snap.catalogDrift,changed=drift&&drift.status==="changed";
+    el.textContent="deep scan \u00b7 "+age+(changed?" \u00b7 catalog changed, rescan":(snap.stale?" \u00b7 stale, rescan":""))
       +(scan&&scan.error?" \u00b7 last scan reported a problem":"");
     el.title=(scan&&scan.error?scan.error+" \u2014 ":"")
       +"deep-tier figures were measured "+age+"; nothing rescans on its own";
-    if(snap.stale)el.setAttribute("data-stale","1");
+    if(snap.stale||changed)el.setAttribute("data-stale","1");
   }
 
   function renderSystem(){
@@ -758,7 +899,7 @@ import { fmtNum, fmtTok, limAge, pct } from './usage.mjs';
     if(SYSTEM.error){
       var ids=["sys-kpis","sys-gauge","sys-consumers","sys-donut","sys-hostsplit","sys-growth",
         "sys-learning","sys-reclaim","sys-topsessions","sys-procs","sys-mem","sys-daemons","sys-radar",
-        "sys-catcounts","sys-matrix","sys-projects"];
+        "sys-catcounts","sys-pressure","sys-matrix","sys-projects"];
       var msg=sysEmpty(SYSTEM.error+(SYSTEM.reason?" \u2014 "+SYSTEM.reason:""));
       for(var i=0;i<ids.length;i++){
         var el=document.getElementById(ids[i]);
@@ -836,4 +977,3 @@ import { fmtNum, fmtTok, limAge, pct } from './usage.mjs';
       loadSystem(true,t.getAttribute("aria-pressed")!=="true");
     });
   }
-

--- a/src/lib/dashboard/page.mjs
+++ b/src/lib/dashboard/page.mjs
@@ -819,7 +819,8 @@ ${LIVE_HTML}
       <header class="view-heading">
         <span class="view-eyebrow">SYSTEM</span>
         <h2>Catalog</h2>
-        <p>What is actually deployed, deduplicated across hosts &mdash; and which host carries what.</p>
+        <p>What is actually deployed, where it came from, and how project-local capabilities overlap
+          user and plugin sources. Inventory is not proof that a host loaded an item into context.</p>
       </header>
       <div class="sy-grid">
         <div class="sy-card sy-5">
@@ -842,8 +843,17 @@ ${LIVE_HTML}
               <span class="sy-filter-l" id="sys-cat-host-l">carried by</span>
               <div class="sy-ctl" id="sys-cat-hosts" role="group" aria-labelledby="sys-cat-host-l"></div>
             </div>
+            <div class="sy-filter-row">
+              <span class="sy-filter-l" id="sys-cat-scope-l">source</span>
+              <div class="sy-ctl" id="sys-cat-scopes" role="group" aria-labelledby="sys-cat-scope-l"></div>
+            </div>
           </div>
+          <div class="sr-only" id="sys-cat-status" role="status" aria-live="polite" aria-atomic="true"></div>
           <div id="sys-matrix"></div>
+        </div>
+        <div class="sy-card">
+          <div class="sy-head"><h3>Project skill pressure</h3><span class="n mono">read-only evidence</span></div>
+          <div id="sys-pressure"></div>
         </div>
       </div>
     </section>

--- a/src/lib/dashboard/styles/system.mjs
+++ b/src/lib/dashboard/styles/system.mjs
@@ -244,13 +244,16 @@ export const SYSTEM_CSS = `
 }
 .sy-link:hover{text-decoration:underline}
 .sy-link:focus-visible{outline:2px solid var(--accent); outline-offset:2px}
-/* The presence matrix is a real table now, and scrolls: it lists EVERY
-   deduplicated item rather than the first fourteen, and a full inventory is
-   several hundred rows on a working machine. The sticky header keeps the host
-   columns meaningful once you are 200 rows down. */
-.sy-catalog-scroll{max-height:420px; overflow-y:auto}
+/* The presence matrix is a real table and retains EVERY deduplicated item, but
+   its viewport is deliberately one header plus no more than five records. The
+   44px minimum accounts for the name and source lines; a wrapped record may
+   make fewer than five visible, never more. The sticky header keeps the host
+   columns meaningful while the remaining inventory scrolls beneath it. */
+.sy-catalog-scroll{max-height:280px; overflow-y:auto}
+.sy-catalog-scroll tbody tr{height:44px}
 .sy-catalog-scroll thead th{position:sticky; top:0; background:var(--panel); z-index:1}
 .sy-matrix-t .nm{font-family:var(--mono); font-size:11.5px; color:var(--ink); word-break:break-all}
+.sy-catmeta{margin-top:3px; font-family:var(--sans); font-size:10px; color:var(--ink-dim)}
 .sy-matrix-t .cell{text-align:center; width:74px}
 .sy-matrix-t th.cell{text-transform:uppercase; letter-spacing:.04em}
 .sy-matrix-t .on{display:inline-block; width:9px; height:9px; border-radius:50%; background:var(--accent)}
@@ -270,6 +273,50 @@ export const SYSTEM_CSS = `
   margin-left:8px; font-family:var(--sans); font-size:9.5px; color:var(--ink-dim);
   text-transform:uppercase; letter-spacing:.05em;
 }
+.sy-pressure-overview{display:grid; grid-template-columns:repeat(4,minmax(0,1fr)); gap:8px; margin-bottom:10px}
+.sy-pressure-overview span{padding:10px 12px; border:1px solid var(--line); border-radius:9px; color:var(--ink-dim); font-size:11px}
+.sy-pressure-overview b{display:block; color:var(--ink); font-family:var(--mono); font-size:18px; line-height:1.2; margin-bottom:2px}
+.sy-pressure-context,.sy-pressure-foot{color:var(--ink-dim); font-size:11.5px; line-height:1.5}
+.sy-pressure-context{padding:9px 11px; border-left:2px solid var(--s1); background:color-mix(in srgb,var(--s1) 7%,transparent); margin-bottom:10px}
+.sy-pressure-context b,.sy-pressure-foot b{color:var(--ink-2)}
+.sy-pressure-list{max-height:520px; overflow:auto; display:flex; flex-direction:column; gap:6px; padding:1px}
+.sy-pressure-list:focus-visible,.sy-pressure-project>summary:focus-visible{outline:2px solid var(--accent); outline-offset:2px}
+.sy-pressure-project{border:1px solid var(--line); border-radius:9px; background:color-mix(in srgb,var(--panel) 92%,var(--ink) 8%)}
+.sy-pressure-project>summary{position:relative; display:grid; grid-template-columns:minmax(180px,.8fr) minmax(0,2fr); gap:12px; align-items:center; min-height:48px; padding:10px 34px 10px 13px; cursor:pointer; list-style:none}
+.sy-pressure-project>summary::-webkit-details-marker{display:none}
+.sy-pressure-project>summary::after{content:'›'; position:absolute; right:14px; top:50%; color:var(--ink-dim); font-size:20px; transform:translateY(-50%); transition:transform .15s ease}
+.sy-pressure-project[open]>summary::after{transform:translateY(-50%) rotate(90deg)}
+.sy-pressure-project[open]>summary{border-bottom:1px solid var(--line)}
+.sy-pressure-project-id{display:flex; flex-direction:column; min-width:0; gap:3px}
+.sy-pressure-project-id>span:first-child{display:flex; align-items:center; gap:7px; min-width:0}
+.sy-pressure-project-id b{color:var(--ink); overflow:hidden; text-overflow:ellipsis; white-space:nowrap}
+.sy-current{padding:2px 6px; border-radius:999px; background:color-mix(in srgb,var(--accent) 15%,transparent); color:var(--accent); font-size:9px; text-transform:uppercase; letter-spacing:.04em; white-space:nowrap}
+.sy-pressure-path{overflow:hidden; text-overflow:ellipsis; white-space:nowrap; color:var(--ink-dim); font-family:var(--mono); font-size:10.5px}
+.sy-pressure-meta{display:flex; justify-content:flex-end; align-items:center; gap:6px; flex-wrap:wrap}
+.sy-pressure-chip,.sy-pressure-state{padding:3px 7px; border:1px solid var(--line); border-radius:999px; color:var(--ink-2); font-size:10.5px; white-space:nowrap}
+.sy-pressure-chip b{color:var(--ink); font-weight:600}
+.sy-pressure-detail{padding:11px 13px 13px}
+.sy-pressure-detail>.sy-path{margin-bottom:9px; word-break:break-word}
+.sy-pressure-t{min-width:720px}
+.sy-pressure-t th,.sy-pressure-t td{vertical-align:top; font-size:11.5px; line-height:1.4}
+.sy-pressure-t tbody th{color:var(--ink-2); font-weight:500}
+.sy-pressure-n{color:var(--ink)}
+.sy-pressure-reason{display:block; max-width:170px; margin-top:2px; color:var(--ink-dim); font-size:9.5px; line-height:1.35}
+.sy-pressure-action{display:grid; grid-template-columns:auto minmax(0,1fr); gap:12px; align-items:center; padding-top:10px}
+.sy-pressure-action>span{display:flex; flex-direction:column; color:var(--ink-2); white-space:nowrap}
+.sy-pressure-action small{color:var(--ink-dim); font-size:10px}
+.sy-pressure-action code{display:block; min-width:0; padding:7px 9px; border-radius:6px; background:var(--bg); color:var(--accent); overflow:auto; white-space:nowrap}
+.sy-pressure-foot{margin-top:10px}
+@media(max-width:900px){
+  .sy-pressure-overview{grid-template-columns:repeat(2,minmax(0,1fr))}
+  .sy-pressure-project>summary{grid-template-columns:1fr}
+  .sy-pressure-meta{justify-content:flex-start}
+}
+@media(max-width:600px){
+  .sy-pressure-overview{grid-template-columns:1fr 1fr}
+  .sy-pressure-action{grid-template-columns:1fr}
+}
+.sy-good{color:var(--ok)}.sy-warn{color:var(--warn)}.sy-zero{color:var(--ink-dim)}
 /* Inline SVG charts share one type treatment with the rest of the page. */
 .sy-card svg{display:block; max-width:100%}
 .sy-card svg text{font-family:var(--sans); fill:var(--ink-2); font-size:11px}

--- a/src/lib/footprint/catalog-config.mjs
+++ b/src/lib/footprint/catalog-config.mjs
@@ -1,0 +1,70 @@
+import fs from 'node:fs';
+
+import {
+  claudeSettingsPath, claudeUserMcpPath, codexConfigPath, opencodeConfigPath,
+  projectSettings, projectSettingsLocal, repoRoot,
+} from '../paths.mjs';
+import { registry, blocksForTarget, guidanceTargets, hasBlock } from '../blocks.mjs';
+import { statNode, measured, unknown } from './walk.mjs';
+
+const SENTINEL_RE = /^<!-- BEGIN [^>]+ -->$/gm;
+
+function fileSize(file, { asOf = null, fsImpl = fs } = {}) {
+  const node = statNode(file, { fsImpl });
+  if (node.status === 'unknown') {
+    return node.reason === 'ENOENT'
+      ? { ...measured(0, { asOf }), present: false, mtimeMs: null, path: file }
+      : { ...unknown(node.reason), present: null, mtimeMs: null, path: file };
+  }
+  return { ...measured(node.bytes ?? 0, { asOf }), present: true, mtimeMs: node.mtimeMs, path: file };
+}
+
+/** Bounded configuration evidence. Guidance prose never leaves this function;
+ * only file sizes and managed-block sentinel counts do. */
+export function collectConfigSurface({
+  cwd = process.cwd(), cfg = {}, asOf = null, extraSettingsFiles = [], fsImpl = fs,
+} = {}) {
+  const rows = registry(/** @type {any} */ (cfg)?.customBlocks ?? []);
+  const guidance = [];
+  for (const target of guidanceTargets({ cwd })) {
+    const bytes = fileSize(target.file, { asOf, fsImpl });
+    const expected = blocksForTarget(rows, target.name);
+    let content;
+    try { content = fsImpl.readFileSync(target.file, 'utf8'); } catch (error) {
+      const absent = error.code === 'ENOENT';
+      guidance.push({
+        name: target.name, label: target.label, path: target.file, bytes,
+        managed: absent ? measured(0, { asOf }) : unknown(error.code ?? 'io'),
+        observed: absent ? measured(0, { asOf }) : unknown(error.code ?? 'io'),
+        expected: expected.length, slugs: [],
+      });
+      continue;
+    }
+    const present = expected.filter((row) => hasBlock(content, row.slug));
+    guidance.push({
+      name: target.name, label: target.label, path: target.file, bytes,
+      managed: measured(present.length, { asOf }),
+      observed: measured((content.match(SENTINEL_RE) ?? []).length, { asOf }),
+      expected: expected.length, slugs: present.map((row) => row.slug),
+    });
+  }
+
+  const projectRoot = repoRoot(cwd);
+  const settings = [
+    { id: 'claude-settings', label: '~/.claude/settings.json', file: claudeSettingsPath() },
+    { id: 'claude-user-mcp', label: '~/.claude.json', file: claudeUserMcpPath() },
+    { id: 'codex-config', label: '~/.codex/config.toml', file: codexConfigPath() },
+    { id: 'opencode-config', label: 'opencode.json', file: opencodeConfigPath() },
+  ];
+  if (projectRoot) {
+    settings.push({ id: 'project-settings', label: '.claude/settings.json', file: projectSettings(projectRoot) });
+    settings.push({ id: 'project-settings-local', label: '.claude/settings.local.json', file: projectSettingsLocal(projectRoot) });
+  }
+  for (const extra of extraSettingsFiles) {
+    settings.push({ id: extra.id, label: extra.label, file: extra.path });
+  }
+  return {
+    guidance,
+    settings: settings.map((row) => ({ id: row.id, label: row.label, ...fileSize(row.file, { asOf, fsImpl }) })),
+  };
+}

--- a/src/lib/footprint/catalog-evidence.mjs
+++ b/src/lib/footprint/catalog-evidence.mjs
@@ -1,0 +1,267 @@
+// Evidence helpers for the machine-footprint catalog. This module may inspect
+// bounded metadata and compute digests, but it never returns artifact bodies.
+import { createHash } from 'node:crypto';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { measured, unknown } from './walk.mjs';
+
+export const CATALOG_ARTIFACT_MAX_BYTES = 1024 * 1024;
+
+export function pluginRefParts(ref) {
+  const value = String(ref ?? '');
+  const at = value.lastIndexOf('@');
+  if (at <= 0 || at >= value.length - 1) {
+    return { ref: value, name: value, marketplace: null };
+  }
+  return { ref: value, name: value.slice(0, at), marketplace: value.slice(at + 1) };
+}
+
+/** SHA-256 a small regular file. The bytes die here; only bounded metadata and
+ * the digest leave this function. Symlinks and oversized files stay explicit
+ * unknowns rather than being followed or silently omitted.
+ * @param {string} file
+ * @param {{ fsImpl?: typeof fs, asOf?: number|null, maxBytes?: number }} [options] */
+export function artifactDigest(file, {
+  fsImpl = fs, asOf = null, maxBytes = CATALOG_ARTIFACT_MAX_BYTES,
+} = {}) {
+  try {
+    const stat = fsImpl.lstatSync(file);
+    if (stat.isSymbolicLink()) return unknown('artifact is a symlink');
+    if (!stat.isFile()) return unknown('artifact is not a regular file');
+    if (stat.size > maxBytes) return unknown(`artifact exceeds ${maxBytes} byte digest limit`);
+    const bytes = fsImpl.readFileSync(file);
+    if (bytes.length > maxBytes) return unknown(`artifact exceeds ${maxBytes} byte digest limit`);
+    return measured(createHash('sha256').update(bytes).digest('hex'), { asOf });
+  } catch (error) {
+    return unknown(error?.code ?? 'io');
+  }
+}
+
+function commandJson(binary, args, run) {
+  let result;
+  try {
+    result = run(binary, args, {
+      encoding: 'utf8', timeout: 15_000, maxBuffer: 8 * 1024 * 1024,
+      stdio: ['ignore', 'pipe', 'pipe'], env: { ...process.env, NO_COLOR: '1' },
+    });
+  } catch (error) {
+    return { status: 'degraded', reason: error?.code ?? error?.message ?? 'spawn failed', plugins: [] };
+  }
+  if (result?.error?.code === 'ENOENT') return { status: 'unsupported', reason: 'binary not installed', plugins: [] };
+  if (result?.error) return { status: 'degraded', reason: result.error.code ?? result.error.message, plugins: [] };
+  if (result?.status !== 0) {
+    return { status: 'degraded', reason: `command exited ${String(result?.status)}`, plugins: [] };
+  }
+  try {
+    return { status: 'ok', reason: null, value: JSON.parse(result.stdout), plugins: [] };
+  } catch {
+    return { status: 'degraded', reason: 'command returned invalid JSON', plugins: [] };
+  }
+}
+
+function normalizeClaude(result) {
+  if (result.status !== 'ok') return { ...result, source: 'claude plugin list --json' };
+  if (!Array.isArray(result.value)) {
+    return { status: 'degraded', reason: 'unexpected Claude plugin-list schema', plugins: [],
+      source: 'claude plugin list --json' };
+  }
+  return {
+    status: 'ok', reason: null, source: 'claude plugin list --json',
+    plugins: result.value.flatMap((row) => {
+      if (!row || typeof row.id !== 'string' || !row.id) return [];
+      const parts = pluginRefParts(row.id);
+      return [{
+        ...parts,
+        version: typeof row.version === 'string' ? row.version : null,
+        enabled: typeof row.enabled === 'boolean' ? row.enabled : null,
+        scope: typeof row.scope === 'string' ? row.scope : 'unknown',
+        root: typeof row.installPath === 'string' && path.isAbsolute(row.installPath) ? row.installPath : null,
+        installedAt: typeof row.installedAt === 'string' ? row.installedAt : null,
+        lastUpdated: typeof row.lastUpdated === 'string' ? row.lastUpdated : null,
+        evidence: 'native',
+      }];
+    }),
+  };
+}
+
+function normalizeCodex(result) {
+  if (result.status !== 'ok') return { ...result, source: 'codex plugin list --json' };
+  const rows = Array.isArray(result.value?.installed) ? result.value.installed : null;
+  if (!rows) {
+    return { status: 'degraded', reason: 'unexpected Codex plugin-list schema', plugins: [],
+      source: 'codex plugin list --json' };
+  }
+  return {
+    status: 'ok', reason: null, source: 'codex plugin list --json',
+    plugins: rows.flatMap((row) => {
+      if (!row || typeof row.pluginId !== 'string' || !row.pluginId) return [];
+      const parts = pluginRefParts(row.pluginId);
+      return [{
+        ...parts,
+        version: typeof row.version === 'string' ? row.version : null,
+        enabled: typeof row.enabled === 'boolean' ? row.enabled : null,
+        scope: 'user',
+        // Native Codex reports the marketplace source tree, not necessarily the
+        // installed cache generation. catalog.mjs joins the inspected cache root
+        // separately and never treats this path as a cleanup target.
+        root: null,
+        sourceKind: typeof row.source?.source === 'string' ? row.source.source : 'unknown',
+        installPolicy: typeof row.installPolicy === 'string' ? row.installPolicy : null,
+        authPolicy: typeof row.authPolicy === 'string' ? row.authPolicy : null,
+        evidence: 'native',
+      }];
+    }),
+  };
+}
+
+/** Read-only native plugin inventory. This is called only by a deep scan using
+ * the real filesystem; fixture-backed unit collectors retain deterministic
+ * manifest/config fallbacks. */
+export function collectNativePluginInventory({ run = spawnSync } = {}) {
+  return {
+    claude: normalizeClaude(commandJson('claude', ['plugin', 'list', '--json'], run)),
+    codex: normalizeCodex(commandJson('codex', ['plugin', 'list', '--json'], run)),
+  };
+}
+
+function matchingPresence(item, { host, scope, project }) {
+  return (item.presence ?? []).some((presence) => presence.host === host
+    && presence.scope === scope
+    && (scope !== 'project' || presence.project === project));
+}
+
+function scopedCount(items, surfaces, { host, kind, scope, project, asOf }) {
+  const relevant = surfaces.filter((surface) => surface.host === host
+    && surface.kind === kind && surface.scope === scope
+    && (scope !== 'project' || surface.project === project));
+  if (!relevant.length) return unknown(`${scope} ${kind} surface is not supported for ${host}`);
+  const readable = relevant.filter((surface) => surface.status !== 'degraded');
+  if (!readable.length) return unknown(relevant.map((surface) => surface.reason).filter(Boolean).join('; ') || 'unreadable');
+  const value = items.filter((item) => item.kind === kind
+    && matchingPresence(item, { host, scope, project })).length;
+  const partial = relevant.some((surface) => surface.status === 'degraded' || surface.partial);
+  return measured(value, { asOf, partial });
+}
+
+function digestValue(presence) {
+  return presence?.digest?.value && presence.digest.status !== 'unknown' ? presence.digest.value : null;
+}
+
+function overlapMeasurement(projectItems, sharedItems, field, asOf) {
+  const projectValues = new Set(projectItems.map(field).filter(Boolean));
+  const sharedValues = new Set(sharedItems.map(field).filter(Boolean));
+  let overlap = 0;
+  for (const value of projectValues) if (sharedValues.has(value)) overlap++;
+  const missing = [...projectItems, ...sharedItems].some((entry) => !field(entry));
+  return measured(overlap, { asOf, partial: missing });
+}
+
+function skillOccurrences(items, host, scopes, project) {
+  const out = [];
+  for (const item of items.filter((candidate) => candidate.kind === 'skill')) {
+    for (const presence of item.presence ?? []) {
+      if (presence.host !== host || !scopes.includes(presence.scope)) continue;
+      if (presence.scope === 'project' && presence.project !== project) continue;
+      out.push({ name: item.capabilityName ?? item.name, digest: digestValue(presence) });
+    }
+  }
+  return out;
+}
+
+/** Project-oriented contribution and overlap read model. User/plugin counts are
+ * repeated intentionally: they are the shared capabilities a project sees in
+ * addition to its own tree. No host context-cutoff claim is inferred. */
+export function buildProjectPressure({ items, surfaces, projects, launchingProject, hosts, kinds, asOf }) {
+  const launching = launchingProject ? path.resolve(launchingProject) : null;
+  return [...new Set((projects ?? []).filter(Boolean).map((project) => path.resolve(project)))]
+    .sort().map((project) => {
+      const byHost = {};
+      const guidance = [];
+      for (const host of hosts) {
+        const sources = {};
+        for (const scope of ['project', 'user', 'plugin']) {
+          sources[scope] = Object.fromEntries(kinds.map((kind) => [kind,
+            scopedCount(items, surfaces, { host, kind, scope, project, asOf })]));
+        }
+        const projectSkills = skillOccurrences(items, host, ['project'], project);
+        const sharedSkills = skillOccurrences(items, host, ['user', 'plugin'], project);
+        const nameOverlap = overlapMeasurement(projectSkills, sharedSkills, (entry) => entry.name, asOf);
+        const digestOverlap = overlapMeasurement(projectSkills, sharedSkills, (entry) => entry.digest, asOf);
+        byHost[host] = { sources, overlaps: { skillNames: nameOverlap, skillDigests: digestOverlap } };
+        if (projectSkills.length) {
+          guidance.push({
+            host, code: 'project-skill-contribution', level: nameOverlap.value ? 'review' : 'info',
+            message: `${projectSkills.length} project-scoped skill${projectSkills.length === 1 ? '' : 's'} observed; ${nameOverlap.value} name overlap${nameOverlap.value === 1 ? '' : 's'} with user/plugin sources`,
+            nextCommand: `ak x skills plan --project ${JSON.stringify(project)}`,
+          });
+        }
+      }
+      const relevant = surfaces.filter((surface) => ['user', 'plugin'].includes(surface.scope)
+        || (surface.scope === 'project' && surface.project === project));
+      const gaps = relevant.filter((surface) => surface.status === 'degraded' || surface.partial)
+        .map((surface) => ({ surface: surface.id, reason: surface.reason ?? 'partial' }));
+      return {
+        project, label: path.basename(project) || project, launching: project === launching, byHost, guidance,
+        complete: gaps.length === 0, gaps,
+        contextInclusion: {
+          status: 'unknown',
+          reason: 'host-owned context inclusion and cutoff are not exposed by this catalog',
+        },
+      };
+    });
+}
+
+function sourceStamp(at, fsImpl) {
+  try {
+    const stat = fsImpl.lstatSync(at);
+    return {
+      path: at, present: true,
+      kind: stat.isFile() ? 'file' : stat.isDirectory() ? 'directory' : stat.isSymbolicLink() ? 'symlink' : 'other',
+      bytes: stat.isFile() ? stat.size : null, mtimeMs: stat.mtimeMs,
+    };
+  } catch (error) {
+    return { path: at, present: false, kind: null, bytes: null, mtimeMs: null, reason: error?.code ?? 'io' };
+  }
+}
+
+/** Persist bounded stat-only probes so the cheap tier can notice likely catalog
+ * drift without re-reading bodies or triggering a deep scan.
+ * @param {{ surfaces?: any[], items?: any[], fsImpl?: typeof fs, maxPaths?: number }} [options] */
+export function buildCatalogSourceStamps({ surfaces, items, fsImpl = fs, maxPaths = 512 } = {}) {
+  const activeSurfaces = (surfaces ?? []).filter((surface) => surface.status !== 'absent')
+    .map((surface) => surface.path);
+  const artifacts = (items ?? []).flatMap((item) => item.presence ?? [])
+    .map((presence) => presence.sourceFile).filter(Boolean);
+  const paths = [...new Set([...activeSurfaces, ...artifacts])].sort();
+  return {
+    entries: paths.slice(0, maxPaths).map((at) => sourceStamp(at, fsImpl)),
+    partial: paths.length > maxPaths,
+    observedPaths: Math.min(paths.length, maxPaths),
+    totalCandidatePaths: paths.length,
+    limitation: 'stat probes detect watched path changes; unobserved nested content requires a deep rescan',
+  };
+}
+
+export function probeCatalogDrift(baseline, { fsImpl = fs, asOf = Date.now() } = {}) {
+  if (!baseline || !Array.isArray(baseline.entries)) {
+    return { status: 'unknown', changed: [], checkedAt: asOf, partial: true, reason: 'no catalog source-stamp baseline' };
+  }
+  const changed = [];
+  let unreadable = 0;
+  for (const before of baseline.entries) {
+    const after = sourceStamp(before.path, fsImpl);
+    if (after.reason && after.reason !== 'ENOENT') unreadable++;
+    if (before.present !== after.present || before.kind !== after.kind
+      || before.bytes !== after.bytes || before.mtimeMs !== after.mtimeMs) {
+      changed.push({ path: before.path, before, after });
+    }
+  }
+  return {
+    status: changed.length ? 'changed' : 'unchanged-at-probes', changed,
+    checkedAt: asOf, partial: baseline.partial === true || unreadable > 0,
+    reason: changed.length ? 'watched catalog sources changed since the deep scan'
+      : baseline.limitation ?? 'nested content was not revalidated',
+  };
+}

--- a/src/lib/footprint/catalog-surfaces.mjs
+++ b/src/lib/footprint/catalog-surfaces.mjs
@@ -1,0 +1,68 @@
+import path from 'node:path';
+
+import { repoRoot } from '../paths.mjs';
+
+/** Declarative filesystem surfaces. Readers are injected to keep traversal and
+ * evidence policy in catalog.mjs while this module owns host conventions. */
+export function catalogSurfaceSpecs(roots, readers, io) {
+  const {
+    claudeRoot, claudeMcpFile, codexRoot, codexConfigFile, opencodeRoot,
+    opencodeConfigFile, agentsRoot, cwd, projects,
+  } = roots;
+  const { marker, markdown, stems, manifest, toml } = readers;
+  const at = (base, ...rest) => path.join(base, ...rest);
+  const specs = [
+    { id: 'claude-skills', host: 'claude', kind: 'skill', scope: 'user', path: at(claudeRoot, 'skills'), read: (p) => marker(p, 'SKILL.md', io) },
+    { id: 'claude-agents', host: 'claude', kind: 'agent', scope: 'user', path: at(claudeRoot, 'agents'), read: (p) => markdown(p, io) },
+    { id: 'claude-commands', host: 'claude', kind: 'command', scope: 'user', path: at(claudeRoot, 'commands'), read: (p) => markdown(p, io) },
+    { id: 'claude-user-mcp', host: 'claude', kind: 'mcpServer', scope: 'user', path: claudeMcpFile, read: (p) => manifest(p, (d) => d?.mcpServers, io) },
+  ];
+  const launchingRoot = repoRoot(cwd);
+  if (launchingRoot) {
+    specs.push({ id: 'claude-project-mcp', host: 'claude', kind: 'mcpServer', scope: 'project', project: launchingRoot,
+      path: at(launchingRoot, '.mcp.json'), read: (p) => manifest(p, (d) => d?.mcpServers, io) });
+  }
+  const catalogProjects = [...new Set([launchingRoot, ...(projects ?? [])]
+    .filter(Boolean).map((project) => path.resolve(typeof project === 'string' ? project : project.path)))];
+  for (const project of catalogProjects) {
+    const claudeProject = at(project, '.claude');
+    specs.push(
+      { id: `claude-project-skills:${project}`, host: 'claude', kind: 'skill', scope: 'project', project, path: at(claudeProject, 'skills'), read: (p) => marker(p, 'SKILL.md', io) },
+      { id: `claude-project-agents:${project}`, host: 'claude', kind: 'agent', scope: 'project', project, path: at(claudeProject, 'agents'), read: (p) => markdown(p, io) },
+      { id: `claude-project-commands:${project}`, host: 'claude', kind: 'command', scope: 'project', project, path: at(claudeProject, 'commands'), read: (p) => markdown(p, io) },
+      { id: `codex-project-skills:${project}`, host: 'codex', kind: 'skill', scope: 'project', project, path: at(project, '.agents', 'skills'), read: (p) => marker(p, 'SKILL.md', io) },
+      { id: `opencode-project-skills:${project}`, host: 'opencode', kind: 'skill', scope: 'project', project, path: at(project, '.agents', 'skills'), read: (p) => marker(p, 'SKILL.md', io) },
+    );
+  }
+  specs.push(
+    { id: 'codex-skills', host: 'codex', kind: 'skill', scope: 'user', path: at(codexRoot, 'skills'), read: (p) => marker(p, 'SKILL.md', io) },
+    { id: 'codex-agents-skills', host: 'codex', kind: 'skill', scope: 'user', path: at(agentsRoot, 'skills'), read: (p) => marker(p, 'SKILL.md', io) },
+    { id: 'codex-prompts', host: 'codex', kind: 'command', scope: 'user', path: at(codexRoot, 'prompts'), read: (p) => markdown(p, io) },
+    { id: 'codex-mcp', host: 'codex', kind: 'mcpServer', scope: 'user', path: codexConfigFile, read: (p) => toml(p, 'mcp_servers', io) },
+    { id: 'opencode-agents', host: 'opencode', kind: 'agent', scope: 'user', path: at(opencodeRoot, 'agents'), read: (p) => markdown(p, io) },
+    { id: 'opencode-skills', host: 'opencode', kind: 'skill', scope: 'user', path: at(opencodeRoot, 'skills'), read: (p) => marker(p, 'SKILL.md', io) },
+    { id: 'opencode-agents-skills', host: 'opencode', kind: 'skill', scope: 'user', path: at(agentsRoot, 'skills'), read: (p) => marker(p, 'SKILL.md', io) },
+    { id: 'opencode-commands', host: 'opencode', kind: 'command', scope: 'user', path: at(opencodeRoot, 'command'), read: (p) => markdown(p, io) },
+    { id: 'opencode-plugins', host: 'opencode', kind: 'plugin', scope: 'user', path: at(opencodeRoot, 'plugins'), read: (p) => stems(p, ['.js', '.mjs', '.cjs', '.ts'], io) },
+    { id: 'opencode-mcp', host: 'opencode', kind: 'mcpServer', scope: 'user', path: opencodeConfigFile, read: (p) => manifest(p, (d) => d?.mcp, io) },
+  );
+  return { specs, catalogProjects, launchingProject: launchingRoot };
+}
+
+export function pluginCapabilitySpecs(host, provider, root, readers, io) {
+  const { marker, markdown, manifest } = readers;
+  const specs = [];
+  for (const [tag, base] of [['', root], ['dot', path.join(root, '.claude')]]) {
+    const id = (kind) => `${host}-plugin:${provider.ref}:${tag ? `${tag}-` : ''}${kind}`;
+    specs.push(
+      { id: id('skills'), host, kind: 'skill', scope: 'plugin', provider, path: path.join(base, 'skills'), prefix: provider.name, read: (p) => marker(p, 'SKILL.md', io) },
+      { id: id('agents'), host, kind: 'agent', scope: 'plugin', provider, path: path.join(base, 'agents'), prefix: provider.name, read: (p) => markdown(p, io) },
+      { id: id('commands'), host, kind: 'command', scope: 'plugin', provider, path: path.join(base, 'commands'), prefix: provider.name, read: (p) => markdown(p, io) },
+    );
+  }
+  specs.push(
+    { id: `${host}-plugin:${provider.ref}:migrated-command-skills`, host, kind: 'skill', scope: 'plugin', provider, path: path.join(root, '.codex-plugin', 'migrated-command-skills'), prefix: provider.name, read: (p) => marker(p, 'SKILL.md', io) },
+    { id: `${host}-plugin:${provider.ref}:mcp`, host, kind: 'mcpServer', scope: 'plugin', provider, path: path.join(root, '.mcp.json'), prefix: provider.name, read: (p) => manifest(p, (d) => d?.mcpServers, io) },
+  );
+  return specs;
+}

--- a/src/lib/footprint/catalog.mjs
+++ b/src/lib/footprint/catalog.mjs
@@ -1,44 +1,29 @@
-// Catalog inventory — the deduplicated set of skills, agents, commands, plugins,
-// and MCP servers actually deployed across hosts, each with a per-host presence
-// matrix (which host carries it, observed from which surface).
-//
-// OBSERVED inventory only (ADR-0025 invariant 10): this module reports what is on
-// disk per host surface and never reads, mirrors, or upgrades Integration
-// management's desired state.
-//
-// Counting is by NAME — directory entries, manifest keys, TOML table names. Item
-// bodies are never parsed (invariant 1). Directory surfaces go through the shared
-// bounded walker, which is why nothing here follows a symlink or escapes a root;
-// the manifest surfaces are single-file reads of keys, the same spawn-free seam
-// mcp.mjs already uses because `claude mcp list` health-checks every server and
-// has no stable schema.
-//
-// The single content read is the managed-block sentinel scan on guidance files,
-// which ADR-0025's config-surface row explicitly sanctions; it retains a count
-// and nothing else.
+// Read-only CatalogInventory v2 (ADR-0025): canonical standalone/plugin identity,
+// per-source occurrences, and bounded entrypoint digests. Bodies never leave the
+// collector; traversal never follows a symlink or escapes a declared root.
 import fs from 'node:fs';
 import path from 'node:path';
 import {
-  claudeDir, claudeSettingsPath, claudeUserMcpPath,
-  codexDir, codexConfigPath,
+  claudeDir, claudeUserMcpPath,
+  codexDir, codexConfigPath, home,
   opencodeDir, opencodeConfigPath,
-  projectSettings, projectSettingsLocal, repoRoot,
 } from '../paths.mjs';
 import { readJson } from '../settings.mjs';
 import { inspectCodexPlugins } from '../codex-plugins.mjs';
-import { registry, blocksForTarget, guidanceTargets, hasBlock } from '../blocks.mjs';
-import { walkTree, statNode, measured, unknown } from './walk.mjs';
+import { walkTree, statNode, measured } from './walk.mjs';
+import {
+  artifactDigest, buildCatalogSourceStamps, buildProjectPressure, collectNativePluginInventory, pluginRefParts,
+} from './catalog-evidence.mjs';
+import { collectConfigSurface } from './catalog-config.mjs';
+import { catalogSurfaceSpecs, pluginCapabilitySpecs } from './catalog-surfaces.mjs';
 
-/** Per-surface name cap. A capped surface reports truncated — its count is then a
- *  floor, never a total. */
+export { collectConfigSurface } from './catalog-config.mjs';
+
+/** A capped surface reports a floor, never a total. */
 const MAX_NAMES = 4096;
 
 export const CATALOG_KINDS = ['skill', 'agent', 'command', 'plugin', 'mcpServer'];
 export const CATALOG_HOSTS = ['claude', 'codex', 'opencode'];
-
-/** Any BEGIN sentinel, kit-managed or not — the count of foreign or orphaned
- *  blocks is the interesting half of "what is deployed in my guidance files". */
-const SENTINEL_RE = /^<!-- BEGIN [^>]+ -->$/gm;
 
 // ── surface readings ──────────────────────────────────────────────────────────
 
@@ -48,24 +33,19 @@ const SENTINEL_RE = /^<!-- BEGIN [^>]+ -->$/gm;
  * zero), 'degraded' (could not look — unknown, never zero). `partial` marks a
  * count that is a floor because a cap fired or a subtree was unreadable.
  * @typedef {{ status: 'ok'|'absent'|'degraded', reason: string|null,
- *             names: string[], partial: boolean, truncated: boolean }} SurfaceReading
+ *             names: string[], entries?: object[], partial: boolean, truncated: boolean }} SurfaceReading
  */
 
-const emptyReading = (status, reason) => ({ status, reason, names: [], partial: false, truncated: false });
+const emptyReading = (status, reason) => ({
+  status, reason, names: [], entries: [], partial: false, truncated: false,
+});
 
-/**
- * Names below `root`, one per file the walker accepts. `nameOf` turns the accepted
- * file's path into the catalog name — the ':'-joined relative path a host uses to
- * namespace nested entries.
- *
- * Scope is enforced with `skipDir` rather than `maxDepth` on purpose: a catalog
- * surface is a shallow name space, and everything below it is an item's own
- * reference material, not another item. Pruning it is a deliberate scope (the
- * walker does not call that truncation), whereas a depth cap would mark every
- * skill that ships a `references/` folder as an incomplete measurement.
- */
-function readNames(root, { accept, nameOf, dirDepth, walk = walkTree, limits = {}, fsImpl = fs }) {
+/** Read accepted names without descending into an item's reference material. */
+function readNames(root, {
+  accept, nameOf, entryOf = null, dirDepth, walk = walkTree, limits = {}, fsImpl = fs,
+}) {
   const names = [];
+  const entries = [];
   const result = walk(root, {
     ...limits, fsImpl,
     skipDir: (dir, name, depth) => depth > dirDepth,
@@ -73,7 +53,10 @@ function readNames(root, { accept, nameOf, dirDepth, walk = walkTree, limits = {
     onFile: ({ file }) => {
       if (names.length >= MAX_NAMES) return;
       const name = nameOf(file);
-      if (name) names.push(name);
+      if (name) {
+        names.push(name);
+        entries.push({ name, ...(entryOf ? entryOf(file, name) : {}) });
+      }
     },
   });
   if (result.status === 'unknown') {
@@ -83,7 +66,7 @@ function readNames(root, { accept, nameOf, dirDepth, walk = walkTree, limits = {
   return {
     status: 'ok',
     reason: result.degraded?.[0]?.reason ?? null,
-    names,
+    names, entries,
     partial: result.complete === false || truncated,
     truncated,
   };
@@ -103,15 +86,19 @@ const readMarkerDirs = (root, marker, opts = {}) => readNames(root, {
   dirDepth: 2,
   accept: (name) => name === marker,
   nameOf: (file) => relativeName(root, path.dirname(file)),
+  entryOf: (file) => ({
+    itemPath: path.dirname(file), sourceFile: file,
+    digest: artifactDigest(file, opts),
+  }),
   ...opts,
 });
 
-/** `*.md` entries below `root`. A README documents the surface rather than being
- *  an entry on it, so it is excluded instead of counted as a command. */
+/** Markdown entries; README documents the surface and is not an entry. */
 const readMarkdownNames = (root, opts = {}) => readNames(root, {
   dirDepth: 3,
   accept: (name) => name.endsWith('.md') && !/^readme\.md$/i.test(name),
   nameOf: (file) => relativeName(root, file, { strip: '.md' }),
+  entryOf: (file) => ({ itemPath: file, sourceFile: file, digest: artifactDigest(file, opts) }),
   ...opts,
 });
 
@@ -120,6 +107,7 @@ const readFileStems = (root, exts, opts = {}) => readNames(root, {
   dirDepth: 0,
   accept: (name) => exts.includes(path.extname(name)),
   nameOf: (file) => path.basename(file, path.extname(file)),
+  entryOf: (file) => ({ itemPath: file, sourceFile: file }),
   ...opts,
 });
 
@@ -133,12 +121,11 @@ function readManifestKeys(file, pick, { fsImpl = fs } = {}) {
   if (doc === null) return emptyReading('degraded', 'EPARSE');
   const bag = pick(doc);
   if (!bag || typeof bag !== 'object') return { ...emptyReading('ok', null), names: [] };
-  return { status: 'ok', reason: null, names: Object.keys(bag), partial: false, truncated: false };
+  const names = Object.keys(bag);
+  return { status: 'ok', reason: null, names, entries: names.map((name) => ({ name })), partial: false, truncated: false };
 }
 
-/** TOML table names under `section` — the same regex-over-source approach
- *  codex-plugins' enabledPluginRefs uses, because codex owns config.toml and this
- *  kit only ever observes it. Exported for tests. */
+/** TOML table names under `section`, exported for tests. */
 export function tomlTableNames(source, section) {
   const names = [];
   const re = new RegExp(
@@ -158,12 +145,11 @@ function readTomlTables(file, section, { fsImpl = fs } = {}) {
   try { source = fsImpl.readFileSync(file, 'utf8'); } catch (error) {
     return emptyReading(error.code === 'ENOENT' ? 'absent' : 'degraded', error.code ?? 'io');
   }
-  return { status: 'ok', reason: null, names: tomlTableNames(source, section), partial: false, truncated: false };
+  const names = tomlTableNames(source, section);
+  return { status: 'ok', reason: null, names, entries: names.map((name) => ({ name })), partial: false, truncated: false };
 }
 
-/** Claude's installed-plugin manifest: `{ plugins: { "<id>@<marketplace>": [ … ] } }`.
- *  Returns the plugin ids plus the newest install root per id — the roots the
- *  plugin-provided skill/agent/command surfaces hang off. */
+/** Claude's installed-plugin manifest and newest install root per full ref. */
 function readClaudePlugins(file, { fsImpl = fs } = {}) {
   const head = statNode(file, { fsImpl });
   if (head.status === 'unknown') {
@@ -172,216 +158,26 @@ function readClaudePlugins(file, { fsImpl = fs } = {}) {
   const doc = readJson(file, null);
   if (doc === null) return { ...emptyReading('degraded', 'EPARSE'), roots: [] };
   const names = [];
+  const entries = [];
   const roots = [];
   for (const [ref, installs] of Object.entries(doc?.plugins ?? {})) {
-    const id = ref.includes('@') ? ref.slice(0, ref.lastIndexOf('@')) : ref;
-    names.push(id);
+    const parts = pluginRefParts(ref);
+    names.push(ref);
     const newest = (Array.isArray(installs) ? installs : []).at(-1);
-    if (newest?.installPath) roots.push({ id, root: newest.installPath });
+    const plugin = {
+      ...parts,
+      version: typeof newest?.version === 'string' ? newest.version : null,
+      enabled: null,
+      scope: typeof newest?.scope === 'string' ? newest.scope : 'unknown',
+      root: typeof newest?.installPath === 'string' ? newest.installPath : null,
+      installedAt: typeof newest?.installedAt === 'string' ? newest.installedAt : null,
+      lastUpdated: typeof newest?.lastUpdated === 'string' ? newest.lastUpdated : null,
+      evidence: 'manifest',
+    };
+    entries.push({ name: ref, plugin });
+    if (plugin.root) roots.push(plugin);
   }
-  return { status: 'ok', reason: null, names, partial: false, truncated: false, roots };
-}
-
-// ── surface specs ─────────────────────────────────────────────────────────────
-
-/**
- * Every catalog surface this machine could carry, as data. A surface that does
- * not exist reads 'absent' and contributes a real zero — which is why a host's
- * documented-but-unused convention (codex prompts, opencode commands) is safe to
- * list: it costs one stat and can never fabricate an entry.
- */
-function surfaceSpecs(roots, io) {
-  const { claudeRoot, claudeMcpFile, codexRoot, codexConfigFile, opencodeRoot, opencodeConfigFile,
-    cwd, projects } = roots;
-  const at = (base, ...rest) => path.join(base, ...rest);
-  const specs = [];
-
-  // claude — user scope
-  specs.push({ id: 'claude-skills', host: 'claude', kind: 'skill', path: at(claudeRoot, 'skills'),
-    read: (p) => readMarkerDirs(p, 'SKILL.md', io) });
-  specs.push({ id: 'claude-agents', host: 'claude', kind: 'agent', path: at(claudeRoot, 'agents'),
-    read: (p) => readMarkdownNames(p, io) });
-  specs.push({ id: 'claude-commands', host: 'claude', kind: 'command', path: at(claudeRoot, 'commands'),
-    read: (p) => readMarkdownNames(p, io) });
-  specs.push({ id: 'claude-plugins', host: 'claude', kind: 'plugin',
-    path: at(claudeRoot, 'plugins', 'installed_plugins.json'),
-    read: (p) => readClaudePlugins(p, io) });
-  specs.push({ id: 'claude-user-mcp', host: 'claude', kind: 'mcpServer', path: claudeMcpFile,
-    read: (p) => readManifestKeys(p, (d) => d?.mcpServers, io) });
-
-  // claude — project scope. The repo root is the same seam mcp.mjs's codexMcpStatus
-  // reads; outside a repo there is simply no project surface to report.
-  const projectRoot = repoRoot(cwd);
-  if (projectRoot) {
-    specs.push({ id: 'claude-project-mcp', host: 'claude', kind: 'mcpServer',
-      path: at(projectRoot, '.mcp.json'), read: (p) => readManifestKeys(p, (d) => d?.mcpServers, io) });
-  }
-
-  // Project-scoped skills, agents and commands, across the launching repository
-  // plus EVERY project the host census has observed on this machine. A fresh
-  // repository has no transcript yet, so the launching root is load-bearing.
-  //
-  // A catalog that reads user scope plus one repo answers "what can I use right
-  // here", which is not the question this panel asks: it is the machine's
-  // deployed inventory, and a skill defined in one repo is as installed as one
-  // in ~/.claude. Deduplication by (kind, name) means a name defined in five
-  // projects is still one row, so the list grows with distinct NAMES rather
-  // than with project count.
-  //
-  // Costs four stats per project against an already-bounded project list; a
-  // project directory that is gone simply reads absent. Resolve and deduplicate
-  // because the launching repository normally also appears in the census.
-  const catalogProjects = [...new Set([
-    projectRoot,
-    ...(projects ?? []),
-  ].filter(Boolean).map((project) => path.resolve(project)))];
-  for (const project of catalogProjects) {
-    const root = at(project, '.claude');
-    specs.push({ id: `claude-project-skills:${project}`, host: 'claude', kind: 'skill',
-      path: at(root, 'skills'), read: (p) => readMarkerDirs(p, 'SKILL.md', io) });
-    specs.push({ id: `claude-project-agents:${project}`, host: 'claude', kind: 'agent',
-      path: at(root, 'agents'), read: (p) => readMarkdownNames(p, io) });
-    specs.push({ id: `claude-project-commands:${project}`, host: 'claude', kind: 'command',
-      path: at(root, 'commands'), read: (p) => readMarkdownNames(p, io) });
-    specs.push({ id: `codex-project-skills:${project}`, host: 'codex', kind: 'skill',
-      path: at(project, '.agents', 'skills'), read: (p) => readMarkerDirs(p, 'SKILL.md', io) });
-  }
-
-  // codex
-  specs.push({ id: 'codex-skills', host: 'codex', kind: 'skill', path: at(codexRoot, 'skills'),
-    read: (p) => readMarkerDirs(p, 'SKILL.md', io) });
-  specs.push({ id: 'codex-prompts', host: 'codex', kind: 'command', path: at(codexRoot, 'prompts'),
-    read: (p) => readMarkdownNames(p, io) });
-  specs.push({ id: 'codex-mcp', host: 'codex', kind: 'mcpServer', path: codexConfigFile,
-    read: (p) => readTomlTables(p, 'mcp_servers', io) });
-
-  // opencode
-  specs.push({ id: 'opencode-agents', host: 'opencode', kind: 'agent', path: at(opencodeRoot, 'agents'),
-    read: (p) => readMarkdownNames(p, io) });
-  specs.push({ id: 'opencode-skills', host: 'opencode', kind: 'skill', path: at(opencodeRoot, 'skills'),
-    read: (p) => readMarkerDirs(p, 'SKILL.md', io) });
-  specs.push({ id: 'opencode-commands', host: 'opencode', kind: 'command', path: at(opencodeRoot, 'command'),
-    read: (p) => readMarkdownNames(p, io) });
-  specs.push({ id: 'opencode-plugins', host: 'opencode', kind: 'plugin', path: at(opencodeRoot, 'plugins'),
-    read: (p) => readFileStems(p, ['.js', '.mjs', '.cjs', '.ts'], io) });
-  specs.push({ id: 'opencode-mcp', host: 'opencode', kind: 'mcpServer', path: opencodeConfigFile,
-    read: (p) => readManifestKeys(p, (d) => d?.mcp, io) });
-
-  return specs;
-}
-
-/**
- * Sub-surfaces contributed by an installed plugin's own cache directory. Names are
- * namespaced `<plugin>:<entry>` — the convention the hosts themselves use, and
- * what keeps a plugin's `migrate` command distinct from a user's.
- *
- * Two layouts are in the wild and both are read: content at the plugin root
- * (`skills/`) and content under a nested `.claude/` (the same shape opencode's
- * catalogSource probes for on a ruflo checkout). A plugin using one layout reports
- * the other absent; an item found in both dedupes to one row with two presence
- * entries.
- */
-function pluginSubSurfaces(host, pluginId, root, idPrefix, io) {
-  const specs = [];
-  for (const [tag, base] of [['', root], ['dot', path.join(root, '.claude')]]) {
-    const id = (kind) => `${idPrefix}:${pluginId}:${tag ? `${tag}-` : ''}${kind}`;
-    specs.push({ id: id('skills'), host, kind: 'skill', path: path.join(base, 'skills'),
-      prefix: pluginId, read: (p) => readMarkerDirs(p, 'SKILL.md', io) });
-    specs.push({ id: id('agents'), host, kind: 'agent', path: path.join(base, 'agents'),
-      prefix: pluginId, read: (p) => readMarkdownNames(p, io) });
-    specs.push({ id: id('commands'), host, kind: 'command', path: path.join(base, 'commands'),
-      prefix: pluginId, read: (p) => readMarkdownNames(p, io) });
-  }
-  // A plugin may ship its own MCP servers; those are registered under the
-  // plugin's identity, not the user's, so they carry the plugin namespace too.
-  specs.push({ id: `${idPrefix}:${pluginId}:mcp`, host, kind: 'mcpServer',
-    path: path.join(root, '.mcp.json'), prefix: pluginId,
-    read: (p) => readManifestKeys(p, (d) => d?.mcpServers, io) });
-  return specs;
-}
-
-// ── config surface ────────────────────────────────────────────────────────────
-
-/** Size of a known file. A missing file is a measured zero flagged
- *  `present: false`, so a renderer says "not present" rather than printing 0 B. */
-function fileSize(file, { asOf = null, fsImpl = fs } = {}) {
-  const node = statNode(file, { fsImpl });
-  if (node.status === 'unknown') {
-    return node.reason === 'ENOENT'
-      ? { ...measured(0, { asOf }), present: false, mtimeMs: null, path: file }
-      : { ...unknown(node.reason), present: null, mtimeMs: null, path: file };
-  }
-  return { ...measured(node.bytes ?? 0, { asOf }), present: true, mtimeMs: node.mtimeMs, path: file };
-}
-
-/**
- * The config-surface row: how many managed blocks each guidance file carries and
- * how big the settings files are. Guidance files are the one place this domain
- * reads content, and it reads only sentinel LINES — `hasBlock` answers "is this
- * registry slug present" and the sentinel regex counts BEGIN markers. No prose,
- * no block bodies, nothing retained past the count.
- *
- * @param {{ cwd?: string, cfg?: { customBlocks?: object[] }, asOf?: number|null,
- *           extraSettingsFiles?: Array<{ id: string, label: string, path: string }>,
- *           fsImpl?: typeof fs }} [options]
- */
-export function collectConfigSurface({
-  cwd = process.cwd(),
-  cfg = /** @type {{ customBlocks?: object[] }} */ ({}),
-  asOf = null,
-  extraSettingsFiles = [],
-  fsImpl = fs,
-} = {}) {
-  const rows = registry(cfg?.customBlocks ?? []);
-  const guidance = [];
-  for (const target of guidanceTargets({ cwd })) {
-    const bytes = fileSize(target.file, { asOf, fsImpl });
-    const expected = blocksForTarget(rows, target.name);
-    let content;
-    try { content = fsImpl.readFileSync(target.file, 'utf8'); } catch (error) {
-      const absent = error.code === 'ENOENT';
-      guidance.push({
-        name: target.name, label: target.label, path: target.file, bytes,
-        managed: absent ? measured(0, { asOf }) : unknown(error.code ?? 'io'),
-        observed: absent ? measured(0, { asOf }) : unknown(error.code ?? 'io'),
-        expected: expected.length,
-        slugs: [],
-      });
-      continue;
-    }
-    const present = expected.filter((row) => hasBlock(content, row.slug));
-    const observed = (content.match(SENTINEL_RE) ?? []).length;
-    guidance.push({
-      name: target.name,
-      label: target.label,
-      path: target.file,
-      bytes,
-      managed: measured(present.length, { asOf }),
-      observed: measured(observed, { asOf }),
-      expected: expected.length,
-      slugs: present.map((row) => row.slug),
-    });
-    // `content` dies with this iteration: the counts above are the whole payload,
-    // and no prose from a guidance file leaves this scope.
-  }
-
-  const projectRoot = repoRoot(cwd);
-  const settings = [
-    { id: 'claude-settings', label: '~/.claude/settings.json', file: claudeSettingsPath() },
-    { id: 'claude-user-mcp', label: '~/.claude.json', file: claudeUserMcpPath() },
-    { id: 'codex-config', label: '~/.codex/config.toml', file: codexConfigPath() },
-    { id: 'opencode-config', label: 'opencode.json', file: opencodeConfigPath() },
-  ];
-  if (projectRoot) {
-    settings.push({ id: 'project-settings', label: '.claude/settings.json', file: projectSettings(projectRoot) });
-    settings.push({ id: 'project-settings-local', label: '.claude/settings.local.json', file: projectSettingsLocal(projectRoot) });
-  }
-  for (const extra of extraSettingsFiles) settings.push({ id: extra.id, label: extra.label, file: extra.path });
-
-  return {
-    guidance,
-    settings: settings.map((row) => ({ id: row.id, label: row.label, ...fileSize(row.file, { asOf, fsImpl }) })),
-  };
+  return { status: 'ok', reason: null, names, entries, partial: false, truncated: false, roots };
 }
 
 // ── assembly ──────────────────────────────────────────────────────────────────
@@ -390,51 +186,108 @@ export function collectConfigSurface({
  *  kind is part of the key because a `tester` agent and a `tester` command are two
  *  different deployed things. */
 const itemKey = (kind, name) => `${kind}::${name.trim().toLowerCase()}`;
+const fallbackInventoryStatus = (configPresent) => (configPresent === false ? 'degraded' : 'partial');
 
-/**
- * Additional catalog specs contributed by installed plugins' own cache
- * directories, discovered from the plugin manifests themselves (Claude's
- * `installed_plugins.json`, codex's inspected plugin cache) rather than
- * hardcoded. A codex read failure is that host's problem, not this catalog's —
- * it must never take the rest of the specs down with it.
- */
-function pluginSurfaceSpecs({ claudeRoot, codexConfigFile, inspectCodexPlugins: inspect, io }) {
+/** Plugin inventories plus enabled plugins' capability surfaces. */
+function pluginSurfaceSpecs({
+  claudeRoot, codexConfigFile, inspectCodexPlugins: inspect, io, readers,
+  nativePlugins, includeComponents,
+}) {
   const specs = [];
-  const claudePlugins = readClaudePlugins(path.join(claudeRoot, 'plugins', 'installed_plugins.json'), io);
-  for (const { id, root } of claudePlugins.roots) {
-    specs.push(...pluginSubSurfaces('claude', id, root, 'claude-plugin', io));
-  }
+  const sources = {};
+  const claudeFallback = readClaudePlugins(path.join(claudeRoot, 'plugins', 'installed_plugins.json'), io);
+  const fallbackByRef = new Map(claudeFallback.entries.map((entry) => [entry.name, entry.plugin]));
   let codexPlugins = { configPresent: false, plugins: [] };
   try { codexPlugins = inspect({ configFile: codexConfigFile }) ?? codexPlugins; }
   catch { codexPlugins = { configPresent: false, plugins: [] }; }
-  for (const plugin of codexPlugins.plugins ?? []) {
-    if (!plugin?.root || !plugin?.ref) continue;
-    const id = plugin.ref.includes('@') ? plugin.ref.slice(0, plugin.ref.lastIndexOf('@')) : plugin.ref;
-    specs.push(...pluginSubSurfaces('codex', id, plugin.root, 'codex-plugin', io));
+  const codexByRef = new Map((codexPlugins.plugins ?? [])
+    .filter((plugin) => plugin?.ref).map((plugin) => [plugin.ref, plugin]));
+
+  const inventory = {};
+  const nativeClaude = nativePlugins?.claude;
+  if (nativeClaude?.status === 'ok') {
+    inventory.claude = nativeClaude.plugins.map((plugin) => ({
+      ...plugin, root: plugin.root ?? fallbackByRef.get(plugin.ref)?.root ?? null,
+    }));
+    sources.claude = { status: 'ok', authority: 'host-native', source: nativeClaude.source, reason: null };
+  } else {
+    inventory.claude = claudeFallback.entries.map((entry) => entry.plugin);
+    sources.claude = {
+      status: claudeFallback.status === 'degraded' ? 'degraded' : 'partial', authority: 'manifest-fallback',
+      source: 'installed_plugins.json', reason: nativeClaude?.reason ?? claudeFallback.reason ?? 'native inventory not measured',
+    };
   }
-  // Codex's enabled refs ARE that host's plugin inventory.
-  const enabled = (codexPlugins.plugins ?? []).map((plugin) => plugin?.ref).filter(Boolean);
-  specs.push({
-    id: 'codex-plugins', host: 'codex', kind: 'plugin', path: codexConfigFile,
-    read: () => (codexPlugins.configPresent === false
-      ? emptyReading('absent', 'ENOENT')
-      : { status: 'ok', reason: null, names: enabled, partial: false, truncated: false }),
-  });
-  return specs;
+  const nativeCodex = nativePlugins?.codex;
+  if (nativeCodex?.status === 'ok') {
+    inventory.codex = nativeCodex.plugins.map((plugin) => ({
+      ...plugin,
+      root: codexByRef.get(plugin.ref)?.root ?? null,
+      cacheGeneration: codexByRef.get(plugin.ref)?.version ?? null,
+    }));
+    sources.codex = { status: 'ok', authority: 'host-native', source: nativeCodex.source, reason: null };
+  } else {
+    inventory.codex = [...codexByRef.entries()].map(([ref, plugin]) => ({
+      ...pluginRefParts(ref), version: plugin.version ?? null, cacheGeneration: plugin.version ?? null,
+      root: plugin.root ?? null, enabled: true, scope: 'user', evidence: 'config-cache-fallback',
+    }));
+    sources.codex = {
+      status: fallbackInventoryStatus(codexPlugins.configPresent), authority: 'config-cache-fallback',
+      source: 'config.toml + plugin cache', reason: nativeCodex?.reason ?? 'native inventory not measured',
+    };
+  }
+
+  for (const host of ['claude', 'codex']) {
+    const plugins = inventory[host];
+    const source = sources[host];
+    specs.push({
+      id: `${host}-plugins`, host, kind: 'plugin', scope: 'plugin',
+      path: host === 'claude' ? path.join(claudeRoot, 'plugins', 'installed_plugins.json') : codexConfigFile,
+      read: () => ({
+        status: source.status === 'degraded' ? 'degraded' : 'ok', reason: source.reason,
+        names: plugins.map((plugin) => plugin.ref),
+        entries: plugins.map((plugin) => ({ name: plugin.ref, plugin })),
+        partial: source.status === 'partial', truncated: false,
+      }),
+    });
+    if (!includeComponents) continue;
+    for (const plugin of plugins) {
+      if (!plugin?.root || !plugin?.ref || plugin.enabled === false) continue;
+      specs.push(...pluginCapabilitySpecs(host, plugin, plugin.root, readers, io));
+    }
+  }
+  return { specs, sources };
 }
 
 /** Add one spec's names to the deduplicated CatalogItem map. A plugin-sourced
  *  name carries its plugin's namespace prefix, exactly as the surface declared. */
-function mergeCatalogItem(items, spec, raw) {
+function mergeCatalogItem(items, spec, entry) {
+  const raw = entry.name;
   const name = spec.prefix ? `${spec.prefix}:${raw}` : raw;
-  const key = itemKey(spec.kind, name);
+  const key = spec.provider
+    ? itemKey(spec.kind, `plugin:${spec.provider.ref}:${raw}`)
+    : itemKey(spec.kind, name);
   let item = items.get(key);
   if (!item) {
-    item = { key, kind: spec.kind, name, hosts: [], presence: [] };
+    item = {
+      key, canonicalId: key, kind: spec.kind, name,
+      capabilityName: raw, pluginRef: spec.provider?.ref ?? null,
+      hosts: [], sourceScopes: [], presence: [],
+    };
     items.set(key, item);
   }
   if (!item.hosts.includes(spec.host)) item.hosts.push(spec.host);
-  item.presence.push({ host: spec.host, surface: spec.id, path: spec.path });
+  if (!item.sourceScopes.includes(spec.scope)) item.sourceScopes.push(spec.scope);
+  const provider = spec.provider ? {
+    ref: spec.provider.ref, name: spec.provider.name, marketplace: spec.provider.marketplace,
+    version: spec.provider.version ?? null, cacheGeneration: spec.provider.cacheGeneration ?? null,
+    enabled: spec.provider.enabled ?? null, evidence: spec.provider.evidence ?? null,
+  } : null;
+  item.presence.push({
+    host: spec.host, surface: spec.id, path: spec.path,
+    itemPath: entry.itemPath ?? null, sourceFile: entry.sourceFile ?? null,
+    scope: spec.scope ?? 'unknown', project: spec.project ?? null,
+    provider, plugin: entry.plugin ?? null, digest: entry.digest ?? null,
+  });
 }
 
 /** Read every spec once, folding hits into deduplicated CatalogItems and
@@ -448,6 +301,9 @@ function readCatalogSurfaces(specs) {
       id: spec.id,
       host: spec.host,
       kind: spec.kind,
+      scope: spec.scope ?? 'unknown',
+      project: spec.project ?? null,
+      provider: spec.provider ? { ref: spec.provider.ref, version: spec.provider.version ?? null } : null,
       path: spec.path,
       status: reading.status,
       reason: reading.reason ?? null,
@@ -457,7 +313,9 @@ function readCatalogSurfaces(specs) {
       count: reading.status === 'degraded' ? null : reading.names.length,
     });
     if (reading.status === 'degraded') continue;
-    for (const raw of reading.names) mergeCatalogItem(items, spec, raw);
+    for (const entry of reading.entries ?? reading.names.map((name) => ({ name }))) {
+      mergeCatalogItem(items, spec, entry);
+    }
   }
   return { items, surfaces };
 }
@@ -478,9 +336,49 @@ function trackIncompleteness(surfaces) {
 /** Deduplicated items, ranked by kind (in the documented CATALOG_KINDS order)
  *  then by name. */
 function sortCatalogItems(items) {
-  return [...items.values()].sort((a, b) => (a.kind === b.kind
+  const list = [...items.values()];
+  for (const item of list) {
+    const digests = item.presence.map((presence) => presence.digest?.value).filter(Boolean);
+    const unique = [...new Set(digests)];
+    item.digestCoverage = {
+      measured: digests.length,
+      unknown: item.presence.length - digests.length,
+      unique: unique.length,
+      exactMatch: digests.length > 1 && unique.length === 1,
+    };
+    item.variantCount = Math.max(unique.length, unique.length ? 1 : 0);
+  }
+  return list.sort((a, b) => (a.kind === b.kind
     ? a.name.localeCompare(b.name)
     : CATALOG_KINDS.indexOf(a.kind) - CATALOG_KINDS.indexOf(b.kind)));
+}
+
+function buildOverlapGroups(list) {
+  const nameGroups = new Map();
+  const digestGroups = new Map();
+  for (const item of list.filter((candidate) => candidate.kind === 'skill')) {
+    const name = item.capabilityName.trim().toLowerCase();
+    if (!nameGroups.has(name)) nameGroups.set(name, []);
+    nameGroups.get(name).push(item);
+    for (const digest of new Set(item.presence.map((presence) => presence.digest?.value).filter(Boolean))) {
+      if (!digestGroups.has(digest)) digestGroups.set(digest, []);
+      digestGroups.get(digest).push(item);
+    }
+  }
+  const mapGroups = (groups, field) => [...groups.entries()].flatMap(([value, items]) => {
+    const occurrences = items.reduce((sum, item) => sum + item.presence.length, 0);
+    if (items.length < 2 && occurrences < 2) return [];
+    return [{ [field]: value, itemKeys: items.map((item) => item.key), occurrences }];
+  });
+  const measuredDigests = list.filter((item) => item.kind === 'skill')
+    .flatMap((item) => item.presence).filter((presence) => presence.digest?.value).length;
+  const total = list.filter((item) => item.kind === 'skill')
+    .reduce((sum, item) => sum + item.presence.length, 0);
+  return {
+    exactName: mapGroups(nameGroups, 'name'),
+    exactEntrypointDigest: mapGroups(digestGroups, 'digest'),
+    digestCoverage: { measured: measuredDigests, unknown: total - measuredDigests, partial: measuredDigests < total },
+  };
 }
 
 /** Total count per kind, `partial` when any surface feeding that kind was
@@ -515,16 +413,19 @@ function tallyCatalogPerHost(list, asOf, incompleteByHost) {
  * evidence; calling it unknown would throw away what was actually observed.
  *
  * @param {{ claudeRoot?: string, claudeMcpFile?: string, codexRoot?: string,
+ *           agentsRoot?: string,
  *           codexConfigFile?: string, opencodeRoot?: string, opencodeConfigFile?: string,
  *           cwd?: string, projects?: string[], cfg?: object, now?: () => number, walk?: Function,
  *           limits?: object, fsImpl?: typeof fs,
- *           inspectCodexPlugins?: Function, includePluginSurfaces?: boolean }} [options]
+ *           inspectCodexPlugins?: Function, collectNativePlugins?: Function,
+ *           nativePlugins?: object, includePluginSurfaces?: boolean }} [options]
  * @returns {object} CatalogInventory
  */
 export function collectCatalog({
   claudeRoot = claudeDir(),
   claudeMcpFile = claudeUserMcpPath(),
   codexRoot = codexDir(),
+  agentsRoot = path.join(home, '.agents'),
   codexConfigFile = codexConfigPath(),
   opencodeRoot = opencodeDir(),
   opencodeConfigFile = opencodeConfigPath(),
@@ -538,16 +439,25 @@ export function collectCatalog({
   limits = {},
   fsImpl = fs,
   inspectCodexPlugins: inspectCodexPluginsImpl = inspectCodexPlugins,
+  collectNativePlugins = collectNativePluginInventory,
+  nativePlugins = null,
   includePluginSurfaces = true,
 } = {}) {
   const asOf = now();
   const io = { walk, limits, fsImpl };
-  const roots = { claudeRoot, claudeMcpFile, codexRoot, codexConfigFile, opencodeRoot, opencodeConfigFile,
+  const roots = { claudeRoot, claudeMcpFile, codexRoot, agentsRoot, codexConfigFile, opencodeRoot, opencodeConfigFile,
     cwd, projects };
-  const specs = surfaceSpecs(roots, io);
-  if (includePluginSurfaces) {
-    specs.push(...pluginSurfaceSpecs({ claudeRoot, codexConfigFile, inspectCodexPlugins: inspectCodexPluginsImpl, io }));
-  }
+  const readers = {
+    marker: readMarkerDirs, markdown: readMarkdownNames, stems: readFileStems,
+    manifest: readManifestKeys, toml: readTomlTables,
+  };
+  const base = catalogSurfaceSpecs(roots, readers, io);
+  const observedNative = nativePlugins ?? (fsImpl === fs ? collectNativePlugins() : null);
+  const plugins = pluginSurfaceSpecs({
+    claudeRoot, codexConfigFile, inspectCodexPlugins: inspectCodexPluginsImpl, io, readers,
+    nativePlugins: observedNative, includeComponents: includePluginSurfaces,
+  });
+  const specs = [...base.specs, ...plugins.specs];
 
   const { items, surfaces } = readCatalogSurfaces(specs);
   const { incomplete, incompleteByHost } = trackIncompleteness(surfaces);
@@ -556,8 +466,10 @@ export function collectCatalog({
   const perHost = tallyCatalogPerHost(list, asOf, incompleteByHost);
   const degraded = surfaces.filter((surface) => surface.status === 'degraded').map((surface) => surface.id);
   const truncated = surfaces.filter((surface) => surface.truncated).map((surface) => surface.id);
+  const partial = surfaces.filter((surface) => surface.partial).map((surface) => surface.id);
 
   return {
+    schemaVersion: 2,
     asOf,
     hosts: CATALOG_HOSTS,
     kinds: CATALOG_KINDS,
@@ -565,9 +477,18 @@ export function collectCatalog({
     counts,
     perHost,
     surfaces,
+    scopes: ['user', 'project', 'plugin'],
+    pluginSources: plugins.sources,
+    sourceStamps: buildCatalogSourceStamps({ surfaces, items: list, fsImpl }),
+    overlaps: buildOverlapGroups(list),
+    projects: buildProjectPressure({
+      items: list, surfaces, projects: base.catalogProjects, launchingProject: base.launchingProject,
+      hosts: CATALOG_HOSTS, kinds: CATALOG_KINDS, asOf,
+    }),
     config: collectConfigSurface({ cwd, cfg, asOf, fsImpl }),
-    complete: degraded.length === 0 && truncated.length === 0,
+    complete: degraded.length === 0 && truncated.length === 0 && partial.length === 0,
     degraded,
     truncated,
+    partial,
   };
 }

--- a/src/lib/footprint/index.mjs
+++ b/src/lib/footprint/index.mjs
@@ -39,6 +39,7 @@ import { collectRuntimeCensus } from './runtime.mjs';
 import { collectInstall } from './install.mjs';
 import { collectStorage } from './storage.mjs';
 import { collectCatalog } from './catalog.mjs';
+import { probeCatalogDrift } from './catalog-evidence.mjs';
 import { collectProjects } from './projects.mjs';
 import { collectConsumers } from './consumers.mjs';
 import { discoverProjectSources } from './project-sources.mjs';
@@ -237,8 +238,8 @@ export function createSystemCollector({
   const snapshotOpts = { ...(snapshotFile ? { file: snapshotFile } : {}), fsImpl };
 
   /** @type {{ at: number, runtime: any, knownFiles: object,
-   *           snapshot: ReturnType<typeof readSnapshot>,
-   *           sections: Record<string, any>, freshness: object }|null} */
+ *           snapshot: ReturnType<typeof readSnapshot>,
+ *           sections: Record<string, any>, freshness: object, catalogDrift: object }|null} */
   let cheap = null;
   /** @type {Promise<object>|null} — the single-flight slot (invariant 7). */
   let inFlight = null;
@@ -270,6 +271,7 @@ export function createSystemCollector({
 
     const persisted = readSnapshotImpl(snapshotOpts);
     const freshness = snapshotFreshness(persisted, { now: at, staleAfterMs });
+    const catalogDrift = probeCatalogDrift(persisted.sections?.['catalog']?.sourceStamps, { fsImpl, asOf: at });
     // Carried forward, not re-stamped as current: a figure measured last week
     // is presented with last week's asOf (invariant 3).
     const sections = persisted.present
@@ -285,6 +287,7 @@ export function createSystemCollector({
       snapshot: persisted,
       sections,
       freshness,
+      catalogDrift,
     };
     return cheap;
   }
@@ -309,6 +312,7 @@ export function createSystemCollector({
         reason,
         completeness,
         ...tier.freshness,
+        catalogDrift: tier.catalogDrift,
       },
       cheapTier: { asOf: tier.at, ttlMs },
       scan: { ...scan },

--- a/src/lib/footprint/snapshot.mjs
+++ b/src/lib/footprint/snapshot.mjs
@@ -27,7 +27,7 @@ import { CARRIED_FORWARD, MEASURED } from './walk.mjs';
  *  written by a different version is not migrated and not guessed at — it
  *  reads as never-measured with an explicit reason, and the next deep scan
  *  replaces it. */
-export const SNAPSHOT_SCHEMA_VERSION = 1;
+export const SNAPSHOT_SCHEMA_VERSION = 2;
 
 /** The deep-tier sections, in collection order. This list is also the write
  *  filter — see the header note on the runtime census. A section absent from a

--- a/src/lib/skill-maintenance-plan.mjs
+++ b/src/lib/skill-maintenance-plan.mjs
@@ -1,0 +1,154 @@
+// Read-only skill remediation planning for #198. This module classifies exact
+// project occurrences and describes a potential change set; it never writes,
+// deletes, stages, or invokes a mutating command.
+import { createHash } from 'node:crypto';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+
+function digestOf(presence) {
+  return presence?.digest?.status === 'measured' ? presence.digest.value : null;
+}
+
+function normalizeReceipt(receipt) {
+  if (!receipt || typeof receipt.path !== 'string') return null;
+  return {
+    path: path.resolve(receipt.path), digest: typeof receipt.digest === 'string' ? receipt.digest : null,
+    desired: receipt.desired !== false, sourceRef: receipt.sourceRef ?? null,
+    sourceVersion: receipt.sourceVersion ?? null,
+  };
+}
+
+const gitPath = (project, artifact) => path.relative(project, artifact).split(path.sep).join('/');
+
+function gitProjectFacts(project, artifacts, run) {
+  const relatives = [...new Set(artifacts.map((artifact) => gitPath(project, artifact.path))
+    .filter((relative) => relative && !relative.startsWith('../') && !path.isAbsolute(relative)))];
+  const probe = run('git', ['-C', project, 'rev-parse', '--is-inside-work-tree'], {
+    encoding: 'utf8', timeout: 5_000, stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  if (probe?.status !== 0 || probe?.stdout?.trim() !== 'true') {
+    return new Map(relatives.map((relative) => [relative,
+      { repository: false, tracked: null, dirty: null, reason: 'project is not a readable git worktree', relative }]));
+  }
+  const trackedResult = run('git', ['-C', project, 'ls-files', '-z', '--', ...relatives], {
+    encoding: 'utf8', timeout: 5_000, stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  const status = run('git', ['-C', project, 'status', '--porcelain=v1', '-z', '--untracked-files=all', '--', ...relatives], {
+    encoding: 'utf8', timeout: 5_000, stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  const tracked = new Set(trackedResult?.status === 0 ? String(trackedResult.stdout).split('\0').filter(Boolean) : []);
+  const dirty = new Set();
+  if (status?.status === 0) {
+    const records = String(status.stdout).split('\0').filter(Boolean);
+    for (let index = 0; index < records.length; index++) {
+      const record = records[index];
+      dirty.add(record.slice(3));
+      if (/^[RC]/.test(record) && records[index + 1]) dirty.add(records[++index]);
+    }
+  }
+  return new Map(relatives.map((relative) => [relative, {
+    repository: true,
+    tracked: trackedResult?.status === 0 ? tracked.has(relative) : null,
+    dirty: status?.status === 0 ? dirty.has(relative) : null,
+    reason: status?.status === 0 && trackedResult?.status === 0 ? null : 'git evidence incomplete',
+    relative,
+  }]));
+}
+
+function sharedSkillDigests(catalog, capabilityName) {
+  const values = new Set();
+  for (const item of catalog.items ?? []) {
+    if (item.kind !== 'skill' || item.capabilityName?.toLowerCase() !== capabilityName.toLowerCase()) continue;
+    for (const presence of item.presence ?? []) {
+      if (!['user', 'plugin'].includes(presence.scope)) continue;
+      const digest = digestOf(presence);
+      if (digest) values.add(digest);
+    }
+  }
+  return values;
+}
+
+function classify(presence, item, receipt, catalog) {
+  const digest = digestOf(presence);
+  if (!digest) {
+    return { classification: 'unmeasured-artifact', recommendation: 'preserve-and-review', safeToPrune: false };
+  }
+  if (receipt) {
+    if (!receipt.digest || receipt.digest !== digest) {
+      return { classification: 'receipt-drifted-or-modified', recommendation: 'preserve-and-review', safeToPrune: false };
+    }
+    if (receipt.desired) {
+      return { classification: 'current-desired', recommendation: 'retain', safeToPrune: false };
+    }
+    return { classification: 'receipt-owned-unchanged', recommendation: 'safe-prune-candidate', safeToPrune: true };
+  }
+  if (sharedSkillDigests(catalog, item.capabilityName).has(digest)) {
+    return { classification: 'exact-known-upstream-revision', recommendation: 'review-project-copy', safeToPrune: false };
+  }
+  return { classification: 'modified-ambiguous-or-unreceipted', recommendation: 'preserve-and-review', safeToPrune: false };
+}
+
+function projectSkillArtifacts(catalog, projectPath, receiptByPath) {
+  const artifacts = new Map();
+  for (const item of catalog?.items ?? []) {
+    if (item.kind !== 'skill') continue;
+    for (const presence of item.presence ?? []) {
+      if (presence.scope !== 'project' || path.resolve(presence.project ?? '') !== projectPath) continue;
+      const artifact = presence.sourceFile ?? presence.itemPath;
+      if (!artifact) continue;
+      const artifactPath = path.resolve(artifact);
+      const previous = artifacts.get(artifactPath);
+      if (previous) {
+        if (!previous.hosts.includes(presence.host)) previous.hosts.push(presence.host);
+        continue;
+      }
+      const receipt = receiptByPath.get(artifactPath) ?? null;
+      artifacts.set(artifactPath, {
+        name: item.capabilityName ?? item.name, displayName: item.name,
+        path: artifactPath, digest: digestOf(presence), hosts: [presence.host],
+        ...classify(presence, item, receipt, catalog),
+        receipt: receipt ? { desired: receipt.desired, sourceRef: receipt.sourceRef, sourceVersion: receipt.sourceVersion } : null,
+      });
+    }
+  }
+  return [...artifacts.values()];
+}
+
+/** Build a credential-free, read-only plan from a fresh CatalogInventory.
+ * @param {{ catalog?: any, project?: string, receipts?: any[], now?: () => number,
+ *           run?: typeof spawnSync }} options */
+export function buildSkillMaintenancePlan({
+  catalog, project, receipts = [], now = Date.now, run = spawnSync,
+} = {}) {
+  const projectPath = path.resolve(project ?? process.cwd());
+  const receiptByPath = new Map(receipts.map(normalizeReceipt).filter(Boolean)
+    .map((receipt) => [receipt.path, receipt]));
+  const artifacts = projectSkillArtifacts(catalog, projectPath, receiptByPath);
+  artifacts.sort((a, b) => a.path.localeCompare(b.path));
+  const gitByPath = gitProjectFacts(projectPath, artifacts, run);
+  for (const artifact of artifacts) {
+    const relative = gitPath(projectPath, artifact.path);
+    artifact.git = gitByPath.get(relative)
+      ?? { repository: false, tracked: null, dirty: null, reason: 'artifact is outside project' };
+  }
+  const uniquePaths = [...new Set(artifacts.map((artifact) => artifact.path))];
+  const prunePaths = [...new Set(artifacts.filter((artifact) => artifact.safeToPrune)
+    .map((artifact) => artifact.path))];
+  const projection = {
+    currentProjectSkillPaths: uniquePaths.length,
+    safePruneCandidates: prunePaths.length,
+    projectedProjectSkillPaths: uniquePaths.length - prunePaths.length,
+  };
+  const stable = { schemaVersion: 1, project: projectPath, artifacts, projection, affectedPaths: prunePaths };
+  const planDigest = createHash('sha256').update(JSON.stringify(stable)).digest('hex');
+  return {
+    ...stable, planId: `skills-plan-${planDigest.slice(0, 16)}`, planDigest,
+    generatedAt: new Date(now()).toISOString(), mode: 'read-only',
+    contextInclusion: catalog?.projects?.find((row) => row.project === projectPath)?.contextInclusion
+      ?? { status: 'unknown', reason: 'host-owned context inclusion is not exposed' },
+    rollback: {
+      requiredForApply: true,
+      note: 'No apply exists in #198. A future #200 transaction must back up untracked paths and preserve source-control recovery.',
+    },
+  };
+}

--- a/tests/kit/footprint-collectors.test.mjs
+++ b/tests/kit/footprint-collectors.test.mjs
@@ -26,6 +26,9 @@ import {
   parseGitRemote, projectRemote, LOC_EXCLUSIONS,
 } from '../../src/lib/footprint/projects.mjs';
 import { collectCatalog, tomlTableNames } from '../../src/lib/footprint/catalog.mjs';
+import {
+  buildCatalogSourceStamps, collectNativePluginInventory, probeCatalogDrift,
+} from '../../src/lib/footprint/catalog-evidence.mjs';
 import { collectConsumers } from '../../src/lib/footprint/consumers.mjs';
 import {
   npmPackageRoot, managedTools, observedRuntimeTools, sharedCacheRoots,
@@ -858,7 +861,8 @@ function catalogFixture(t) {
   write(opencodeConfigFile, JSON.stringify({ mcp: { ruflo: {} } }));
 
   return {
-    root, claudeRoot, codexRoot, opencodeRoot, claudeMcpFile, codexConfigFile, opencodeConfigFile,
+    root, claudeRoot, codexRoot, opencodeRoot, agentsRoot: path.join(root, 'agents'),
+    claudeMcpFile, codexConfigFile, opencodeConfigFile,
   };
 }
 
@@ -899,8 +903,9 @@ test('catalog dedups by normalized name and keeps a per-host presence matrix', (
   assert.equal(result.perHost.opencode.agent.value, 1);
   assert.equal(result.perHost.codex.agent.value, 0);
   assert.equal(result.perHost.codex.mcpServer.value, 2);
-  assert.equal(result.complete, true);
+  assert.equal(result.complete, false, 'fallback plugin inventories keep overall evidence partial');
   assert.deepEqual(result.degraded, []);
+  assert.deepEqual(result.partial.sort(), ['claude-plugins', 'codex-plugins']);
 });
 
 test('catalog includes project-scoped Codex skills from .agents/skills', (t) => {
@@ -917,13 +922,13 @@ test('catalog includes project-scoped Codex skills from .agents/skills', (t) => 
   });
 
   const skill = result.items.find((item) => item.kind === 'skill' && item.name === 'project-only');
-  assert.deepEqual(skill?.hosts, ['codex']);
+  assert.deepEqual(skill?.hosts, ['codex', 'opencode']);
   assert.equal(skill?.presence[0]?.surface, `codex-project-skills:${project}`);
   assert.equal(result.perHost.codex.skill.value, 2);
   assert.equal(result.surfaces.find((surface) => surface.id === `codex-project-skills:${project}`)?.count, 1);
 });
 
-test('catalog counting reads names only — item bodies are never opened', (t) => {
+test('catalog hashes bounded entrypoints but never returns their bodies', (t) => {
   const fixtureRoots = catalogFixture(t);
   const { root, ...roots } = fixtureRoots;
   const reads = [];
@@ -936,14 +941,12 @@ test('catalog counting reads names only — item bodies are never opened', (t) =
     },
   };
 
-  collectCatalog({
+  const result = collectCatalog({
     ...roots, cwd: root, now: () => 1_700_000_000_000,
     includePluginSurfaces: false, fsImpl: spy,
   });
-  for (const file of reads) {
-    assert.doesNotMatch(file, /SKILL\.md$/, `${file} was opened; a name is all the catalog counts`);
-    assert.doesNotMatch(file, /(agents|commands)[\\/].*\.md$/, `${file} was opened`);
-  }
+  assert.ok(reads.some((file) => /SKILL\.md$/.test(file)), 'skill entrypoints are hashed');
+  assert.doesNotMatch(JSON.stringify(result), /SECRET BODY/, 'artifact prose must not leave the collector');
 });
 
 test('an unreadable catalog surface has no count, and the total it feeds is a floor', (t) => {
@@ -997,7 +1000,7 @@ test('plugin-contributed entries are namespaced to the plugin that carries them'
   assert.ok(names.includes('skill:ruvnet-brain:grounding'));
   // A host's plugin inventory is its enabled refs, kept whole.
   assert.deepEqual(result.items.filter((item) => item.kind === 'plugin').map((item) => item.name),
-    ['beads', 'ruvnet-brain@store']);
+    ['beads@marketplace', 'ruvnet-brain@store']);
   assert.equal(result.perHost.codex.skill.value, 2,
     'a plugin skill joins the host that carries it');
 
@@ -1008,6 +1011,131 @@ test('plugin-contributed entries are namespaced to the plugin that carries them'
     inspectCodexPlugins: () => { throw new Error('codex config unreadable'); },
   });
   assert.equal(survived.counts.skill.value >= 2, true);
+});
+
+test('standalone and plugin skills stay distinct while exact-name and digest overlap is explicit', (t) => {
+  const fixtureRoots = catalogFixture(t);
+  const { root, ...roots } = fixtureRoots;
+  const body = '---\nname: shared\nversion: 1.0.0\n---\nBOUNDED BODY\n';
+  write(path.join(roots.claudeRoot, 'skills', 'shared', 'SKILL.md'), body);
+  write(path.join(root, 'p', 'skills', 'shared', 'SKILL.md'), body);
+
+  const result = collectCatalog({
+    ...roots, cwd: root, now: () => 1_700_000_000_000, fsImpl: fixtureFs(root),
+  });
+  const standalone = result.items.find((item) => item.kind === 'skill' && item.name === 'shared');
+  const contributed = result.items.find((item) => item.kind === 'skill' && item.name === 'beads:shared');
+
+  assert.ok(standalone);
+  assert.equal(contributed?.pluginRef, 'beads@marketplace');
+  assert.equal(contributed?.presence[0]?.provider?.ref, 'beads@marketplace');
+  assert.notEqual(standalone.key, contributed.key, 'producer is part of capability identity');
+  assert.ok(result.overlaps.exactName.some((group) => group.name === 'shared'
+    && group.itemKeys.includes(standalone.key) && group.itemKeys.includes(contributed.key)));
+  assert.ok(result.overlaps.exactEntrypointDigest.some((group) => group.itemKeys.includes(standalone.key)
+    && group.itemKeys.includes(contributed.key)));
+  assert.doesNotMatch(JSON.stringify(result), /BOUNDED BODY/);
+});
+
+test('project pressure separates project, user and plugin skill contributions', (t) => {
+  const fixtureRoots = catalogFixture(t);
+  const { root, ...roots } = fixtureRoots;
+  const project = path.join(root, 'project-pressure');
+  const body = 'same bytes\n';
+  write(path.join(project, '.git', 'HEAD'), 'ref: refs/heads/main\n');
+  write(path.join(project, '.agents', 'skills', 'shared', 'SKILL.md'), body);
+  write(path.join(roots.agentsRoot, 'skills', 'shared', 'SKILL.md'), body);
+  write(path.join(root, 'p', 'skills', 'plugin-only', 'SKILL.md'), 'plugin\n');
+
+  const result = collectCatalog({
+    ...roots, cwd: project, now: () => 1_700_000_000_000, fsImpl: fixtureFs(root),
+  });
+  const pressure = result.projects.find((row) => row.project === project);
+  assert.equal(pressure.byHost.codex.sources.project.skill.value, 1);
+  assert.equal(pressure.byHost.codex.sources.user.skill.value >= 1, true);
+  assert.equal(pressure.byHost.claude.sources.plugin.skill.value >= 1, true);
+  assert.equal(pressure.byHost.codex.overlaps.skillNames.value, 1);
+  assert.equal(pressure.byHost.codex.overlaps.skillDigests.value, 1);
+  assert.equal(pressure.launching, true, 'launching project is explicit for summary-first rendering');
+  assert.equal(pressure.contextInclusion.status, 'unknown');
+  assert.match(pressure.guidance[0].nextCommand, /^ak x skills plan --project /);
+});
+
+test('native plugin inventory whitelists lifecycle evidence and drops sensitive fields', () => {
+  const run = (binary) => ({
+    status: 0,
+    stdout: binary === 'claude'
+      ? JSON.stringify([{ id: 'safe@market', version: '1.2.3', enabled: false,
+        scope: 'user', installPath: '/plugins/safe', mcpServers: { secret: { headers: { authorization: 'nope' } } } }])
+      : JSON.stringify({ installed: [{ pluginId: 'safe@market', version: '1.2.3', enabled: true,
+        installPolicy: 'prompt', source: { source: 'marketplace', document: 'private' }, headers: { token: 'nope' } }] }),
+  });
+  const result = collectNativePluginInventory({ run });
+  assert.equal(result.claude.plugins[0].enabled, false, 'installed-disabled state survives');
+  assert.equal(result.codex.plugins[0].sourceKind, 'marketplace');
+  const serialized = JSON.stringify(result);
+  assert.doesNotMatch(serialized, /authorization|private|token|mcpServers|headers/);
+});
+
+test('native plugin command/schema failures degrade instead of becoming an empty success', () => {
+  const result = collectNativePluginInventory({
+    run: (binary) => (binary === 'claude'
+      ? { status: 1, stdout: '', stderr: 'failed' }
+      : { status: 0, stdout: '{"unexpected":true}' }),
+  });
+  assert.equal(result.claude.status, 'degraded');
+  assert.match(result.claude.reason, /exited 1/);
+  assert.equal(result.codex.status, 'degraded');
+  assert.match(result.codex.reason, /schema/);
+});
+
+test('installed-disabled plugins remain inventory but contribute no capabilities', (t) => {
+  const fixtureRoots = catalogFixture(t);
+  const { root, ...roots } = fixtureRoots;
+  write(path.join(root, 'disabled', 'skills', 'hidden', 'SKILL.md'), 'hidden\n');
+  const nativePlugins = {
+    claude: { status: 'ok', source: 'fixture', plugins: [{
+      ...{ ref: 'disabled@market', name: 'disabled', marketplace: 'market' },
+      version: '1.0.0', enabled: false, root: path.join(root, 'disabled'), evidence: 'native',
+    }] },
+    codex: { status: 'ok', source: 'fixture', plugins: [] },
+  };
+  const result = collectCatalog({
+    ...roots, cwd: root, nativePlugins, fsImpl: fixtureFs(root),
+  });
+  assert.ok(result.items.some((item) => item.kind === 'plugin' && item.name === 'disabled@market'));
+  assert.equal(result.items.some((item) => item.kind === 'skill' && item.name === 'disabled:hidden'), false);
+});
+
+test('oversized skill entrypoints remain visible with unknown digest evidence', (t) => {
+  const fixtureRoots = catalogFixture(t);
+  const { root, ...roots } = fixtureRoots;
+  write(path.join(roots.claudeRoot, 'skills', 'large', 'SKILL.md'), Buffer.alloc(1024 * 1024 + 1, 65));
+  const result = collectCatalog({
+    ...roots, cwd: root, includePluginSurfaces: false, fsImpl: fixtureFs(root),
+  });
+  const large = result.items.find((item) => item.kind === 'skill' && item.name === 'large');
+  assert.ok(large, 'oversize is not omission');
+  assert.equal(large.presence[0].digest.status, 'unknown');
+  assert.match(large.presence[0].digest.reason, /exceeds/);
+});
+
+test('catalog source stamps expose likely cache drift without claiming nested content freshness', (t) => {
+  const root = fixture(t, 'catalog-drift');
+  const file = path.join(root, 'plugins.json');
+  write(file, '{}\n');
+  const baseline = buildCatalogSourceStamps({
+    surfaces: [{ status: 'ok', path: file }], items: [], fsImpl: fixtureFs(root),
+  });
+  const unchanged = probeCatalogDrift(baseline, { fsImpl: fixtureFs(root), asOf: 10 });
+  assert.equal(unchanged.status, 'unchanged-at-probes');
+  assert.match(unchanged.reason, /nested content|deep rescan/);
+
+  write(file, '{"plugin":true}\n');
+  const changed = probeCatalogDrift(baseline, { fsImpl: fixtureFs(root), asOf: 20 });
+  assert.equal(changed.status, 'changed');
+  assert.deepEqual(changed.changed.map((entry) => entry.path), [file]);
+  assert.match(changed.reason, /changed since the deep scan/);
 });
 
 test('codex MCP table names are read from config.toml without parsing values', () => {

--- a/tests/kit/footprint-snapshot-v2.test.mjs
+++ b/tests/kit/footprint-snapshot-v2.test.mjs
@@ -1,0 +1,28 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  readSnapshot, SNAPSHOT_SCHEMA_VERSION, writeSnapshot,
+} from '../../src/lib/footprint/snapshot.mjs';
+
+test('catalog identity change invalidates a v1 footprint snapshot instead of guessing', (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ak-footprint-snapshot-v2-'));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const file = path.join(root, 'snapshot.json');
+  fs.writeFileSync(file, `${JSON.stringify({ schemaVersion: 1, asOf: 10, sections: { catalog: {} } })}\n`);
+
+  const old = readSnapshot({ file });
+  assert.equal(SNAPSHOT_SCHEMA_VERSION, 2);
+  assert.equal(old.present, false);
+  assert.match(old.reason, /schema 1 is not readable/);
+
+  const written = writeSnapshot({ catalog: { asOf: 20, complete: true } }, { file, now: 21, asOf: 20 });
+  assert.equal(written.ok, true);
+  const current = readSnapshot({ file });
+  assert.equal(current.present, true);
+  assert.equal(current.schemaVersion, 2);
+  assert.equal(current.sections.catalog.asOf, 20);
+});

--- a/tests/kit/skill-maintenance-plan.test.mjs
+++ b/tests/kit/skill-maintenance-plan.test.mjs
@@ -1,0 +1,83 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+
+import { buildSkillMaintenancePlan } from '../../src/lib/skill-maintenance-plan.mjs';
+
+const measuredDigest = (value) => ({
+  status: 'measured', value, reason: null, asOf: 1, partial: false,
+});
+
+function catalog(project) {
+  const projectSkill = path.join(project, '.agents', 'skills', 'shared', 'SKILL.md');
+  const modifiedSkill = path.join(project, '.agents', 'skills', 'modified', 'SKILL.md');
+  return {
+    items: [
+      { kind: 'skill', name: 'shared', capabilityName: 'shared', presence: [
+        { host: 'codex', scope: 'project', project, sourceFile: projectSkill, digest: measuredDigest('same') },
+        { host: 'codex', scope: 'user', sourceFile: '/user/shared/SKILL.md', digest: measuredDigest('same') },
+      ] },
+      { kind: 'skill', name: 'modified', capabilityName: 'modified', presence: [
+        { host: 'codex', scope: 'project', project, sourceFile: modifiedSkill, digest: measuredDigest('changed') },
+      ] },
+    ],
+    projects: [{ project, contextInclusion: { status: 'unknown', reason: 'host-owned' } }],
+  };
+}
+
+const gitRun = (_binary, args) => {
+  if (args.includes('rev-parse')) return { status: 0, stdout: 'true\n' };
+  if (args.includes('ls-files')) return { status: 0, stdout: 'tracked\n' };
+  return { status: 0, stdout: '' };
+};
+
+test('read-only plan distinguishes exact upstream, modified and receipt-proven cleanup', () => {
+  const project = path.resolve('/repo');
+  const input = catalog(project);
+  const modifiedPath = path.join(project, '.agents', 'skills', 'modified', 'SKILL.md');
+  const plan = buildSkillMaintenancePlan({
+    catalog: input, project, run: gitRun, now: () => 100,
+    receipts: [{ path: modifiedPath, digest: 'changed', desired: false, sourceRef: 'kit' }],
+  });
+  const shared = plan.artifacts.find((artifact) => artifact.name === 'shared');
+  const modified = plan.artifacts.find((artifact) => artifact.name === 'modified');
+  assert.equal(shared.classification, 'exact-known-upstream-revision');
+  assert.equal(shared.safeToPrune, false, 'digest equality without ownership is not delete authority');
+  assert.equal(modified.classification, 'receipt-owned-unchanged');
+  assert.equal(modified.safeToPrune, true);
+  assert.deepEqual(plan.affectedPaths, [modifiedPath]);
+  assert.equal(plan.mode, 'read-only');
+  assert.equal(plan.projection.currentProjectSkillPaths, 2);
+  assert.equal(plan.projection.projectedProjectSkillPaths, 1);
+  assert.equal(plan.contextInclusion.status, 'unknown');
+});
+
+test('plan digest is content-derived and drifted receipts preserve files', () => {
+  const project = path.resolve('/repo');
+  const modifiedPath = path.join(project, '.agents', 'skills', 'modified', 'SKILL.md');
+  const first = buildSkillMaintenancePlan({
+    catalog: catalog(project), project, run: gitRun, now: () => 100,
+    receipts: [{ path: modifiedPath, digest: 'old', desired: false }],
+  });
+  const second = buildSkillMaintenancePlan({
+    catalog: catalog(project), project, run: gitRun, now: () => 200,
+    receipts: [{ path: modifiedPath, digest: 'old', desired: false }],
+  });
+  assert.equal(first.planDigest, second.planDigest);
+  assert.notEqual(first.generatedAt, second.generatedAt);
+  const modified = first.artifacts.find((artifact) => artifact.name === 'modified');
+  assert.equal(modified.classification, 'receipt-drifted-or-modified');
+  assert.equal(modified.recommendation, 'preserve-and-review');
+  assert.deepEqual(first.affectedPaths, []);
+});
+
+test('one physical project skill is classified once across multiple capable hosts', () => {
+  const project = path.resolve('/repo');
+  const input = catalog(project);
+  const occurrence = input.items[0].presence[0];
+  input.items[0].presence.push({ ...occurrence, host: 'opencode' });
+  const plan = buildSkillMaintenancePlan({ catalog: input, project, run: gitRun });
+  const shared = plan.artifacts.find((artifact) => artifact.name === 'shared');
+  assert.deepEqual(shared.hosts, ['codex', 'opencode']);
+  assert.equal(plan.artifacts.filter((artifact) => artifact.name === 'shared').length, 1);
+});

--- a/tests/ui/dashboard-ui.mjs
+++ b/tests/ui/dashboard-ui.mjs
@@ -1481,14 +1481,49 @@ async function main() {
       asOf: SYS_DEEP_ASOF,
       hosts: ['claude', 'codex', 'opencode'],
       kinds: ['skill', 'agent', 'command'],
+      scopes: ['user', 'project', 'plugin'],
       counts: { skill: meas(2), agent: meas(1), command: meas(1) },
       perHost: {},
       items: [
-        { kind: 'skill', name: 'alpha-skill', hosts: ['claude'] },
-        { kind: 'skill', name: 'beta-skill', hosts: ['claude', 'codex'] },
-        { kind: 'agent', name: 'gamma-agent', hosts: ['opencode'] },
-        { kind: 'command', name: 'delta-command', hosts: ['codex'] },
+        { kind: 'skill', name: 'alpha-skill', hosts: ['claude'], sourceScopes: ['user'], presence: [] },
+        { kind: 'skill', name: 'beta-skill', hosts: ['claude', 'codex'], sourceScopes: ['project', 'user'], presence: [], digestCoverage: { unique: 2 } },
+        { kind: 'agent', name: 'gamma-agent', hosts: ['opencode'], sourceScopes: ['plugin'], presence: [{ provider: { ref: 'gamma@market', version: '1.2.3' } }] },
+        { kind: 'command', name: 'delta-command', hosts: ['codex'], sourceScopes: ['user'], presence: [] },
       ],
+      projects: [{
+        project: '/repo/example', label: 'example', complete: true, launching: true,
+        contextInclusion: { status: 'unknown', reason: 'host-owned' },
+        guidance: [{ host: 'codex', message: '1 project-scoped skill observed', nextCommand: 'ak x skills plan --project "/repo/example"' }],
+        byHost: Object.fromEntries(['claude', 'codex', 'opencode'].map((host) => [host, {
+          sources: {
+            project: { skill: meas(host === 'codex' ? 1 : 0), agent: meas(0), command: meas(0) },
+            user: { skill: meas(2), agent: meas(0), command: meas(1) },
+            plugin: { skill: meas(0), agent: meas(host === 'opencode' ? 1 : 0), command: meas(0) },
+          },
+          overlaps: { skillNames: meas(host === 'codex' ? 1 : 0), skillDigests: meas(0) },
+        }])),
+      }, {
+        project: '/repo/secondary', label: 'secondary', complete: false, launching: false,
+        contextInclusion: { status: 'unknown', reason: 'host-owned' },
+        guidance: [{ host: 'codex', message: '4 project-scoped skills observed', nextCommand: 'ak x skills plan --project "/repo/secondary"' }],
+        byHost: Object.fromEntries(['claude', 'codex', 'opencode'].map((host) => [host, {
+          sources: {
+            project: { skill: meas(host === 'codex' ? 4 : 0) },
+            user: { skill: meas(2) },
+            plugin: { skill: host === 'codex'
+              ? { value: null, status: 'unknown', reason: 'native inventory unavailable', asOf: null, partial: false }
+              : meas(0) },
+          },
+          overlaps: { skillNames: meas(host === 'codex' ? 1 : 0), skillDigests: meas(0) },
+        }])),
+      }, {
+        project: '/repo/no-local-skills', label: 'no-local-skills', complete: true, launching: false,
+        contextInclusion: { status: 'unknown', reason: 'host-owned' }, guidance: [],
+        byHost: Object.fromEntries(['claude', 'codex', 'opencode'].map((host) => [host, {
+          sources: { project: { skill: meas(0) }, user: { skill: meas(2) }, plugin: { skill: meas(3) } },
+          overlaps: { skillNames: meas(0), skillDigests: meas(0) },
+        }])),
+      }],
       complete: true,
     };
     await page.route(/\/api\/system(\?|$)/, (route) => route.fulfill({
@@ -1515,6 +1550,84 @@ async function main() {
       await page.$$eval('#sys-matrix tbody tr', (els) => els.every((e) => !!e.querySelector('.sy-kindtag'))),
       'a filtered list must never leave a name unexplained');
     check('unfiltered shows every item', await rowCount() === 4, `saw ${await rowCount()} of 4`);
+    check('project pressure follows the two inventory panels as a full-width second row',
+      await page.$eval('#panel-sys-catalog .sy-grid', (grid) => {
+        const cards = [...grid.querySelectorAll(':scope > .sy-card')];
+        const pressure = document.querySelector('#sys-pressure')?.closest('.sy-card');
+        const profile = document.querySelector('#sys-radar')?.closest('.sy-card');
+        const unique = document.querySelector('#sys-matrix')?.closest('.sy-card');
+        if (!pressure || !profile || !unique) return false;
+        const pressureBox = pressure.getBoundingClientRect();
+        const profileBox = profile.getBoundingClientRect();
+        const uniqueBox = unique.getBoundingClientRect();
+        return cards.indexOf(pressure) > cards.indexOf(profile)
+          && cards.indexOf(pressure) > cards.indexOf(unique)
+          && pressureBox.top >= Math.max(profileBox.bottom, uniqueBox.bottom)
+          && Math.abs(pressureBox.width - grid.getBoundingClientRect().width) < 2;
+      }), 'project pressure did not render beneath both inventory cards at full width');
+    const catalogViewport = await page.$eval('#sys-matrix .sy-catalog-scroll', (viewport) => {
+      const body = viewport.querySelector('tbody');
+      const originalCount = body.rows.length;
+      while (body.rows.length < 8) body.append(body.rows[0].cloneNode(true));
+      const box = viewport.getBoundingClientRect();
+      const fullyVisible = [...body.rows].filter((row) => {
+        const rowBox = row.getBoundingClientRect();
+        return rowBox.top >= box.top && rowBox.bottom <= box.bottom + 0.5;
+      });
+      const result = {
+        fullyVisible: fullyVisible.length,
+        clientHeight: viewport.clientHeight,
+        scrollHeight: viewport.scrollHeight,
+        rowHeights: [...body.rows].slice(0, 6).map((row) => row.getBoundingClientRect().height),
+        headerHeight: viewport.querySelector('thead').getBoundingClientRect().height,
+      };
+      while (body.rows.length > originalCount) body.deleteRow(-1);
+      return result;
+    });
+    check('the Unique across hosts viewport shows no more than five records before scrolling',
+      catalogViewport.fullyVisible === 5
+        && catalogViewport.scrollHeight > catalogViewport.clientHeight,
+      `catalog viewport measured ${JSON.stringify(catalogViewport)}`);
+    const pressureText = await visibleText(page, '#sys-pressure');
+    const pressureProjects = await page.$$('#sys-pressure details.sy-pressure-project');
+    check('project pressure groups once per relevant project instead of repeating project × host',
+      pressureProjects.length === 2 && !/no-local-skills/.test(pressureText),
+      `pressure rendered ${pressureProjects.length} disclosures and read ${JSON.stringify(pressureText)}`);
+    check('the launching project is first and open while other projects stay summary-only',
+      await page.$eval('#sys-pressure details:first-of-type', (d) => d.open && d.dataset.launching === 'true')
+        && !(await page.$eval('#sys-pressure details:nth-of-type(2)', (d) => d.open)),
+      'progressive disclosure did not prioritize the current project');
+    check('inventory completeness and host-owned context are separate, non-contradictory facts',
+      /Inventory complete/.test(pressureText)
+        && (pressureText.match(/Context inclusion is not reported by these hosts/g) || []).length === 1
+        && !/complete\s*[·-]\s*context unknown/i.test(pressureText),
+      `pressure read ${JSON.stringify(pressureText)}`);
+    check('collapsed projects hide full paths and repeated plan commands',
+      !(await page.$eval('#sys-pressure details:nth-of-type(2)', (d) => d.innerText.includes('/repo/secondary')))
+        && await page.$$eval('#sys-pressure details:nth-of-type(2) code', (els) => els.length) === 1,
+      'a collapsed disclosure leaked its detailed path or repeated its command');
+    await page.focus('#sys-pressure details:nth-of-type(2) summary');
+    await page.keyboard.press('Enter');
+    const secondaryText = await visibleText(page, '#sys-pressure details:nth-of-type(2)');
+    check('expanding one project reveals source counts, visible unknown reason, and one read-only command',
+      /Project skills|User skills|Plugin skills|native inventory unavailable|Read-only plan/.test(secondaryText)
+        && await page.$$eval('#sys-pressure details:nth-of-type(2) code', (els) => els.length) === 1,
+      `secondary project read ${JSON.stringify(secondaryText)}`);
+    check('keyboard focus on a project disclosure remains visibly outlined',
+      await page.$eval('#sys-pressure details:nth-of-type(2) summary', (summary) => {
+        const style = getComputedStyle(summary);
+        return style.outlineStyle !== 'none' && parseFloat(style.outlineWidth) >= 2;
+      }), 'the summary accepted keyboard input but had no visible focus indicator');
+    check('pressure disclosures use native accessible structure and scoped table headers',
+      await page.$eval('#sys-pressure details:nth-of-type(2)', (d) => !!d.querySelector(':scope > summary'))
+        && await page.$$eval('#sys-pressure details:nth-of-type(2) thead th[scope="col"]', (els) => els.length) === 6
+        && await page.$$eval('#sys-pressure details:nth-of-type(2) tbody th[scope="row"]', (els) => els.length) === 1
+        && await page.getAttribute('#sys-pressure .sy-pressure-list', 'tabindex') === '0',
+      'native disclosure, headers, or focusable overflow region is missing');
+    check('project pressure remains read-only with no destructive control labels',
+      !/(apply|delete|remove|prune|upgrade)/i.test(await visibleText(page, '#sys-pressure button')),
+      'the System view exposed a mutating action');
+    await shoot(page, 'system-catalog-pressure');
 
     await page.click('#sys-cat-kinds .chipf:nth-child(2)'); // drop agents
     await page.click('#sys-cat-kinds .chipf:nth-child(3)'); // drop commands
@@ -1536,6 +1649,15 @@ async function main() {
     check('re-selecting everything restores the full inventory',
       await rowCount() === 4 && (await chipStates()).every((s) => s === 'true'),
       `saw ${await rowCount()} rows and ${JSON.stringify(await chipStates())}`);
+
+    await page.click('#sys-cat-scopes .chipf:nth-child(1)'); // drop user
+    await page.click('#sys-cat-scopes .chipf:nth-child(2)'); // drop project
+    check('source scope filter isolates plugin-contributed capabilities',
+      await rowCount() === 1 && /gamma@market v1\.2\.3/.test(await visibleText(page, '#sys-matrix')),
+      `source-filtered matrix read ${JSON.stringify(await visibleText(page, '#sys-matrix'))}`);
+    check('catalog filter changes are announced',
+      /1 of 4/.test(await page.$eval('#sys-cat-status', (e) => e.textContent)),
+      'the live filter result count was not updated');
 
     await page.click('[data-system-view="projects"]');
     await page.waitForSelector('#sys-projects table');


### PR DESCRIPTION
## Summary

- advance the System catalog to v2 identities that keep standalone and plugin-qualified capabilities distinct while retaining marketplace, version, enabled-state, scope, digest, and evidence provenance;
- group project skill pressure once per project, with project/user/plugin contributions and exact-name versus matching-entrypoint relationships exposed separately;
- add the read-only `ak x skills plan --project <absolute-path> [--json]` classifier with git, rollback, projected-count, preservation, and content-derived plan evidence;
- invalidate v1 snapshots under the new identity semantics and report source-probe drift honestly;
- record Maintenance as the separate mutation boundary tracked by #200.

## Dashboard

- keep Host inventory profile and Unique across hosts together in the first Catalog row;
- place Project skill pressure full-width beneath them;
- bound Unique across hosts to five visible records with a sticky header and keyboard-scrollable overflow;
- collapse host evidence behind one native disclosure per relevant project, prioritize the launching project, omit measured-zero local contributions, and show one deduplicated plan command;
- separate inventory completeness from unknown host-owned context inclusion.

## Safety boundary

System measures; Maintenance acts. This PR performs no apply, prune, upgrade, uninstall, or ownership adoption. Unreadable, oversized, symlinked, dirty, modified, ambiguous, unreceipted, and partial evidence fails toward preservation or review. Persisted and API output contains bounded metadata and digests, never skill bodies.

## Validation

- `npm run check` — passed: typecheck, lint, complexity ratchet, Markdown lint, build/package verification, and the full automated suite;
- `npm run test:ui` — 395 passed, 0 failed, including rendered panel order and the five-record viewport;
- focused catalog, plan, and snapshot tests — 64 passed, 0 failed;
- change-specific Agentic QE SAST — no critical findings;
- repository-wide Agentic QE score remains 37/100, matching the existing baseline rather than a regression introduced here.

Closes #198.

Relates #189 and #200.