### PR TITLE
fix: remediate Ruflo audit detection and release evidence gaps

### DIFF
--- a/config/agentic-dependency-constraints.json
+++ b/config/agentic-dependency-constraints.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 3,
+  "schemaVersion": 4,
   "lastVerifiedAt": "2026-09-02",
   "recheckPolicy": {
     "cadence": "weekly-and-before-upgrade",
@@ -79,14 +79,13 @@
       "dependency": "ruflo",
       "kind": "blocked-version",
       "affected": ["3.38.17", "3.38.18"],
-      "issue": "https://github.com/ruvnet/ruflo/issues/2885",
-      "issueState": "open-at-last-verification",
-      "primaryEvidence": "upstream issue plus local host conformance failure",
+      "releaseUrl": "https://github.com/ruvnet/ruflo/releases/tag/v3.38.19",
+      "primaryEvidence": "Ruflo 3.38.19 release notes explicitly deprecate 3.38.17/18 because concurrent publication broke the dependency graph; verified 2026-09-09.",
       "strategy": "retain the last proven version and re-run host conformance before removing the block",
       "versionGate": "apply only when the installed version exactly matches an affected entry",
       "expiryPolicy": "retest within 14 days; do not silently extend stale evidence",
       "nextRetestAt": "2026-09-09",
-      "sunsetWhen": "an upstream release closes the issue and passes agentic-kit's host-neutral hook and lifecycle conformance suite",
+      "sunsetWhen": "keep the immutable bad-version block; qualify a different released version through host-neutral conformance",
       "notification": {
         "status": "draft-only",
         "requiredFields": ["minimalReproduction", "expected", "observed", "hostVersions", "dependencyVersion", "evidenceDigests", "boundedWorkaround", "expiry", "removalProof"]

--- a/docs/audits/2026-09-09-ruflo-remediation.md
+++ b/docs/audits/2026-09-09-ruflo-remediation.md
@@ -1,0 +1,65 @@
+# Ruflo audit remediation: first pass
+
+This follows the [cross-host audit](2026-09-09-ruflo-cross-host-alignment.md).
+PR #207 was squash-merged as `8dc6924`; this work branched from that main revision.
+
+## Repository changes
+
+- Detect effective duplicate Codex Ruflo transports even with environment tables,
+  aliases, or layered configuration. Automatic removal still requires the existing
+  strict ownership match; detection does not grant deletion authority.
+- Report release observations per package, distinguishing live, cached, and failed
+  refresh fallback. Historical cache entries with no timestamp disclose that gap.
+- Inspect Claude's selected user-scope Brain plugin, independently of its marketplace
+  and KB versions. Report missing commands, ambiguous payloads, and hook declarations
+  outside the audited 4.3.16 baseline. Static inspection does not prove execution.
+- Bind the blocked Ruflo release constraint to actual release evidence, using schema 4
+  rather than an unrelated issue reference.
+
+## Machine remediation and evidence
+
+Configuration preimages are retained under the local agentic-kit backups directory,
+in `ruflo-audit-remediation-20260909`. No memory databases were reset or migrated.
+
+| Action or proof | Result |
+| --- | --- |
+| Exact Ruflo upgrade | 3.39.0 to 3.39.2; resolved fast-uri 3.1.7 |
+| `ak sync --no-upgrade --yes` | Exit 0; repaired aidefence and native bindings, refreshed OpenCode projection and Claude footer |
+| Codex duplicate removal | Backed up config; removed user `claude-flow` with native CLI after confirming its sole browser environment setting matches the canonical launcher |
+| Fresh canonical Ruflo MCP discovery | Ready, 356 tools; initialize 76 ms, total 80 ms |
+| Isolated memory proof after healing | Store/retrieve exact value and on-disk compatibility-store row passed; temporary namespace purged |
+| Existing native corpus proof | Known native AgentDB row present, but CLI retrieve returned exit 1; unresolved |
+| Exact Brain installer | KB 4.3.16 installed with signature validation; source-grounded search verified in 121.8 seconds |
+| Claude Brain plugin update | Native plugin update moved selected payload from 0.5.0-dev to 4.3.17 |
+| Codex Brain plugin | Installer reported installed and enabled at 4.3.16; existing sessions require restart |
+
+The Brain installer exited 1: the marketplace advanced to 4.3.17 during this work.
+That payload explicitly declares bounded SessionStart and Stop continuity hooks,
+while the 4.3.16 installer requires zero automatic registrations. The hooks were
+preserved. This is a version-contract mismatch, not proof that the new hooks are
+unintended. The selected 4.3.17 payload now includes `commands/rvbc.md`.
+
+## Remaining work
+
+1. Qualify Brain 4.3.17's continuity contract and align installer, KB, and both host
+   projections. Release metadata was published at 2026-09-09T14:11:20Z:
+   <https://github.com/stuinfla/ruvnet-brain/releases/tag/v4.3.17>.
+2. Correct existing-corpus routing and strengthen memory health reporting. Native
+   dependency presence and an isolated canary do not prove access to existing data.
+   Windows split-store behavior still needs platform-specific validation.
+3. Run fresh host execution checks after restarting Claude and Codex. A live session
+   can retain an old tool catalog; no measured context-token reduction is claimed.
+4. Retain the audit's unresolved upstream constraints and unrelated user plugin
+   warnings. A fresh release check also observed OpenCode 1.18.30; this pass kept
+   installed 1.18.29 rather than qualifying another runtime incidentally.
+
+## Validation
+
+Full suite at `5235721`: 3,772 tests, 3,766 passed, six skipped; coverage 91.88%
+lines, 80.55% branches, 91.34% functions. Typecheck, Markdown lint, complexity
+gate, and build passed. The final Brain warning wording was checked with its
+seven focused tests. Independent source review found no remaining blockers.
+
+Eight proven-merged local branches and 23 stale worktree metadata records were
+removed. Existing worktree files, archives, and branches with uncertain merge
+status were preserved. Dashboard project grouping remains queued and unstarted.

--- a/src/commands/status/sections/codex-mcp.mjs
+++ b/src/commands/status/sections/codex-mcp.mjs
@@ -69,7 +69,7 @@ function topologyRows(cwd) {
     }
     if (topology.duplicateRuflo) {
       rows.push(row('codex-mcp', 'warn',
-        `duplicate Ruflo MCP registrations in Codex: ${topology.rufloRegistrations.map((entry) => entry.name).join(', ')}`,
+        `duplicate Ruflo MCP registrations in Codex: ${topology.effectiveRufloRegistrations.map((entry) => entry.name).join(', ')}`,
         'keep the workspace-aware [mcp_servers.ruflo] entry and remove legacy duplicates after reviewing ownership'));
     }
   } catch (e) {

--- a/src/commands/status/sections/ruvnet-brain.mjs
+++ b/src/commands/status/sections/ruvnet-brain.mjs
@@ -2,6 +2,18 @@
 // on disk, drift via GitHub releases, TTL-cached like `self`)
 import { drift as ruvnetBrainDrift, nightlyAgentPresent as rbNightlyPresent, NIGHTLY_LABEL as RB_NIGHTLY_LABEL } from '../../../lib/ruvnet-brain.mjs';
 import { row } from '../row.mjs';
+import { inspectClaudeBrainPlugin } from '../../../lib/ruvnet-brain-plugin.mjs';
+import { releaseObservationLabel } from '../../../lib/versions.mjs';
+
+export function brainPluginRows(state) {
+  const enabled = state.enabled === true ? 'enabled' : state.enabled === false ? 'disabled' : 'enablement unknown';
+  const selected = state.payloadVersion ?? state.registryVersion ?? 'unknown';
+  if (state.registration === 'absent') return [row('ruvnet-brain-plugin', 'info',
+    'Claude user plugin registry has no Brain registration; KB and MCP health are separate')];
+  const summary = `Claude user Brain plugin ${selected} (${enabled}; project overrides and runtime unverified)`;
+  return [row('ruvnet-brain-plugin', state.issues.length ? 'warn' : 'info',
+    `${summary}; ${state.issues.length ? state.issues.join('; ') : 'selected payload passes static checks'}`)];
+}
 
 /** One status row for the installed/release state. A GitHub tag without the
  *  installer's required bundle asset is visible but deliberately non-actionable:
@@ -33,9 +45,9 @@ export function brainReleaseRow(b) {
   if (b.outdated) {
     const have = b.installedRelease ? `release v${b.installedRelease}` : 'present (unversioned install)';
     return row('ruvnet-brain', 'warn',
-      `ruvnet-brain ${have}, release v${b.latest} available`, 'sync refreshes the KB');
+      `ruvnet-brain ${have}, release v${b.latest} available (${releaseObservationLabel(b)})`, 'sync refreshes the KB');
   }
-  const shown = b.installedRelease ? `release v${b.installedRelease}${b.latest ? ' (latest)' : ''}` : 'present';
+  const shown = b.installedRelease ? `release v${b.installedRelease}${b.latest ? ` (latest known; ${releaseObservationLabel(b)})` : ' (release metadata unavailable)'}` : 'present';
   return row('ruvnet-brain', 'ok', `ruvnet-brain ${shown}`);
 }
 
@@ -50,6 +62,7 @@ export default {
     } catch (e) {
       rows.push(row('ruvnet-brain', 'warn', `ruvnet-brain check unavailable: ${e.message}`));
     }
+    rows.push(...brainPluginRows(inspectClaudeBrainPlugin()));
     // The installer's own nightly self-updater (macOS LaunchAgent, 03:47) bypasses
     // ak-managed updates: it rewrites the KB outside ak's release stamp, so status
     // and the statusline drift from disk. Own subsystem so sync's fix is "disable

--- a/src/commands/status/sections/versions.mjs
+++ b/src/commands/status/sections/versions.mjs
@@ -1,4 +1,4 @@
-import { driftReport } from '../../../lib/versions.mjs';
+import { driftReport, releaseObservationLabel } from '../../../lib/versions.mjs';
 import { row } from '../row.mjs';
 
 export default {
@@ -12,9 +12,10 @@ export default {
             `${r.pkg} not installed globally`, 'setup installs it'));
         } else if (r.outdated) {
           rows.push(row('versions', 'warn',
-            `${r.pkg} ${r.installed} installed, ${r.latest} available`, 'sync upgrades + re-heals'));
+            `${r.pkg} ${r.installed} installed, ${r.latest} available (${releaseObservationLabel(r)})`, 'sync upgrades + re-heals'));
         } else {
-          rows.push(row('versions', 'ok', `${r.pkg} ${r.installed}${r.latest ? ' (latest)' : ''}`));
+          rows.push(row('versions', r.latest ? 'ok' : 'info',
+            `${r.pkg} ${r.installed}${r.latest ? ` (latest known; ${releaseObservationLabel(r)})` : ' (release metadata unavailable)'}`));
         }
       }
     } catch (e) {

--- a/src/lib/hook-audit/upstream.mjs
+++ b/src/lib/hook-audit/upstream.mjs
@@ -7,6 +7,16 @@ const defaultFile = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '
 const ISSUE_STATES = new Set(['open-at-last-verification', 'closed-at-last-verification']);
 const NOTIFICATION_STATES = new Set(['draft-only', 'published']);
 
+function validConstraintSource(entry, schemaVersion) {
+  if (typeof entry.issue === 'string' && /^https:\/\/github\.com\/[^/]+\/[^/]+\/issues\/\d+$/.test(entry.issue)) {
+    return ISSUE_STATES.has(entry.issueState);
+  }
+  return schemaVersion === 4 && entry.kind === 'blocked-version'
+    && entry.issue == null && entry.issueState == null
+    && typeof entry.releaseUrl === 'string'
+    && /^https:\/\/github\.com\/[\w.-]+\/[\w.-]+\/releases\/tag\/[\w.-]+$/.test(entry.releaseUrl);
+}
+
 function validDate(value) {
   return typeof value === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(value)
     && Number.isFinite(Date.parse(`${value}T00:00:00Z`))
@@ -29,7 +39,7 @@ export function loadUpstreamConstraints({
   const document = source.document;
   const errors = [];
   const asOf = now();
-  if (![2, 3].includes(document?.schemaVersion)) errors.push('unsupported upstream constraint schema');
+  if (![2, 3, 4].includes(document?.schemaVersion)) errors.push('unsupported upstream constraint schema');
   if (!Array.isArray(document?.constraints)) errors.push('constraints must be an array');
   if (!Array.isArray(document?.dependencyPolicies)) errors.push('dependencyPolicies must be an array');
   if (!validDate(document?.lastVerifiedAt)) errors.push('lastVerifiedAt must be an ISO date');
@@ -61,8 +71,7 @@ export function loadUpstreamConstraints({
       && typeof entry.id === 'string' && typeof entry.dependency === 'string' && typeof entry.kind === 'string'
       && Array.isArray(entry.affected) && typeof entry.strategy === 'string'
       && typeof entry.primaryEvidence === 'string' && typeof entry.versionGate === 'string'
-      && typeof entry.issue === 'string' && /^https:\/\/github\.com\/[^/]+\/[^/]+\/issues\/\d+$/.test(entry.issue)
-      && ISSUE_STATES.has(entry.issueState)
+      && validConstraintSource(entry, document.schemaVersion)
       && typeof entry.expiryPolicy === 'string' && validDate(entry.nextRetestAt)
       && typeof entry.sunsetWhen === 'string'
       && NOTIFICATION_STATES.has(entry.notification?.status)

--- a/src/lib/mcp.mjs
+++ b/src/lib/mcp.mjs
@@ -202,6 +202,8 @@ function codexMcpSections(file, scope) {
     const body = source.slice(bodyStart, bodyEnd);
     const command = tomlString(/^\s*command\s*=\s*("(?:[^"\\]|\\.)*")\s*$/m.exec(body)?.[1]);
     const args = tomlStringArray(/^\s*args\s*=\s*(\[[^\n]*\])\s*$/m.exec(body)?.[1]);
+    const enabledValue = /^\s*enabled\s*=\s*(true|false)\s*(?:#.*)?$/m.exec(body)?.[1];
+    const enabled = enabledValue == null ? undefined : enabledValue === 'true';
     const meaningful = body.split(/\r?\n/).map((line) => line.trim())
       .filter((line) => line && !line.startsWith('#'));
     const exactFields = meaningful.length === 2
@@ -216,7 +218,7 @@ function codexMcpSections(file, scope) {
     if (exactFields && !hasChildren && name === 'claude-flow' && command === 'ruflo'
       && sameArgs(args, ['mcp', 'start'])) repairKind = 'legacy-ruflo';
     return [{
-      name, scope, file, command, args, repairKind, regularFile,
+      name, scope, file, command, args, enabled, repairKind, regularFile,
       fingerprint: fingerprint(source.slice(header.index, bodyEnd)),
       start: header.index, end: bodyEnd, source,
     }];
@@ -240,17 +242,31 @@ export function codexMcpTopology({ cwd = process.cwd(), home = os.homedir() } = 
   const selfRegistrations = registrations.filter((entry) =>
     entry.name === 'codex' && entry.command === 'codex' && entry.args?.includes('mcp-server'));
   const agenticQeRegistrations = registrations.filter((entry) => entry.name === 'agentic-qe');
-  const rufloRegistrations = registrations.filter((entry) =>
-    (entry.name === 'ruflo' && (entry.command === 'ruflo'
-      || (entry.command === 'ak' && sameArgs(entry.args, ['x', 'ruflo-mcp']))))
-    || entry.repairKind === 'legacy-ruflo');
+  // Detection is broader than permission to remove a table. Custom environment
+  // and timeout fields preserve ownership without hiding duplicate transports.
+  const isRuflo = (entry) => (entry.command === 'ruflo' && sameArgs(entry.args, ['mcp', 'start']))
+    || (entry.command === 'ak' && sameArgs(entry.args, ['x', 'ruflo-mcp']));
+  const rufloRegistrations = registrations.filter(isRuflo);
+  // Merge observed fields user→project: a timeout-only project table inherits
+  // the user's transport. Keep raw tables separate for exact repair matching.
+  const layered = new Map();
+  for (const entry of [...registrations].reverse()) {
+    const prior = layered.get(entry.name);
+    layered.set(entry.name, { ...entry,
+      command: entry.command ?? prior?.command,
+      args: entry.args ?? prior?.args,
+      enabled: entry.enabled ?? prior?.enabled ?? true,
+    });
+  }
+  const effectiveRufloRegistrations = [...layered.values()].filter((entry) => entry.enabled && isRuflo(entry));
   return {
     files,
     registrations,
     selfRegistrations,
     agenticQeRegistrations,
     rufloRegistrations,
-    duplicateRuflo: rufloRegistrations.length > 1,
+    effectiveRufloRegistrations,
+    duplicateRuflo: effectiveRufloRegistrations.length > 1,
   };
 }
 

--- a/src/lib/ruvnet-brain-plugin.mjs
+++ b/src/lib/ruvnet-brain-plugin.mjs
@@ -75,7 +75,7 @@ export function inspectClaudeBrainPlugin({ claudeRoot = claudeDir() } = {}) {
     const hooks = readJson(payloadFile(root, 'hooks/hooks.json'))?.hooks;
     if (!object(hooks)) throw new Error('invalid hooks');
     result.hookEvents = Object.keys(hooks);
-    if (result.hookEvents.length) result.issues.push(`Selected payload declares retired automatic hooks: ${result.hookEvents.join(', ')}`);
+    if (result.hookEvents.length) result.issues.push(`Selected payload declares automatic hooks outside the audited 4.3.16 retirement baseline: ${result.hookEvents.join(', ')}`);
   } catch { result.issues.push('Automatic hook retirement is unverified: missing or invalid hook manifest'); }
   return result;
 }

--- a/src/lib/ruvnet-brain-plugin.mjs
+++ b/src/lib/ruvnet-brain-plugin.mjs
@@ -1,0 +1,81 @@
+// Static observations of the selected Claude user plugin, independent of the
+// marketplace checkout and KB release. Never loads plugin code or repairs it.
+import fs from 'node:fs';
+import path from 'node:path';
+import { claudeDir } from './paths.mjs';
+
+const ID = 'ruvnet-brain@ruvnet-brain';
+const object = (v) => v && typeof v === 'object' && !Array.isArray(v);
+const readJson = (file) => JSON.parse(fs.readFileSync(file, 'utf8'));
+const within = (root, file) => file.startsWith(`${root}${path.sep}`);
+
+function payloadFile(root, relative) {
+  const file = path.join(root, relative);
+  const stat = fs.lstatSync(file);
+  if (!stat.isFile() || stat.isSymbolicLink() || !within(root, fs.realpathSync(file))) {
+    throw new Error(`${relative} is not a regular file inside the selected payload`);
+  }
+  return file;
+}
+
+/** User-scope enablement only; project and managed-policy overrides are unknown. */
+export function inspectClaudeBrainPlugin({ claudeRoot = claudeDir() } = {}) {
+  const result = {
+    registration: 'absent', scope: 'user', enabled: null,
+    registryVersion: null, payloadVersion: null, hookEvents: [], issues: [],
+    evidence: 'static-registry-and-files', runtimeVerified: false,
+  };
+  if (!path.isAbsolute(claudeRoot)) {
+    result.registration = 'invalid'; result.issues.push('Claude config root is not absolute'); return result;
+  }
+  try {
+    const enabled = readJson(path.join(claudeRoot, 'settings.json'))?.enabledPlugins?.[ID];
+    if (typeof enabled === 'boolean') result.enabled = enabled;
+  } catch { /* No claim about enablement when settings are unavailable. */ }
+  let records;
+  try {
+    const registry = readJson(path.join(claudeRoot, 'plugins', 'installed_plugins.json'));
+    if (!object(registry) || !object(registry.plugins)) throw new Error('invalid registry');
+    records = registry.plugins[ID];
+    if (records == null) return result;
+    if (!Array.isArray(records)) throw new Error('invalid plugin records');
+  } catch (error) {
+    if (error.code === 'ENOENT' && result.enabled !== true) return result;
+    result.registration = 'invalid'; result.issues.push('Claude plugin registry is missing or invalid'); return result;
+  }
+  const users = records.filter((r) => object(r) && r.scope === 'user');
+  if (users.length !== 1) {
+    result.registration = 'invalid'; result.issues.push('Expected one unambiguous user plugin registration'); return result;
+  }
+  const record = users[0];
+  result.registration = 'present';
+  result.registryVersion = typeof record.version === 'string' ? record.version : null;
+  let root;
+  try {
+    if (typeof record.installPath !== 'string' || !path.isAbsolute(record.installPath)) throw new Error('invalid path');
+    const cache = fs.realpathSync(path.join(claudeRoot, 'plugins', 'cache', 'ruvnet-brain', 'ruvnet-brain'));
+    root = fs.realpathSync(record.installPath);
+    if (!within(cache, root)) throw new Error('outside cache');
+  } catch {
+    result.registration = 'invalid'; result.issues.push('Selected payload is missing or outside the managed Brain cache'); return result;
+  }
+  try {
+    const manifest = readJson(payloadFile(root, '.claude-plugin/plugin.json'));
+    if (manifest?.name !== 'ruvnet-brain' || typeof manifest.version !== 'string') throw new Error('invalid manifest');
+    result.payloadVersion = manifest.version;
+    if (manifest.hooks !== undefined && manifest.hooks !== './hooks/hooks.json') {
+      result.issues.push('Explicit plugin hook declaration is outside the verified retirement contract');
+    }
+    if (result.registryVersion !== manifest.version) result.issues.push('Registry and selected payload versions differ');
+  } catch { result.issues.push('Selected plugin manifest is missing or invalid'); }
+  try { payloadFile(root, 'commands/rvbc.md'); }
+  catch { result.issues.push('Selected payload lacks the current regular commands/rvbc.md entry'); }
+  // Inspect independently: a missing command must not hide retired hook events.
+  try {
+    const hooks = readJson(payloadFile(root, 'hooks/hooks.json'))?.hooks;
+    if (!object(hooks)) throw new Error('invalid hooks');
+    result.hookEvents = Object.keys(hooks);
+    if (result.hookEvents.length) result.issues.push(`Selected payload declares retired automatic hooks: ${result.hookEvents.join(', ')}`);
+  } catch { result.issues.push('Automatic hook retirement is unverified: missing or invalid hook manifest'); }
+  return result;
+}

--- a/src/lib/ruvnet-brain.mjs
+++ b/src/lib/ruvnet-brain.mjs
@@ -179,10 +179,12 @@ export async function drift({ force = false } = {}) {
   // metadata before collection; ordinary status waits for the normal TTL.
   const fresh = !force && cached.last && Date.now() - cached.last < ttlMs;
   let latest = fresh ? cached.latest ?? null : null;
+  let latestObservedAt = fresh ? cached.last : null;
   let releaseAssetAvailable = fresh ? cached.releaseAssetAvailable ?? null : null;
   if (!fresh) {
     const release = await latestRelease();
     latest = release?.version ?? null;
+    latestObservedAt = latest ? Date.now() : null;
     releaseAssetAvailable = release?.releaseAssetAvailable ?? null;
     // Preserve installedRelease across the cache write.
     cfg.versionCheck = {
@@ -195,6 +197,8 @@ export async function drift({ force = false } = {}) {
   return {
     ...classifyDrift({ present: present(), installedRelease, latest }),
     releaseAssetAvailable,
+    latestSource: fresh ? 'cache' : 'live',
+    latestObservedAt,
     pluginVersion: installedVersion(),
   };
 }

--- a/src/lib/versions.mjs
+++ b/src/lib/versions.mjs
@@ -81,17 +81,19 @@ export async function driftReport({ force = false, fetchLatest = latestVersion }
   const pkgs = ['ruflo', 'agentic-qe', ...HOST_PKGS.filter((p) => installedVersion(p))];
   const report = [];
   const cached = cfg.versionCheck?.seen ?? {};
+  const observedAt = { ...cfg.versionCheck?.observedAt };
+  const live = new Set();
   let latest = cached;
   if (!fresh) {
     latest = {};
     let succeeded = 0;
     for (const p of pkgs) {
       const v = await fetchLatest(p);
-      if (v) succeeded += 1;
+      if (v) { succeeded += 1; live.add(p); observedAt[p] = Date.now(); }
       latest[p] = v ?? cached[p] ?? null;
     }
     if (succeeded > 0) {
-      cfg.versionCheck = { ...cfg.versionCheck, last: Date.now(), seen: latest };
+      cfg.versionCheck = { ...cfg.versionCheck, last: Date.now(), seen: latest, observedAt };
       try { saveKitConfig(cfg); } catch { /* read-only envs: nudge just re-fetches */ }
     }
   }
@@ -101,10 +103,19 @@ export async function driftReport({ force = false, fetchLatest = latestVersion }
       pkg: p,
       installed,
       latest: latest[p] ?? null,
+      latestSource: live.has(p) ? 'live' : fresh ? 'cache' : 'cache-fallback',
+      latestObservedAt: observedAt[p] ?? null,
       outdated: !!(installed && latest[p] && newer(latest[p], installed)),
     });
   }
   return report;
+}
+
+/** Do not turn cached registry data into an unqualified "latest" claim. */
+export function releaseObservationLabel({ latestSource, latestObservedAt }) {
+  const when = Number.isFinite(latestObservedAt) && latestObservedAt > 0
+    && latestObservedAt <= 8.64e15 ? new Date(latestObservedAt).toISOString() : 'time unknown';
+  return `${latestSource ?? 'unverified'}; observed ${when}`;
 }
 
 export const KIT_PKG = '@pacphi/agentic-kit';

--- a/tests/kit/codex-mcp.test.mjs
+++ b/tests/kit/codex-mcp.test.mjs
@@ -117,6 +117,39 @@ test('Codex MCP topology detects recursive self-registration, duplicate Ruflo, a
   } finally { rm(dir); rm(home); }
 });
 
+test('Codex should detect an environment-bearing Ruflo duplicate without allowing automatic removal', () => {
+  const dir = tmpProject();
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'kit-codexmcp-home-'));
+  try {
+    fs.mkdirSync(path.join(home, '.codex'), { recursive: true });
+    const file = path.join(home, '.codex', 'config.toml');
+    const source = [
+      '[mcp_servers.claude-flow]', 'command = "ruflo"', 'args = ["mcp", "start"]',
+      '[mcp_servers.claude-flow.env]', 'AGENT_BROWSER_CONFIG = "/owned/browser.json"',
+      '[mcp_servers.ruflo]', 'command = "ak"', 'args = ["x", "ruflo-mcp"]', '',
+    ].join('\n');
+    fs.writeFileSync(file, source);
+    const topology = codexMcpTopology({ cwd: dir, home });
+    assert.equal(topology.duplicateRuflo, true);
+    assert.deepEqual(codexMcpRepairPlan(topology), []);
+    assert.equal(fs.readFileSync(file, 'utf8'), source);
+  } finally { rm(dir); rm(home); }
+});
+
+test('Codex should exclude disabled transports from duplicate detection', () => {
+  const dir = tmpProject();
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'kit-codexmcp-home-'));
+  try {
+    fs.mkdirSync(path.join(home, '.codex'), { recursive: true });
+    fs.writeFileSync(path.join(home, '.codex', 'config.toml'), [
+      '[mcp_servers.claude-flow]', 'command = "ruflo"', 'args = ["mcp", "start"]',
+      'enabled = false # retained by the user',
+      '[mcp_servers.ruflo]', 'command = "ak"', 'args = ["x", "ruflo-mcp"]', '',
+    ].join('\n'));
+    assert.equal(codexMcpTopology({ cwd: dir, home }).duplicateRuflo, false);
+  } finally { rm(dir); rm(home); }
+});
+
 test('Codex MCP topology treats absent and malformed files as empty', () => {
   const dir = tmpProject();
   const home = fs.mkdtempSync(path.join(os.tmpdir(), 'kit-codexmcp-home-'));
@@ -129,8 +162,32 @@ test('Codex MCP topology treats absent and malformed files as empty', () => {
       selfRegistrations: [],
       agenticQeRegistrations: [],
       rufloRegistrations: [],
+      effectiveRufloRegistrations: [],
       duplicateRuflo: false,
     });
+  } finally { rm(dir); rm(home); }
+});
+
+test('Codex should count a repeated configured name once and honor a disabled project override', () => {
+  const dir = tmpProject();
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'kit-codexmcp-home-'));
+  try {
+    for (const root of [dir, home]) fs.mkdirSync(path.join(root, '.codex'), { recursive: true });
+    const canonical = '[mcp_servers.ruflo]\ncommand = "ak"\nargs = ["x", "ruflo-mcp"]\n';
+    fs.writeFileSync(path.join(home, '.codex', 'config.toml'), canonical);
+    fs.writeFileSync(path.join(dir, '.codex', 'config.toml'), canonical);
+    assert.equal(codexMcpTopology({ cwd: dir, home }).duplicateRuflo, false);
+    fs.appendFileSync(path.join(home, '.codex', 'config.toml'),
+      '[mcp_servers.custom-ruflo]\ncommand = "ruflo"\nargs = ["mcp", "start"]\n');
+    assert.equal(codexMcpTopology({ cwd: dir, home }).duplicateRuflo, true);
+    fs.appendFileSync(path.join(dir, '.codex', 'config.toml'),
+      '[mcp_servers.custom-ruflo]\nstartup_timeout_sec = 60\nenabled = true\n');
+    assert.equal(codexMcpTopology({ cwd: dir, home }).duplicateRuflo, true,
+      'a partial project override retains inherited command and args');
+    fs.writeFileSync(path.join(dir, '.codex', 'config.toml'), canonical);
+    fs.appendFileSync(path.join(dir, '.codex', 'config.toml'),
+      '[mcp_servers.custom-ruflo]\nenabled = false\n');
+    assert.equal(codexMcpTopology({ cwd: dir, home }).duplicateRuflo, false);
   } finally { rm(dir); rm(home); }
 });
 

