### PR TITLE
Manage native Codex model context capacities through agentic-kit

### DIFF
--- a/MAINTAINER.md
+++ b/MAINTAINER.md
@@ -27,7 +27,7 @@ release this kit. User-facing docs live in [README.md](README.md); this file is 
 - **Porcelain** (daily): `setup`, `status`, `sync`, `dashboard`, `admin`, `usage`, `run`,
   `host`, `maintain`, `uninstall`. Bare `ak` → `status --hint`. (`dashboard`, `admin`, and `host`
   are also reachable under `ak x`.)
-- **Plumbing** (power users): `ak x admin | daemon-gc | dashboard | harvest | host | mcp |
+- **Plumbing** (power users): `ak x admin | codex-context | daemon-gc | dashboard | harvest | host | mcp |
   reference | statusline | verify | improvement-eval`.
 - Each command module exports `options` (a `parseArgs` config) and `run({ flags, positionals, pkgRoot })`.
 - A best-effort drift nudge runs after non-`sync`, non-`--json` commands.
@@ -42,7 +42,7 @@ src/
   commands/              # porcelain verbs
     setup.mjs  status.mjs  sync.mjs  run.mjs  maintain.mjs  uninstall.mjs
     x/                   # plumbing verbs
-      admin.mjs  daemon-gc.mjs  dashboard.mjs  harvest.mjs  host.mjs  mcp.mjs  reference.mjs  statusline.mjs  verify.mjs
+      admin.mjs  codex-context.mjs  daemon-gc.mjs  dashboard.mjs  harvest.mjs  host.mjs  mcp.mjs  reference.mjs  statusline.mjs  verify.mjs
   lib/                   # the engine — each file is one concern
     heal.mjs             # the mutations sync/setup apply (idempotent, {ok,detail})
     natives.mjs          # better-sqlite3 / agentdb native detection
@@ -98,13 +98,15 @@ docs/
 `bin/agentic-kit.mjs`, `src/`, `claude/`, `docs/DEJA-VU.md`, `docs/DASHBOARD.md`, `docs/HOST-SUPPORT.md`, `docs/HOOKS.md`,
 `docs/INSTALLATION.md`, `docs/MODELS.md`, `docs/PROVIDERS.md`, `docs/SETUP.md`,
 `docs/MAINTENANCE.md`, `docs/TROUBLESHOOTING.md`, `docs/UPGRADING.md`, `docs/CODEX-STATUSLINE.md`,
+`docs/evidence/codex-context-0.153.4.md`,
 `docs/adr/0015-managed-codex-native-statusline.md`,
 `docs/adr/0032-model-lifecycle-intelligence.md`,
 `docs/adr/0033-retire-codex-mcp-and-bound-qe-court-participants.md`,
 `docs/adr/0043-managed-ruflo-browser-executor.md`,
 `docs/adr/0044-receipt-aware-maintenance-control-plane.md`,
 `tests/live/aqe-external-provider-transport.test.mjs`,
-`tests/live/qe-court-participant-transport.test.mjs`, and
+`tests/live/qe-court-participant-transport.test.mjs`,
+`tests/live/codex-context-contract.test.mjs`, and
 `docs/ddd/maintenance.md`, `docs/ddd/model-lifecycle-intelligence.md`. Generated workspace state under
 the shipped source trees is explicitly excluded. Nothing else ships — verify with
 `npm pack --dry-run` before a release if you touch `files`.

--- a/bin/agentic-kit.mjs
+++ b/bin/agentic-kit.mjs
@@ -44,6 +44,7 @@ const PLUMBING = Object.assign(Object.create(null), {
   'reference': () => import('../src/commands/x/reference.mjs'),
   'ruflo-mcp': () => import('../src/commands/x/ruflo-mcp.mjs'),
   'skills': () => import('../src/commands/x/skills.mjs'),
+  'codex-context': () => import('../src/commands/x/codex-context.mjs'),
   'statusline': () => import('../src/commands/x/statusline.mjs'),
   'verify': () => import('../src/commands/x/verify.mjs'),
 });
@@ -89,6 +90,7 @@ Plumbing (power users) — each takes --help:
   ak x host [status|pick|refresh|off]   manage hosts, routing, and provider bindings
   ak x reference [diff|sync]   CLAUDE.md managed-block inspection/reconcile
   ak x skills plan             read-only project skill evidence + remediation plan
+  ak x codex-context [status|max|off]   manage native Codex context capacities
   ak x statusline [status|codex native|codex extended|codex off]   manage Codex's native user status line
   ak x verify [learning|security|aqe|providers|harvest|all]   deep proofs (slow, spawns real CLIs)
   ak x improvement-eval [...]  causal self-improvement eval (route Q-learner)`;

--- a/docs/CODEX-STATUSLINE.md
+++ b/docs/CODEX-STATUSLINE.md
@@ -48,6 +48,55 @@ Selecting `native` or `extended` records explicit ownership in agentic-kit's
 machine configuration. From then on, `ak status` reports drift and `ak sync`
 reconciles the selected preset.
 
