### PR TITLE
fix: qualify Brain continuity and disclose memory routing uncertainty

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -50,7 +50,7 @@ ak sync             # apply it
 | opencode: `status` reports a later `opencode.jsonc` override | stock OpenCode loads that file after `opencode.json`, so it can shadow the exact MCP/permission values ak receipts; ak cannot verify JSONC without rewriting user comments | merge the Agentic Kit entries into the later file and remove the duplicate override, or keep the override and use direct user-managed wiring; ak preserves both files and does not deploy its gateway against ambiguous effective config |
 | opencode: an agent/skill/plugin file you created yourself keeps ak's version away | deploys are no-clobber: only exact receipt-matching bytes are repairable; an unreceipted or edited destination is user-owned and preserved (`status` reports it as `foreign`) | rename yours (or remove it and run `ak sync` to get ak's managed copy) |
 | opencode: `status` says `no ruflo catalog source` | the agent/skill catalog resolves override → `$RUFLO_REPO` → claude marketplace clone → `@claude-flow/cli` (direct, then nested under ruflo) — all missing | install ruflo (`ak setup` does), or point `integrations.ownership.opencode.catalogDir` / `$RUFLO_REPO` at a ruflo checkout |
-| `ruflo memory store` says OK but reads return nothing | Absolute project pin missing, a legacy Codex MCP launcher inherited the wrong cwd, or an older check looked only at `.swarm/memory.db` while the native bridge selected `.swarm/agentdb-memory.db` | Run `ak sync` to migrate an ak-owned Codex registration, then `ak x verify memory` for an isolated store/retrieve/on-disk/purge proof; `ak setup` pins Claude, Codex, and OpenCode to the project while accepting the runtime-selected native sibling |
+| `ruflo memory store` says OK but reads return nothing | Missing project pin, wrong working directory, or CLI and MCP selecting different files when both `.swarm/memory.db` and `.swarm/agentdb-memory.db` exist | `ak sync` can repair owned registration drift. `ak x verify memory` proves an isolated canary only; inspect existing-corpus routing separately as described below |
 | `status` shows a `codex-plugins` warning | A plugin is enabled in the wrong host, its newest cached hooks or skills fail a known Codex compatibility check, or `config.toml` cannot be inspected safely. The exact `codex@openai-codex` identity is a Claude Code companion and must not be enabled inside Codex | For a valid, regular `config.toml` and verified companion 1.0.6, preview the approval-required repair with `ak heal hooks --host codex`; it changes only that Codex entry, never Claude Code or the cache. Repair malformed TOML or merge symlink-managed config manually. For other plugin findings, open Codex `/plugins`, refresh or disable the named plugin, then start a new session. Setup and sync never rewrite Codex-owned plugin state |
 | `status` shows a `memory-pin` warning | `CLAUDE_FLOW_DB_PATH` is pinned to a dead or foreign path, so every memory op targets the wrong DB ("Database not initialized" beside a healthy in-repo DB). The pin may be deliberate, so `sync` never touches it | repoint (or remove) the pin in `.claude/settings.local.json` `env` |
 | Want to run `ak sync` but Claude/Codex/OpenCode sessions are open in other terminals | Upgrade-bearing syncs stop **all** ruflo daemons machine-wide and swap the global npm trees live sessions execute hooks/statusline/MCP calls from; converged syncs touch nothing | `ak sync --dry-run` first; a `versions` row means idle the other sessions or use `ak sync --no-upgrade`; see [Running `ak sync` while sessions are live](UPGRADING.md#running-ak-sync-while-sessions-are-live) |
@@ -82,6 +82,28 @@ ak sync             # apply it
 > [!WARNING]
 > The `natives … WASM fallback` row is the one that loses data: on the WASM path,
 > memory writes print "OK" and silently vanish. Treat it as the highest-priority fix.
+
+## Existing memory corpus routing
+
+Ruflo 3.39.2 can select different stores through its CLI and MCP bridge. A passing
+`ak x verify memory` canary does not establish access to pre-existing records.
+`ak status` reports both files and leaves writer identity unverified.
+
+A snapshot test retrieved a known native-store record only when the CLI received
+the explicit native file path. For a record independently confirmed in that store,
+use an absolute path:
+
+```sh
+ruflo memory retrieve --namespace YOUR_NAMESPACE --key YOUR_KEY \
+  --path /absolute/project/.swarm/agentdb-memory.db --value-only
+```
+
+Keep the shared MCP path until its routing contract is qualified. Do not rename,
+merge, or delete either database to hide the discrepancy. CLI retrieval can update
+access counters and schema, so use SQLite backup snapshots for read-only diagnostic
+experiments; copying a live database without its WAL is not a consistent snapshot.
+This workaround addresses explicit retrieval, not cross-host writer convergence or
+Windows split-store behavior.
 
 ## Deep proofs (slow, spawn real CLIs)
 

--- a/docs/audits/2026-09-09-memory-brain-alignment.md
+++ b/docs/audits/2026-09-09-memory-brain-alignment.md
@@ -1,0 +1,55 @@
+# Existing-corpus routing and Brain continuity alignment
+
+Follow-up to [the first remediation pass](2026-09-09-ruflo-remediation.md),
+branched from squash merge `c7fee0a` of PR #208.
+
+## Memory result
+
+Ruflo 3.39.2's CLI resolves and passes `memory.db` explicitly to its bridge.
+The bridge otherwise defaults to the native `agentdb-memory.db` sibling. Restoring
+native bindings therefore does not make both invocation paths select one corpus.
+
+A known existing native-store record was tested using SQLite backup snapshots of
+both project stores. With explicit `memory.db`, retrieval exited 1 and did not
+return the value. With explicit `agentdb-memory.db`, retrieval exited 0 and returned
+the exact value. Temporary snapshots were removed. Live project databases were
+opened read-only for this experiment; no records were migrated or rewritten.
+
+Status now reports both observed stores without claiming an active writer. The
+[troubleshooting guide](../TROUBLESHOOTING.md#existing-memory-corpus-routing)
+documents explicit-path retrieval. This is a verified workaround, not a universal
+writer-convergence fix. Shared MCP paths remain unchanged. Windows split-store
+behavior and fresh execution across every host remain unverified.
+
+## Brain result
+
+The selected Claude plugin, KB/code bundle, and Codex plugin are now 4.3.17.
+The exact-version installer exited 0 and verified the signed bundle
+SHA-256 `f4c0109a83ac2d5788850559c4825e0d25df8a1f87535eced66271c64c59d93e`.
+Its source-grounded search passed in 128.3 seconds. Previous generations remain
+preserved by the installer; no automatic cleanup was performed.
+
+The exact static continuity contract is pinned to
+[upstream commit 3f7c3b8](https://github.com/stuinfla/ruvnet-brain/blob/3f7c3b8cd894e30090825322a2de0ac1ab12d9d1/plugin/hooks/hooks.json).
+It includes precisely one SessionStart handler and one Stop handler with their
+reviewed matchers, commands, and timeouts. Additional behavior, unknown versions,
+or absent/unsafe shim paths do not pass qualification. Static registration does
+not establish that host lifecycle behavior has executed correctly.
+
+The independent `ruvnet-brain@4.3.17 --doctor --hooks` query passed in 121.5 seconds.
+Its continuity policy reported zero legacy/invalid registrations and zero manifest
+errors. Nevertheless the command exited 1: a separate Codex diagnostic still labels
+the two supported hooks retired. This contradictory upstream check remains open;
+the hooks were preserved. Existing Claude/Codex sessions require restart before
+their loaded plugin generations can be considered aligned.
+
+## Validation and scope
+
+The final regression suite passed: 3,776 tests, 3,770 passed, six skipped. Coverage
+was 91.88% lines, 80.58% branches, and 91.34% functions. Typecheck, complexity gate,
+build, and Markdown lint passed. Independent read-only review found no blockers;
+its recommended selected-shim integration test was added and passed.
+
+No additional stale local branches were proven safe to delete after #208 cleanup.
+Archives, existing worktrees, and uncertain branches remain intact. The separately
+queued dashboard grouping and cross-host context-panel design remain unstarted.

--- a/src/commands/status/sections/project-memory.mjs
+++ b/src/commands/status/sections/project-memory.mjs
@@ -1,7 +1,7 @@
 // Project memory may legitimately have two stores: the compatibility/sql.js
 // memory.db and the native bridge's plaintext agentdb-memory.db sibling.
-// Presence is a quick signal only; `ak x verify memory` performs the write
-// round-trip proof.
+// Presence cannot establish the active writer or CLI/MCP routing. The isolated
+// `ak x verify memory` canary does not prove access to an existing corpus.
 import { projectMemoryStatus } from '../../../lib/project-memory.mjs';
 import { row } from '../row.mjs';
 
@@ -13,15 +13,14 @@ export default {
       const memory = projectMemoryStatus(cwd);
       if (!memory.active) {
         rows.push(row('memory', 'info', 'no project memory store yet (run setup here to initialize)'));
-      } else if (!memory.active.readable) {
-        rows.push(row('memory', 'warn',
-          `active ${memory.active.kind} store is unreadable (${memory.active.file}) — run: ak x verify memory`));
       } else {
-        const sibling = memory.secondary
-          ? `; ${memory.secondary.kind} compatibility store also present`
-          : '';
-        rows.push(row('memory', 'ok',
-          `${memory.active.kind} active writer: ${memory.active.entries} active entr${memory.active.entries === 1 ? 'y' : 'ies'}${sibling}`));
+        for (const store of memory.stores.filter((candidate) => candidate.present)) {
+          rows.push(row('memory', store.readable ? 'info' : 'warn', store.readable
+            ? `${store.kind}: ${store.entries} active entr${store.entries === 1 ? 'y' : 'ies'} observed; writer and existing-corpus routing unverified`
+            : `${store.kind} store is unreadable (${store.file}); existing-corpus access unverified`));
+        }
+        if (memory.secondary) rows.push(row('memory', 'warn',
+          'two project memory stores coexist; CLI and MCP may select different files — an isolated canary does not verify existing-corpus routing'));
       }
     } catch (e) {
       rows.push(row('memory', 'warn', `project memory check unavailable: ${e.message}`));

--- a/src/lib/brain-hook-contract.mjs
+++ b/src/lib/brain-hook-contract.mjs
@@ -1,0 +1,23 @@
+import { isDeepStrictEqual } from 'node:util';
+
+// Exact registration contract, not a runtime/safety certification.
+// https://github.com/stuinfla/ruvnet-brain/blob/3f7c3b8cd894e30090825322a2de0ac1ab12d9d1/plugin/hooks/hooks.json
+const handler = (matcher, action, timeout) => [{ matcher, hooks: [{
+  type: 'command',
+  command: `node "\${CLAUDE_PLUGIN_ROOT}/scripts/hook-shim.mjs" ${action} || true`,
+  timeout,
+}] }];
+const CONTINUITY = {
+  SessionStart: handler('startup|resume|clear|compact|fork', 'session-start', 5),
+  Stop: handler('*', 'continuation-gate', 10),
+};
+
+export function brainHookContract(version, hooks) {
+  if (version === '4.3.17') return isDeepStrictEqual(hooks, CONTINUITY)
+    ? { qualified: true, contract: '4.3.17-continuity' }
+    : { qualified: false, issue: 'Automatic hook declarations differ from the exact 4.3.17 continuity contract' };
+  if (['4.3.14', '4.3.15', '4.3.16'].includes(version)) return isDeepStrictEqual(hooks, {})
+    ? { qualified: true, contract: '4.3.14-4.3.16-retirement' }
+    : { qualified: false, issue: 'Selected payload declares automatic hooks outside the audited retirement baseline' };
+  return { qualified: false, issue: `Automatic hook contract is unqualified for plugin version ${version ?? 'unknown'}` };
+}

--- a/src/lib/project-memory.mjs
+++ b/src/lib/project-memory.mjs
@@ -1,6 +1,7 @@
 // Project-memory observability. The native bridge keeps its plaintext store in
 // agentdb-memory.db while the compatibility/sql.js surface remains memory.db.
-// Both are legitimate; the native sibling is the active writer when present.
+// Both are legitimate. `active` is a historical preferred-display field, not
+// evidence of the actual writer or which corpus a CLI/MCP invocation selects.
 import fs from 'node:fs';
 import * as paths from './paths.mjs';
 import { withDb } from './sqlite.mjs';

--- a/src/lib/ruvnet-brain-plugin.mjs
+++ b/src/lib/ruvnet-brain-plugin.mjs
@@ -3,6 +3,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { claudeDir } from './paths.mjs';
+import { brainHookContract } from './brain-hook-contract.mjs';
 
 const ID = 'ruvnet-brain@ruvnet-brain';
 const object = (v) => v && typeof v === 'object' && !Array.isArray(v);
@@ -75,7 +76,12 @@ export function inspectClaudeBrainPlugin({ claudeRoot = claudeDir() } = {}) {
     const hooks = readJson(payloadFile(root, 'hooks/hooks.json'))?.hooks;
     if (!object(hooks)) throw new Error('invalid hooks');
     result.hookEvents = Object.keys(hooks);
-    if (result.hookEvents.length) result.issues.push(`Selected payload declares automatic hooks outside the audited 4.3.16 retirement baseline: ${result.hookEvents.join(', ')}`);
+    const contract = brainHookContract(result.payloadVersion, hooks);
+    if (!contract.qualified) result.issues.push(contract.issue);
+    else {
+      result.hookContract = contract.contract;
+      if (result.payloadVersion === '4.3.17') payloadFile(root, 'scripts/hook-shim.mjs');
+    }
   } catch { result.issues.push('Automatic hook retirement is unverified: missing or invalid hook manifest'); }
   return result;
 }

--- a/tests/kit/brain-hook-contract.test.mjs
+++ b/tests/kit/brain-hook-contract.test.mjs
@@ -1,0 +1,37 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { brainHookContract } from '../../src/lib/brain-hook-contract.mjs';
+
+const fixture = () => ({
+  SessionStart: [{ matcher: 'startup|resume|clear|compact|fork', hooks: [{ type: 'command',
+    command: 'node "${CLAUDE_PLUGIN_ROOT}/scripts/hook-shim.mjs" session-start || true', timeout: 5 }] }],
+  Stop: [{ matcher: '*', hooks: [{ type: 'command',
+    command: 'node "${CLAUDE_PLUGIN_ROOT}/scripts/hook-shim.mjs" continuation-gate || true', timeout: 10 }] }],
+});
+
+test('Brain continuity is qualified only for the exact reviewed release', () => {
+  assert.equal(brainHookContract('4.3.17', fixture()).qualified, true);
+  assert.equal(brainHookContract('4.3.16', {}).qualified, true);
+  for (const version of ['4.3.16', '4.3.18', '4.3.17-beta.1', null]) {
+    assert.equal(brainHookContract(version, fixture()).qualified, false);
+  }
+  assert.equal(brainHookContract('4.3.17', {}).qualified, false);
+});
+
+test('continuity qualification rejects altered or extra behavior', () => {
+  const changes = [
+    (h) => { h.PreToolUse = []; },
+    (h) => { h.Stop.push(h.Stop[0]); },
+    (h) => { h.Stop[0].hooks.push(h.Stop[0].hooks[0]); },
+    (h) => { h.Stop[0].hooks[0].command += '; arbitrary-command'; },
+    (h) => { h.Stop[0].hooks[0].timeout = 99; },
+    (h) => { h.Stop[0].hooks[0].type = 'prompt'; },
+    (h) => { h.Stop[0].hooks[0].async = true; },
+    (h) => { h.SessionStart[0].matcher = '*'; },
+    (h) => { h.Stop[0].extra = true; },
+  ];
+  for (const change of changes) {
+    const hooks = fixture(); change(hooks);
+    assert.equal(brainHookContract('4.3.17', hooks).qualified, false);
+  }
+});

--- a/tests/kit/project-memory-status.test.mjs
+++ b/tests/kit/project-memory-status.test.mjs
@@ -1,0 +1,26 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+import section from '../../src/commands/status/sections/project-memory.mjs';
+
+test('memory status never treats file presence as a proven writer and checks both stores', async (t) => {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'ak-memory-status-'));
+  t.after(() => fs.rmSync(cwd, { recursive: true, force: true }));
+  assert.equal((await section.collect({ cwd }))[0].level, 'info');
+  fs.mkdirSync(path.join(cwd, '.swarm'));
+  const native = path.join(cwd, '.swarm/agentdb-memory.db');
+  const db = new DatabaseSync(native);
+  db.exec('CREATE TABLE memory_entries (status TEXT); INSERT INTO memory_entries VALUES (NULL)');
+  db.close();
+  const single = await section.collect({ cwd });
+  assert.equal(single[0].level, 'info');
+  assert.match(single[0].message, /1 active entry observed.*routing unverified/);
+  fs.writeFileSync(path.join(cwd, '.swarm/memory.db'), 'corrupt');
+  const dual = await section.collect({ cwd });
+  assert.ok(dual.some((r) => r.level === 'warn' && /sqljs store is unreadable/.test(r.message)));
+  assert.ok(dual.some((r) => /two project memory stores/.test(r.message)));
+  assert.ok(dual.every((r) => r.level !== 'ok' && r.fix === null));
+});

--- a/tests/kit/ruvnet-brain-plugin.test.mjs
+++ b/tests/kit/ruvnet-brain-plugin.test.mjs
@@ -33,6 +33,29 @@ test('Brain should observe the selected payload without asserting runtime health
   assert.equal(brainPluginRows(r)[0].fix, null);
 });
 