--- a/tests/kit/drift-freshness.test.mjs
+++ b/tests/kit/drift-freshness.test.mjs
@@ -68,6 +68,20 @@ test('a successful forced fetch updates seen, stamps last, and reports drift', a
   assert.ok(after.last > 1, 'last stamped on success');
 });
 
+test('release observations should retain per-package timestamps after a partial refresh failure', async () => {
+  seedHome({ last: 1, seen: { ruflo: '9.9.9', 'agentic-qe': '9.9.9' } });
+  const first = await driftReport({ force: true, fetchLatest: async () => '9.9.10' });
+  const observed = first.find((r) => r.pkg === 'agentic-qe').latestObservedAt;
+  assert.ok(observed > 0);
+  const partial = await driftReport({ force: true, fetchLatest: async (pkg) => pkg === 'ruflo' ? '9.9.11' : null });
+  const aqe = partial.find((r) => r.pkg === 'agentic-qe');
+  assert.equal(aqe.latestSource, 'cache-fallback');
+  assert.equal(aqe.latestObservedAt, observed);
+  const cached = await driftReport({ fetchLatest: async () => { throw new Error('fresh cache must not fetch'); } });
+  assert.equal(cached.find((r) => r.pkg === 'agentic-qe').latestObservedAt, observed);
+  assert.equal(cached.find((r) => r.pkg === 'ruflo').latestSource, 'cache');
+});
+
 test('a STALE cache with newer seen data reaches the sync plan even when npm is unreachable', async () => {
   // The collect() path: last=0 forces a refetch; offline that refetch fails.
   // Resilient fallback must keep 9.9.10 visible so the plan includes the upgrade.

--- a/tests/kit/fixtures/status-golden.json
+++ b/tests/kit/fixtures/status-golden.json
@@ -8,13 +8,13 @@
   {
     "subsystem": "versions",
     "level": "ok",
-    "message": "ruflo 9.9.9 (latest)",
+    "message": "ruflo 9.9.9 (latest known; cache; observed time unknown)",
     "fix": null
   },
   {
     "subsystem": "versions",
     "level": "ok",
-    "message": "agentic-qe 9.9.9 (latest)",
+    "message": "agentic-qe 9.9.9 (latest known; cache; observed time unknown)",
     "fix": null
   },
   {

--- a/tests/kit/hook-upstream.test.mjs
+++ b/tests/kit/hook-upstream.test.mjs
@@ -16,6 +16,9 @@ test('upstream registry separates valid shape, current evidence, and version app
   assert.equal(result.status, 'valid');
   assert.equal(result.registryStatus, 'valid');
   assert.equal(result.evidenceStatus, 'current');
+  const publication = result.constraints.find((entry) => entry.id === 'ruflo-3.38.17-3.38.18-block');
+  assert.equal(publication.issue, undefined);
+  assert.match(publication.releaseUrl, /releases\/tag\/v3\.38\.19$/);
   const blocked = result.constraints.find((entry) => entry.id === 'ruflo-3.38.17-3.38.18-block');
   assert.equal(blocked.evidence.observedVersion, '3.38.17');
   assert.equal(blocked.evidence.applicability, 'affected');

--- a/tests/kit/ruvnet-brain-plugin.test.mjs
+++ b/tests/kit/ruvnet-brain-plugin.test.mjs
@@ -1,0 +1,99 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { inspectClaudeBrainPlugin } from '../../src/lib/ruvnet-brain-plugin.mjs';
+import { brainPluginRows } from '../../src/commands/status/sections/ruvnet-brain.mjs';
+
+function fixture(t) {
+  const claudeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ak-brain-plugin-'));
+  t.after(() => fs.rmSync(claudeRoot, { recursive: true, force: true }));
+  const payload = path.join(claudeRoot, 'plugins/cache/ruvnet-brain/ruvnet-brain/4.3.14');
+  const write = (file, value) => { fs.mkdirSync(path.dirname(file), { recursive: true }); fs.writeFileSync(file, JSON.stringify(value)); };
+  const record = { scope: 'user', version: '4.3.14', installPath: payload };
+  const registry = (records) => write(path.join(claudeRoot, 'plugins/installed_plugins.json'),
+    { plugins: { 'ruvnet-brain@ruvnet-brain': records } });
+  registry([record]);
+  write(path.join(claudeRoot, 'settings.json'), { enabledPlugins: { 'ruvnet-brain@ruvnet-brain': true } });
+  write(path.join(payload, '.claude-plugin/plugin.json'), { name: 'ruvnet-brain', version: '4.3.14' });
+  write(path.join(payload, 'commands/rvbc.md'), 'console');
+  write(path.join(payload, 'hooks/hooks.json'), { hooks: {} });
+  return { claudeRoot, payload, record, registry, write, inspect: () => inspectClaudeBrainPlugin({ claudeRoot }) };
+}
+
+test('Brain should observe the selected payload without asserting runtime health or prescribing sync', (t) => {
+  const f = fixture(t);
+  f.write(path.join(f.claudeRoot, 'plugins/marketplaces/ruvnet-brain/plugin/.claude-plugin/plugin.json'),
+    { name: 'ruvnet-brain', version: '99.0.0' });
+  const r = f.inspect();
+  assert.equal(r.payloadVersion, '4.3.14');
+  assert.deepEqual(r.issues, []);
+  assert.equal(r.runtimeVerified, false);
+  assert.equal(brainPluginRows(r)[0].fix, null);
+});
+
+test('Brain should disclose both missing commands and retired hooks in a disabled old payload', (t) => {
+  const f = fixture(t);
+  fs.unlinkSync(path.join(f.payload, 'commands/rvbc.md'));
+  f.write(path.join(f.payload, 'hooks/hooks.json'), { hooks: { SessionStart: [], UserPromptSubmit: [], PreToolUse: [] } });
+  f.write(path.join(f.claudeRoot, 'settings.json'), { enabledPlugins: { 'ruvnet-brain@ruvnet-brain': false } });
+  const r = f.inspect();
+  assert.equal(r.enabled, false);
+  assert.equal(r.issues.length, 2);
+  assert.deepEqual(r.hookEvents, ['SessionStart', 'UserPromptSubmit', 'PreToolUse']);
+  assert.match(brainPluginRows(r)[0].message, /disabled.*runtime unverified/);
+});
+
+test('Brain should reject ambiguous registrations and paths outside the managed cache', (t) => {
+  const f = fixture(t);
+  f.registry([f.record, f.record]);
+  assert.equal(f.inspect().registration, 'invalid');
+  for (const installPath of ['relative', f.claudeRoot]) {
+    f.registry([{ ...f.record, installPath }]);
+    assert.equal(f.inspect().registration, 'invalid');
+  }
+});
+
+test('Brain should not claim retirement for an uninspected explicit hook declaration', (t) => {
+  const f = fixture(t);
+  for (const hooks of ['./other-hooks.json', { hooks: { SessionStart: [] } }]) {
+    f.write(path.join(f.payload, '.claude-plugin/plugin.json'), { name: 'ruvnet-brain', version: '4.3.14', hooks });
+    assert.match(f.inspect().issues.join(' '), /outside the verified retirement contract/);
+  }
+});
+
+test('Brain should keep absent, malformed and unverified hook state distinct', (t) => {
+  const f = fixture(t);
+  f.registry([]);
+  assert.equal(f.inspect().registration, 'invalid');
+  f.registry([f.record]);
+  f.write(path.join(f.payload, 'hooks/hooks.json'), { hooks: null });
+  assert.match(f.inspect().issues.join(' '), /retirement is unverified/);
+  f.write(path.join(f.claudeRoot, 'plugins/installed_plugins.json'), { plugins: {} });
+  assert.equal(f.inspect().registration, 'absent');
+  f.write(path.join(f.claudeRoot, 'plugins/installed_plugins.json'), {});
+  assert.equal(f.inspect().registration, 'invalid');
+});
+
+test('Brain should honor CLAUDE_CONFIG_DIR without writing to its selected payload', (t) => {
+  const f = fixture(t);
+  const before = fs.readFileSync(path.join(f.payload, 'hooks/hooks.json'));
+  const prior = process.env.CLAUDE_CONFIG_DIR;
+  try {
+    process.env.CLAUDE_CONFIG_DIR = f.claudeRoot;
+    assert.deepEqual(inspectClaudeBrainPlugin(), f.inspect());
+    assert.deepEqual(fs.readFileSync(path.join(f.payload, 'hooks/hooks.json')), before);
+  } finally {
+    if (prior === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+    else process.env.CLAUDE_CONFIG_DIR = prior;
+  }
+});
+
+test('Brain should refuse symlinked payload evidence', { skip: process.platform === 'win32' ? 'symlink privilege unavailable' : false }, (t) => {
+  const f = fixture(t);
+  const file = path.join(f.payload, 'hooks/hooks.json');
+  const elsewhere = path.join(f.claudeRoot, 'external-hooks.json');
+  f.write(elsewhere, { hooks: {} }); fs.unlinkSync(file); fs.symlinkSync(elsewhere, file);
+  assert.match(f.inspect().issues.join(' '), /retirement is unverified/);
+});

--- a/tests/kit/versions.test.mjs
+++ b/tests/kit/versions.test.mjs
@@ -3,7 +3,14 @@
 // 4.0.0-alpha.1 vs 4.0.0-alpha.0 compare equal and self-update impossible.
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { cmpVersions, isValidSemver, latestVersion } from '../../src/lib/versions.mjs';
+import { cmpVersions, isValidSemver, latestVersion, releaseObservationLabel } from '../../src/lib/versions.mjs';
+
+test('release labels should disclose cached observations and missing timestamps', () => {
+  assert.equal(releaseObservationLabel({ latestSource: 'cache', latestObservedAt: 1788919211591 }),
+    'cache; observed 2026-09-09T02:00:11.591Z');
+  assert.equal(releaseObservationLabel({ latestSource: 'cache-fallback', latestObservedAt: null }),
+    'cache-fallback; observed time unknown');
+});
 
 const newer = (a, b) => cmpVersions(a, b) > 0;
 


### PR DESCRIPTION
Codex could load two Ruflo tool catalogs while status missed the duplicate because the legacy transport had an environment table. Detect effective duplicates across layered configuration while preserving strict ownership requirements for automatic removal.

Also report per-package release observation age, inspect Claude's selected Brain plugin separately from its KB/marketplace, and replace an unrelated issue reference with primary release evidence in the blocked-version constraint.

Validation: 3,772 tests (3,766 passed, six skipped), typecheck, Markdown lint, complexity gate, and build passed. Final warning wording passed seven focused tests. Independent source review found no remaining blockers.

The remediation report records machine upgrades and convergence separately from repository changes. Existing-corpus CLI retrieval remains unresolved despite a passing isolated canary. Brain 4.3.17 reintroduces continuity hooks outside the audited 4.3.16 contract; those hooks are preserved pending qualification. Fresh host sessions are still needed. See docs/audits/2026-09-09-ruflo-remediation.md.