+## Native context capacities
+
+`context-remaining` uses Codex's active session allocation. The API model's
+advertised context capacity is a separate measurement. On Codex 0.153.4,
+Astra and Sol default to 272,000 tokens with a 95% effective allocation
+(258,400 tokens). Their native catalog maximum is 872,000, giving 828,400
+effective tokens when explicitly requested. A fresh session with a 1,050,000
+request still reports 828,400. GPT-5.5 remains at 258,400 under that same
+request: Codex caps the allocation for each selected model.
+
+Agentic-kit can maintain the native maximum preference:
+
+```bash
+ak x codex-context max --dry-run
+ak x codex-context max
+ak x codex-context status --json
+ak sync --no-upgrade
+# Restore the original setting while the owned value is unchanged:
+ak x codex-context off
+```
+
+This is an explicit opt-in independent of the status-line preset. Setup and
+sync reconcile the persisted preference; uninstall restores the original scalar
+only if the current value matches a successful or pending owned projection.
+User-modified values survive removal. Recovery receipts retain both projections
+across interrupted writes, and every changed configuration gets a backup.
+
+The request comes from a fresh native model cache, with a verified per-model
+clamp profile for Codex 0.153.4. Unknown versions, stale or malformed caches,
+custom providers/catalogs, ambiguous TOML, and mismatched `CODEX_HOME` ownership
+prevent writes. Refresh stale metadata with `codex debug models`; a new Codex
+version needs its own conformance evidence. The native cache is never patched.
+
+The new command and model inventory honor absolute `CODEX_HOME`. The projection
+owns only the top-level `model_context_window` scalar. Profile, project, managed,
+or command-line overrides may supersede it. Status labels catalog/config
+estimates separately from runtime observations; restart existing Codex clients
+and verify the window in a fresh session. Auto-compaction settings remain owned
+by Codex or the user and are reported when explicitly configured.
+
+The opt-in `tests/live/codex-context-contract.test.mjs` checks fresh Astra/Sol
+and GPT-5.5 sessions under `AK_CODEX_CONTEXT_CONFORMANCE=1`. It makes three short
+model requests and inspects their recorded effective windows; it does not
+claim that a near-limit input was processed successfully.
+
+See the [Codex configuration reference](https://learn.chatgpt.com/docs/config-file/config-reference)
+for native settings and the [capacity evidence](evidence/codex-context-0.153.4.md)
+for the initial conformance observations.
+
 Agentic-kit narrowly updates only these keys under `[tui]`:
 
 ```toml

--- a/docs/evidence/codex-context-0.153.4.md
+++ b/docs/evidence/codex-context-0.153.4.md
@@ -1,0 +1,52 @@
+# Codex 0.153.4 context allocation conformance
+
+Observed September 9, 2026, using the installed `codex-cli 0.153.4` and its
+refreshed native catalog. No model cache or provider catalog was modified.
+
+| Model | Requested tokens | Native maximum | Recorded effective window |
+|---|---:|---:|---:|
+| GPT-6 Astra | 1,050,000 | 872,000 | 828,400 |
+| GPT-5.6 Sol | 872,000 | 872,000 | 828,400 |
+| GPT-5.5 | 872,000 | 272,000 | 258,400 |
+
+Each bounded `codex exec` session ran in an empty temporary directory with
+read-only sandboxing, low reasoning effort, and a synthetic request to reply
+`AK_CAPACITY_OK` without tools. All three returned that marker successfully.
+Native `task_started` records retained the effective window; Astra's subsequent
+`token_count` observation independently reported the same window.
+
+The allocation matches `min(request, native maximum) × 95%`. This establishes
+the installed client's model-specific allocation behavior, including a smaller
+model control. It does not establish actual processing of an 828K-token input,
+provider entitlement for every catalog model, or equivalence with the API
+capacity. User-configured compaction thresholds remain separate.
+
+The [Astra API model](https://developers.openai.com/api/docs/models/gpt-6-astra)
+and [Sol API model](https://developers.openai.com/api/docs/models/gpt-5.6-sol)
+pages advertise 1,050,000 tokens. That capacity does not override this Codex
+client's smaller native maximum. The native setting is documented in the
+[configuration reference](https://learn.chatgpt.com/docs/config-file/config-reference).
+
+Re-run `AK_CODEX_CONTEXT_CONFORMANCE=1 node --test tests/live/codex-context-contract.test.mjs`
+to validate this exact client profile. The test intentionally rejects other
+versions; new versions need their own evidence before expanding the profile.
+
+## Managed configuration verification
+
+`ak x codex-context max` applied an 872,000-token request with a native-config
+backup and a persisted kit ownership receipt. A second application was a no-op.
+The opt-in contract suite then ran with `AK_CODEX_CONTEXT_USE_CONFIG=1`, omitting
+the command-line window override. All three fresh sessions passed with the
+effective windows above. Model inventory also reported Astra/Sol at 828,400
+and GPT-5.5 at 258,400 from the saved user configuration and native catalog.
+
+The 36 focused tests passed. The full test command passed 3,753 Node tests with
+six skipped, followed by all CJS suites; coverage was 91.83% lines, 80.48%
+branches, and 91.28% functions. Typecheck, ESLint, complexity lint, Markdown
+lint, build, and whitespace checks passed. Existing ESLint warnings remain.
+An initial coverage-reporting attempt encountered truncated coverage JSON;
+the complete rerun used an isolated `NODE_V8_COVERAGE` directory and passed.
+
+Application policy receipt:
+`sha256:241a9eb98fe118b99565972d0dd8a8b19dfd647bf3a7da1e306206cd33956484`.
+This authorizes the requested local configuration, not a package release.

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "docs/TROUBLESHOOTING.md",
     "docs/UPGRADING.md",
     "docs/CODEX-STATUSLINE.md",
+    "docs/evidence/codex-context-0.153.4.md",
     "docs/adr/0015-managed-codex-native-statusline.md",
     "docs/adr/0032-model-lifecycle-intelligence.md",
     "docs/adr/0033-retire-codex-mcp-and-bound-qe-court-participants.md",
@@ -39,6 +40,7 @@
     "docs/adr/0044-receipt-aware-maintenance-control-plane.md",
     "tests/live/aqe-external-provider-transport.test.mjs",
     "tests/live/qe-court-participant-transport.test.mjs",
+    "tests/live/codex-context-contract.test.mjs",
     "docs/ddd/maintenance.md",
     "docs/ddd/model-lifecycle-intelligence.md"
   ],

--- a/src/commands/setup.mjs
+++ b/src/commands/setup.mjs
@@ -9,6 +9,7 @@ import path from 'node:path';
 import readline from 'node:readline/promises';
 import { run as runCmd, have } from '../lib/exec.mjs';
 import * as heal from '../lib/heal.mjs';
+import { manageCodexContext } from '../lib/codex-context.mjs';
 import { fixStatusline } from '../lib/statusline.mjs';
 import { reconcileGuidance } from '../lib/blocks.mjs';
 import { captureProjectGuidance, reconcileProjectGuidance } from '../lib/project-guidance.mjs';
@@ -463,6 +464,10 @@ export async function run_machine({ flags, pkgRoot, cfg }) {
   deployTokenAuditSkill(pkgRoot);
   await installEnabledAbsentHosts(cfg, flags);
   if (!(await applyMachineHostLifecycles(cfg, pkgRoot))) return false;
+  if (cfg.codexContext && cfg.integrations?.hosts?.codex) {
+    try { await manageCodexContext(cfg, { persist: saveKitConfig }); }
+    catch (error) { warn(`Codex context reconciliation incomplete: ${error.message}`); return false; }
+  }
   await printUndetectedHostHints(cfg);
   return true;
 }

--- a/src/commands/status/sections/codex-context.mjs
+++ b/src/commands/status/sections/codex-context.mjs
@@ -1,0 +1,18 @@
+import { inspectCodexContext } from '../../../lib/codex-context.mjs';
+import { row } from '../row.mjs';
+
+export default {
+  id: 'codex-context',
+  async collect({ cfg }) {
+    if (!cfg.integrations?.hosts?.codex && !cfg.codexContext) return [];
+    const status = inspectCodexContext(cfg);
+    if (!status.owned) return [row('codex-context', 'info', 'Codex context is unmanaged; opt in with `ak x codex-context max`')];
+    if (!status.available) return [row('codex-context', 'warn', `managed Codex context unavailable: ${status.reason}`)];
+    if (!status.enabled) return [row('codex-context', 'warn', 'Codex context ownership retained while host is disabled; use `ak x codex-context off` to restore')];
+    if (status.drifted) return [row('codex-context', 'warn', 'managed Codex context request has drifted', 'sync restores the native maximum request')];
+    const rows = [row('codex-context', 'ok', `native maximum request ${status.configuredWindow}; per-model limits apply to new sessions (cache client ${status.clientVersion}; running client and session unverified)`)];
+    for (const m of status.models) rows.push(row('codex-context/model', 'info', `${m.model}: ${m.effectiveWindow} effective / ${m.maximumWindow} native maximum`));
+    if (status.autoCompactTokenLimit) rows.push(row('codex-context', 'info', `user auto-compaction threshold ${status.autoCompactTokenLimit} retained`));
+    return rows;
+  },
+};

--- a/src/commands/status/sections/index.mjs
+++ b/src/commands/status/sections/index.mjs
@@ -8,6 +8,7 @@
 // across both registries plus those three calls is unchanged from the
 // original monolithic collect().
 import models from './models.mjs';
+import codexContext from './codex-context.mjs';
 import versions from './versions.mjs';
 import ruvnetBrain from './ruvnet-brain.mjs';
 import ruvector from './ruvector.mjs';
@@ -50,5 +51,5 @@ export const SECTIONS_BEFORE_HOST_DETAIL = [
 export const SECTIONS_AFTER_HOST_DETAIL = [
   hosts, providersStatus, providersExternalIntent, providersExternalProjection,
   providersRufloModels, providersLocalBindings, routing, daemons, blocks,
-  statusline, qeCourt,
+  statusline, codexContext, qeCourt,
 ];

--- a/src/commands/sync.mjs
+++ b/src/commands/sync.mjs
@@ -2,6 +2,7 @@
 // uses; --dry-run prints it and stops. Apply order: upgrades first (they wipe
 // natives), then heals, then re-collect to prove convergence.
 import path from 'node:path';
+import { manageCodexContext } from '../lib/codex-context.mjs';
 import readline from 'node:readline/promises';
 import { collect } from './status.mjs';
 import * as heal from '../lib/heal.mjs';
@@ -428,6 +429,14 @@ export const SYNC_STEPS = [
   // files on disk, and the new code applies from the next ak run, so nothing
   // after this point should depend on the kit's own modules being current.
   // (Array position — the final entry in SYNC_STEPS — is the invariant.)
+  {
+    id: 'codex-context',
+    when: (subs, flags, cfg) => subs.has('codex-context') && !!cfg.codexContext && !!cfg.integrations?.hosts?.codex,
+    run: async (ctx) => {
+      await manageCodexContext(ctx.cfg, { persist: saveKitConfig });
+      ok('Codex native context maximum reconciled; start new sessions');
+    },
+  },
   {
     id: 'self',
     when: (subs, flags) => subs.has('self') && !flags['no-upgrade'],

--- a/src/commands/uninstall.mjs
+++ b/src/commands/uninstall.mjs
@@ -4,6 +4,7 @@
 // LEGACY shell-kit install (rc source lines, ~/.local/bin/ruflo-*,
 // ~/.config/ruflo shell files) — the migration path off the bash era.
 import fs from 'node:fs';
+import { releaseCodexContext } from '../lib/codex-context.mjs';
 import path from 'node:path';
 import readline from 'node:readline/promises';
 import { run as runCmd } from '../lib/exec.mjs';
@@ -432,7 +433,8 @@ function stepPurgeKitConfig(ctx) {
     ctx.act('removed kit.json', () => fs.rmSync(paths.kitConfigPath()));
   } else if (!ctx.state.dejaVuTeardownOk) {
     warn('kit.json retained because deja-vu teardown is incomplete; it contains recovery ownership receipts');
-  } else warn('kit.json retained because OpenCode teardown is incomplete; it contains the recovery ownership receipt');
+  } else if (ctx.cfg.codexContext) warn('kit.json retained because Codex context teardown is incomplete; it contains the recovery ownership receipt');
+  else warn('kit.json retained because OpenCode teardown is incomplete; it contains the recovery ownership receipt');
 }
 
 // 3. MCP registration + deny rules
@@ -538,6 +540,14 @@ function stepRuvnetBrainNotice() {
 }
 
 export const UNINSTALL_STEPS = [
+  { id: 'codex-context', when: ctx => !!ctx.cfg.codexContext, run: async ctx => {
+    if (ctx.dry) { info('[dry-run] restore unchanged managed Codex context scalar'); return; }
+    try { await releaseCodexContext(ctx.cfg, { persist: saveKitConfig }); }
+    catch (error) {
+      ctx.state.ownershipTeardownOk = false;
+      warn(`Codex context ownership retained: ${error.message}`);
+    }
+  } },
   { id: 'codex-statusline', when: (ctx) => !!ctx.cfg.statusline?.codex, run: stepCodexStatusline },
   { id: 'claude-md-blocks', when: () => true, run: stepClaudeMdBlocks },
   { id: 'skill', when: () => true, run: stepSkill },

--- a/src/commands/x/codex-context.mjs
+++ b/src/commands/x/codex-context.mjs
@@ -1,0 +1,45 @@
+import { loadKitConfig, saveKitConfig } from '../../lib/config.mjs';
+import { inspectCodexContext, manageCodexContext, releaseCodexContext } from '../../lib/codex-context.mjs';
+import { info, ok, warn } from '../../lib/output.mjs';
+
+export const options = { 'dry-run': { type: 'boolean', default: false }, json: { type: 'boolean', default: false } };
+export const help = `ak x codex-context — manage Codex's native per-model context capacities
+
+Usage: ak x codex-context [status|max|off] [--dry-run] [--json]
+
+max opts in to the fresh native catalog's maximum request. Codex caps that
+request for each selected model and reserves its native effective percentage.
+Setup and sync maintain this preference. off restores the prior scalar only
+while the managed value is unchanged. No native model catalog is rewritten.
+Start a new Codex session after applying; API maxima are separate evidence.
+
+Examples:
+  ak x codex-context max --dry-run
+  ak x codex-context max
+  ak x codex-context status --json
+  ak x codex-context off`;
+
+export async function run({ flags, positionals, contextOptions = {} }) {
+  const choice = positionals[0] ?? 'status';
+  if (!['status', 'max', 'off'].includes(choice) || positionals.length > 1) { warn(help); return 2; }
+  const cfg = loadKitConfig();
+  const status = inspectCodexContext(cfg, contextOptions);
+  if (choice === 'status' || flags['dry-run']) {
+    if (flags.json) console.log(JSON.stringify({ ...status, plannedAction: choice, dryRun: !!flags['dry-run'] }, null, 2));
+    else {
+      info(`Codex context: ${status.owned ? 'managed native maximum' : 'unmanaged'}${status.drifted ? ' (drifted)' : ''}`);
+      if (!status.available) warn(status.reason);
+      for (const m of status.models) info(`${m.model}: ${m.effectiveWindow} effective; native maximum ${m.maximumWindow}`);
+      if (choice !== 'status') info(`[dry-run] ${choice}: ${choice === 'max' ? `request ${status.requestedWindow} tokens` : 'restore unchanged owned scalar'}`);
+    }
+    return choice === 'max' && (!status.available || !cfg.integrations?.hosts?.codex) ? 1 : 0;
+  }
+  try {
+    const result = choice === 'off'
+      ? await releaseCodexContext(cfg, { ...contextOptions, persist: saveKitConfig })
+      : await manageCodexContext(cfg, { ...contextOptions, enable: true, persist: saveKitConfig });
+    if (flags.json) console.log(JSON.stringify({ ...result, status: inspectCodexContext(cfg, contextOptions) }, null, 2));
+    else ok(`Codex context ${choice === 'off' ? 'ownership released' : 'native maximum configured'}${result.changed ? ' (config updated)' : ''}; start new Codex sessions`);
+    return 0;
+  } catch (error) { warn(`Codex context operation incomplete: ${error.message}`); return 1; }
+}

--- a/src/lib/codex-context-config.mjs
+++ b/src/lib/codex-context-config.mjs
@@ -1,0 +1,94 @@
+// Narrow top-level scalar projection; never parse instruction strings as config.
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { inspectCodexTomlStructure, isTomlTableLine } from './codex-toml-safety.mjs';
+
+export const WINDOW_KEY = 'model_context_window';
+export const positiveTokens = value => Number.isSafeInteger(value) && value > 0;
+
+export function contextHome(env = process.env) {
+  const home = env.CODEX_HOME || path.join(os.homedir(), '.codex');
+  if (!path.isAbsolute(home)) throw new Error('CODEX_HOME must be absolute');
+  return path.resolve(home);
+}
+
+export function readContextConfig(source) {
+  if (Buffer.byteLength(source) > 4 * 1024 * 1024) throw new Error('Codex config exceeds inspection bound');
+  const structure = inspectCodexTomlStructure(source);
+  if (!structure.valid) throw new Error(structure.error);
+  const result = { window: null, autoCompact: null, model: null, provider: null, catalog: null, reasoningEffort: null, span: null, source };
+  const seen = new Set();
+  const keys = { model_context_window: 'window', model_auto_compact_token_limit: 'autoCompact',
+    model_reasoning_effort: 'reasoningEffort', model: 'model', model_provider: 'provider', model_catalog_json: 'catalog' };
+  for (const line of structure.lines) {
+    if (!line.live) continue;
+    if (isTomlTableLine(line.text)) break;
+    const match = /^\s*([^=]+?)\s*=\s*(.*?)\s*(?:#.*)?$/.exec(line.text);
+    if (!match) continue;
+    const key = match[1].trim();
+    if (/^["'](?:model_context_window|model_auto_compact_token_limit|model|model_provider|model_catalog_json)["']$/.test(key)) {
+      throw new Error('quoted context configuration keys are not safely patchable');
+    }
+    if (!Object.hasOwn(keys, key)) continue;
+    if (seen.has(key)) throw new Error(`duplicate ${key}`);
+    seen.add(key);
+    const field = keys[key];
+    if (field === 'window' || field === 'autoCompact') {
+      if (!/^[+]?[1-9](?:_?\d)*$/.test(match[2])) throw new Error(`invalid ${key}`);
+      const value = Number(match[2].replaceAll('_', ''));
+      if (!positiveTokens(value)) throw new Error(`invalid ${key}`);
+      result[field] = value;
+      if (field === 'window') result.span = line;
+    } else {
+      const string = /^(?:"([^"\\]*)"|'([^']*)')$/.exec(match[2]);
+      if (!string) throw new Error(`unsupported ${key} value`);
+      result[field] = string[1] ?? string[2];
+    }
+  }
+  return result;
+}
+
+export function replaceContextWindow(parsed, value, originalLine) {
+  const nl = parsed.source.includes('\r\n') ? '\r\n' : '\n';
+  let line = originalLine !== undefined ? originalLine ?? '' : `${WINDOW_KEY} = ${value}${nl}`;
+  const span = parsed.span;
+  if (line && !line.endsWith('\n') && (span ? span.end < parsed.source.length : parsed.source.length > 0)) line += nl;
+  return span ? parsed.source.slice(0, span.start) + line + parsed.source.slice(span.end)
+    : line + parsed.source;
+}
+
+export function writeContextConfig(file, before, after) {
+  if (before === after) return { changed: false };
+  if (fs.readFileSync(file, 'utf8') !== before) throw new Error('Codex config changed during planning; retry');
+  if (fs.lstatSync(file).isSymbolicLink()) throw new Error('symlinked Codex config is not safely patchable');
+  const stat = fs.statSync(file);
+  const backup = `${file}.ak-context-backup.${randomUUID()}`;
+  fs.copyFileSync(file, backup, fs.constants.COPYFILE_EXCL);
+  const tmp = `${file}.ak-context-tmp.${randomUUID()}`;
+  try {
+    fs.writeFileSync(tmp, after, { flag: 'wx', mode: stat.mode & 0o777 });
+    if (fs.readFileSync(file, 'utf8') !== before) throw new Error('Codex config changed before write; retry');
+    fs.renameSync(tmp, file);
+  } finally { if (fs.existsSync(tmp)) fs.unlinkSync(tmp); }
+  return { changed: true, backup };
+}
+
+export function validateCodexContextIntent(intent) {
+  if (intent == null) return;
+  if (intent.mode !== 'max' || !path.isAbsolute(intent.file ?? '')
+    || path.basename(intent.file) !== 'config.toml'
+    || !(positiveTokens(intent.lastProjection) || (intent.lastProjection === null && positiveTokens(intent.pendingProjection)))
+    || !(intent.pendingProjection == null || positiveTokens(intent.pendingProjection))
+    || !(intent.originalLine === null || typeof intent.originalLine === 'string')
+    || typeof intent.clientVersion !== 'string' || typeof intent.cacheSha256 !== 'string') {
+    throw new TypeError('invalid codexContext ownership receipt');
+  }
+  if (intent.originalLine !== null) {
+    const parsed = readContextConfig(intent.originalLine);
+    if (!parsed.span || parsed.span.start !== 0 || parsed.span.end !== intent.originalLine.length) {
+      throw new TypeError('invalid codexContext original scalar');
+    }
+  }
+}

--- a/src/lib/codex-context.mjs
+++ b/src/lib/codex-context.mjs
@@ -1,0 +1,118 @@
+// Native per-model clamp is verified on 0.153.4. An API maximum is not a
+// Codex allocation. New host versions need their own native contract evidence.
+import fs from 'node:fs';
+import path from 'node:path';
+import { createHash } from 'node:crypto';
+import { run } from './exec.mjs';
+import { contextHome, positiveTokens, readContextConfig, replaceContextWindow,
+  writeContextConfig, validateCodexContextIntent } from './codex-context-config.mjs';
+
+export const VERIFIED_CODEX_CONTEXT_VERSIONS = Object.freeze(['0.153.4']);
+export const CONTEXT_CACHE_MAX_AGE_MS = 7 * 86400000;
+
+export function contextCapacity(raw, request = null) {
+  const nativeWindow = positiveTokens(raw.context_window) ? raw.context_window : null;
+  const maximumWindow = positiveTokens(raw.max_context_window) ? raw.max_context_window : nativeWindow;
+  const percent = Number.isInteger(raw.effective_context_window_percent)
+    && raw.effective_context_window_percent > 0 && raw.effective_context_window_percent <= 100
+    ? raw.effective_context_window_percent : null;
+  const allocatedWindow = request === null ? nativeWindow : maximumWindow === null ? null : Math.min(request, maximumWindow);
+  return { model: raw.slug, nativeWindow, maximumWindow, requestedWindow: request, allocatedWindow,
+    effectivePercent: percent, effectiveWindow: allocatedWindow !== null && percent !== null
+      ? Math.floor(allocatedWindow * percent / 100) : null };
+}
+
+function readEvidence(home, now) {
+  const file = path.join(home, 'config.toml');
+  const config = readContextConfig(fs.readFileSync(file, 'utf8'));
+  if (config.provider && config.provider !== 'openai') throw new Error('native maximum requires the OpenAI Codex provider');
+  if (config.catalog) throw new Error('custom model catalog requires separate capacity conformance');
+  const raw = fs.readFileSync(path.join(home, 'models_cache.json'), 'utf8');
+  if (Buffer.byteLength(raw) > 4 * 1024 * 1024) throw new Error('Codex model cache exceeds inspection bound');
+  const cache = JSON.parse(raw);
+  const age = now - Date.parse(cache.fetched_at);
+  if (!Number.isFinite(age) || age < -300000 || age > CONTEXT_CACHE_MAX_AGE_MS) {
+    throw new Error('Codex model cache is stale or undated; run codex debug models to refresh');
+  }
+  if (!VERIFIED_CODEX_CONTEXT_VERSIONS.includes(cache.client_version)) {
+    throw new Error('Codex version has no verified per-model context clamp profile');
+  }
+  if (!Array.isArray(cache.models) || cache.models.length === 0 || cache.models.length > 1000) throw new Error('invalid Codex model catalog');
+  const models = cache.models.filter(m => !['hide', 'hidden'].includes(m.visibility));
+  if (!models.length || models.some(m => typeof m.slug !== 'string' || !/^[a-zA-Z0-9._:-]{1,128}$/.test(m.slug)
+    || !positiveTokens(m.context_window) || !positiveTokens(m.max_context_window)
+    || m.max_context_window < m.context_window || contextCapacity(m).effectivePercent === null)) {
+    throw new Error('Codex catalog lacks valid native capacity bounds');
+  }
+  return { file, config, cache, models, requestedWindow: Math.max(...models.map(m => m.max_context_window)),
+    cacheSha256: createHash('sha256').update(raw).digest('hex') };
+}
+
+function checkScope(cfg, home) {
+  validateCodexContextIntent(cfg.codexContext);
+  if (cfg.codexContext && cfg.codexContext.file !== path.join(home, 'config.toml')) {
+    throw new Error('Codex context ownership scope differs from the current CODEX_HOME');
+  }
+}
+
+export function inspectCodexContext(cfg, { home = contextHome(), now = Date.now() } = {}) {
+  const owned = !!cfg.codexContext;
+  try {
+    checkScope(cfg, home);
+    const evidence = readEvidence(home, now);
+    return { owned, available: true, drifted: owned && evidence.config.window !== evidence.requestedWindow,
+      enabled: cfg.integrations?.hosts?.codex === true,
+      file: evidence.file, requestedWindow: evidence.requestedWindow, configuredWindow: evidence.config.window,
+      autoCompactTokenLimit: evidence.config.autoCompact, clientVersion: evidence.cache.client_version,
+      evidence: 'native-catalog-and-user-config', runtimeVerified: false,
+      models: evidence.models.map(m => contextCapacity(m, evidence.config.window)) };
+  } catch (error) {
+    return { owned, available: false, drifted: false, reason: error.message, models: [], runtimeVerified: false };
+  }
+}
+
+async function persistIntent(cfg, intent, persist) {
+  await persist({ ...cfg, codexContext: intent });
+  cfg.codexContext = intent;
+}
+
+export async function manageCodexContext(cfg, {
+  enable = false, home = contextHome(), now = Date.now(), runner = run, persist = /** @type {((cfg: any) => any) | undefined} */ (undefined),
+} = {}) {
+  if (!enable && !cfg.codexContext) return { changed: false };
+  if (!cfg.integrations?.hosts?.codex) throw new Error('enable the Codex host before managing its context');
+  if (typeof persist !== 'function') throw new Error('ownership persistence is required');
+  checkScope(cfg, home);
+  const evidence = readEvidence(home, now);
+  const version = await runner('codex', ['--version'], { timeout: 5000 });
+  if (version.code !== 0 || version.stdout.trim() !== `codex-cli ${evidence.cache.client_version}`) {
+    throw new Error('running Codex version differs from the verified model cache');
+  }
+  const { config, file, requestedWindow, cacheSha256 } = evidence;
+  const originalLine = cfg.codexContext?.originalLine ?? (cfg.codexContext ? null
+    : config.span ? config.source.slice(config.span.start, config.span.end) : null);
+  const pending = { mode: 'max', file, originalLine,
+    lastProjection: config.window !== null && config.window === cfg.codexContext?.pendingProjection
+      ? config.window : cfg.codexContext?.lastProjection ?? null, pendingProjection: requestedWindow,
+    clientVersion: evidence.cache.client_version, cacheSha256 };
+  await persistIntent(cfg, pending, persist); // intent survives interrupted native writes
+  const result = writeContextConfig(file, config.source, replaceContextWindow(config, requestedWindow));
+  await persistIntent(cfg, { ...pending, lastProjection: requestedWindow, pendingProjection: null }, persist);
+  return result;
+}
+
+export async function releaseCodexContext(cfg, { home = contextHome(), persist = /** @type {((cfg: any) => any) | undefined} */ (undefined) } = {}) {
+  if (!cfg.codexContext) return { changed: false };
+  checkScope(cfg, home);
+  if (typeof persist !== 'function') throw new Error('ownership persistence is required');
+  const { file, originalLine, lastProjection, pendingProjection } = cfg.codexContext;
+  let result = { changed: false };
+  if (fs.existsSync(file)) {
+    const config = readContextConfig(fs.readFileSync(file, 'utf8'));
+    if (config.window !== null && [lastProjection, pendingProjection].includes(config.window)) {
+      result = writeContextConfig(file, config.source, replaceContextWindow(config, null, originalLine));
+    }
+  }
+  await persistIntent(cfg, null, persist);
+  return result;
+}

--- a/src/lib/config.mjs
+++ b/src/lib/config.mjs
@@ -2,6 +2,7 @@
 // Prompts-once-config-forever: choices made during `setup` land here and
 // `sync`/`status` reapply them without re-asking.
 import fs from 'node:fs';
+import { validateCodexContextIntent } from './codex-context-config.mjs';
 import { validateAqeCodexGuidance } from './aqe-guidance.mjs';
 import path from 'node:path';
 import { kitConfigPath, legacyKitConfigPath } from './paths.mjs';
@@ -19,6 +20,7 @@ import {
 } from './routing-config.mjs';
 
 const DEFAULTS = {
+  codexContext: null, // opt-in native maximum with original scalar and ownership receipt
   aqeCodexGuidance: 'compact', // full | compact | none; AQE ≥3.14.1
   aqe: true,            // manage agentic-qe alongside ruflo
   agentBrowser: true,   // manage Ruflo's currently-shipped browser executor (disable with setup --no-agent-browser)
@@ -101,6 +103,7 @@ function warnUnknownTopLevelKeys(parsed) {
 }
 
 function assertLoadableEnvelopes(config) {
+  validateCodexContextIntent(config.codexContext);
   validateAqeCodexGuidance(config.aqeCodexGuidance);
   if (!plain(config.integrations)) {
     throw new TypeError(
@@ -230,6 +233,7 @@ export function loadKitConfig(file = kitConfigPath()) {
 }
 
 export function saveKitConfig(cfg, file = kitConfigPath()) {
+  validateCodexContextIntent(cfg.codexContext);
   validateAqeCodexGuidance(cfg.aqeCodexGuidance);
   const serialized = JSON.stringify(migrateKitConfig(cfg), null, 2) + '\n';
   try {

--- a/src/lib/model-inventory/discovery/codex.mjs
+++ b/src/lib/model-inventory/discovery/codex.mjs
@@ -1,3 +1,5 @@
+import { readContextConfig } from '../../codex-context-config.mjs';
+import { VERIFIED_CODEX_CONTEXT_VERSIONS, contextCapacity } from '../../codex-context.mjs';
 import {
   MAX_COMMAND_BYTES, MAX_MODELS, diagnostic, modelRecord, sourceRecord,
 } from './index.mjs';
@@ -7,18 +9,26 @@ const REASONING = new Set(['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 
 const bounded = (value, max = 256) => typeof value === 'string' && value.length > 0 && value.length <= max ? value : null;
 const positiveSafeInteger = (value) => Number.isSafeInteger(value) && value > 0 ? value : null;
 
-function codexContextVariant(raw) {
+function codexContextVariant(raw, config, clientVersion) {
   const contextWindow = positiveSafeInteger(raw.context_window);
   const maximumContextWindow = positiveSafeInteger(raw.max_context_window);
   const effectiveContextWindowPercent = Number.isSafeInteger(raw.effective_context_window_percent)
     && raw.effective_context_window_percent > 0 && raw.effective_context_window_percent <= 100
     ? raw.effective_context_window_percent : null;
+  const requested = config.window;
+  const supported = VERIFIED_CODEX_CONTEXT_VERSIONS.includes(clientVersion);
+  const capacity = contextCapacity(raw, requested);
+  const configured = requested !== null && (!config.provider || config.provider === 'openai') && !config.catalog;
   return {
-    contextWindow,
+    nativeContextWindow: contextWindow,
+    configuredContextWindow: configured ? requested : null,
+    configuredAutoCompactTokenLimit: config.autoCompact,
+    contextWindow: configured ? (supported ? capacity.allocatedWindow : null) : contextWindow,
     maximumContextWindow,
     effectiveContextWindowPercent,
-    effectiveContextWindow: contextWindow !== null && effectiveContextWindowPercent !== null
-      ? Math.floor(contextWindow * effectiveContextWindowPercent / 100) : contextWindow,
+    effectiveContextWindow: configured ? (supported ? capacity.effectiveWindow : null)
+      : contextWindow !== null && effectiveContextWindowPercent !== null
+        ? Math.floor(contextWindow * effectiveContextWindowPercent / 100) : contextWindow,
     autoCompactTokenLimit: positiveSafeInteger(raw.auto_compact_token_limit),
     maxOutputTokens: positiveSafeInteger(raw.max_output_tokens),
   };
@@ -35,20 +45,8 @@ function parseCache(raw) {
 }
 
 function parseConfig(raw) {
-  if (raw === undefined || raw === null || raw === '') return {};
-  const text = String(raw);
-  if (Buffer.byteLength(text) > MAX_COMMAND_BYTES) throw new TypeError('config-too-large');
-  const result = {};
-  let topLevel = true;
-  for (const line of text.split(/\r?\n/)) {
-    const clean = line.replace(/\s+#.*$/, '').trim();
-    if (!clean) continue;
-    if (/^\[/.test(clean)) { topLevel = false; continue; }
-    if (!topLevel) continue;
-    const match = clean.match(/^(model|model_provider|model_reasoning_effort)\s*=\s*["']([^"']{1,256})["']\s*$/);
-    if (match) result[match[1]] = match[2];
-  }
-  return result;
+  const parsed = readContextConfig(String(raw ?? ''));
+  return { ...parsed, model_provider: parsed.provider };
 }
 
 function codexUnsupportedSchemaResult(scopeCtx, message) {
@@ -74,7 +72,7 @@ function codexModelStates(config, modelId, visibility) {
   };
 }
 
-function codexModelFromCacheEntry(raw, index, config, source) {
+function codexModelFromCacheEntry(raw, index, config, source, clientVersion) {
   const modelId = bounded(raw?.slug ?? raw?.id);
   const visibility = raw?.visibility ?? 'list';
   if (!modelId || !VISIBILITY.has(visibility)) {
@@ -86,7 +84,7 @@ function codexModelFromCacheEntry(raw, index, config, source) {
       displayName: bounded(raw.display_name) ?? modelId, source,
       variant: {
         reasoningEfforts: codexReasoningEfforts(raw),
-        ...codexContextVariant(raw),
+        ...codexContextVariant(raw, config, clientVersion),
       },
       // `upgrade` is a local client hint, not a public retirement notice. It
       // must never promote a target model into a lifecycle warning or cause a
@@ -98,12 +96,12 @@ function codexModelFromCacheEntry(raw, index, config, source) {
   };
 }
 
-function codexModelsFromCache(cacheModels, config, source) {
+function codexModelsFromCache(cacheModels, config, source, clientVersion) {
   const models = [];
   const diagnostics = [];
   let complete = true;
   for (const [index, raw] of cacheModels.slice(0, MAX_MODELS).entries()) {
-    const { model, diagnostic: rowDiagnostic } = codexModelFromCacheEntry(raw, index, config, source);
+    const { model, diagnostic: rowDiagnostic } = codexModelFromCacheEntry(raw, index, config, source, clientVersion);
     if (model) models.push(model);
     if (rowDiagnostic) { complete = false; diagnostics.push(rowDiagnostic); }
   }
@@ -119,7 +117,7 @@ function codexConfiguredFallbackModel(config, source) {
   return modelRecord({
     host: 'codex', provider: bounded(config.model_provider), modelId: config.model,
     scopeId: source.scopeId, source,
-    variant: { reasoningEffort: REASONING.has(config.model_reasoning_effort) ? config.model_reasoning_effort : null },
+    variant: { reasoningEffort: REASONING.has(config.reasoningEffort) ? config.reasoningEffort : null },
     states: { configured: true, effective: true, discoverable: 'unknown', entitled: 'unknown' },
   });
 }
@@ -143,7 +141,7 @@ export function discoverCodex({
     schema: `codex-model-cache-v1${bounded(cache.client_version, 32) ? `@${cache.client_version}` : ''}`,
     freshness: stale ? 'stale' : 'current',
   });
-  const { models, diagnostics, complete: rowsComplete } = codexModelsFromCache(cache.models, config, source);
+  const { models, diagnostics, complete: rowsComplete } = codexModelsFromCache(cache.models, config, source, cache.client_version);
   const complete = cache.models.length <= MAX_MODELS && rowsComplete;
   const fallback = codexConfiguredFallbackModel(config, source);
   if (fallback && !models.some((model) => model.identity.modelId === fallback.identity.modelId)) {

--- a/src/lib/model-inventory/read-model.mjs
+++ b/src/lib/model-inventory/read-model.mjs
@@ -135,7 +135,8 @@ const publicSchema = (value) => PUBLIC_SOURCE_SCHEMAS.has(value)
 const SAFE_VARIANT_FIELDS = new Set([
   'digest', 'reasoningEffort', 'reasoningEfforts', 'serviceTier', 'contextWindow',
   'maximumContextWindow', 'effectiveContextWindowPercent', 'effectiveContextWindow',
-  'autoCompactTokenLimit', 'maxOutputTokens',
+  'autoCompactTokenLimit', 'maxOutputTokens', 'nativeContextWindow',
+  'configuredContextWindow', 'configuredAutoCompactTokenLimit',
   'configuredVariants', 'availableVariants', 'modalities', 'input', 'output',
   'text', 'audio', 'image', 'video', 'pdf', 'sizeBytes', 'modifiedAt', 'format',
   'family', 'families', 'parameterSize', 'quantizationLevel', 'loaded', 'memoryBytes',

--- a/src/lib/model-inventory/refresh.mjs
+++ b/src/lib/model-inventory/refresh.mjs
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import { contextHome } from '../codex-context-config.mjs';
 import path from 'node:path';
 import { createHash } from 'node:crypto';
 import * as paths from '../paths.mjs';
@@ -40,10 +41,10 @@ const DISCOVERY_OPTIONS = Object.freeze({
       .filter((name) => typeof processEnvironment?.[name] === 'string')
       .map((name) => [name, processEnvironment[name]])),
   }),
-  'codex-cache': ({ base, inputs, readFileFn }) => ({
+  'codex-cache': ({ base, inputs, readFileFn, processEnvironment }) => ({
     ...base,
-    cacheRaw: inputs.codex?.cacheRaw ?? readOptional(path.join(paths.codexDir(), 'models_cache.json'), readFileFn),
-    configRaw: inputs.codex?.configRaw ?? readOptional(path.join(paths.codexDir(), 'config.toml'), readFileFn),
+    cacheRaw: inputs.codex?.cacheRaw ?? readOptional(path.join(contextHome(processEnvironment), 'models_cache.json'), readFileFn),
+    configRaw: inputs.codex?.configRaw ?? readOptional(path.join(contextHome(processEnvironment), 'config.toml'), readFileFn),
   }),
   'opencode-models': ({ base, inputs, runner, online }) => ({
     ...base, runner, online, provider: inputs.opencode?.provider,

--- a/tests/kit/codex-context-command.test.mjs
+++ b/tests/kit/codex-context-command.test.mjs
@@ -1,0 +1,66 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { sandboxHome, captureLog, snapshot, assertUnchanged } from './helpers/home-sandbox.mjs';
+
+const root = sandboxHome('ak-context-command');
+process.env.CODEX_HOME = path.join(root, '.codex');
+const { loadKitConfig, saveKitConfig } = await import('../../src/lib/config.mjs');
+const command = await import('../../src/commands/x/codex-context.mjs');
+const section = (await import('../../src/commands/status/sections/codex-context.mjs')).default;
+const { SYNC_STEPS } = await import('../../src/commands/sync.mjs');
+const { UNINSTALL_STEPS } = await import('../../src/commands/uninstall.mjs');
+const contextOptions = { runner: async () => ({ code: 0, stdout: 'codex-cli 0.153.4' }) };
+const run = (positionals, flags = {}) => command.run({ positionals, flags, contextOptions });
+function seed() {
+  fs.mkdirSync(process.env.CODEX_HOME, { recursive: true });
+  fs.writeFileSync(path.join(process.env.CODEX_HOME, 'config.toml'), 'model = "gpt-6-astra"\n');
+  fs.writeFileSync(path.join(process.env.CODEX_HOME, 'models_cache.json'), JSON.stringify({
+    client_version: '0.153.4', fetched_at: new Date().toISOString(), models: [{
+      slug: 'gpt-6-astra', context_window: 272000, max_context_window: 872000, effective_context_window_percent: 95,
+    }],
+  }));
+  const cfg = loadKitConfig(); cfg.codexContext = null; cfg.integrations.hosts.codex = true; saveKitConfig(cfg);
+}
+
+test('command dry-run preserves both native config and persisted ownership', async () => {
+  seed(); const before = snapshot(root);
+  const output = await captureLog(() => run(['max'], { 'dry-run': true, json: true }));
+  assert.equal(JSON.parse(output.out).requestedWindow, 872000);
+  assertUnchanged(before, root, 'dry-run writes nothing');
+});
+
+test('max survives reload, status creates an actionable sync repair, and off restores original', async () => {
+  seed(); await captureLog(() => run(['max']));
+  const cfg = loadKitConfig();
+  assert.equal(cfg.codexContext.lastProjection, 872000);
+  const current = await section.collect({ cfg });
+  assert.equal(current[0].level, 'ok');
+  fs.writeFileSync(path.join(process.env.CODEX_HOME, 'config.toml'), 'model = "gpt-6-astra"\n');
+  const drift = await section.collect({ cfg });
+  assert.ok(drift[0].fix);
+  const step = SYNC_STEPS.find(s => s.id === 'codex-context');
+  assert.equal(step.when(new Set(['codex-context']), {}, cfg), true);
+  assert.equal(step.when(new Set(['codex-context']), {}, { ...cfg, integrations: { hosts: { codex: false } } }), false);
+  await captureLog(() => run(['max']));
+  await captureLog(() => run(['off']));
+  assert.equal(loadKitConfig().codexContext, null);
+  assert.equal(fs.readFileSync(path.join(process.env.CODEX_HOME, 'config.toml'), 'utf8'), 'model = "gpt-6-astra"\n');
+});
+
+test('uninstall context step is dry-run safe and retains ownership when native restoration fails', async () => {
+  seed(); await captureLog(() => run(['max']));
+  const cfg = loadKitConfig();
+  const step = UNINSTALL_STEPS.find(s => s.id === 'codex-context');
+  const before = snapshot(root);
+  await captureLog(() => step.run({ cfg, dry: true }));
+  assertUnchanged(before, root, 'dry-run writes nothing');
+  fs.writeFileSync(path.join(process.env.CODEX_HOME, 'config.toml'), 'model_context_window = -1\n');
+  const ctx = { cfg, dry: false, state: { ownershipTeardownOk: true } };
+  await captureLog(() => step.run(ctx));
+  assert.equal(ctx.state.ownershipTeardownOk, false);
+  assert.ok(loadKitConfig().codexContext);
+});
+
+test.after(() => fs.rmSync(root, { recursive: true, force: true }));

--- a/tests/kit/codex-context.test.mjs
+++ b/tests/kit/codex-context.test.mjs
@@ -1,0 +1,152 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { readContextConfig, contextHome } from '../../src/lib/codex-context-config.mjs';
+import { inspectCodexContext, manageCodexContext, releaseCodexContext } from '../../src/lib/codex-context.mjs';
+
+const now = Date.parse('2026-09-09T14:00:00Z');
+function fixture(t, source = 'model = "gpt-6-astra"\n[tui]\nstatus_line = ["context-remaining"]\n') {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'ak-context-'));
+  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
+  fs.writeFileSync(path.join(home, 'config.toml'), source);
+  const cache = { client_version: '0.153.4', fetched_at: new Date(now).toISOString(), models: [
+    { slug: 'gpt-6-astra', context_window: 272000, max_context_window: 872000, effective_context_window_percent: 95 },
+    { slug: 'gpt-5.6-sol', context_window: 272000, max_context_window: 872000, effective_context_window_percent: 95 },
+    { slug: 'gpt-5.5', context_window: 272000, max_context_window: 272000, effective_context_window_percent: 95 },
+  ] };
+  const writeCache = () => fs.writeFileSync(path.join(home, 'models_cache.json'), JSON.stringify(cache));
+  writeCache();
+  const cfg = { integrations: { hosts: { codex: true } }, codexContext: null };
+  const options = { home, now, runner: async () => ({ code: 0, stdout: 'codex-cli 0.153.4' }), persist: () => {} };
+  return { home, cfg, options, cache, writeCache, source, read: () => fs.readFileSync(path.join(home, 'config.toml'), 'utf8') };
+}
+
+test('native maximum is model-aware and sync is idempotent without altering the cache', async (t) => {
+  const f = fixture(t);
+  const beforeCache = fs.readFileSync(path.join(f.home, 'models_cache.json'), 'utf8');
+  await manageCodexContext(f.cfg, { ...f.options, enable: true });
+  const status = inspectCodexContext(f.cfg, f.options);
+  assert.deepEqual(status.models.map(m => [m.model, m.effectiveWindow]), [
+    ['gpt-6-astra', 828400], ['gpt-5.6-sol', 828400], ['gpt-5.5', 258400],
+  ]);
+  assert.equal(status.drifted, false);
+  assert.equal((await manageCodexContext(f.cfg, f.options)).changed, false);
+  assert.equal(fs.readFileSync(path.join(f.home, 'models_cache.json'), 'utf8'), beforeCache);
+  assert.match(f.read(), /\[tui\]\nstatus_line = \["context-remaining"\]/);
+});
+
+test('unmanaged inspection never writes or requests a repair', (t) => {
+  const f = fixture(t);
+  const result = inspectCodexContext(f.cfg, f.options);
+  assert.equal(result.owned, false);
+  assert.equal(result.drifted, false);
+  assert.equal(f.read(), f.source);
+});
+
+test('restore prior scalar and CRLF formatting when disabling owned context', async (t) => {
+  const f = fixture(t, '# keep\r\nmodel_context_window = 100_000 # original\r\n[tui]\r\nother = true\r\n');
+  await manageCodexContext(f.cfg, { ...f.options, enable: true });
+  assert.equal(/(?<!\r)\n/.test(f.read()), false);
+  await releaseCodexContext(f.cfg, f.options);
+  assert.equal(f.read(), f.source);
+  assert.equal(f.cfg.codexContext, null);
+});
+
+test('disable preserves user edits; sync repairs owned drift', async (t) => {
+  const f = fixture(t);
+  await manageCodexContext(f.cfg, { ...f.options, enable: true });
+  fs.writeFileSync(path.join(f.home, 'config.toml'), f.read().replace('872000', '500000'));
+  assert.equal(inspectCodexContext(f.cfg, f.options).drifted, true);
+  await manageCodexContext(f.cfg, f.options);
+  fs.writeFileSync(path.join(f.home, 'config.toml'), f.read().replace('872000', '400000'));
+  await releaseCodexContext(f.cfg, f.options);
+  assert.match(f.read(), /400000/);
+});
+
+test('multiline instructions and profile tables cannot masquerade as top-level overrides', () => {
+  const parsed = readContextConfig('instructions = """\nmodel_context_window = 1\n"""\nmodel_context_window = 872000\n[profiles.small]\nmodel_context_window = 10\n');
+  assert.equal(parsed.window, 872000);
+});
+
+for (const source of ['model_context_window = 1\nmodel_context_window = 2\n', '"model_context_window" = 1\n', 'model_context_window = -1\n', 'model_context_window = 1.2\n', 'model_context_window = 9007199254740992\n', 'instructions = """\nunterminated']) {
+  test('ambiguous or invalid TOML is rejected before ownership or file mutation: ' + source.slice(0, 40), async t => {
+    const f = fixture(t, source);
+    await assert.rejects(manageCodexContext(f.cfg, { ...f.options, enable: true }));
+    assert.equal(f.read(), source);
+    assert.equal(f.cfg.codexContext, null);
+  });
+}
+
+for (const change of [c => { c.fetched_at = '2020-01-01'; }, c => { c.client_version = '0.999.0'; }, c => { c.models[0].max_context_window = -1; }, c => { c.models = []; }]) {
+  test('untrusted capacity evidence prevents a write', async t => {
+    const f = fixture(t); change(f.cache); f.writeCache();
+    await assert.rejects(manageCodexContext(f.cfg, { ...f.options, enable: true }));
+    assert.equal(f.read(), f.source);
+  });
+}
+
+test('native version mismatch and custom providers cannot acquire ownership', async t => {
+  const f = fixture(t);
+  await assert.rejects(manageCodexContext(f.cfg, { ...f.options, enable: true, runner: async () => ({ code: 0, stdout: 'codex-cli 0.154.0' }) }));
+  fs.writeFileSync(path.join(f.home, 'config.toml'), 'model_provider = "local"\n');
+  await assert.rejects(manageCodexContext(f.cfg, { ...f.options, enable: true }));
+  assert.equal(f.cfg.codexContext, null);
+});
+
+test('ownership persists before writing and failed persistence cannot alter config', async t => {
+  const f = fixture(t);
+  await assert.rejects(manageCodexContext(f.cfg, { ...f.options, enable: true, persist: () => { throw new Error('disk full'); } }));
+  assert.equal(f.read(), f.source);
+});
+
+test('CODEX_HOME must be absolute and ownership cannot cross homes', async t => {
+  assert.throws(() => contextHome({ CODEX_HOME: '../other' }), /absolute/);
+  const f = fixture(t); await manageCodexContext(f.cfg, { ...f.options, enable: true });
+  await assert.rejects(releaseCodexContext(f.cfg, { ...f.options, home: '/another/home' }), /scope/);
+});
+
+test('interrupted reprojection retains both old and pending values for recovery', async t => {
+  const f = fixture(t);
+  await manageCodexContext(f.cfg, { ...f.options, enable: true });
+  f.cache.models[0].max_context_window = 900000; f.writeCache();
+  await assert.rejects(manageCodexContext(f.cfg, { ...f.options, persist: () => { fs.appendFileSync(path.join(f.home, 'config.toml'), '# concurrent edit\n'); } }));
+  assert.equal(f.cfg.codexContext.lastProjection, 872000);
+  assert.equal(f.cfg.codexContext.pendingProjection, 900000);
+  await releaseCodexContext(f.cfg, f.options);
+  assert.equal(f.read(), f.source + '# concurrent edit\n');
+});
+
+test('restoring an original EOF scalar retains a boundary before newly appended settings', async t => {
+  const f = fixture(t, 'model_context_window = 100');
+  await manageCodexContext(f.cfg, { ...f.options, enable: true });
+  fs.appendFileSync(path.join(f.home, 'config.toml'), 'model = "gpt-6-astra"\n');
+  await releaseCodexContext(f.cfg, f.options);
+  assert.equal(readContextConfig(f.read()).model, 'gpt-6-astra');
+  assert.equal(readContextConfig(f.read()).window, 100);
+});
+
+test('failed release persistence retains recovery ownership in memory', async t => {
+  const f = fixture(t); await manageCodexContext(f.cfg, { ...f.options, enable: true });
+  const receipt = structuredClone(f.cfg.codexContext);
+  await assert.rejects(releaseCodexContext(f.cfg, { ...f.options, persist: () => { throw new Error('disk full'); } }));
+  assert.deepEqual(f.cfg.codexContext, receipt);
+  await releaseCodexContext(f.cfg, f.options);
+  assert.equal(f.read(), f.source);
+});
+
+test('repeated interrupted reconciliations retain the owned value actually on disk', async t => {
+  const f = fixture(t); let saves = 0;
+  await assert.rejects(manageCodexContext(f.cfg, { ...f.options, enable: true,
+    persist: () => { if (++saves === 2) throw new Error('final save failed'); },
+  }));
+  assert.equal(f.cfg.codexContext.pendingProjection, 872000);
+  f.cache.models[0].max_context_window = 900000; f.writeCache();
+  await assert.rejects(manageCodexContext(f.cfg, { ...f.options,
+    persist: () => { fs.appendFileSync(path.join(f.home, 'config.toml'), '# race\n'); },
+  }));
+  assert.equal(f.cfg.codexContext.lastProjection, 872000);
+  await releaseCodexContext(f.cfg, f.options);
+  assert.equal(f.read(), f.source + '# race\n');
+});

--- a/tests/kit/model-discovery-claude-codex.test.mjs
+++ b/tests/kit/model-discovery-claude-codex.test.mjs
@@ -190,3 +190,20 @@ test('Codex schema and enum guards degrade explicitly and never manufacture mode
   assert.deepEqual(badEnum.models, []);
   assert.equal(badEnum.source.complete, false);
 });
+
+test('Codex inventory applies configured capacity per model and preserves native defaults', () => {
+  const cache = JSON.parse(fixture('codex', 'models-cache.json'));
+  cache.client_version = '0.153.4';
+  const result = discoverCodex({ cacheRaw: cache, configRaw: 'model_context_window = 872_000\n', scopeKey: SCOPE_KEY });
+  const model = result.models[0];
+  assert.equal(model.variant.contextWindow, 872000);
+  assert.equal(model.variant.nativeContextWindow, 272000);
+  assert.equal(model.variant.configuredContextWindow, 872000);
+  assert.equal(model.variant.effectiveContextWindow, 828400);
+});
+
+test('Codex inventory never fabricates an effective override for an unverified client', () => {
+  const result = discoverCodex({ cacheRaw: fixture('codex', 'models-cache.json'),
+    configRaw: 'model_context_window = 872000\n', scopeKey: SCOPE_KEY });
+  assert.equal(result.models[0].variant.effectiveContextWindow, null);
+});

--- a/tests/live/codex-context-contract.test.mjs
+++ b/tests/live/codex-context-contract.test.mjs
@@ -1,0 +1,34 @@
+// Opt in to three short model requests with AK_CODEX_CONTEXT_CONFORMANCE=1.
+// Proves native allocation/clamping, not successful use of an 828K-token prompt.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { contextHome } from '../../src/lib/codex-context-config.mjs';
+
+const enabled = process.env.AK_CODEX_CONTEXT_CONFORMANCE === '1';
+for (const [model, expected] of [['gpt-6-astra', 828400], ['gpt-5.6-sol', 828400], ['gpt-5.5', 258400]]) {
+  test(`Codex 0.153.4 native per-model clamp: ${model}`, { skip: !enabled, timeout: 65000 }, t => {
+    assert.equal(spawnSync('codex', ['--version'], { encoding: 'utf8', timeout: 5000 }).stdout.trim(), 'codex-cli 0.153.4');
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'ak-context-contract-'));
+    t.after(() => fs.rmSync(cwd, { recursive: true, force: true }));
+    const result = spawnSync('codex', ['exec', '--skip-git-repo-check', '-C', cwd, '-s', 'read-only',
+      '-m', model, ...(process.env.AK_CODEX_CONTEXT_USE_CONFIG === '1' ? [] : ['-c', 'model_context_window=1050000']), '-c', 'model_reasoning_effort="low"',
+      '--json', 'Reply exactly AK_CAPACITY_OK. Do not call any tools.'], { encoding: 'utf8', timeout: 55000, maxBuffer: 4 * 1024 * 1024 });
+    assert.equal(result.status, 0, 'native smoke request must complete');
+    const events = result.stdout.trim().split('\n').map(line => JSON.parse(line));
+    const id = events.find(e => e.type === 'thread.started')?.thread_id;
+    assert.ok(id);
+    assert.ok(events.some(e => e.item?.text === 'AK_CAPACITY_OK'));
+    const sessions = path.join(contextHome(), 'sessions');
+    const files = fs.readdirSync(sessions, { recursive: true }).filter(name => name.endsWith(`${id}.jsonl`));
+    assert.equal(files.length, 1);
+    const records = fs.readFileSync(path.join(sessions, files[0]), 'utf8').trim().split('\n').map(line => JSON.parse(line));
+    const windows = records.filter(r => r.type === 'event_msg' && r.payload.type === 'token_count')
+      .map(r => r.payload.info?.model_context_window).filter(Number.isFinite);
+    assert.ok(windows.length);
+    assert.ok(windows.every(window => window === expected));
+  });
+}


### PR DESCRIPTION
Codex's native status line showed Astra/Sol against their default 258,400-token effective window even though this client supports a larger allocation. Add `ak x codex-context max` to persist an explicit native-maximum preference, reconcile it through setup/sync, report it through status/model inventory, and restore the original scalar on disable/uninstall while preserving user-modified values.

The requested window is derived from a fresh native catalog; the catalog itself is never patched. Codex 0.153.4 caps the request per selected model: Astra/Sol yield 828,400 effective tokens from an 872,000-token native maximum, while GPT-5.5 remains at 258,400. The API's 1,050,000-token capacity is kept separate. Unknown client profiles and unavailable capacity evidence prevent writes. Absolute CODEX_HOME is honored by the new feature and inventory.

Ownership preserves original, successful, and pending values across interrupted writes and failed persistence. The TOML writer uses live-line lexical inspection, preimage checks, backups, and atomic replacement. Auto-compaction remains user/native owned; profile, project, managed, and command-line overrides can supersede the user-scoped setting.

Validation:
- 36 focused tests passed; read-only review findings were fixed with recovery regressions.
- Full test command: 3,753 Node tests passed, six skipped; all subsequent CJS suites passed. Coverage: 91.83% lines, 80.48% branches, 91.28% functions.
- Typecheck, ESLint, complexity lint, Markdown lint, build/package checks, and whitespace checks passed. Existing ESLint warnings remain.
- Three fresh native sessions passed after applying through agentic-kit, with no command-line capacity override. Astra/Sol recorded 828,400 and GPT-5.5 recorded 258,400. Reapplication was a no-op.
- Initial coverage reporting hit truncated JSON; a complete rerun with an isolated coverage directory passed.

Native smoke tests prove allocation/clamping, not actual processing of a near-limit input. This change is opt-in and currently profiles Codex 0.153.4 only; existing sessions require restart.

Depends on the AQE repairs merged in #205. This PR targets main and contains the Codex-context feature plus its maintainer inventory correction. No package release is included.