+test('Brain continuity requires the selected shim without claiming runtime execution', (t) => {
+  const f = fixture(t);
+  f.registry([{ ...f.record, version: '4.3.17' }]);
+  f.write(path.join(f.payload, '.claude-plugin/plugin.json'), { name: 'ruvnet-brain', version: '4.3.17' });
+  const entry = (matcher, action, timeout) => [{ matcher, hooks: [{ type: 'command',
+    command: `node "\${CLAUDE_PLUGIN_ROOT}/scripts/hook-shim.mjs" ${action} || true`, timeout }] }];
+  f.write(path.join(f.payload, 'hooks/hooks.json'), { hooks: {
+    SessionStart: entry('startup|resume|clear|compact|fork', 'session-start', 5),
+    Stop: entry('*', 'continuation-gate', 10),
+  } });
+  assert.equal(f.inspect().issues.length, 1, 'missing shim cannot pass');
+  const shim = path.join(f.payload, 'scripts/hook-shim.mjs');
+  f.write(shim, 'not executed');
+  assert.deepEqual(f.inspect().issues, []);
+  assert.equal(f.inspect().runtimeVerified, false);
+  assert.equal(f.inspect().hookContract, '4.3.17-continuity');
+  if (process.platform !== 'win32') {
+    fs.unlinkSync(shim);
+    fs.symlinkSync(path.join(f.payload, 'commands/rvbc.md'), shim);
+    assert.equal(f.inspect().issues.length, 1, 'symlinked shim cannot pass');
+  }
+});
+
 test('Brain should disclose both missing commands and retired hooks in a disabled old payload', (t) => {
   const f = fixture(t);
   fs.unlinkSync(path.join(f.payload, 'commands/rvbc.md'));

--- a/tests/kit/status-command.test.mjs
+++ b/tests/kit/status-command.test.mjs
@@ -492,7 +492,7 @@ test('status reports malformed Codex config separately from plugin compatibility
   assert.equal(plugin.fix, null);
 });
 
-test('status identifies the native project-memory writer when both stores exist', async () => {
+test('status discloses both project-memory stores without asserting writer identity', async () => {
   seedHome();
   const swarm = path.join(PROJECT, '.swarm');
   fs.mkdirSync(swarm, { recursive: true });
@@ -505,10 +505,10 @@ test('status identifies the native project-memory writer when both stores exist'
     db.prepare('INSERT INTO memory_entries VALUES (?, ?, ?)').run(key, 'test', 'active');
     db.close();
   }
-  const memory = one(await collect(), 'memory');
-  assert.equal(memory.level, 'ok');
-  assert.match(memory.message, /native-agentdb active writer: 1 active entry/);
-  assert.match(memory.message, /sqljs compatibility store also present/);
+  const memory = (await collect()).filter((r) => r.subsystem === 'memory');
+  assert.ok(memory.some((r) => r.level === 'info' && /native-agentdb: 1 active entry observed/.test(r.message)));
+  assert.ok(memory.some((r) => r.level === 'info' && /sqljs: 1 active entry observed/.test(r.message)));
+  assert.ok(memory.some((r) => r.level === 'warn' && /two project memory stores/.test(r.message)));
   rmrf(swarm);
 });
 


### PR DESCRIPTION
Memory status inferred an active native writer from file presence, even when Ruflo's CLI selected the other database. Report both stores with routing explicitly unverified and document the snapshot-verified explicit-path retrieval workaround. Preserve all project data and existing shared MCP paths.

Qualify Brain's exact 4.3.17 continuity hook declarations without treating arbitrary future versions or matching event names as validated. Reject extra behavior and keep static configuration separate from runtime execution evidence.

Validation: 3,776 tests, 3,770 passed, six skipped; typecheck, complexity gate, build, and Markdown lint passed. Independent read-only review found no blockers. Runtime and outstanding cross-host limitations are recorded in the follow-up audit.

Deferred dashboard changes are excluded.
