### PR TITLE
Fix audit follow-ups for usage evidence, teardown preservation, and status checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,17 @@ on:
   workflow_dispatch:
 
 jobs:
+  minimum-runtime:
+    name: minimum runtime (Node 22.13.0)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22.13.0'
+      - run: node bin/agentic-kit.mjs --help --all
+      - run: node --test tests/kit/node-runtime.test.mjs tests/kit/sqlite.test.mjs tests/kit/usage-audit-211.test.mjs
+
   test:
     name: test (${{ matrix.os }}, node ${{ matrix.node }})
     runs-on: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -185,12 +185,12 @@ rollback, and the current parity boundary.
 
 ## Requirements
 
-The package declares `engines.node: >=22`, but SQLite-backed commands import
-`node:sqlite`, available without a flag from Node 22.13.0. Use a maintained patch
-release in the tested Node 22/24/26 lines; the broad manifest range does not prove
-compatibility with early Node 22 releases. See [Node SQLite history](https://nodejs.org/api/sqlite.html).
+The runtime requires Node 22.13.0+ on the 22.x line or Node 23.4.0+ on later
+lines (`>=22.13.0 <23 || >=23.4.0`), where `node:sqlite` is available without a
+flag. Use a maintained release in the tested Node 22/24/26 lines. CI separately
+checks the minimum 22.13.0 runtime. See [Node SQLite history](https://nodejs.org/api/sqlite.html).
 
-Node ≥ 22 and npm are the runner prerequisites. Enabled host CLIs can be installed
+A supported Node release and npm are the runner prerequisites. Enabled host CLIs can be installed
 by setup; authentication is separate and required for inference.
 **ruflo and agentic-qe are not prerequisites; `ak setup` installs them for you**
 (pre-installing them is fine too — setup just detects and reuses them). Everything

--- a/bin/agentic-kit.mjs
+++ b/bin/agentic-kit.mjs
@@ -5,6 +5,13 @@ import { parseArgs } from 'node:util';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 import { fail, dim, exitWhenFlushed } from '../src/lib/output.mjs';
+import { nodeRuntimeError } from '../src/lib/node-runtime.mjs';
+
+const runtimeError = nodeRuntimeError();
+if (runtimeError) {
+  console.error(runtimeError);
+  process.exit(1);
+}
 
 const PKG_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 

--- a/docs/CODEX-USAGE-DIAGNOSTIC.md
+++ b/docs/CODEX-USAGE-DIAGNOSTIC.md
@@ -73,9 +73,9 @@ faith:
    documented bug signature (`tests/kit/usage-index.test.mjs`). Run the tests from your checkout
    for its current result; the original pass count is not a release guarantee.
 3. **A before/after comparison you can run yourself**, on your own data,
-   computed by code that does **not** import or reuse the fix — so it's an
-   independent check, not a restatement of the same claim. That's the
-   script below.
+   computed by a separate cumulative-token parser. Pricing shares the
+   maintained repository module; parsing does not import the dashboard
+   implementation. This checks replay exclusion, not every dashboard path.
 
 If you want the full engineering detail — exact formulas, file:line
 citations, provider pricing sources — that's
@@ -84,59 +84,59 @@ need to read it to use this document.
 
 ## How to check your own numbers
 
-You'll need Node.js 18 or newer (`node --version` to check) and a terminal.
-Nothing else — no `npm install`, no cloning this repo, no network access
-beyond the one download below, and nothing gets written to your disk except
-the script file itself.
+Use a repository checkout and its supported Node runtime (Node 22.13.0 or a
+maintained later release with unflagged `node:sqlite`). No dependency installation
+is needed. The diagnostic itself makes no network requests and writes no files.
 
-**1. Get the script.** If you already have the repository checked out:
+**1. Run the diagnostic from the checkout.**
 
 ```bash
 node scripts/codex-usage-diagnostic.mjs
+# Optional: another transcript root, with machine-readable output
+node scripts/codex-usage-diagnostic.mjs --root /absolute/path/to/sessions --json
 ```
 
-If you don't have the repo, just download the one file:
+Keep the script with the repository: it imports `src/lib/pricing.mjs` so model
+rates, aliases, and cache discounts cannot drift into a second embedded table.
+Downloading the script alone is no longer supported.
 
-```bash
-curl -fsSL https://raw.githubusercontent.com/pacphi/agentic-kit/main/scripts/codex-usage-diagnostic.mjs -o codex-usage-diagnostic.mjs
-node codex-usage-diagnostic.mjs
-```
+**2. Read the two aggregate totals.** **ALL rollouts** includes every qualifying
+session's last cumulative token record; **EXCLUDING explicitly marked subagent
+rollouts** removes sessions whose first metadata record says `thread_source:
+"subagent"`. The report gives the excluded token and estimated-cost percentages.
+Historical `beforeFix_allSessions` and `afterFix_excludingSubagentReplays` JSON
+keys remain for compatibility; they do not describe the current dashboard as buggy.
 
-**2. Read the output before sending anything.** The script prints a report
-with two totals: **"before the fix"** (every session log counted — this
-should be close to what you'd currently see if you ran the unpatched
-dashboard) and **"after the fix"** (subagent-replay logs excluded). It also
-tells you what percentage of tokens/cost, if any, is attributable to
-subagent-replay logs.
+The script reads complete local rollout files into memory and parses their JSON
+lines. It selects model, thread-source, cumulative token, and assistant-event
+fields. Both legacy `agent_message` and newer `item_completed` / `AgentMessage`
+responses qualify. First-session metadata takes precedence over later replayed
+metadata, including when that first record has no thread source.
 
-The script reads complete local rollout files into memory and parses their JSON lines. It
-selects model, thread-source, cumulative token, and response-event fields for an aggregate
-report; it does not print prompts, titles, session identifiers, or individual file paths.
-The human-readable report **does print the rollout scan root**, which can identify
-your OS account or workspace. Review and redact that line before sharing. Its default root is
-`~/.codex/sessions`; pass `--root /absolute/path/to/sessions` for another Codex home.
+Reports contain numeric aggregates, not the scan root, transcript strings, prompts,
+titles, session identifiers, timestamps, model names, or arbitrary thread-source
+values. Unknown and other thread sources are counted separately. The default
+scan root is `~/.codex/sessions`.
 
-This is a **legacy replay comparison**, not a second implementation of today's dashboard.
-Its fixed July 2026 rate table, model fallback, string-only `thread_source` handling, and
-last-cumulative-event logic are retained for that comparison. The maintained parser also
-handles newer message formats and first-session metadata precedence. Consequently, the
-script's dollar totals and even its replay classification may differ from current Usage.
-Use the maintained dashboard and metrics reference for current estimates; do not use this
-script as billing reconciliation or proof that every current parser path is correct.
+This remains an **independent cumulative snapshot comparison**, not a second
+implementation of the dashboard. It does not read the Codex state ledger, split
+cumulative tokens across models or days, or analyze context. A missing thread
+source remains unknown and is included in totals. Both parsers currently use
+string-valued `thread_source`; this script does not infer object-shaped sources.
+Costs use the current maintained pricing snapshot, applied to each rollout's
+last model, and represent API equivalents rather than actual subscription bills.
+Use the dashboard and metrics reference for detailed current estimates.
 
 ## What to send back
 
-**Share only output you have reviewed and redacted.** Remove the rollout-root
-line from the human report if it identifies your account or workspace. `--json`
-provides aggregate output without that human-report path line, but still review
-model identifiers and any sensitive metadata before sending it. No transcript
-files or session descriptions are needed.
+Share the aggregate report only if you are comfortable sharing usage and estimated
+cost totals. No transcript files or session descriptions are needed.
 
-If "before" and "after" are close, this legacy comparison found little
-string-marked subagent replay. It does not rule out a current parsing or pricing
-discrepancy that the standalone script does not model. If a
-meaningful percentage is excluded, that's the concrete number behind it —
-not a guess.
+If the two totals are close, this comparison found little explicitly marked
+subagent usage. It does not rule out a discrepancy in a parser path, ledger
+classification, or historical model/day allocation that the diagnostic omits.
+The excluded percentage measures usage in marked subagent rollouts, not a proof
+that every excluded token was duplicated.
 
 ## Appendix — references
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -12,13 +12,13 @@ live. The second command performs agentic-kit's machine/user and optional projec
 work. Those scopes are independent: running a local or one-shot `ak setup` does
 not make setup local or temporary.
 
-The package requires Node.js 22 or newer. The `next` tag is the 4.0 prerelease
+The package requires the Node.js runtime described below. The `next` tag is the 4.0 prerelease
 channel; after 4.0 GA, use the release channel documented in the README.
 
-The package declares `engines.node: >=22`, but SQLite-backed commands import
-`node:sqlite`, available without a flag from Node 22.13.0. Use a maintained patch
-release in the tested Node 22/24/26 lines; the broad manifest range does not prove
-compatibility with early Node 22 releases. See [Node SQLite history](https://nodejs.org/api/sqlite.html).
+The runtime requires Node 22.13.0+ on the 22.x line or Node 23.4.0+ on later
+lines (`>=22.13.0 <23 || >=23.4.0`), where `node:sqlite` is available without a
+flag. Use a maintained release in the tested Node 22/24/26 lines. CI separately
+checks the minimum 22.13.0 runtime. See [Node SQLite history](https://nodejs.org/api/sqlite.html).
 
 ## The two independent scope decisions
 

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -582,13 +582,13 @@ neither agentic-kit nor AQE persists them.
 ak host off     # reset to the claude-only default, reversibly
 ```
 
-This removes the known managed environment keys, including later edits to those keys.
-For a router file still marked `_managedBy: agentic-kit`, it restores the whole
-pre-`ak` `llm-config.json` backup, or removes the whole file if no backup exists.
-Later user edits in that managed file can therefore be lost. Save them before `off`
-and review the result. A file without the managed tag is left alone. This legacy
-whole-file teardown differs from the exact-value receipts used by external-provider
-reconciliation.
+This reverts only environment values that still match their saved projection
+receipts. Later edits and unowned values survive. Router teardown requires an
+exact postimage receipt and an unchanged original backup: pristine projections
+restore atomically (retaining the backup), or are removed if ak created them.
+Legacy marker-only ownership, changed files, missing/changed backups, and ambiguous
+interrupted projections are preserved with a manual-reconciliation diagnostic.
+The `_managedBy` tag alone never authorizes whole-file deletion or restoration.
 
 ---
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -141,3 +141,100 @@ Why this kit exists, the original root-cause investigations (Node-ABI/WASM memor
 loss, the F1–F6 self-improvement findings, the June-2026 token-burn incident), and
 the shell-era docs are preserved verbatim in [docs/archive/](https://github.com/pacphi/agentic-kit/tree/main/docs/archive) — see its
 [index](https://github.com/pacphi/agentic-kit/blob/main/docs/archive/README.md).
+
+## Ruflo `policy_evaluate`: `invalid-policy-request`
+
+This error is request validation, before a policy decision. The installed Ruflo
+MCP schema may expose `request` as an unrestricted object even though the engine
+requires `identity.id`, `identity.type`, and `action.type`. `identity.agentId` is
+not a substitute for `identity.id`.
+
+Use the installed contract, for example:
+
+```json
+{
+  "request": {
+    "identity": { "id": "codex-worker", "type": "agent" },
+    "action": {
+      "type": "workspace.edit",
+      "resource": "project:scoped-task",
+      "environment": "development",
+      "destructive": false,
+      "network": false
+    },
+    "context": {
+      "metadata": { "authorization": "User requested this scoped change" }
+    }
+  }
+}
+```
+
+Evidence belongs in `context.evidence` as an array of provenance-bearing records;
+freeform annotations belong in `context.metadata`. An annotation is not a grant of
+permission. Inspect `policy_status` for the actual mode and ledger integrity.
+An `allowed` result in `legacy` mode means compatibility default-allow, not that
+an enforcement policy or signed approval was established. Do not change policy
+mode to work around malformed requests or denied actions.
+
+Verified on 2026-09-09 against installed `@claude-flow/security`'s
+`policy/types.d.ts` and `PolicyEngine.validateRequest`, and the CLI's
+`mcp-tools/policy-tools.js`. A corrected live call returned `allowed` with a
+receipt. The weak nested MCP schema is upstream-owned; agentic-kit does not
+implement this tool and does not patch installed packages during sync.
+
+## Codex plugin skill-name false positives
+
+Older agentic-kit checks incorrectly required each skill's frontmatter name to
+match its folder and use lowercase kebab-case. Codex 0.153.4's own `skills/list`
+loaded `spreadsheets:Spreadsheets` and `presentations:Presentations` with no errors.
+The four reported issues were two naming complaints per skill, not four broken
+plugins. Update agentic-kit and restart the dashboard process; do not rename or
+disable those bundled skills to satisfy the old check.
+
+The corrected compatibility check accepts display names up to 64 Unicode
+characters and still reports missing required frontmatter. This is a loader
+compatibility check, not a claim of compliance with every cross-host authoring
+convention. [Official skill documentation](https://learn.chatgpt.com/docs/build-skills)
+requires `name` and `description` and describes host skill discovery.
+
+## Ruflo memory stores and routing
+
+Two files can contain different project corpora:
+
+- `.swarm/memory.db`, historically the compatibility store.
+- `.swarm/agentdb-memory.db`, the native bridge's default sibling.
+
+The filenames do not prove the active backend: native code can also open
+`memory.db`. Status now names the files and keeps backend/writer/routing unknown
+unless separately verified. File presence alone does not prove lost data or
+correct cross-client routing. `ak x verify memory` tests an isolated canary;
+it cannot establish access to an existing corpus.
+
+Inspection of installed Ruflo 3.39.2 found a concrete path split: CLI memory
+commands pass a resolved `dbPath`, defaulting to `memory.db`; MCP calls omit that
+argument, and the native bridge defaults to `agentdb-memory.db`. Agentic-kit pins
+the project cwd and compatibility environment path, but that environment variable
+is not a universal native MCP filename override in this version.
+
+For an intentional CLI lookup, choose the file explicitly after checking your
+installed `ruflo memory retrieve --help`:
+
+```bash
+ruflo memory retrieve --path /absolute/project/.swarm/agentdb-memory.db --namespace your-namespace --key your-key
+ruflo memory retrieve --path /absolute/project/.swarm/memory.db --namespace your-namespace --key your-key
+```
+
+These are operational lookups, not forensic read-only probes: Ruflo retrieval
+can update access metadata, and initialization can migrate schemas. For a strict
+read-only inspection, open SQLite read-only, enable `PRAGMA query_only=ON`, and
+inspect counts, schemas, and key presence without printing stored values.
+
+Preserve both files and their live WAL state. Do not delete the smaller file,
+globally repin the environment, or merge automatically: it may have unique keys,
+and writers may still be active. A durable upstream fix needs one path-resolution
+contract shared by CLI/MCP/backend selection, registries keyed by resolved path,
+and cross-process tests over existing disjoint corpora. Migration requires a
+separate, reviewed backup, conflict-resolution, and writer-quiescence procedure.
+
+[Local investigation and upstream boundary](audits/plugin-memory-status-followup.md)
+records the source evidence and counts observed on 2026-09-09.

--- a/docs/USAGE-SCORECARD-METRICS.md
+++ b/docs/USAGE-SCORECARD-METRICS.md
@@ -517,11 +517,11 @@ export function costOf(usage) {
 }
 ```
 
-OpenCode rows with non-null `costObserved` use that recorded value instead of
-`costOf`; zero is retained as a recorded value. A `(day, model)` row with a mixture
-of priced and missing-cost messages currently retains only its recorded cost sum
-and does not estimate the missing messages separately. That can understate the row.
-The account invoice and subscription charge remain outside the estimator.
+OpenCode accepts finite nonnegative numeric costs, including zero. A `(day, model)`
+row retains reported costs and the tokens from missing/invalid-cost messages
+separately; only those missing portions use `costOf` at the row's model/day rate.
+Session payloads expose `costEvidence` with observed/estimated dollar sums and
+message counts. The account invoice and subscription charge remain outside the estimator.
 
 `priceFor` resolves both cache multipliers per model. Anthropic 5-minute
 writes and OpenAI GPT-5.6+ writes use 1.25×; older OpenAI models have no
@@ -2317,13 +2317,11 @@ describes.
 
 **Independent, third-party verification.**
 [`docs/CODEX-USAGE-DIAGNOSTIC.md`](CODEX-USAGE-DIAGNOSTIC.md) is a
-non-maintainer-facing companion to this section: a standalone, zero-dependency
-script plus instructions for anyone with real Codex usage to compute the
-same before/after comparison on their own machine, from a separate
-reimplementation of the parsing logic, and report back an aggregate-only
-result with no transcript content. Point anyone questioning their own
-Codex numbers there for the historical replay comparison only: its rate table and
-parser are older than the maintained dashboard, as its guide now explains.
+non-maintainer-facing companion to this section: a repository-local script with
+zero runtime dependencies and an independent cumulative-snapshot parser. It shares
+the maintained pricing module and preserves first-metadata precedence. Its
+aggregate-only report is an independent replay comparison, not full dashboard
+parity: it does not apply ledger fallback or allocate costs per turn/day/model.
 
 ### Smaller corrections
 

--- a/docs/audits/211-code-followups.md
+++ b/docs/audits/211-code-followups.md
@@ -1,5 +1,8 @@
 # Issue 211: implementation follow-ups found by the documentation audit
 
+Implementation follow-up: [remediation and validation](211-remediation.md).
+The findings below preserve the original audit baseline.
+
 Reference baseline: `67fb5c0` (2026-09-09). These defects/limitations were **not
 changed** by the documentation remediation. Documentation now states the existing
 behavior. The first four findings have actual-source synthetic reproductions.

--- a/docs/audits/211-remediation-results.json
+++ b/docs/audits/211-remediation-results.json
@@ -1,0 +1,107 @@
+{
+  "referenceBaseline": "67fb5c0",
+  "sourceCheckout": "current checkout",
+  "sourceDigests": {
+    "src/lib/usage-opencode.mjs": "6344480e33a4f26d8ce6e178e9a70c988ba47e921834df8ea12756e9898084e5",
+    "src/lib/usage-parsers.mjs": "8c5c65973d0bad915584a2a3917f71ea18fdd50b0dbb92c96c0b61ad067063e9",
+    "src/lib/usage-aggregate.mjs": "29cc5e1525b0f9787fe5f852f2c2500a10139553f20f949bceee3fe81bd05096",
+    "src/lib/pricing.mjs": "dd12022b1862659db292fb2e3e282de56648e1ed0c82ac6d83794244a9fa95ef",
+    "src/lib/aqe-router.mjs": "a7a417a2635785e9128964180ea75adb849efba532294055c621b8b188b6e016",
+    "src/lib/provider-ownership.mjs": "7c4f8780d7c13fe2a6971bf0896b3ab643e355fe444d1d72324f5eedb9981c4e",
+    "src/lib/usage-cost.mjs": "d0d330562178e30a2f6a656f8631636360cd5a6295dfa68b2f67a928b365bba9",
+    "src/lib/dashboard/client/usage.mjs": "dbe04c36e9d47cb58455c3ec5ab6ff9f42442fdde5252136a327ee05f6da5816",
+    "scripts/codex-usage-diagnostic.mjs": "b39818f142bccfe8a24d7e41867b1a65612eba4daa3f2d92bc288fe3c0fe5100"
+  },
+  "syntheticOnly": true,
+  "results": [
+    {
+      "issue": "OpenCode cost coverage",
+      "case": "null-cost",
+      "inputTokens": 1000000,
+      "retainedCostObserved": null,
+      "expectedCostWithMissingEstimated": 4,
+      "actualCost": 4,
+      "pass": true
+    },
+    {
+      "issue": "OpenCode cost coverage",
+      "case": "missing-cost",
+      "inputTokens": 1000000,
+      "retainedCostObserved": null,
+      "expectedCostWithMissingEstimated": 4,
+      "actualCost": 4,
+      "pass": true
+    },
+    {
+      "issue": "OpenCode cost coverage",
+      "case": "mixed-cost",
+      "inputTokens": 2000000,
+      "retainedCostObserved": 0.25,
+      "expectedCostWithMissingEstimated": 4.25,
+      "actualCost": 4.25,
+      "pass": true
+    },
+    {
+      "issue": "Session context chip",
+      "input": 100000,
+      "window": 200000,
+      "evidenceState": "partial",
+      "pairedSamples": null,
+      "expected": "No pressure percentage for independently observed input/window",
+      "actualHtml": "",
+      "pass": true
+    },
+    {
+      "issue": "Legacy router undo",
+      "before": {
+        "_managedBy": "agentic-kit",
+        "defaultProvider": "openai",
+        "userKey": "edited-after-setup",
+        "newUserKey": "keep-me"
+      },
+      "outcome": {
+        "ok": false,
+        "changed": false,
+        "detail": "llm-config.json preserved: no verified postimage ownership; review the current file and .bak, then reconcile manually"
+      },
+      "after": {
+        "_managedBy": "agentic-kit",
+        "defaultProvider": "openai",
+        "userKey": "edited-after-setup",
+        "newUserKey": "keep-me"
+      },
+      "expected": "Preserve later user edits or refuse drift",
+      "actualLostKeys": [],
+      "pass": true
+    },
+    {
+      "issue": "Legacy diagnostic pricing",
+      "model": "gpt-5.6-sol",
+      "inputTokens": 1000000,
+      "currentParserPrice": 4,
+      "diagnosticPrice": 4,
+      "pass": true
+    },
+    {
+      "issue": "Legacy diagnostic privacy",
+      "claims": [
+        "No prompts, titles, session ids, file paths, or timestamps below."
+      ],
+      "actualPathLine": null,
+      "pass": true
+    },
+    {
+      "issue": "Legacy diagnostic replay",
+      "currentThreadSource": "subagent",
+      "currentUsageRows": 0,
+      "diagnosticThreadSources": {
+        "user": 0,
+        "unknown": 0,
+        "subagent": 1,
+        "other": 0
+      },
+      "diagnosticAfterTokens": 0,
+      "pass": true
+    }
+  ]
+}

--- a/docs/audits/211-remediation.md
+++ b/docs/audits/211-remediation.md
@@ -1,0 +1,53 @@
+# Issue 211 remediation
+
+Date: 2026-09-09. Starting checkout: `9b75092`. Implemented as focused commits on
+`fix/audit-211-status-remediation`.
+The [original audit](211-code-followups.md) remains historical evidence.
+[Fresh synthetic results](211-remediation-results.json) bind the first four
+findings to source SHA-256 digests; every reported reproduction now passes.
+
+## Decisions and behavior
+
+| Finding | Implemented outcome |
+| --- | --- |
+| CODE-01 | Only finite nonnegative numeric costs are observed, including zero. Missing portions retain their tokens before coalescing and are priced by model/day. `costEvidence` exposes observed/estimated dollars and message counts in session rows and reader metadata. Cache schema 21 forces reconstruction. |
+| CODE-02 | Session chips use normalized paired pressure, not independently observed legacy fields. Values above 100% remain visible; tooltip identifies the last paired measurement. |
+| CODE-03 | Router teardown requires exact postimage and backup evidence. Unknown legacy ownership and drift fail closed with recovery guidance. Exact restores are atomic and retain backups. Provider environment teardown checks value-specific receipts; interrupted writes retain ambiguity across retries. |
+| CODE-04 | Diagnostic preserves first metadata, recognizes current message forms, labels missing source unknown, shares maintained pricing, and emits no scan root or arbitrary transcript strings. It remains an independent cumulative-snapshot comparison, with limitations documented. |
+| CODE-05 | JSONL acquisition uses 64 KiB chunks, 1 MiB per reconciliation, and a 1 MiB line ceiling. SQLite preflight bounds selected session bytes/rows at 64 MiB/100,000 in the same read transaction. Coverage survives live snapshots, playback, session metadata, and aggregate omission notices. |
+| CODE-06 | Engine range and early CLI diagnostic require `>=22.13.0 <23 \|\| >=23.4.0`. CI adds exact minimum-runtime smoke/tests. |
+| CODE-07 | OpenCode's built-in usage capability now advertises SQLite collection; contract regression covers descriptor and collector. Native live-transcript support remains a separate capability. |
+| CODE-08 | UI explains whole retained sessions selected by end, model-specific cache rates, and host-dependent prompt provenance. Runtime Context uses locale defaults. GET query-token compatibility and existing relative-time helpers are deliberately retained. |
+| Added policy-call scope | Live call failed because `identity.agentId` was supplied instead of required `identity.id` and `identity.type`. Corrected request succeeded; verified contract and diagnostics documented in Troubleshooting. Upstream MCP nested schema remains weak; no installed package was patched. |
+
+## Research
+
+- [OpenCode session cost handling](https://github.com/anomalyco/opencode/blob/dev/packages/opencode/src/session/session.ts): finite, nonnegative numeric checks support strict cost validation.
+- [Node SQLite history](https://nodejs.org/api/sqlite.html): unflagged in 22.13.0 and 23.4.0, so early Node 23 must also be excluded.
+- [SQLite octet_length](https://www.sqlite.org/lang_corefunc.html#octet_length): stored byte lengths can be measured without loading complete text bodies.
+- Installed Ruflo CLI `mcp-tools/policy-tools.js` and security `policy/types.d.ts` /
+  `PolicyEngine.validateRequest`: nested request fields, not registration alone,
+  define the actual contract. Live policy status reported legacy mode and a valid
+  ledger. Corrected request receipt:
+  `sha256:2c5747e7409f99b819a16e1b442fb4029f82e6efb7d5ff5d70524087fcaa1379`.
+
+## Validation
+
+- Focused regression suites cover absent/null/invalid/zero costs, mixed order,
+  model/day allocation, paired/unpaired/over-window context, destructive teardown
+  drift and interruption, bounded ingestion, diagnostic privacy, and runtime edges.
+- Actual Node 22.13.0: 85 integrated tests passed.
+- `pnpm test`: 3,906 unit tests passed, six platform skips, zero failures;
+  all subsequent legacy renderer/server suites passed. Coverage: 92.01% lines,
+  80.90% branches, 91.56% functions (above both enforced floors and 80% line target).
+- Typecheck, lint, hard complexity ceiling, Markdown lint, build and diff whitespace
+  checks passed. Lint retains existing advisory complexity warnings.
+- `pnpm run test:ui`: 491 browser assertions and six browser suites passed.
+- Ownership helper focused coverage: 100% lines, branches, and functions.
+
+AQE's initial quality assessment returned 20/100 using metrics not bound to this
+fresh source/test run. It is not a validated score for this change; no 98/100
+repository-score claim is made. Measured test evidence above is the acceptance
+basis. No live user transcripts or configuration were used in regression fixtures.
+Publication is limited to the user-authorized branch and pull request; no merge,
+release, or worktree deletion is authorized by this work.

--- a/docs/audits/211-repros.mjs
+++ b/docs/audits/211-repros.mjs
@@ -56,7 +56,7 @@ try {
   const ctxChip=vm.runInNewContext(`(${snippet.trim()})`,{esc:String,fmtTok:String});
   results.push({issue:'Session context chip',input:ctx.ctxLastTokens,window:ctx.ctxWindow,
     evidenceState:ctx.contextEvidence.state,pairedSamples:ctx.contextEvidence.pressure?.samples??null,
-    expected:'No pressure percentage for independently observed input/window',actualHtml:ctxChip(ctx)});
+    expected:'No pressure percentage for independently observed input/window',actualHtml:ctxChip(ctx),pass:ctxChip(ctx)===''});
   const project=path.join(tmp,'project');fs.mkdirSync(path.join(project,'.git'),{recursive:true});
   const routerDir=path.join(project,'.agentic-qe');fs.mkdirSync(routerDir);
   const routerFile=path.join(routerDir,'llm-config.json');
@@ -65,7 +65,8 @@ try {
   fs.writeFileSync(routerFile,JSON.stringify(current));fs.writeFileSync(`${routerFile}.bak`,JSON.stringify(prior));
   const outcome=undoAqeRouter(project),after=JSON.parse(fs.readFileSync(routerFile,'utf8'));
   results.push({issue:'Legacy router undo',before:current,outcome,after,
-    expected:'Preserve later user edits or refuse drift',actualLostKeys:['newUserKey'],actualRevertedKey:'userKey'});
+    expected:'Preserve later user edits or refuse drift',actualLostKeys:Object.keys(current).filter(key=>!(key in after)),
+    pass:after.newUserKey===current.newUserKey&&after.userKey===current.userKey});
   const rollRoot=path.join(tmp,'rollouts');const dayDir=path.join(rollRoot,'2026','09','09');fs.mkdirSync(dayDir,{recursive:true});
   const rateRaw=[evt('session_meta',{id:'price-synthetic',cwd:tmp,thread_source:'user'}),
     evt('turn_context',{model:'gpt-5.6-sol'},1),
@@ -75,10 +76,12 @@ try {
   const diagnostic=JSON.parse(execFileSync(process.execPath,[`${root}/scripts/codex-usage-diagnostic.mjs`,'--root',rollRoot,'--json'],{encoding:'utf8'}));
   const modernPrice=sessionPayload(parseCodex(rateRaw,{id:'price-synthetic'}).session,[],{costOf}).meta.cost;
   results.push({issue:'Legacy diagnostic pricing',model:'gpt-5.6-sol',inputTokens:1000000,
-    currentParserPrice:modernPrice,diagnosticPrice:diagnostic.tokens.afterFix_excludingSubagentReplays.cost});
+    currentParserPrice:modernPrice,diagnosticPrice:diagnostic.tokens.afterFix_excludingSubagentReplays.cost,
+    pass:modernPrice===diagnostic.tokens.afterFix_excludingSubagentReplays.cost});
   const humanOutput=execFileSync(process.execPath,[`${root}/scripts/codex-usage-diagnostic.mjs`,'--root',rollRoot],{encoding:'utf8'});
   results.push({issue:'Legacy diagnostic privacy',claims:humanOutput.split('\n').filter(x=>/No prompts|safe to paste/.test(x)),
-    actualPathLine:humanOutput.split('\n').find(x=>x.startsWith('Rollout files scanned root:'))});
+    actualPathLine:humanOutput.split('\n').find(x=>x.startsWith('Rollout files scanned root:'))??null,
+    pass:!humanOutput.includes(rollRoot)});
   fs.rmSync(path.join(dayDir,'rollout-price-synthetic.jsonl'));
   const replayRaw=[evt('session_meta',{id:'child-synthetic',cwd:tmp,thread_source:'subagent'}),
     evt('session_meta',{id:'parent-synthetic',cwd:tmp,thread_source:'user'},1),
@@ -90,8 +93,9 @@ try {
   const currentReplay=parseCodex(replayRaw,{id:'child-synthetic'}).session;
   results.push({issue:'Legacy diagnostic replay',currentThreadSource:currentReplay.threadSource,
     currentUsageRows:currentReplay.usage.length,diagnosticThreadSources:replayDiag.threadSourceCounts,
-    diagnosticAfterTokens:replayDiag.tokens.afterFix_excludingSubagentReplays.total});
-  const primarySources=['src/lib/usage-opencode.mjs','src/lib/usage-parsers.mjs','src/lib/usage-aggregate.mjs','src/lib/pricing.mjs','src/lib/aqe-router.mjs','src/lib/dashboard/client/usage.mjs','scripts/codex-usage-diagnostic.mjs'];
+    diagnosticAfterTokens:replayDiag.tokens.afterFix_excludingSubagentReplays.total,
+    pass:replayDiag.threadSourceCounts.subagent===1&&replayDiag.tokens.afterFix_excludingSubagentReplays.total===0});
+  const primarySources=['src/lib/usage-opencode.mjs','src/lib/usage-parsers.mjs','src/lib/usage-aggregate.mjs','src/lib/pricing.mjs','src/lib/aqe-router.mjs','src/lib/provider-ownership.mjs','src/lib/usage-cost.mjs','src/lib/dashboard/client/usage.mjs','scripts/codex-usage-diagnostic.mjs'];
   const sourceDigests=Object.fromEntries(primarySources.map(file=>[file,createHash('sha256').update(fs.readFileSync(path.join(root,file))).digest('hex')]));
   console.log(JSON.stringify({referenceBaseline:'67fb5c0',sourceCheckout:'current checkout',sourceDigests,syntheticOnly:true,results},null,2).split(tmp).join('<temporary-root>'));
 } finally {fs.rmSync(tmp,{recursive:true,force:true});}

--- a/docs/audits/plugin-memory-status-followup.md
+++ b/docs/audits/plugin-memory-status-followup.md
@@ -1,0 +1,101 @@
+# Plugin and memory status follow-up
+
+Observed 2026-09-09. Scope: agentic-kit diagnostics and evidence only; no external
+plugin edits, changes to existing memory stores, migrations, or consolidation.
+Concurrent Ruflo workers continued writing during the memory inspection.
+
+## Plugin compatibility
+
+Installed Codex CLI: 0.153.4. A temporary stdio app-server client initialized,
+called `skills/list` with `forceReload: true`, and terminated without starting
+an inference turn. It returned no skill errors and enabled entries for
+`spreadsheets:Spreadsheets`, `presentations:Presentations`, and
+`spreadsheets:excel-live-control` from `openai-primary-runtime` 26.905.11957.
+
+Agentic-kit's old validator emitted four issues: directory mismatch and
+lowercase-name rejection for each of the first two entries. The repaired
+validator accepts nonempty display names up to 64 Unicode characters. A live
+recheck found 24 enabled plugins, zero skill issues, and zero hook issues.
+
+Upstream source inspected at Codex revision
+`2617ed2e1c4b9fb59a9058fe28a8f9e78bc81878`:
+`codex-rs/ext/skills/src/loader/mod.rs` defines `MAX_NAME_LEN = 64`, and
+`loader/metadata.rs` validates nonempty names by Unicode character length.
+[Official skill documentation](https://learn.chatgpt.com/docs/build-skills)
+describes required frontmatter and discovery. No plugin cache repair is needed.
+
+## Memory routing
+
+Installed Ruflo and `@claude-flow/cli`: 3.39.2. Read-only SQLite inspection
+compared active `(namespace, key)` pairs, without emitting values:
+
+| Observation | Count |
+| --- | ---: |
+| `memory.db` distinct active keys | 51 |
+| `agentdb-memory.db` distinct active keys | 16,671 |
+| Shared keys | 1 |
+| Only in `memory.db` | 50 |
+| Only in `agentdb-memory.db` | 16,670 |
+
+Counts are observations from an active installation, not a frozen migration
+snapshot. The second store grew during inspection. Both stores have compatible
+`memory_entries` columns, including `status` and `provenance_type`. The known
+synthetic audit-result key exists only in the sibling store. This establishes
+separate corpora; it does not establish value equality for the shared key.
+
+Installed CLI source, relative to `@claude-flow/cli/dist/src/`:
+
+| Location | Evidence |
+| --- | --- |
+| `commands/memory.js:279` | CLI resolves and passes `dbPath` to retrieval. |
+| `memory/memory-initializer.js:149` | Explicit path, then `CLAUDE_FLOW_DB_PATH`, then memory-root default. |
+| `mcp-tools/memory-tools.js:383` | MCP calls retrieval without `dbPath`. |
+| `memory/memory-initializer.js:3009` | Options pass to the native bridge. |
+| `memory/memory-bridge.js:1228` | Bridge passes optional path to its registry. |
+| `memory/memory-bridge.js:168` | Registry uses explicit path or `getAgentDbPath()`. |
+| `memory/memory-bridge.js:127` | Default native filename is `agentdb-memory.db`. |
+| `memory/memory-initializer.js:103` | Native root reads memory-path environment/JSON configuration, not the compatibility DB filename variable. |
+| `memory/memory-bridge.js:1278` | Retrieval updates access metadata; it is not a read-only forensic probe. |
+
+Agentic-kit's `src/lib/ruflo-memory.mjs` pins project cwd and the compatibility
+path; changing that alone cannot repair upstream's conflicting path contracts.
+The status fix uses filenames rather than claiming a backend from a filename,
+and supplies explicit targeting/preservation guidance. The warning remains
+because the underlying split remains unresolved.
+
+Upstream remediation: centralize resolved path identity across CLI, MCP and
+backend selection; key native registries by resolved path; test cross-process
+CLI-to-MCP-to-CLI behavior with disjoint preexisting corpora, custom paths,
+native-disabled mode, and encryption; expose a read-only route/peek operation.
+Existing stores need separately reviewed migration, not an automatic rename.
+The exact existing report is [Ruflo #3196](https://github.com/ruvnet/ruflo/issues/3196).
+A [3.39.2 confirmation](https://github.com/ruvnet/ruflo/issues/3196#issuecomment-5606621769)
+adds system versions, discovery details, the isolated reproduction, and proposed
+acceptance criteria. No duplicate issue or upstream code patch was submitted.
+
+## Validation
+
+Regression tests cover accepted capitalized/different-directory names, Unicode
+length boundaries, file-based memory labels, and preservation/targeting guidance.
+Live Codex loader and repaired agentic-kit inspection agree for the reported
+bundled skills. Memory facts came from read-only SQLite and installed source;
+no CLI/MCP retrieval was used as a supposedly read-only probe.
+
+## Follow-through
+
+Agentic-kit tracking issue: [upstream integration plan](https://github.com/pacphi/agentic-kit/issues/213). It records
+release verification, isolated candidate testing, path-identity regression cases,
+existing-corpus preservation and rollback, and closure criteria. A closed upstream
+issue is not sufficient evidence to remove this warning.
+
+The [isolated reproduction](ruflo-memory-route-repro.mjs) and
+[recorded result](ruflo-memory-route-results.jsonl) use fresh processes, real
+installed MCP handlers and CLI-shaped storage calls. Both directional default
+lookups miss the other store; an explicit sibling lookup succeeds. This tests
+path selection independently of the singleton defect, without claiming full
+stdio-transport coverage. All writes are to a disposable temporary corpus.
+
+Final combined checks: 3,908 unit tests passed, six platform skips, zero failures;
+coverage 92.02% lines, 80.89% branches, 91.58% functions. The earlier full browser
+run passed 491 assertions and six suites. Subsequent changes affect backend
+status text/plugin validation and documentation; focused status/plugin tests pass.

--- a/docs/audits/ruflo-memory-route-repro.mjs
+++ b/docs/audits/ruflo-memory-route-repro.mjs
@@ -1,0 +1,33 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {pathToFileURL} from 'node:url';
+import {spawnSync} from 'node:child_process';
+import {DatabaseSync} from 'node:sqlite';
+// Run with the installed @claude-flow/cli/dist/src directory as argv[2].
+// Only a newly created temporary corpus is read/written; it is removed at end.
+const base=process.argv[2];
+if(!base||!fs.existsSync(path.join(base,'memory/memory-initializer.js')))throw Error('Pass the installed @claude-flow/cli/dist/src directory');
+const sandbox=fs.mkdtempSync(path.join(os.tmpdir(),'ruflo-3196-'));
+fs.mkdirSync(path.join(sandbox,'.swarm'));
+const env={...process.env,CLAUDE_FLOW_MEMORY_PATH:path.join(sandbox,'.swarm'),CLAUDE_FLOW_ENCRYPT_AT_REST:'0',RUFLO_DAEMON_AUTOSTART:'0',HF_HUB_OFFLINE:'1',TRANSFORMERS_OFFLINE:'1'};
+delete env.CLAUDE_FLOW_DB_PATH; delete env.CLAUDE_FLOW_DISABLE_BRIDGE;
+const mod=relative=>JSON.stringify(pathToFileURL(path.join(base,relative)).href);
+function run(label,code){
+ const result=spawnSync(process.execPath,['--input-type=module','-e',`${code}\nconst {shutdownBridge}=await import(${mod('memory/memory-bridge.js')});await shutdownBridge();process.exit(0);`],{cwd:sandbox,env,encoding:'utf8',timeout:45000,maxBuffer:2*1024*1024});
+ const lines=result.stdout?.split('\n').filter(s=>s.startsWith('PROBE:'))??[];
+ console.log(JSON.stringify({label,exit:result.status,error:result.error?.message,result:lines.map(s=>JSON.parse(s.slice(6)))}));
+ if(result.status!==0||lines.length!==1)throw Error('probe failed');
+ return JSON.parse(lines[0].slice(6));
+}
+try{
+const put=run('CLI-shaped store with explicit resolved path',`const {storeEntry,resolveDbPath}=await import(${mod('memory/memory-initializer.js')}); const r=await storeEntry({key:'cli-key',namespace:'route-proof',value:'synthetic-cli-value',dbPath:resolveDbPath(),generateEmbeddingFlag:false,upsert:true});console.log('PROBE:'+JSON.stringify({success:r.success,dbPath:r.dbPath,error:r.error}));`);
+if(!put.success)throw Error('seed write failed');
+const mcpGet=run('actual MCP retrieve handler fresh process',`const {memoryTools}=await import(${mod('mcp-tools/memory-tools.js')});const r=await memoryTools.find(t=>t.name==='memory_retrieve').handler({key:'cli-key',namespace:'route-proof'});console.log('PROBE:'+JSON.stringify(r));`);
+const mcpPut=run('actual MCP store handler fresh process',`const {memoryTools}=await import(${mod('mcp-tools/memory-tools.js')});const r=await memoryTools.find(t=>t.name==='memory_store').handler({key:'mcp-key',namespace:'route-proof',value:'synthetic-mcp-value'});console.log('PROBE:'+JSON.stringify(r));`);
+if(!mcpPut.success)throw Error('MCP seed write failed');
+const cliGet=run('CLI-shaped retrieve default fresh process',`const {getEntry,resolveDbPath}=await import(${mod('memory/memory-initializer.js')});const r=await getEntry({key:'mcp-key',namespace:'route-proof',dbPath:resolveDbPath()});console.log('PROBE:'+JSON.stringify({found:r.found}));`);
+const explicitGet=run('CLI-shaped retrieve explicit sibling fresh process',`const {getEntry}=await import(${mod('memory/memory-initializer.js')});const r=await getEntry({key:'mcp-key',namespace:'route-proof',dbPath:${JSON.stringify(path.join(sandbox,'.swarm/agentdb-memory.db'))}});console.log('PROBE:'+JSON.stringify({found:r.found}));`);
+console.log(JSON.stringify({splitReproduced:mcpGet.found===false&&cliGet.found===false&&explicitGet.found===true}));
+for(const name of ['memory.db','agentdb-memory.db']){const db=new DatabaseSync(path.join(sandbox,'.swarm',name),{readOnly:true});console.log(JSON.stringify({file:name,keys:db.prepare("SELECT key FROM memory_entries WHERE namespace='route-proof' AND (status='active' OR status IS NULL) ORDER BY key").all()}));db.close();}
+}finally{fs.rmSync(sandbox,{recursive:true,force:true});}

--- a/docs/audits/ruflo-memory-route-results.jsonl
+++ b/docs/audits/ruflo-memory-route-results.jsonl
@@ -1,0 +1,8 @@
+{"label":"CLI-shaped store with explicit resolved path","exit":0,"result":[{"success":true}]}
+{"label":"actual MCP retrieve handler fresh process","exit":0,"result":[{"key":"cli-key","namespace":"route-proof","value":null,"found":false}]}
+{"label":"actual MCP store handler fresh process","exit":0,"result":[{"success":true,"key":"mcp-key","namespace":"route-proof","stored":true,"storedAt":"2026-09-09T18:13:08.240Z","hasEmbedding":true,"embeddingDimensions":384,"provenanceType":"unknown","backend":"sqlite (bridge, brute-force cosine)","storeTime":"178.67ms"}]}
+{"label":"CLI-shaped retrieve default fresh process","exit":0,"result":[{"found":false}]}
+{"label":"CLI-shaped retrieve explicit sibling fresh process","exit":0,"result":[{"found":true}]}
+{"splitReproduced":true}
+{"file":"memory.db","keys":[{"key":"cli-key"}]}
+{"file":"agentdb-memory.db","keys":[{"key":"mcp-key"}]}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "ak": "bin/agentic-kit.mjs"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=22.13.0 <23 || >=23.4.0"
   },
   "files": [
     "bin/agentic-kit.mjs",

--- a/scripts/codex-usage-diagnostic.mjs
+++ b/scripts/codex-usage-diagnostic.mjs
@@ -1,40 +1,21 @@
 #!/usr/bin/env node
-// codex-usage-diagnostic.mjs — standalone, zero-dependency (Node built-ins
-// only), read-only diagnostic for the two Codex usage-scorecard bugs fixed in
-// this branch (see docs/USAGE-SCORECARD-METRICS.md Appendix A):
+// Repository-local, zero-runtime-dependency Codex replay diagnostic.
+// Parsing remains independent of the dashboard parser; pricing deliberately
+// shares the maintained rate module. This compares an all-rollout cumulative
+// snapshot with one excluding explicitly marked subagent rollouts. It is not
+// a dashboard parity oracle: no ledger fallback, per-turn/day/model allocation,
+// or context analysis is performed. Historical JSON keys are kept for callers.
 //
-//   Bug A — Codex model rows always showed 0 responses (display-only, no $/tok effect).
-//   Bug B — a rollout whose session_meta.thread_source is "subagent" replays its
-//           parent thread's ENTIRE prior token history as duplicate events before
-//           its own new turns (openai/codex thread_spawn behavior — see
-//           ccusage/ccusage#950, which measured up to 91x cost inflation from
-//           exactly this). The old code counted that replayed total as real spend.
-//
-// This script reproduces BOTH the OLD (buggy) and NEW (fixed) token totals
-// side by side, computed independently from this diagnostic's own small
-// reimplementation of the relevant parsing logic — not by importing the fix
-// itself — so the comparison is a genuine check, not a tautology:
-//
-//   "before" should match what your CURRENT (unpatched) dashboard shows you.
-//   "after"  is what it will show once this branch's fix lands.
-//
-// PRIVACY: this script never reads, stores, or prints session titles, prompts,
-// message bodies, file paths, session ids, or working directories. It reads
-// only three fields per rollout line: `type`, `session_meta.thread_source`,
-// and the numeric fields inside `token_count.info.total_token_usage`. The
-// entire printed report is aggregate counts — safe to paste back in full.
-//
-// USAGE:
-//   node codex-usage-diagnostic.mjs                # scans ~/.codex/sessions
-//   node codex-usage-diagnostic.mjs --root <path>   # scan a different root
-//   node codex-usage-diagnostic.mjs --json          # machine-readable output
-//   node codex-usage-diagnostic.mjs --help
-//
-// Requires Node 18+. No npm install, no network access, no writes to disk.
+// PRIVACY: files are read and parsed locally (including their JSON bodies), but
+// only aggregate numeric counts leave this process. No transcript strings,
+// paths, prompts, titles, ids, or timestamps are printed or retained in reports.
+// Run from this repository: node scripts/codex-usage-diagnostic.mjs [--root path] [--json]
+// No network access or disk writes.
 
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { costOf, PRICES_AS_OF } from '../src/lib/pricing.mjs';
 
 // ── CLI args ─────────────────────────────────────────────────────────────
 
@@ -47,52 +28,14 @@ codex-usage-diagnostic.mjs — read-only, aggregate-only Codex usage check
   --json          print machine-readable JSON instead of the human-readable report
   --help          show this message
 
-Prints only counts and token/cost totals. Never reads or prints prompts,
-titles, session ids, file paths, or timestamps of any individual session.
+Reads local rollout JSON and prints only counts and token/cost totals.
+No prompts, titles, session ids, file paths, or timestamps appear in reports.
 `.trim());
   process.exit(0);
 }
 const rootIdx = args.indexOf('--root');
 const root = rootIdx >= 0 && args[rootIdx + 1] ? args[rootIdx + 1] : path.join(os.homedir(), '.codex', 'sessions');
 const asJson = args.includes('--json');
-
-// ── minimal OpenAI rate table, for a $ estimate only ────────────────────
-// Kept intentionally tiny (Codex-relevant entries only) and mirrors
-// src/lib/pricing.mjs as of 2026-07-25. If this script is run long after
-// that date, treat the $ figures as directional, not exact — re-check
-// src/lib/pricing.mjs for the current table. Same cache multipliers as
-// Anthropic's own published rates (0.1x read, 1.25x write); see
-// docs/USAGE-SCORECARD-METRICS.md §13 for the citations behind those two
-// numbers.
-const RATES = [
-  ['gpt-5.6-sol', 5, 30],
-  ['gpt-5.6-terra', 2.5, 15],
-  ['gpt-5.6-luna', 1, 6],
-  ['gpt-5.5-pro', 30, 180],
-  ['gpt-5.5', 5, 30],
-  ['gpt-5.4-mini', 0.75, 4.5],
-  ['gpt-5.4-nano', 0.2, 1.25],
-  ['gpt-5.4-pro', 30, 180],
-  ['gpt-5.4', 2.5, 15],
-  ['gpt-5.3-codex', 1.75, 14],
-];
-const FALLBACK_RATE = [3, 15]; // unrecognized model: mid-line estimate, never $0
-// Codex rollouts report no separate cache-write figure (parseCodex always
-// passes cacheWrite: 0 — see src/lib/usage-index.mjs), so only the read
-// multiplier is needed here.
-const CACHE_READ_MULTIPLIER = 0.1;
-
-function rateFor(model) {
-  const id = String(model || '').toLowerCase();
-  const hit = RATES.find(([key]) => id === key || id.startsWith(`${key}-`));
-  return hit ? [hit[1], hit[2]] : FALLBACK_RATE;
-}
-
-function costOf({ model, input, output, cacheRead }) {
-  const [rin, rout] = rateFor(model);
-  const inputUnits = (Number(input) || 0) + (Number(cacheRead) || 0) * CACHE_READ_MULTIPLIER;
-  return (inputUnits * Number(rin) + (Number(output) || 0) * Number(rout)) / 1e6;
-}
 
 // ── walk root/<yyyy>/<mm>/<dd>/rollout-*.jsonl ──────────────────────────
 
@@ -122,13 +65,14 @@ function findRolloutFiles(rootDir) {
 
 // ── parse one rollout: mirrors src/lib/usage-index.mjs's parseCodex, but
 //    extracts ONLY thread_source, model, and the last cumulative token_count.
-//    Never reads or retains message text, prompts, ids, or paths. ─────────
+//    Does not include transcript strings in the returned aggregate. ─────────
 
 function parseRollout(file) {
   let raw;
   try { raw = fs.readFileSync(file, 'utf8'); } catch { return null; }
 
   let threadSource = null;
+  let seenMeta = false;
   let model = 'unknown';
   let lastUsage = null;
   let hasResponse = false;
@@ -142,7 +86,8 @@ function parseRollout(file) {
     const p = e.payload ?? {};
 
     if (e.type === 'session_meta') {
-      if (typeof p.thread_source === 'string') threadSource = p.thread_source;
+      if (!seenMeta && typeof p.thread_source === 'string') threadSource = p.thread_source;
+      seenMeta = true;
       continue;
     }
     if (e.type === 'turn_context') {
@@ -156,7 +101,7 @@ function parseRollout(file) {
       if (t && typeof t === 'object') lastUsage = t;
       continue;
     }
-    if (p.type === 'agent_message') hasResponse = true;
+    if (p.type === 'agent_message' || (p.type === 'item_completed' && p.item?.type === 'AgentMessage')) hasResponse = true;
   }
 
   if (!hasResponse || !lastUsage) return null; // no assistant turn → not a session, per usage-index.mjs
@@ -164,7 +109,7 @@ function parseRollout(file) {
   const cacheRead = Number(lastUsage.cached_input_tokens) || 0;
   const gross = Number(lastUsage.input_tokens) || 0;
   return {
-    threadSource: threadSource ?? 'user', // absent field == "user" (openai/codex#23001: older rollouts predate the field)
+    threadSource, // unknown without metadata; this diagnostic does not read the Codex ledger
     model,
     input: Math.max(0, gross - cacheRead),
     output: Number(lastUsage.output_tokens) || 0,
@@ -183,9 +128,6 @@ for (const f of files) {
 }
 
 const subagentSessions = sessions.filter((s) => s.threadSource === 'subagent');
-const otherThreadSources = [...new Set(
-  sessions.map((s) => s.threadSource).filter((v) => v !== 'user' && v !== 'subagent'),
-)];
 
 function sumTokens(list) {
   return list.reduce(
@@ -211,9 +153,10 @@ const report = {
   parsedAsSessions: sessions.length,
   unreadableOrNoAssistantTurn: unparsed,
   threadSourceCounts: {
-    user: sessions.length - subagentSessions.length - sessions.filter((s) => otherThreadSources.includes(s.threadSource)).length,
+    user: sessions.filter((s) => s.threadSource === 'user').length,
+    unknown: sessions.filter((s) => s.threadSource === null).length,
     subagent: subagentSessions.length,
-    other: otherThreadSources.length ? otherThreadSources : undefined,
+    other: sessions.filter((s) => s.threadSource !== null && !['user', 'subagent'].includes(s.threadSource)).length,
   },
   tokens: {
     beforeFix_allSessions: { ...before, total: totalTok(before) },
@@ -222,7 +165,7 @@ const report = {
     pctOfTotalTokensExcluded: pct(totalTok(excluded), totalTok(before)),
     pctOfTotalCostExcluded: pct(excluded.cost, before.cost),
   },
-  costEstimateNote: 'Uses a small embedded OpenAI rate table (gpt-5.x family) mirroring src/lib/pricing.mjs as of 2026-07-25 — directional, not authoritative. See docs/USAGE-SCORECARD-METRICS.md §13.2.',
+  costEstimateNote: `Uses repository pricing as of ${PRICES_AS_OF}; estimates are API equivalents, not billing. Independent cumulative snapshot, not full dashboard parity; missing thread source remains unknown and is included.`,
 };
 
 if (asJson) {
@@ -233,21 +176,19 @@ if (asJson) {
   console.log('Codex usage diagnostic — Bug B (subagent thread-replay) check');
   console.log('='.repeat(64));
   console.log('No prompts, titles, session ids, file paths, or timestamps below.');
-  console.log('This entire block is safe to paste back in full.\n');
-  console.log(`Rollout files scanned root: ${root}`);
+  console.log('Only aggregate counts and estimates are shown.\n');
   console.log(`Rollout files found:        ${report.rolloutFilesFound}`);
   console.log(`Counted as real sessions:   ${report.parsedAsSessions}  (>=1 assistant reply)`);
   console.log(`Skipped (unreadable / no reply): ${report.unreadableOrNoAssistantTurn}\n`);
-  console.log(`thread_source = "user" (or absent): ${report.threadSourceCounts.user}`);
+  console.log(`thread_source = "user": ${report.threadSourceCounts.user}`);
   console.log(`thread_source = "subagent":          ${report.threadSourceCounts.subagent}`);
-  if (report.threadSourceCounts.other) {
-    console.log(`thread_source = other values seen:   ${report.threadSourceCounts.other.join(', ')}`);
-  }
+  console.log(`thread_source = unknown:             ${report.threadSourceCounts.unknown}`);
+  console.log(`thread_source = other:               ${report.threadSourceCounts.other}`);
   console.log('');
-  console.log('BEFORE the fix (what your current dashboard shows — verify this matches):');
+  console.log('ALL rollouts (historical replay-inclusive comparison):');
   console.log(`  tokens: ${tok(before.input + before.output + before.cacheRead)}  (input ${tok(before.input)} · output ${tok(before.output)} · cache-read ${tok(before.cacheRead)})`);
   console.log(`  API-equivalent cost estimate: ${usd(before.cost)}\n`);
-  console.log('AFTER the fix (excludes thread_source:"subagent" rollouts):');
+  console.log('EXCLUDING explicitly marked subagent rollouts:');
   console.log(`  tokens: ${tok(after.input + after.output + after.cacheRead)}  (input ${tok(after.input)} · output ${tok(after.output)} · cache-read ${tok(after.cacheRead)})`);
   console.log(`  API-equivalent cost estimate: ${usd(after.cost)}\n`);
   console.log(`Excluded as subagent replay: ${tok(totalTok(excluded))} tokens (${report.tokens.pctOfTotalTokensExcluded}% of before-fix total), ~${usd(excluded.cost)} (${report.tokens.pctOfTotalCostExcluded}% of before-fix cost)`);

--- a/src/commands/status/sections/project-memory.mjs
+++ b/src/commands/status/sections/project-memory.mjs
@@ -2,6 +2,7 @@
 // memory.db and the native bridge's plaintext agentdb-memory.db sibling.
 // Presence cannot establish the active writer or CLI/MCP routing. The isolated
 // `ak x verify memory` canary does not prove access to an existing corpus.
+import path from 'node:path';
 import { projectMemoryStatus } from '../../../lib/project-memory.mjs';
 import { row } from '../row.mjs';
 
@@ -16,11 +17,11 @@ export default {
       } else {
         for (const store of memory.stores.filter((candidate) => candidate.present)) {
           rows.push(row('memory', store.readable ? 'info' : 'warn', store.readable
-            ? `${store.kind}: ${store.entries} active entr${store.entries === 1 ? 'y' : 'ies'} observed; writer and existing-corpus routing unverified`
-            : `${store.kind} store is unreadable (${store.file}); existing-corpus access unverified`));
+            ? `${path.basename(store.file)}: ${store.entries} active entr${store.entries === 1 ? 'y' : 'ies'} observed; backend, writer and existing-corpus routing unverified`
+            : `${path.basename(store.file)} store is unreadable (${store.file}); existing-corpus access unverified`));
         }
         if (memory.secondary) rows.push(row('memory', 'warn',
-          'two project memory stores coexist; CLI and MCP may select different files — an isolated canary does not verify existing-corpus routing'));
+          'two project memory stores coexist; preserve both. CLI --path selects a store; MCP routing needs separate verification. See Troubleshooting: Ruflo memory stores and routing'));
       }
     } catch (e) {
       rows.push(row('memory', 'warn', `project memory check unavailable: ${e.message}`));

--- a/src/lib/adapters/registries.mjs
+++ b/src/lib/adapters/registries.mjs
@@ -240,7 +240,7 @@ const hostEntries = [
   {
     id: 'opencode', label: 'OpenCode', enabledByDefault: false,
     install: { bin: 'opencode', npmPackage: 'opencode-ai', externalInstallPolicy: 'detect-never-overwrite' },
-    capabilities: { canDriveSession: true, canBePrimary: false, canRouteActivities: true, commandStatusline: false, transcripts: true, usage: false, nativeMcpConfig: true, nativeGuidance: true },
+    capabilities: { canDriveSession: true, canBePrimary: false, canRouteActivities: true, commandStatusline: false, transcripts: true, usage: true, nativeMcpConfig: true, nativeGuidance: true },
     auth: { apiKeyEnv: [], loginFile: ['.local', 'share', 'opencode', 'auth.json'], keyOverridesLogin: false },
     legacy: {
       guidanceFile: 'agents-opencode', configFormat: 'json',

--- a/src/lib/aqe-router.mjs
+++ b/src/lib/aqe-router.mjs
@@ -22,7 +22,8 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { repoRoot } from './paths.mjs';
-import { readJson, writeJsonWithBackup } from './settings.mjs';
+import { readJson } from './settings.mjs';
+import { writeOwnedRouter, undoOwnedRouter } from './provider-ownership.mjs';
 import { configuredPolicyToAgentOverrides, AGENT_ACTIVITY_MAP } from './routing.mjs';
 import { admittedAqeProviders } from './adapters/aqe-provider.mjs';
 import {
@@ -634,7 +635,7 @@ export function applyAqeRouter(cfg, cwd = process.cwd()) {
     return { ok: !error, changed: false, detail: details.join('; ') || 'nothing to apply' };
   }
   fs.mkdirSync(path.dirname(file), { recursive: true });
-  writeJsonWithBackup(file, next);
+  writeOwnedRouter(file, next);
   return { ok: !error, changed: true, detail: details.join('; ') };
 }
 
@@ -662,20 +663,12 @@ export function aqeRouterDrift(cfg, cwd = process.cwd()) {
   return { applicable: true, drift, order };
 }
 
-/** Reversible teardown of ak's router management. Restores the pre-ak file from
- *  its one-time .bak, or removes an ak-created file. Never touches a file ak
- *  didn't write (no `_managedBy` tag). */
+/** Restore/remove only a verified unchanged projection. Legacy ownership or
+ *  post-setup drift is preserved with a manual recovery path. */
 export function undoAqeRouter(cwd = process.cwd()) {
   const file = aqeRouterFile(cwd);
   if (!fs.existsSync(file)) return { ok: true, changed: false, detail: 'no aqe router config' };
   const cur = readJson(file);
   if (cur?._managedBy !== AQE_MANAGED_TAG) return { ok: true, changed: false, detail: 'llm-config.json not ak-managed — left as-is' };
-  const bak = `${file}.bak`;
-  if (fs.existsSync(bak)) {
-    fs.copyFileSync(bak, file);
-    fs.rmSync(bak, { force: true });
-    return { ok: true, changed: true, detail: 'restored pre-ak llm-config.json' };
-  }
-  fs.rmSync(file, { force: true });
-  return { ok: true, changed: true, detail: 'removed ak-created llm-config.json' };
+  return undoOwnedRouter(file);
 }

--- a/src/lib/codex-plugins.mjs
+++ b/src/lib/codex-plugins.mjs
@@ -8,7 +8,10 @@ import { inspectCodexTomlStructure, isTomlTableLine } from './codex-toml-safety.
 import { cmpVersions } from './versions.mjs';
 
 const HOOK_KEYS = new Set(['description', 'hooks']);
-const SKILL_NAME = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+// Codex validates a nonempty display name up to 64 Unicode characters.
+// Folder equality/kebab-case are authoring conventions, not loader failures.
+// Verified with Codex 0.153.4 skills/list and upstream ext/skills loader.
+const MAX_SKILL_NAME = 64;
 const ADVISORIES = [{
   ref: 'security-guidance@claude-plugins-official',
   through: '2.0.7',
@@ -206,11 +209,8 @@ function inspectSkills(root) {
     const { name, description } = parsed.metadata;
     if (!name) issues.push(`${file}: frontmatter requires a non-empty name`);
     if (!description) issues.push(`${file}: frontmatter requires a non-empty description`);
-    if (name && name !== directory.name) {
-      issues.push(`${file}: frontmatter name "${name}" must match directory "${directory.name}"`);
-    }
-    if (name && (!SKILL_NAME.test(name) || name.length > 63)) {
-      issues.push(`${file}: frontmatter name must be lowercase kebab-case and at most 63 characters`);
+    if ([...name].length > MAX_SKILL_NAME) {
+      issues.push(`${file}: frontmatter name must be at most 64 characters`);
     }
   }
   return { files, issues };

--- a/src/lib/dashboard/client/usage-context-hooks.mjs
+++ b/src/lib/dashboard/client/usage-context-hooks.mjs
@@ -32,7 +32,7 @@ import { authHeaders, esc } from './bootstrap.mjs';
   }
 
   function contextCount(value){
-    return Number.isInteger(value)&&value>=0?value.toLocaleString('en-US'):'—';
+    return Number.isInteger(value)&&value>=0?value.toLocaleString():'—';
   }
 
   function contextCoverageDescription(coverage){

--- a/src/lib/dashboard/client/usage.mjs
+++ b/src/lib/dashboard/client/usage.mjs
@@ -446,7 +446,7 @@ import { renderUsage } from './usage-orchestrators.mjs';
   // discount factor would. Rendered only when there is a figure to render.
   function cacheSubtitle(t){
     var saved=Number(t.cacheSavedUsd)||0;
-    return "priced at 0.1&times; input"
+    return "model-specific cache rates"
       +(saved>0?'<span class="d-note">saved &asymp; '+esc(fmtUsd(saved))+" vs uncached</span>":"");
   }
   var CACHE_TIP="Share of this window's tokens that were cache reads. Higher is cheaper, so a rise "
@@ -503,7 +503,7 @@ import { renderUsage } from './usage-orchestrators.mjs';
     +"the streak.\nStreak counts consecutive active days ending at the most recent one.\n"
     +"Sessions INCLUDES delegated subagent sessions, which the harness dispatches rather than you — "
     +"the how-you-run panel carries the main/subagent split.";
-  var TIP_AUTONOMY="Assistant responses ÷ prompts you typed — how far each prompt travels.\n"
+  var TIP_AUTONOMY="Assistant responses ÷ recorded main-thread prompts — how far each prompt travels.\n"
     +"Prompts are MAIN-THREAD only: a subagent's prompts are written by the harness, not by you, so "
     +"counting them would inflate the denominator with work nobody asked for by hand.\nTouch rate is "
     +"those same prompts per engaged hour.";
@@ -538,7 +538,7 @@ import { renderUsage } from './usage-orchestrators.mjs';
       esc(fmtNum(active))+" active day"+(active===1?"":"s")
       +'<span class="d-note">streak '+esc(String(streak))+" day"+(streak===1?"":"s")+"</span>","",TIP_PER_DAY)
       +kpi("autonomy",auto==null?"—":fmtRatio(auto)+"×",
-        auto==null?"no prompts you typed in window"
+        auto==null?"no recorded main-thread prompts in window"
           :(touch==null?"touch rate not recorded"
             :esc(fmtRatio(touch))+" prompts / engaged hour"),"",TIP_AUTONOMY)
       +kpi("cost / session",med==null?"—":fmtUsdMin(med),
@@ -670,7 +670,8 @@ import { renderUsage } from './usage-orchestrators.mjs';
     var days=dayRows(d);
     var maxDay=0;
     for(var i=0;i<days.length;i++)maxDay=Math.max(maxDay,fld(days[i].v,"cost"));
-    document.getElementById("u-days-note").textContent="api-equivalent · "+usageDays+"-day window";
+    document.getElementById("u-days-note").textContent="reported + estimated cost · sessions ending in "+usageDays+" days · whole retained sessions"
+      +(d.acquisitionCoverage&&d.acquisitionCoverage.omittedSessions?" · "+d.acquisitionCoverage.omittedSessions+" oversized session(s) omitted":"");
     document.getElementById("u-daybars").innerHTML=days.length?days.map(function(x){
       var c=fld(x.v,"cost"), h=maxDay?Math.max(2,c/maxDay*100):2;
       var tip=x.day+" · "+fmtUsd(c)+" · "+fmtTok(fld(x.v,"tokens"))+" tok · "+fmtNum(fld(x.v,"sessions"))+" started";
@@ -1191,7 +1192,7 @@ import { renderUsage } from './usage-orchestrators.mjs';
     kpis.innerHTML=promptKpis(p);
     setText("u-pr-prov-note",win+" · every fingerprinted user-role turn");
     document.getElementById("u-pr-provenance").innerHTML=provenancePanel(p);
-    setText("u-pr-steer-note",win+" · typed prompts only");
+    setText("u-pr-steer-note",win+" · fingerprinted prompt-kind turns");
     document.getElementById("u-pr-steer").innerHTML=steerPanel(p);
     document.getElementById("u-pr-taps").innerHTML=tapLengthPanel(p);
     setText("u-pr-patterns-note",win+" · deterministic clusters");
@@ -1287,18 +1288,14 @@ import { renderUsage } from './usage-orchestrators.mjs';
         +(raw?" · recorded by the host as \""+raw+"\"":" · the host's own spelling was not recorded"))
       +'">'+esc(mode)+"</span>";
   }
-  // Context fill, and only when BOTH halves were observed: the last turn's
-  // context tokens AND that model's window. Codex records a window; claude and
-  // opencode do not, and this page carries no published-window table to fall
-  // back on — so the chip is omitted rather than divided by a guessed
-  // denominator, which would be a fabricated percentage.
+  // Only paired normalized evidence supports a ratio; legacy fields may
+  // contain independent observations from different turns/windows.
   function ctxChip(sx){
-    var used=Number(sx.ctxLastTokens),win=Number(sx.ctxWindow);
-    if(!isFinite(used)||!isFinite(win)||used<=0||win<=0)return "";
+    var pressure=sx.contextEvidence&&sx.contextEvidence.pressure;
+    if(!pressure||typeof pressure.lastBps!=="number"||!isFinite(pressure.lastBps))return "";
     return '<span class="s-chip" title="'
-      +esc("context at the last turn: "+fmtTok(used)+" of "+fmtTok(win)
-        +" tokens — both recorded by the transcript")
-      +'">ctx '+esc(Math.min(100,used/win*100).toFixed(0))+"%</span>";
+      +esc("context pressure at the last paired transcript measurement")
+      +'">ctx '+esc((pressure.lastBps/100).toFixed(0))+"%</span>";
   }
   function sessionChips(sx){
     var out="",len=Number(sx.lenSeconds)||0,p50=sessionP50(sx);

--- a/src/lib/dashboard/context-card.mjs
+++ b/src/lib/dashboard/context-card.mjs
@@ -3,7 +3,7 @@ import { esc, rowLine } from './groups.mjs';
 // Also injected into the browser bundle: one tested formatter for both paths.
 export function contextCard(group) {
   const report = group.rows.find(row => row.contextReport)?.contextReport;
-  const tokens = value => Number.isFinite(value) && value >= 0 ? value.toLocaleString('en-US') : '—';
+  const tokens = value => Number.isFinite(value) && value >= 0 ? value.toLocaleString(undefined) : '—';
   const controls = {
     claude: ['Model & compaction', 'https://code.claude.com/docs/en/model-config'],
     codex: ['Model & compaction', 'https://learn.chatgpt.com/docs/config-file/config-reference'],
@@ -36,7 +36,7 @@ export function contextCard(group) {
     const compact = threshold != null ? '<p>Configured compaction: ' + tokens(threshold) + ' tokens</p>' : '';
     const freshness = codex ? host.cacheFetchedAt : host.inventoryCapturedAt;
     const basis = models.length && freshness ? '<p class="context-basis">Cache <time datetime="' + esc(freshness) + '">'
-      + esc(new Date(freshness).toLocaleString('en-US', {dateStyle:'medium',timeStyle:'short'})) + '</time></p>' : '';
+      + esc(new Date(freshness).toLocaleString(undefined, {dateStyle:'medium',timeStyle:'short'})) + '</time></p>' : '';
     return summary + compact + table.replace('</details>', basis + '</details>') + '</section>';
   };
   const warnings = group.rows.filter(row => row.level === 'warn' || row.level === 'fail');

--- a/src/lib/dashboard/page.mjs
+++ b/src/lib/dashboard/page.mjs
@@ -444,10 +444,9 @@ export function renderPage({ name, version }) {
 
     <section class="view" id="v-score" role="tabpanel" aria-labelledby="usage-tab-score">
       <div class="hero" id="u-hero"></div>
-      <div class="note"><span class="i">&#8505;</span><span>Dollar figures are <b>API list-price equivalents</b> &mdash;
-        what these tokens would cost metered. On a Max/Pro subscription you are not billed this.
-        Cache reads bill at 0.1&times; input and cache writes at 1.25&times;; ignoring that would overstate
-        a window by roughly <b>10&times;</b>. <span class="mono" id="u-asof"></span></span></div>
+      <div class="note"><span class="i">&#8505;</span><span>Dollar figures combine <b>reported costs and API list-price estimates</b>.
+        Subscription estimates are not your bill. Cache rates vary by model and date.
+        The timeframe selects sessions by their end and includes their whole retained usage. <span class="mono" id="u-asof"></span></span></div>
       <section class="strip">
         <div class="sh"><h2>Cost per day</h2><span class="n mono" id="u-days-note"></span></div>
         <div class="days" id="u-daybars"></div>
@@ -524,15 +523,15 @@ export function renderPage({ name, version }) {
     </section>
 
     <section class="view" id="v-prompts" role="tabpanel" aria-labelledby="usage-tab-prompts" hidden>
-      <div class="note"><span class="i">&#8505;</span><span>What you actually type, across every host.
+      <div class="note"><span class="i">&#8505;</span><span>Recorded prompt patterns, across every host.
         Every figure here is computed from prompt <b>fingerprints</b> &mdash; hashes, counts, provenance, and
         bounded intent/topic codes recorded at scan time. <b>No prompt text is stored in the index or served by this
         view.</b> Semantic names require repeated majority evidence; unknown vocabulary stays unclassified.
-        Only turns a person typed are counted; agent deliveries, tool templates and slash records
-        are filtered out before anything below is measured.</span></div>
+        Prompt-kind turns are selected using host-specific provenance filters; this does not
+        prove a person typed every turn. Filter coverage varies by host.</span></div>
       <div class="hero" id="u-pr-kpis"></div>
       <section class="strip">
-        <div class="sh"><h2>Who is typing</h2><span class="n mono" id="u-pr-prov-note"></span></div>
+        <div class="sh"><h2>Prompt provenance</h2><span class="n mono" id="u-pr-prov-note"></span></div>
         <div id="u-pr-provenance"></div>
       </section>
       <section class="strip">

--- a/src/lib/live/jsonl-tailer.mjs
+++ b/src/lib/live/jsonl-tailer.mjs
@@ -1,6 +1,9 @@
 import fs from 'node:fs';
 import { StringDecoder } from 'node:string_decoder';
 
+const limit = (value, ceiling) => Number.isSafeInteger(value) && value > 0
+  ? Math.min(value, ceiling) : ceiling;
+
 /**
  * Append-aware JSONL reader. Polling is deliberate: fs.watch is only a hint on
  * several supported filesystems, while stat reconciliation catches missed
@@ -15,12 +18,19 @@ export class JsonlTailer {
   #decoder = new StringDecoder('utf8');
   #identity = null;
   #timer = null;
+  #dropping = false;
+  #droppedLines = 0;
+  #onCoverage;
 
   /**
    * @param {string} file
    * @param {{
    *   onRecord: (record: object) => void,
    *   onError?: (error: unknown, line?: string) => void,
+   *   onCoverage?: (coverage: { complete: boolean, truncated: boolean, droppedLines: number, pendingBytes: number, bufferedBytes: number }) => void,
+   *   maxChunkBytes?: number,
+   *   maxReadBytes?: number,
+   *   maxLineBytes?: number,
    *   intervalMs?: number,
    *   startAtEnd?: boolean,
    *   startOffset?: number,
@@ -29,12 +39,17 @@ export class JsonlTailer {
    */
   constructor(file, {
     onRecord, onError = () => {}, intervalMs = 500, startAtEnd = false,
-    startOffset, canRead = () => true,
+    startOffset, canRead = () => true, onCoverage = () => {},
+    maxChunkBytes, maxReadBytes, maxLineBytes,
   }) {
     if (typeof onRecord !== 'function') throw new TypeError('onRecord is required');
     this.#file = file;
     this.#onRecord = onRecord;
     this.#onError = onError;
+    this.#onCoverage = onCoverage;
+    this.maxChunkBytes = limit(maxChunkBytes, 64 * 1024);
+    this.maxReadBytes = limit(maxReadBytes, 1024 * 1024);
+    this.maxLineBytes = limit(maxLineBytes, 1024 * 1024);
     this.intervalMs = intervalMs;
     this.startAtEnd = startAtEnd;
     this.startOffset = Number.isSafeInteger(startOffset) && startOffset >= 0 ? startOffset : null;
@@ -57,28 +72,58 @@ export class JsonlTailer {
       this.#identity = identity;
       this.#offset = 0;
       this.#carry = '';
+      this.#dropping = false;
       this.#decoder = new StringDecoder('utf8');
     }
-    if (stat.size <= this.#offset) return;
-    let bytes;
+    if (stat.size <= this.#offset) { this.#coverage(stat.size); return; }
     try {
       const flags = fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW ?? 0);
       const fd = fs.openSync(this.#file, flags);
       try {
-        bytes = Buffer.alloc(stat.size - this.#offset);
-        fs.readSync(fd, bytes, 0, bytes.length, this.#offset);
+        let remaining = Math.min(stat.size - this.#offset, this.maxReadBytes);
+        const bytes = Buffer.alloc(Math.min(remaining, this.maxChunkBytes));
+        while (remaining > 0) {
+          const count = fs.readSync(fd, bytes, 0, Math.min(bytes.length, remaining), this.#offset);
+          if (!count) break;
+          this.#offset += count;
+          remaining -= count;
+          this.#consume(this.#decoder.write(bytes.subarray(0, count)));
+        }
       } finally { fs.closeSync(fd); }
-    } catch (error) {
-      this.#onError(error);
-      return;
+    } catch (error) { this.#onError(error); }
+    this.#coverage(stat.size);
+  }
+
+  #consume(text) {
+    const parts = text.split('\n');
+    for (let i = 0; i < parts.length; i++) {
+      const complete = i < parts.length - 1;
+      if (!this.#dropping) {
+        if (Buffer.byteLength(this.#carry) + Buffer.byteLength(parts[i]) > this.maxLineBytes) {
+          this.#carry = '';
+          this.#dropping = true;
+          this.#droppedLines++;
+          this.#onError(new RangeError('JSONL line exceeds acquisition byte limit'));
+        } else this.#carry += parts[i];
+      }
+      if (!complete) continue;
+      const line = this.#carry;
+      this.#carry = '';
+      if (!this.#dropping && line.trim()) {
+        try { this.#onRecord(JSON.parse(line)); } catch (error) { this.#onError(error, line); }
+      }
+      this.#dropping = false;
     }
-    this.#offset += bytes.length;
-    const parts = (this.#carry + this.#decoder.write(bytes)).split('\n');
-    this.#carry = parts.pop() ?? '';
-    for (const line of parts) {
-      if (!line.trim()) continue;
-      try { this.#onRecord(JSON.parse(line)); } catch (error) { this.#onError(error, line); }
-    }
+  }
+
+  #coverage(size) {
+    const pendingBytes = Math.max(0, size - this.#offset);
+    const bufferedBytes = Buffer.byteLength(this.#carry);
+    this.#onCoverage({
+      complete: this.#droppedLines === 0 && pendingBytes === 0 && bufferedBytes === 0,
+      truncated: this.#droppedLines > 0,
+      droppedLines: this.#droppedLines, pendingBytes, bufferedBytes,
+    });
   }
 
   start() {

--- a/src/lib/live/live-sessions-service.mjs
+++ b/src/lib/live/live-sessions-service.mjs
@@ -121,6 +121,15 @@ export class LiveSessionsService {
     return {
       ...serializeLiveProjection(this.#projection),
       health: Object.fromEntries(this.#health),
+      acquisitionCoverage: [...this.#contexts.values()].reduce((total, context) => {
+        const coverage = context.acquisitionCoverage;
+        if (!coverage) return total;
+        total.complete &&= coverage.complete;
+        total.truncated ||= coverage.truncated;
+        total.droppedLines += coverage.droppedLines;
+        total.pendingBytes += coverage.pendingBytes;
+        return total;
+      }, { complete: true, truncated: false, droppedLines: 0, pendingBytes: 0 }),
     };
   }
 
@@ -220,7 +229,10 @@ export class LiveSessionsService {
     }
     const onRecord = (record) => this.#record(record, context, file);
     const onError = (error) => this.#error(context.adapter, error);
-    const tailer = new JsonlTailer(file, { onRecord, onError, startAtEnd: initial });
+    const tailer = new JsonlTailer(file, {
+      onRecord, onError, startAtEnd: initial,
+      onCoverage: (coverage) => { context.acquisitionCoverage = coverage; },
+    });
     this.#tailers.set(file, tailer);
     this.#contexts.set(file, context);
     this.#mark(context.adapter, { files: (this.#health.get(context.adapter)?.files ?? 0) + 1 });

--- a/src/lib/live/transcript-streams.mjs
+++ b/src/lib/live/transcript-streams.mjs
@@ -148,6 +148,7 @@ class TranscriptStream {
   #seen = new Set();
   #lastMessage = null;
   #historyTruncated = false;
+  #acquisitionCoverage = { complete: true, truncated: false };
   #published = 0;
 
   constructor(host, sessionId, file, options) {
@@ -175,6 +176,10 @@ class TranscriptStream {
         for (const candidate of this.#adapt(record)) this.#publish(candidate);
       },
       onError: () => {},
+      onCoverage: (coverage) => {
+        this.#acquisitionCoverage = coverage;
+        this.#historyTruncated ||= coverage.truncated;
+      },
     }).start();
   }
 
@@ -229,6 +234,7 @@ class TranscriptStream {
     return {
       schemaVersion: 1, sessionKey: canonicalSessionKey(this.#host, this.#sessionId),
       cursor: snapshot.cursor, events: snapshot.events,
+      acquisitionCoverage: this.#acquisitionCoverage,
     };
   }
   replay(cursor) { return this.#stream.replay(cursor); }
@@ -283,6 +289,7 @@ class TranscriptStream {
       startAt,
       endAt,
       durationMs,
+      acquisitionCoverage: this.#acquisitionCoverage,
       truncated: this.#historyTruncated,
       gap: this.#historyTruncated,
       events,

--- a/src/lib/node-runtime.mjs
+++ b/src/lib/node-runtime.mjs
@@ -1,0 +1,17 @@
+// node:sqlite is available without an experimental flag in 22.13 and 23.4.
+// Keep this dependency-free so the CLI can reject older runtimes before loading
+// any command that imports SQLite. Official history: https://nodejs.org/api/sqlite.html
+export const NODE_RUNTIME_RANGE = '>=22.13.0 <23 || >=23.4.0';
+
+export function supportsNodeRuntime(version = process.versions.node) {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version);
+  if (!match) return false;
+  const major = Number(match[1]);
+  const minor = Number(match[2]);
+  return (major === 22 && minor >= 13) || (major === 23 && minor >= 4) || major >= 24;
+}
+
+export function nodeRuntimeError(version = process.versions.node) {
+  return supportsNodeRuntime(version) ? null
+    : `agentic-kit requires Node ${NODE_RUNTIME_RANGE} for built-in SQLite; found ${version}. Install a maintained Node 22, 24, or 26 patch release.`;
+}

--- a/src/lib/provider-ownership.mjs
+++ b/src/lib/provider-ownership.mjs
@@ -1,0 +1,106 @@
+// Exact postimages authorize teardown; labels and environment names do not.
+// Receipts are persisted before projection, so interruption can only withdraw
+// teardown authority. Router drift remains unresolved across subsequent syncs.
+import fs from 'node:fs';
+import { createHash } from 'node:crypto';
+import { readJson, writeJsonWithBackup } from './settings.mjs';
+import { writePrivateFileAtomic } from './file-write.mjs';
+
+export const routerReceiptFile = (file) => `${file}.agentic-kit-ownership.json`;
+const envReceiptFile = (file) => `${file}.agentic-kit-env-ownership.json`;
+const hash = (bytes) => createHash('sha256').update(bytes).digest('hex');
+const jsonBytes = (value) => `${JSON.stringify(value, null, 2)}\n`;
+const regular = (file) => {
+  try { return fs.lstatSync(file).isFile(); } catch { return false; }
+};
+function hashFile(file) { return regular(file) ? hash(fs.readFileSync(file)) : null; }
+
+export function writeOwnedRouter(file, next) {
+  const receiptFile = routerReceiptFile(file);
+  const prior = readJson(receiptFile);
+  const currentHash = hashFile(file);
+  const existing = readJson(file);
+  const backupHash = hashFile(`${file}.bak`);
+  const established = prior?.version === 1 && prior.postimage === currentHash && !prior.unresolved;
+  const fresh = !fs.existsSync(receiptFile) && existing?._managedBy !== 'agentic-kit'
+    && (!fs.existsSync(file) || regular(file))
+    && (!fs.existsSync(`${file}.bak`) || backupHash === currentHash);
+  const receipt = {
+    version: 1,
+    postimage: hash(jsonBytes(next)),
+    preimage: established ? prior.preimage : currentHash,
+    unresolved: !(established || fresh),
+  };
+  writePrivateFileAtomic(receiptFile, jsonBytes(receipt));
+  if (established && prior.preimage === null) writePrivateFileAtomic(file, jsonBytes(next));
+  else writeJsonWithBackup(file, next);
+}
+
+export function undoOwnedRouter(file, { fsImpl = fs } = {}) {
+  const receiptFile = routerReceiptFile(file);
+  const receipt = readJson(receiptFile);
+  const preserved = (reason) => ({ ok: false, changed: false,
+    detail: `llm-config.json preserved: ${reason}; review the current file and .bak, then reconcile manually` });
+  if (receipt?.version !== 1 || receipt.unresolved || typeof receipt.postimage !== 'string') {
+    return preserved('no verified postimage ownership');
+  }
+  if (hashFile(file) !== receipt.postimage) return preserved('post-setup edits or interrupted projection');
+  if (receipt.preimage !== null) {
+    if (typeof receipt.preimage !== 'string' || hashFile(`${file}.bak`) !== receipt.preimage) {
+      return preserved('original backup missing or changed');
+    }
+    // Atomic rename keeps both the live postimage and backup intact if the
+    // replacement fails. Keep the backup as recovery evidence after success.
+    writePrivateFileAtomic(file, fs.readFileSync(`${file}.bak`), { fsImpl });
+    fsImpl.rmSync(receiptFile, { force: true });
+    return { ok: true, changed: true, detail: 'restored pre-ak llm-config.json (backup retained)' };
+  }
+  fsImpl.rmSync(file);
+  fsImpl.rmSync(receiptFile, { force: true });
+  return { ok: true, changed: true, detail: 'removed ak-created llm-config.json' };
+}
+
+const state = (env, key) => Object.hasOwn(env, key) ? { present: true, value: env[key] } : { present: false };
+const matches = (a, b) => JSON.stringify(a) === JSON.stringify(b);
+const validState = (s) => s && typeof s === 'object' && typeof s.present === 'boolean'
+  && (!s.present || Object.hasOwn(s, 'value'));
+const validEntry = (entry) => validState(entry?.before) && validState(entry?.after);
+
+export function recordProviderEnv(file, env, desired, keys) {
+  const prior = readJson(envReceiptFile(file));
+  const entries = {};
+  for (const key of keys) {
+    const before = state(env, key); const after = state(desired, key);
+    const entry = prior?.version === 1 ? prior.entries?.[key] : null;
+    if (validEntry(entry) && matches(before, entry.after)) entries[key] = { before: entry.before, after };
+    else if (!matches(before, after)) entries[key] = { before, after };
+  }
+  const receipt = { version: 1, entries, pending: true,
+    unresolved: prior?.pending === true || prior?.unresolved === true };
+  writePrivateFileAtomic(envReceiptFile(file), jsonBytes(receipt));
+  // Confirm only after the target write succeeds. A failed/interrupted
+  // projection cannot be mistaken for a later user edit on the next sync.
+  return () => writePrivateFileAtomic(envReceiptFile(file), jsonBytes({ ...receipt, pending: false }));
+}
+
+export function undoOwnedProviderEnv(file, settings, keys) {
+  const receiptFile = envReceiptFile(file); const receipt = readJson(receiptFile);
+  if (receipt?.pending || receipt?.unresolved) return { ok: false, changed: false,
+    detail: 'env values preserved: interrupted projection; review settings and .bak, then reconcile manually' };
+  let restored = 0; let preserved = 0;
+  for (const key of keys) {
+    const entry = receipt?.version === 1 ? receipt.entries?.[key] : null;
+    if (!validEntry(entry) || !matches(state(settings.env, key), entry.after)) {
+      if (Object.hasOwn(settings.env, key)) preserved++;
+      continue;
+    }
+    if (entry.before.present) settings.env[key] = entry.before.value;
+    else delete settings.env[key];
+    restored++;
+  }
+  if (restored) writeJsonWithBackup(file, settings);
+  if (fs.existsSync(receiptFile)) fs.rmSync(receiptFile);
+  return { ok: preserved === 0, changed: restored > 0,
+    detail: `${restored} owned env key(s) reverted; ${preserved} unowned/edited key(s) preserved`
+      + (preserved ? ' — review preserved settings manually' : '') };
+}

--- a/src/lib/providers.mjs
+++ b/src/lib/providers.mjs
@@ -1,3 +1,4 @@
+import { recordProviderEnv, undoOwnedProviderEnv } from './provider-ownership.mjs';
 // Frontier-host + LLM-provider detection and wiring.
 //
 // why: rUv ships this downstream — ak only detects + wires it (detect→heal→verify),
@@ -835,11 +836,13 @@ export function applyHosts(cfg, cwd = process.cwd()) {
   s.env ??= {};
   const changed = providerEnvDrift(cfg, s.env);
   if (changed) {
+    const completeOwnership = recordProviderEnv(file, s.env, desired, MANAGED_ENV_KEYS);
     for (const k of MANAGED_ENV_KEYS) {
       if (k in desired) s.env[k] = desired[k];
       else delete s.env[k];
     }
     writeJsonWithBackup(file, s);
+    completeOwnership();
   }
   const on = HOSTS.filter((h) => cfg.integrations?.hosts?.[h.id]).map((h) => h.id).join('+') || 'none';
   return { ok: true, changed, detail: `hosts=${on} (${scope}${changed ? ', written' : ', in sync'})` };
@@ -1051,13 +1054,10 @@ export async function convergeProviderStack(cfg, cwd = process.cwd(), {
   };
 }
 
-/** Reversible teardown: strip every managed env key from the target file. */
+/** Revert only unchanged env values whose exact pre/postimages were recorded. */
 export function undoProviders(cwd = process.cwd()) {
   const { file } = settingsTarget(cwd);
   const s = readJson(file);
   if (!s?.env) return { ok: true, changed: false, detail: 'nothing wired' };
-  let removed = 0;
-  for (const k of MANAGED_ENV_KEYS) if (k in s.env) { delete s.env[k]; removed++; }
-  if (removed) writeJsonWithBackup(file, s);
-  return { ok: true, changed: removed > 0, detail: `${removed} managed env key(s) removed` };
+  return undoOwnedProviderEnv(file, s, MANAGED_ENV_KEYS);
 }

--- a/src/lib/sqlite.mjs
+++ b/src/lib/sqlite.mjs
@@ -1,4 +1,4 @@
-// Embedded SQLite via node:sqlite (Node >=22) — replaces every external
+// Embedded SQLite via node:sqlite (Node >=22.13 / >=23.4) — replaces every external
 // `sqlite3` binary call from the shell kit (memory verification, WAL
 // checkpoint, statusline QE metrics).
 import { DatabaseSync } from 'node:sqlite';

--- a/src/lib/usage-aggregate.mjs
+++ b/src/lib/usage-aggregate.mjs
@@ -1,3 +1,4 @@
+import { rowCostEvidence, sessionCostEvidence, acquisitionSummary } from './usage-cost.mjs';
 // usage-aggregate.mjs — pure arithmetic over ALREADY-PARSED session records:
 // interval math, secret masking, and the two shapes usage-index.mjs hands its
 // consumers (the batch Aggregate from `aggregate()`, and the single-session
@@ -632,14 +633,8 @@ function buildPromptPatterns(records, { cutoff, now }) {
 /** Sum a record's per-model usage rows into one API-equivalent cost. Rows with
  *  an observed transcript cost (opencode) use it — same preference as aggregate. */
 function sessionCost(rec, deps) {
-  let cost = 0;
-  for (const row of rec.usage ?? []) {
-    cost += row.costObserved != null ? row.costObserved : (deps.costOf({
-      model: row.model, provider: rec.provider,
-      input: row.input, output: row.output, cacheRead: row.cacheRead, cacheWrite: row.cacheWrite,
-    }) || 0);
-  }
-  return round(cost);
+  const evidence = sessionCostEvidence(rec, deps);
+  return round(evidence.observedUsd + evidence.estimatedUsd);
 }
 
 // ── aggregation ─────────────────────────────────────────────────────────────
@@ -751,10 +746,8 @@ function cacheSavedFor(row, rec, deps, rates) {
  *  today's) and fold it into a session's running sums plus the shared
  *  byDay/byModel buckets. Mutates `acc` and `activeDays`. */
 function foldSessionUsageRow(row, rec, deps, acc, byDay, byModel, activeDays) {
-  const rowCost = row.costObserved != null ? row.costObserved : (deps.costOf({
-    model: row.model, provider: rec.provider, day: row.day,
-    input: row.input, output: row.output, cacheRead: row.cacheRead, cacheWrite: row.cacheWrite,
-  }) || 0);
+  const evidence = rowCostEvidence(row, rec, deps);
+  const rowCost = evidence.observedUsd + evidence.estimatedUsd;
   acc.input += row.input; acc.output += row.output;
   acc.cacheRead += row.cacheRead; acc.cacheWrite += row.cacheWrite;
   acc.cost += rowCost;
@@ -792,7 +785,7 @@ function foldSessionUsageRows(rec, deps, byDay, byModel, rates) {
     foldSessionUsageRow(row, rec, deps, acc, byDay, byModel, activeDays);
   }
   for (const day of activeDays) byDay[day].sessionsActive++;
-  return { ...acc, firstDay: firstBilledDay(rec) };
+  return { ...acc, costEvidence: sessionCostEvidence(rec, deps), firstDay: firstBilledDay(rec) };
 }
 
 /**
@@ -855,6 +848,8 @@ function buildSessionRow(rec, usage, verdict) {
     input, output, cacheRead, cacheWrite,
     tokens: input + output + cacheRead + cacheWrite,
     cost: round(cost),
+    costEvidence: usage.costEvidence,
+    acquisitionCoverage: rec.acquisitionCoverage ?? null,
     // What the cache avoided for THIS session, so the window total is
     // auditable a row at a time rather than only in aggregate.
     cacheSavedUsd: round(cacheSaved),
@@ -1251,6 +1246,8 @@ export function aggregate(records, { days, now, cutoff, deps, previous = false, 
   const agg = {
     generatedAt,
     windowDays: days,
+    windowScope: 'whole-retained-sessions-selected-by-end',
+    acquisitionCoverage: acquisitionSummary(records, cutoff),
     pricesAsOf: deps.pricesAsOf ?? null,
     totals, byDay, engagedByDay, byModel, byHost, byProvider,
     byMode, bySource, byTool,
@@ -1336,6 +1333,8 @@ export function sessionPayload(rec, turns, deps) {
       // panel whose whole subject is cost. `.filter(Boolean)` could not drop it
       // because fmtUsd(undefined) is the truthy string "$0.00".
       cost: sessionCost(rec, deps),
+      costEvidence: sessionCostEvidence(rec, deps),
+      acquisitionCoverage: rec.acquisitionCoverage ?? null,
       ...usage, tokens: usage.input + usage.output + usage.cacheRead + usage.cacheWrite,
     },
     // ADR-0009 §8: truncation is the other way content is withheld, and it used

--- a/src/lib/usage-cost.mjs
+++ b/src/lib/usage-cost.mjs
@@ -1,0 +1,36 @@
+// Price only the missing-cost portion of a coalesced row. Reported zero is
+// evidence; missing coverage is an estimate even when that estimate is zero.
+export function rowCostEvidence(row, rec, deps) {
+  const observed = typeof row.costObserved === 'number' && Number.isFinite(row.costObserved) && row.costObserved >= 0;
+  const missing = row.costMissingUsage ?? (observed ? null : row);
+  const estimatedUsd = missing ? (deps.costOf({
+    model: row.model, provider: rec.provider, day: row.day,
+    input: missing.input, output: missing.output,
+    cacheRead: missing.cacheRead, cacheWrite: missing.cacheWrite,
+  }) || 0) : 0;
+  return {
+    observedUsd: observed ? row.costObserved : 0,
+    estimatedUsd,
+    observedMessages: observed ? (row.costObservedMessages ?? row.responses ?? 0) : 0,
+    estimatedMessages: missing?.responses ?? 0,
+  };
+}
+
+export function sessionCostEvidence(rec, deps) {
+  const total = { observedUsd: 0, estimatedUsd: 0, observedMessages: 0, estimatedMessages: 0 };
+  for (const row of rec.usage ?? []) {
+    const evidence = rowCostEvidence(row, rec, deps);
+    for (const key of Object.keys(total)) total[key] += evidence[key];
+  }
+  total.observedUsd = Math.round(total.observedUsd * 1e6) / 1e6;
+  total.estimatedUsd = Math.round(total.estimatedUsd * 1e6) / 1e6;
+  return total;
+}
+
+
+export function acquisitionSummary(records, cutoff) {
+  const incomplete = records.filter(rec => rec?.acquisitionCoverage?.complete === false
+    && (rec.end == null || rec.end >= cutoff));
+  return { complete: incomplete.length === 0, omittedSessions: incomplete.length,
+    reasons: [...new Set(incomplete.map(rec => rec.acquisitionCoverage.reason))] };
+}

--- a/src/lib/usage-index.mjs
+++ b/src/lib/usage-index.mjs
@@ -151,7 +151,8 @@ export { MAX_TURN_CHARS, mergeIntervals, maskSecrets, normalizeSessionIdentity, 
 // from parsing. Earlier cache entries discarded this metadata and must reparse.
 // v20 records exact user-root exclusion and verified real-parent eligibility
 // for the Git-only score ranking. A v19 cache cannot establish either fact.
-export const SCHEMA_VERSION = 20;
+// v21 retains per-message missing-cost coverage before OpenCode row coalescing.
+export const SCHEMA_VERSION = 21;
 
 const DAY_MS = 86_400_000;
 // One day of slack past dashboard-server.mjs's 365-day clampDays ceiling —

--- a/src/lib/usage-opencode-bounds.mjs
+++ b/src/lib/usage-opencode-bounds.mjs
@@ -1,0 +1,33 @@
+// Bound native-to-JS materialization before any JSON bodies are selected.
+// SQLite octet_length can inspect stored byte lengths without materializing
+// long TEXT/BLOB bodies. Include ids and metadata too, not only JSON payloads.
+const MAX_BYTES = 64 * 1024 * 1024;
+const MAX_ROWS = 100_000;
+const limit = (value, ceiling) => Number.isSafeInteger(value) && value > 0
+  ? Math.min(value, ceiling) : ceiling;
+
+export function sessionAcquisitionCoverage(db, id, { maxSessionBytes, maxSessionRows }) {
+  const byteLimit = limit(maxSessionBytes, MAX_BYTES);
+  const rowLimit = limit(maxSessionRows, MAX_ROWS);
+  const totals = db.prepare(`
+    SELECT COALESCE(SUM(bytes), 0) AS bytes, COALESCE(SUM(rows), 0) AS rows, MAX(latest) AS latest FROM (
+      SELECT COALESCE(SUM(octet_length(id) + COALESCE(octet_length(parent_id), 0)
+        + COALESCE(octet_length(directory), 0) + COALESCE(octet_length(title), 0)), 0) AS bytes,
+        COUNT(*) AS rows, MAX(CASE WHEN typeof(time_created) IN ('integer', 'real')
+          THEN time_created END) AS latest FROM session WHERE id = ?
+      UNION ALL
+      SELECT COALESCE(SUM(octet_length(id) + octet_length(data) + 8), 0), COUNT(*),
+        MAX(CASE WHEN typeof(time_created) IN ('integer', 'real') THEN time_created END)
+        FROM message WHERE session_id = ?
+      UNION ALL
+      SELECT COALESCE(SUM(octet_length(p.message_id) + octet_length(p.data)), 0), COUNT(*), NULL
+        FROM part p JOIN message m ON m.id = p.message_id WHERE m.session_id = ?
+    )
+  `).get(id, id, id);
+  const reason = totals.bytes > byteLimit ? 'session-byte-limit'
+    : totals.rows > rowLimit ? 'session-row-limit' : null;
+  return {
+    complete: reason === null, truncated: reason !== null, reason,
+    latestMessageAt: totals.latest, sourceBytes: totals.bytes, sourceRows: totals.rows, byteLimit, rowLimit,
+  };
+}

--- a/src/lib/usage-opencode.mjs
+++ b/src/lib/usage-opencode.mjs
@@ -25,6 +25,7 @@
 // record their OWN messages, not a replay of the parent's — the codex
 // double-count rule does not apply (different storage semantics).
 import { withDb } from './sqlite.mjs';
+import { sessionAcquisitionCoverage } from './usage-opencode-bounds.mjs';
 // Shared record shape/accumulator with parseClaude/parseCodex — see their
 // definitions in usage-parsers.mjs. usage-index.mjs imports FROM this module
 // (defaultOpencodeDbPath, parseSession, …), but that is no longer a cycle:
@@ -191,14 +192,18 @@ function recordAssistantUsage(rec, data, at) {
     input: num(t.input), output: num(t.output),
     cacheRead: num(cache.read), cacheWrite: num(cache.write), responses: 1,
   });
-  // opencode's OWN metered cost for this message — observed truth, summed
-  // per (day, model) row. Rows where NO message carried a cost stay null
-  // (the field is always present, unlike an absent key, so a consumer
-  // checking `costObserved != null` never needs to guess whether this row
-  // was ever priced), so the aggregate falls back to the pricing table
-  // rather than misreporting a fabricated $0.
+  // Retain missing-cost tokens separately before coalescing by day/model.
   usageRow.costObserved ??= null;
-  if (Number.isFinite(Number(data.cost))) usageRow.costObserved = (usageRow.costObserved ?? 0) + Number(data.cost);
+  if (typeof data.cost === 'number' && Number.isFinite(data.cost) && data.cost >= 0) {
+    usageRow.costObserved = (usageRow.costObserved ?? 0) + data.cost;
+    usageRow.costObservedMessages = (usageRow.costObservedMessages ?? 0) + 1;
+  } else {
+    usageRow.costMissingUsage ??= { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, responses: 0 };
+    const missing = usageRow.costMissingUsage;
+    missing.input += num(t.input); missing.output += num(t.output);
+    missing.cacheRead += num(cache.read); missing.cacheWrite += num(cache.write);
+    missing.responses++;
+  }
   rec.reasoningOutput += num(t.reasoning);
   // Context pressure for THIS turn, evidence-gated: only a row that actually
   // carries a tokens object can claim one — a token-less row (error or not)
@@ -330,15 +335,28 @@ function initSessionRecord(srow) {
  *  built from the SAME blankSession/addUsage parseClaude and parseCodex use.
  *  Returns { session, turns }; null when the session is gone or unreadable.
  *  withTurns emits the transcript-view turn rows alongside the record.
- *  @param {{ dbFile: string, id: string, withTurns?: boolean }} opts */
-export function parseSession({ dbFile, id, withTurns = false }) {
+ *  @param {{ dbFile: string, id: string, withTurns?: boolean, maxSessionBytes?: number, maxSessionRows?: number }} opts */
+export function parseSession({ dbFile, id, withTurns = false, maxSessionBytes, maxSessionRows }) {
   const result = withDb(dbFile, (db) => {
-    const srow = db.prepare('SELECT * FROM session WHERE id = ?').get(id);
+    // Pin preflight and payload queries to one snapshot: concurrent growth cannot
+    // bypass the budget between measurement and acquisition. Closing rolls back
+    // this read-only transaction, including on malformed rows/query errors.
+    db.exec('BEGIN');
+    const acquisitionCoverage = sessionAcquisitionCoverage(db, id, { maxSessionBytes, maxSessionRows });
+    if (!acquisitionCoverage.complete) {
+      const rec = blankSession(id, 'opencode');
+      Object.assign(rec, { acquisitionCoverage });
+      rec.end = acquisitionCoverage.latestMessageAt;
+      delete rec.stamps;
+      return { session: rec, turns: [] };
+    }
+    const srow = db.prepare('SELECT id, parent_id, directory, title FROM session WHERE id = ?').get(id);
     if (!srow) return null;
     const msgRows = db.prepare('SELECT id, time_created, data FROM message WHERE session_id = ? ORDER BY time_created ASC, id ASC').all(id);
     const partsByMessage = buildPartsIndex(loadTextParts(db, id, withTurns));
 
     const rec = initSessionRecord(srow);
+    Object.assign(rec, { acquisitionCoverage });
     const turns = [];
     for (const row of msgRows) processMessageRow(rec, turns, row, { withTurns, partsByMessage });
     if (!withTurns) collectScanToolCounts(db, id, rec);

--- a/tests/kit/codex-plugins.test.mjs
+++ b/tests/kit/codex-plugins.test.mjs
@@ -264,3 +264,26 @@ test('known Codex runtime-output incompatibilities are version-bounded advisorie
 });
 
 test.after(() => fs.rmSync(ROOT, { recursive: true, force: true }));
+
+test('Codex skill display names may contain capitals and differ from directory names', () => {
+  fs.rmSync(cacheDir, { recursive: true, force: true });
+  fs.writeFileSync(configFile, '[plugins."runtime@official"]\nenabled = true\n');
+  seedPlugin({ marketplace: 'official', plugin: 'runtime', version: '1.0.0', skills: [
+    { directory: 'spreadsheets', source: '---\nname: "Spreadsheets"\ndescription: Work with sheets\n---\n' },
+    { directory: 'presentations', source: '---\nname: "Presentations"\ndescription: Work with slides\n---\n' },
+    { directory: 'different-directory', source: '---\nname: "Readable skill name"\ndescription: A valid name\n---\n' },
+  ] });
+  assert.deepEqual(inspect().skillIssues, []);
+});
+
+test('Codex skill names accept 64 Unicode characters but reject 65', () => {
+  fs.rmSync(cacheDir, { recursive: true, force: true });
+  fs.writeFileSync(configFile, '[plugins."runtime@official"]\nenabled = true\n');
+  seedPlugin({ marketplace: 'official', plugin: 'runtime', version: '1.0.0', skills: [
+    { directory: 'boundary', source: `---\nname: "${'é'.repeat(64)}"\ndescription: boundary\n---\n` },
+    { directory: 'over-limit', source: `---\nname: "${'é'.repeat(65)}"\ndescription: too long\n---\n` },
+  ] });
+  const issues = inspect().skillIssues;
+  assert.equal(issues.length, 1);
+  assert.match(issues[0], /over-limit.*at most 64 characters/);
+});

--- a/tests/kit/codex-usage-diagnostic.test.mjs
+++ b/tests/kit/codex-usage-diagnostic.test.mjs
@@ -1,0 +1,65 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { costOf } from '../../src/lib/pricing.mjs';
+
+const script = fileURLToPath(new URL('../../scripts/codex-usage-diagnostic.mjs', import.meta.url));
+function run(t, records, json = true) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'PRIVATE-DIAGNOSTIC-ROOT-'));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const dir = path.join(root, '2026', '09', '09');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'rollout-private-session.jsonl'), records.map(JSON.stringify).join('\n'));
+  const result = spawnSync(process.execPath, [script, '--root', root, ...(json ? ['--json'] : [])], { encoding: 'utf8' });
+  assert.equal(result.status, 0, result.stderr);
+  assert.ok(!result.stdout.includes('PRIVATE-DIAGNOSTIC-ROOT'));
+  return json ? JSON.parse(result.stdout) : result.stdout;
+}
+const meta = (thread_source) => ({ type: 'session_meta', payload: { thread_source } });
+const body = (model = 'gpt-5.6-sol', reply = { type: 'agent_message' }) => [
+  { type: 'turn_context', payload: { model } },
+  { type: 'event_msg', payload: { type: 'token_count', info: { total_token_usage: { input_tokens: 1000000, cached_input_tokens: 100000, output_tokens: 1000 } } } },
+  { type: 'event_msg', payload: reply },
+];
+
+test('diagnostic keeps first metadata ownership despite replayed parent', (t) => {
+  const report = run(t, [meta('subagent'), meta('user'), ...body()]);
+  assert.equal(report.threadSourceCounts.subagent, 1);
+  assert.equal(report.tokens.afterFix_excludingSubagentReplays.total, 0);
+});
+test('diagnostic handles current item_completed assistant responses', (t) => {
+  const report = run(t, [meta('user'), ...body('gpt-5.6-sol', { type: 'item_completed', item: { type: 'AgentMessage', content: [{ type: 'Text', text: 'private' }] } })]);
+  assert.equal(report.parsedAsSessions, 1);
+});
+test('missing thread source stays unknown even after later replayed metadata', (t) => {
+  const report = run(t, [meta(undefined), meta('subagent'), ...body()]);
+  assert.equal(report.threadSourceCounts.unknown, 1);
+  assert.equal(report.threadSourceCounts.subagent, 0);
+});
+test('human and JSON output contain no supplied paths or arbitrary source text', (t) => {
+  for (const json of [true, false]) {
+    const report = run(t, [meta('PRIVATE-DIAGNOSTIC-ROOT-source'), ...body()], json);
+    assert.ok(!JSON.stringify(report).includes('PRIVATE-DIAGNOSTIC-ROOT'));
+  }
+});
+for (const model of ['gpt-6-astra', 'gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna', 'gpt-5.5-pro', 'gpt-5.4-pro', 'gpt-5.6', 'unknown']) {
+  test(`diagnostic shares current model pricing: ${model}`, (t) => {
+    const report = run(t, [meta('user'), ...body(model)]);
+    assert.equal(report.tokens.afterFix_excludingSubagentReplays.cost, costOf({ model, input: 900000, output: 1000, cacheRead: 100000 }));
+  });
+}
+test('rollout without metadata reports unknown source and retains usage', (t) => {
+  const report = run(t, body());
+  assert.equal(report.threadSourceCounts.unknown, 1);
+  assert.equal(report.threadSourceCounts.user, 0);
+  assert.equal(report.tokens.afterFix_excludingSubagentReplays.total, 1001000);
+});
+test('first user metadata wins and user-only item is not a response', (t) => {
+  assert.equal(run(t, [meta('user'), meta('subagent'), ...body()]).threadSourceCounts.user, 1);
+  const report = run(t, body('gpt-5.6-sol', { type: 'item_completed', item: { type: 'UserMessage' } }));
+  assert.equal(report.parsedAsSessions, 0);
+});

--- a/tests/kit/dashboard-usage-telemetry.test.mjs
+++ b/tests/kit/dashboard-usage-telemetry.test.mjs
@@ -1210,7 +1210,8 @@ test('the fields the chips read are actually projected onto the session row', ()
     mode: 'auto-edit',
     usageRows: [{ day: '2026-08-18', model: 'claude-opus-5', input: 10, output: 5, cacheRead: 0, cacheWrite: 0, responses: 1 }],
   });
-  Object.assign(rec, { modeRaw: 'acceptEdits', ctxWindow: 200_000, ctxLastTokens: 151_000 });
+  Object.assign(rec, { modeRaw: 'acceptEdits', ctxWindow: 200_000, ctxLastTokens: 151_000,
+    contextEvidence: { schemaVersion: 1, state: 'observed', pressure: { lastBps: 7550, samples: 1 } } });
   const agg = aggregate([rec], { days: 7, now: NOW, cutoff: NOW - 7 * DAY_MS, deps: FIXTURE_DEPS });
   const row = agg.sessions[0];
   assert.equal(row.modeRaw, 'acceptEdits', 'the badge tooltip has a raw spelling to print');
@@ -1218,7 +1219,7 @@ test('the fields the chips read are actually projected onto the session row', ()
   assert.equal(row.ctxLastTokens, 151_000, 'the ctx chip has a numerator');
   // …and the client reads exactly those names.
   assert.match(JS, /reportedIdentity\(sx\.modeRaw\)/);
-  assert.match(JS, /Number\(sx\.ctxLastTokens\),win=Number\(sx\.ctxWindow\)/);
+  assert.equal(row.contextEvidence.pressure.lastBps, 7550, 'paired pressure survives projection');
 });
 
 test('the host spelling is rendered, not filtered — the "[object Object]" band-aid is gone', () => {
@@ -1230,16 +1231,6 @@ test('the host spelling is rendered, not filtered — the "[object Object]" band
   // the spelling the host actually recorded.
   assert.doesNotMatch(JS, /rawSpelling/, 'the band-aid and every call to it are removed');
   assert.doesNotMatch(JS, /indexOf\("\[object "\)/, 'no sentinel-string filtering survives');
-});
-
-test('the context chip requires BOTH halves, and is omitted rather than divided by a guess', () => {
-  assert.match(JS, /var used=Number\(sx\.ctxLastTokens\),win=Number\(sx\.ctxWindow\)/);
-  assert.match(JS, /if\(!isFinite\(used\)\|\|!isFinite\(win\)\|\|used<=0\|\|win<=0\)return ""/);
-  assert.match(JS, /both recorded by the transcript/);
-  // The window is only ever READ. No `||` or `??` fallback stands behind it,
-  // which is what a guessed denominator would have to look like.
-  assert.doesNotMatch(JS, /ctxWindow\s*(\|\||\?\?)/);
-  assert.doesNotMatch(JS, /CONTEXT_WINDOWS|DEFAULT_CTX_WINDOW/, 'no published-window lookup table');
 });
 
 test('the session detail strip spells out posture and rhythm, and never omits the line', () => {

--- a/tests/kit/live-service.test.mjs
+++ b/tests/kit/live-service.test.mjs
@@ -714,3 +714,18 @@ test('historyPage() pages the complete cross-host set after materialization', (t
   assert.equal([...seen].filter((key) => key.startsWith('claude:')).length, 1001);
   assert.equal([...seen].filter((key) => key.startsWith('codex:')).length, 1);
 });
+
+test('service coverage retains dropped-line evidence when a different source is healthy', async (t) => {
+  const sb = sandbox();
+  const file = path.join(sb.claude, 'bad.jsonl');
+  fs.writeFileSync(file, '');
+  fs.writeFileSync(path.join(sb.claude, 'good.jsonl'), '');
+  const service = new LiveSessionsService({ roots: sb.roots, intervalMs: 10, readCodexState: () => null });
+  t.after(() => { service.close(); fs.rmSync(sb.dir, { recursive: true, force: true }); });
+  service.start();
+  fs.appendFileSync(file, 'x'.repeat(1024 * 1024 + 1) + '\n');
+  await waitUntil(() => service.snapshot().acquisitionCoverage.truncated, 'missing live acquisition coverage');
+  const coverage = service.snapshot().acquisitionCoverage;
+  assert.equal(coverage.complete, false);
+  assert.equal(coverage.droppedLines, 1);
+});

--- a/tests/kit/live-tailer.test.mjs
+++ b/tests/kit/live-tailer.test.mjs
@@ -51,3 +51,42 @@ test('tailer isolates malformed lines and continues', () => {
   assert.equal(errors.length, 1);
   assert.equal(errors[0][1], 'not-json');
 });
+
+test('tailer bounds each reconciliation, retains burst backlog, and decodes split UTF-8', (t) => {
+  const file = tempFile();
+  t.after(() => fs.rmSync(path.dirname(file), { recursive: true, force: true }));
+  const lines = Array.from({ length: 20 }, (_, n) => ({ n, text: 'é😀' }));
+  fs.writeFileSync(file, lines.map(JSON.stringify).join('\n') + '\n');
+  const rows = [], coverage = [];
+  const tailer = new JsonlTailer(file, {
+    onRecord: (row) => rows.push(row), onCoverage: (value) => coverage.push(value),
+    maxChunkBytes: 7, maxReadBytes: 31,
+  });
+  tailer.reconcile();
+  assert.ok(rows.length < lines.length, 'a burst must not be acquired in one reconciliation');
+  assert.ok(coverage.at(-1).pendingBytes > 0);
+  fs.appendFileSync(file, '{"n":20}\n');
+  for (let i = 0; i < 100; i++) tailer.reconcile();
+  assert.deepEqual(rows, [...lines, { n: 20 }]);
+  assert.equal(coverage.at(-1).complete, true);
+});
+
+test('tailer discards oversized incomplete lines with explicit coverage and recovers at newline', (t) => {
+  const file = tempFile();
+  t.after(() => fs.rmSync(path.dirname(file), { recursive: true, force: true }));
+  fs.writeFileSync(file, '{"text":"' + 'x'.repeat(80));
+  const rows = [], coverage = [];
+  const tailer = new JsonlTailer(file, {
+    onRecord: (row) => rows.push(row), onCoverage: (value) => coverage.push(value),
+    maxChunkBytes: 9, maxReadBytes: 100, maxLineBytes: 32,
+  });
+  tailer.reconcile();
+  assert.equal(coverage.at(-1)?.truncated, true);
+  assert.equal(coverage.at(-1).droppedLines, 1);
+  assert.ok(coverage.at(-1).bufferedBytes <= 32);
+  fs.appendFileSync(file, 'x'.repeat(80) + '"}\n{"n":1}\n');
+  tailer.reconcile();
+  assert.deepEqual(rows, [{ n: 1 }]);
+  assert.equal(coverage.at(-1).droppedLines, 1);
+  assert.equal(coverage.at(-1).complete, false);
+});

--- a/tests/kit/live-transcript.test.mjs
+++ b/tests/kit/live-transcript.test.mjs
@@ -324,3 +324,17 @@ test('selected stream builds a deterministic bounded playback timeline with live
     'the same retained history and seek point must reconstruct identically');
   streams.close();
 });
+
+test('selected transcript discloses live acquisition truncation in snapshot and playback', async (t) => {
+  const sb = sandbox();
+  const file = path.join(sb.claude, 's1.jsonl');
+  fs.writeFileSync(file, '');
+  const streams = new TranscriptStreams({ roots: sb.roots, intervalMs: 10, mask: (value) => value });
+  t.after(() => { streams.close(); fs.rmSync(sb.dir, { recursive: true, force: true }); });
+  const stream = streams.open('claude', 's1');
+  fs.appendFileSync(file, 'x'.repeat(1024 * 1024 + 1) + '\n');
+  await waitUntil(() => stream.snapshot().acquisitionCoverage?.truncated,
+    'oversized live line was not disclosed');
+  assert.equal(stream.playback().truncated, true);
+  assert.equal(stream.playback().acquisitionCoverage.complete, false);
+});

--- a/tests/kit/node-runtime.test.mjs
+++ b/tests/kit/node-runtime.test.mjs
@@ -1,0 +1,26 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { supportsNodeRuntime, nodeRuntimeError } from '../../src/lib/node-runtime.mjs';
+
+for (const version of ['18.20.0', '22.0.0', '22.5.0', '22.12.0', '22.12.99', '23.0.0', '23.3.99', '22.13.0-rc.1', '', 'bogus']) {
+  test(`runtime rejects unsupported Node ${version}`, () => {
+    assert.equal(supportsNodeRuntime(version), false);
+    assert.match(nodeRuntimeError(version), /22\.13\.0/);
+  });
+}
+for (const version of ['22.13.0', '22.13.1', '22.99.0', '23.4.0', '24.0.0', '26.0.0']) {
+  test(`runtime admits Node ${version}`, () => {
+    assert.equal(supportsNodeRuntime(version), true);
+    assert.equal(nodeRuntimeError(version), null);
+  });
+}
+test('CLI rejects early Node before dispatching SQLite commands', () => {
+  const cli = fileURLToPath(new URL('../../bin/agentic-kit.mjs', import.meta.url));
+  const result = spawnSync(process.execPath, ['--input-type=module', '-e', `Object.defineProperty(process.versions, 'node', { value: '22.12.0' }); process.argv = ['node', ${JSON.stringify(cli)}, 'status', '--json']; await import(${JSON.stringify(new URL('../../bin/agentic-kit.mjs', import.meta.url).href)});`], { encoding: 'utf8' });
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /22\.13\.0/);
+  assert.doesNotMatch(result.stderr, /ERR_UNKNOWN_BUILTIN_MODULE|at file:/);
+  assert.equal(result.stdout, '');
+});

--- a/tests/kit/project-memory-status.test.mjs
+++ b/tests/kit/project-memory-status.test.mjs
@@ -17,10 +17,13 @@ test('memory status never treats file presence as a proven writer and checks bot
   db.close();
   const single = await section.collect({ cwd });
   assert.equal(single[0].level, 'info');
-  assert.match(single[0].message, /1 active entry observed.*routing unverified/);
+  assert.match(single[0].message, /agentdb-memory\.db: 1 active entry observed.*backend.*routing unverified/);
+  assert.doesNotMatch(single[0].message, /native-agentdb:/);
   fs.writeFileSync(path.join(cwd, '.swarm/memory.db'), 'corrupt');
   const dual = await section.collect({ cwd });
-  assert.ok(dual.some((r) => r.level === 'warn' && /sqljs store is unreadable/.test(r.message)));
+  assert.ok(dual.some((r) => r.level === 'warn' && /memory\.db store is unreadable/.test(r.message)));
   assert.ok(dual.some((r) => /two project memory stores/.test(r.message)));
+  assert.ok(dual.some((r) => /--path/.test(r.message)));
+  assert.ok(dual.some((r) => /preserve both/.test(r.message)));
   assert.ok(dual.every((r) => r.level !== 'ok' && r.fix === null));
 });

--- a/tests/kit/provider-teardown-preservation.test.mjs
+++ b/tests/kit/provider-teardown-preservation.test.mjs
@@ -1,0 +1,164 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { applyAqeRouter, undoAqeRouter, aqeRouterFile, applyHosts, undoProviders } from '../../src/lib/providers.mjs';
+
+function fixture(t) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ak-preserve-'));
+  fs.mkdirSync(path.join(dir, '.git'));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  return dir;
+}
+const config = () => ({ integrations: { hosts: { claude: true, codex: true } }, providers: {
+  aqeFallback: [{ provider: 'openai', models: ['gpt-5.6'] }],
+} });
+function put(file, data) { fs.mkdirSync(path.dirname(file), { recursive: true }); fs.writeFileSync(file, JSON.stringify(data)); }
+function get(file) { return JSON.parse(fs.readFileSync(file, 'utf8')); }
+
+for (const backup of [false, true]) {
+  for (const legacy of [false, true]) {
+    for (const key of ['defaultProvider', 'userKey']) {
+      test(`router preserves ${key} edit (backup=${backup}, legacy=${legacy})`, (t) => {
+        const dir = fixture(t); const file = aqeRouterFile(dir);
+        if (backup) put(file, { defaultProvider: 'gemini', userKey: 'original' });
+        if (legacy) {
+          if (backup) fs.copyFileSync(file, `${file}.bak`);
+          put(file, { _managedBy: 'agentic-kit', defaultProvider: 'openai' });
+        } else applyAqeRouter(config(), dir);
+        const cur = get(file); cur[key] = 'edited-after-setup'; put(file, cur);
+        const before = fs.readFileSync(file, 'utf8');
+        const result = undoAqeRouter(dir);
+        assert.equal(result.ok, false);
+        assert.equal(result.changed, false);
+        assert.match(result.detail, /preserved|review/i);
+        assert.equal(fs.readFileSync(file, 'utf8'), before);
+        if (backup) assert.ok(fs.existsSync(`${file}.bak`));
+      });
+    }
+  }
+}
+test('sync after a foreign router edit cannot authorize restoring the old backup', (t) => {
+  const dir = fixture(t); const file = aqeRouterFile(dir);
+  put(file, { userKey: 'original' });
+  applyAqeRouter(config(), dir);
+  put(file, { ...get(file), userKey: 'edited' });
+  const cfg = config(); cfg.providers.aqeFallback[0].models = ['different-model'];
+  applyAqeRouter(cfg, dir);
+  assert.equal(undoAqeRouter(dir).ok, false);
+  assert.equal(get(file).userKey, 'edited');
+});
+test('changed backup is preserved instead of replacing the router with unverified bytes', (t) => {
+  const dir = fixture(t); const file = aqeRouterFile(dir);
+  put(file, { userKey: 'original' }); applyAqeRouter(config(), dir);
+  put(`${file}.bak`, { userKey: 'modified backup' });
+  const before = fs.readFileSync(file, 'utf8');
+  assert.equal(undoAqeRouter(dir).ok, false);
+  assert.equal(fs.readFileSync(file, 'utf8'), before);
+});
+test('provider teardown preserves edited and unowned env keys and restores overwritten values', (t) => {
+  const dir = fixture(t); const file = path.join(dir, '.claude', 'settings.local.json');
+  put(file, { env: { ENABLE_CODEX: 'prior', EXTRA: 'keep' } });
+  applyHosts(config(), dir);
+  const live = get(file); live.env.ENABLE_CLAUDE_CODE = 'user-edit'; live.env.AQE_MAX_BUDGET_USD = '17'; put(file, live);
+  undoProviders(dir);
+  assert.deepEqual(get(file).env, { ENABLE_CODEX: 'prior', ENABLE_CLAUDE_CODE: 'user-edit', AQE_MAX_BUDGET_USD: '17', EXTRA: 'keep' });
+});
+test('legacy provider env without exact receipts is preserved', (t) => {
+  const dir = fixture(t); const file = path.join(dir, '.claude', 'settings.local.json');
+  put(file, { env: { ENABLE_CODEX: 'true', AQE_MAX_BUDGET_USD: '17' } });
+  const before = fs.readFileSync(file, 'utf8');
+  assert.equal(undoProviders(dir).changed, false);
+  assert.equal(fs.readFileSync(file, 'utf8'), before);
+});
+
+test('router restore interruption leaves live file, backup and receipt available for retry', async (t) => {
+  const { undoOwnedRouter, routerReceiptFile } = await import('../../src/lib/provider-ownership.mjs');
+  const dir = fixture(t); const file = aqeRouterFile(dir);
+  put(file, { userKey: 'original' }); applyAqeRouter(config(), dir);
+  const before = fs.readFileSync(file, 'utf8'); const backup = fs.readFileSync(`${file}.bak`, 'utf8');
+  const fsImpl = { ...fs, renameSync() { throw new Error('injected interrupted restore'); } };
+  assert.throws(() => undoOwnedRouter(file, { fsImpl }), /interrupted restore/);
+  assert.equal(fs.readFileSync(file, 'utf8'), before);
+  assert.equal(fs.readFileSync(`${file}.bak`, 'utf8'), backup);
+  assert.ok(fs.existsSync(routerReceiptFile(file)));
+  assert.equal(undoAqeRouter(dir).ok, true);
+  assert.equal(fs.readFileSync(file, 'utf8'), backup);
+});
+test('unchanged successive router projections still remove a newly created file', (t) => {
+  const dir = fixture(t); const file = aqeRouterFile(dir); const cfg = config();
+  applyAqeRouter(cfg, dir);
+  cfg.providers.aqeFallback[0].models = ['next-model']; applyAqeRouter(cfg, dir);
+  assert.equal(undoAqeRouter(dir).ok, true);
+  assert.equal(fs.existsSync(file), false);
+  assert.equal(fs.existsSync(`${file}.bak`), false);
+  applyAqeRouter(cfg, dir);
+  assert.equal(undoAqeRouter(dir).ok, true);
+});
+test('legacy unchanged router marker does not prove ownership', (t) => {
+  const dir = fixture(t); const file = aqeRouterFile(dir);
+  put(file, { _managedBy: 'agentic-kit', defaultProvider: 'openai' });
+  const before = fs.readFileSync(file, 'utf8');
+  assert.equal(undoAqeRouter(dir).ok, false);
+  assert.equal(fs.readFileSync(file, 'utf8'), before);
+});
+test('router rejects a stale preexisting backup even on the first managed projection', (t) => {
+  const dir = fixture(t); const file = aqeRouterFile(dir);
+  put(file, { userKey: 'current' }); put(`${file}.bak`, { userKey: 'ancient' });
+  applyAqeRouter(config(), dir);
+  assert.equal(undoAqeRouter(dir).ok, false);
+  assert.equal(get(file).userKey, 'current');
+});
+
+test('malformed router receipt cannot authorize teardown', async (t) => {
+  const { routerReceiptFile } = await import('../../src/lib/provider-ownership.mjs');
+  const dir = fixture(t); const file = aqeRouterFile(dir);
+  applyAqeRouter(config(), dir);
+  put(routerReceiptFile(file), { version: 1, postimage: null, preimage: null });
+  assert.equal(undoAqeRouter(dir).ok, false);
+  assert.ok(fs.existsSync(file));
+});
+test('missing or symlinked original backup cannot authorize router restore', (t) => {
+  const dir = fixture(t); const file = aqeRouterFile(dir);
+  put(file, { userKey: 'original' }); applyAqeRouter(config(), dir);
+  const backup = fs.readFileSync(`${file}.bak`); fs.rmSync(`${file}.bak`);
+  assert.equal(undoAqeRouter(dir).ok, false);
+  const other = path.join(dir, 'foreign-backup.json'); fs.writeFileSync(other, backup);
+  fs.symlinkSync(other, `${file}.bak`);
+  assert.equal(undoAqeRouter(dir).ok, false);
+  assert.deepEqual(fs.readFileSync(other), backup);
+});
+test('provider env receipts retain original values across reconfiguration', (t) => {
+  const dir = fixture(t); const file = path.join(dir, '.claude', 'settings.local.json');
+  put(file, { env: { ENABLE_CODEX: 'original' } });
+  const cfg = config(); applyHosts(cfg, dir);
+  cfg.providers.maxBudgetUsd = 20; applyHosts(cfg, dir);
+  assert.equal(undoProviders(dir).ok, true);
+  assert.deepEqual(get(file).env, { ENABLE_CODEX: 'original' });
+});
+test('malformed env receipts preserve values', (t) => {
+  const dir = fixture(t); const file = path.join(dir, '.claude', 'settings.local.json');
+  applyHosts(config(), dir);
+  const before = fs.readFileSync(file, 'utf8');
+  put(`${file}.agentic-kit-env-ownership.json`, { version: 1, entries: { ENABLE_CODEX: { before: null, after: { present: true } } } });
+  assert.equal(undoProviders(dir).changed, false);
+  assert.equal(fs.readFileSync(file, 'utf8'), before);
+});
+
+test('failed env projection and retry cannot claim the intermediate managed value as original', (t) => {
+  const dir = fixture(t); const file = path.join(dir, '.claude', 'settings.local.json');
+  put(file, { env: { ENABLE_CODEX: 'original' } });
+  const cfg = config(); applyHosts(cfg, dir);
+  const backup = fs.readFileSync(`${file}.bak`);
+  fs.rmSync(`${file}.bak`); fs.mkdirSync(`${file}.bak`);
+  cfg.integrations.hosts.codex = false; cfg.providers.aqeProvider = 'openai';
+  assert.throws(() => applyHosts(cfg, dir), /unusable backup/);
+  assert.equal(undoProviders(dir).ok, false, 'pending projection has no teardown authority');
+  fs.rmdirSync(`${file}.bak`); fs.writeFileSync(`${file}.bak`, backup);
+  applyHosts(cfg, dir);
+  const before = fs.readFileSync(file, 'utf8');
+  assert.equal(undoProviders(dir).ok, false, 'ambiguous preimage remains unresolved after retry');
+  assert.equal(fs.readFileSync(file, 'utf8'), before);
+  assert.equal(JSON.parse(fs.readFileSync(`${file}.bak`, 'utf8')).env.ENABLE_CODEX, 'original');
+});

--- a/tests/kit/sqlite.test.mjs
+++ b/tests/kit/sqlite.test.mjs
@@ -18,7 +18,9 @@ test('withDb classifies corrupt input instead of returning the caller fallback',
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ak-sqlite-corrupt-'));
   const file = path.join(dir, 'store.db');
   fs.writeFileSync(file, 'not a sqlite database');
-  const result = withDb(file, (db) => db.prepare('SELECT 1').get());
+  // Read the on-disk schema: SELECT 1 can succeed without opening database
+  // pages on the SQLite bundled with Node 22.13.0.
+  const result = withDb(file, (db) => db.prepare('SELECT * FROM sqlite_schema').all());
   assert.equal(result.ok, false);
   assert.equal(result.error.kind, 'corrupt');
   assert.equal(result.error.stage, 'query');

--- a/tests/kit/status-command.test.mjs
+++ b/tests/kit/status-command.test.mjs
@@ -507,8 +507,8 @@ test('status discloses both project-memory stores without asserting writer ident
     db.close();
   }
   const memory = (await collect()).filter((r) => r.subsystem === 'memory');
-  assert.ok(memory.some((r) => r.level === 'info' && /native-agentdb: 1 active entry observed/.test(r.message)));
-  assert.ok(memory.some((r) => r.level === 'info' && /sqljs: 1 active entry observed/.test(r.message)));
+  assert.ok(memory.some((r) => r.level === 'info' && /agentdb-memory\.db: 1 active entry observed/.test(r.message)));
+  assert.ok(memory.some((r) => r.level === 'info' && /memory\.db: 1 active entry observed/.test(r.message)));
   assert.ok(memory.some((r) => r.level === 'warn' && /two project memory stores/.test(r.message)));
   rmrf(swarm);
 });

--- a/tests/kit/usage-audit-211.test.mjs
+++ b/tests/kit/usage-audit-211.test.mjs
@@ -1,0 +1,96 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import vm from 'node:vm';
+import { DatabaseSync } from 'node:sqlite';
+import { parseSession } from '../../src/lib/usage-opencode.mjs';
+import { aggregate, sessionPayload } from '../../src/lib/usage-aggregate.mjs';
+import { parseCodex } from '../../src/lib/usage-parsers.mjs';
+import { HOST_REGISTRY } from '../../src/lib/adapters/registries.mjs';
+const T = Date.parse('2026-09-09T12:00:00Z');
+const deps = { costOf: ({ input }) => input * 4 / 1e6, classify: () => ({}), detectInsights: () => [] };
+function fixture(t, costs) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ak-cost-211-'));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const dbFile = path.join(dir, 'opencode.db');
+  const db = new DatabaseSync(dbFile);
+  db.exec(`CREATE TABLE session(id TEXT, directory TEXT, title TEXT, parent_id TEXT, time_created INTEGER);
+    CREATE TABLE message(id TEXT, session_id TEXT, time_created INTEGER, data TEXT);
+    CREATE TABLE part(id TEXT, message_id TEXT, data TEXT);`);
+  db.prepare('INSERT INTO session VALUES (?, ?, ?, NULL, ?)').run('s', '/synthetic', 'costs', T);
+  for (const [i, cost] of costs.entries()) db.prepare('INSERT INTO message VALUES (?, ?, ?, ?)').run(String(i), 's', T + i * 1000,
+    JSON.stringify({ role: 'assistant', modelID: 'gpt-5.6-sol', tokens: { input: 1e6 }, ...(cost === undefined ? {} : { cost }) }));
+  db.close();
+  return parseSession({ dbFile, id: 's' }).session;
+}
+for (const cost of [undefined, null, -1, '0', false, {}, [], 'invalid']) {
+  test(`missing or invalid cost ${JSON.stringify(cost)} is estimated`, t => {
+    const rec = fixture(t, [cost]);
+    assert.equal(sessionPayload(rec, [], deps).meta.cost, 4);
+    assert.equal(rec.usage[0].costObserved, null);
+  });
+}
+for (const costs of [[0], [0.25, undefined], [undefined, 0.25], [null, 0.25], [0.25, null]]) {
+  test(`observed cost and missing coverage survive coalescing ${JSON.stringify(costs)}`, t => {
+    const rec = fixture(t, costs);
+    const expected = costs.length === 1 ? 0 : 4.25;
+    const meta = sessionPayload(rec, [], deps).meta;
+    const agg = aggregate([rec], { days: 1, now: T + 10000, cutoff: T - 1000, deps });
+    assert.equal(meta.cost, expected);
+    assert.equal(agg.totals.cost, expected);
+    assert.equal(meta.costEvidence.observedUsd, costs.length === 1 ? 0 : 0.25);
+    assert.equal(meta.costEvidence.estimatedUsd, costs.length === 1 ? 0 : 4);
+    assert.deepEqual(agg.sessions[0].costEvidence, meta.costEvidence);
+  });
+}
+const js = fs.readFileSync(new URL('../../src/lib/dashboard/client/usage.mjs', import.meta.url), 'utf8');
+const snippet = js.slice(js.indexOf('  function ctxChip(sx){'), js.indexOf('  function sessionChips(sx){'));
+const ctxChip = vm.runInNewContext(`(${snippet.trim()})`, { esc: String, fmtTok: String });
+function context(records) {
+  return parseCodex(records.map(payload => JSON.stringify({ type: 'event_msg', timestamp: new Date(T).toISOString(), payload })).join('\n'), { id: 'ctx' }).session;
+}
+const count = (input, window) => ({ type: 'token_count', info: { last_token_usage: { input_tokens: input }, ...(window ? { model_context_window: window } : {}) } });
+test('context chip omits separately observed numerator and window and legacy-only values', () => {
+  assert.equal(ctxChip(context([{ type: 'task_started', model_context_window: 200000 }, count(100000)])), '');
+  assert.equal(ctxChip({ ctxLastTokens: 100000, ctxWindow: 200000 }), '');
+  assert.equal(ctxChip({}), '');
+});
+test('paired context percentage preserves over-window and zero pressure', () => {
+  assert.match(ctxChip(context([count(250000, 200000)])), /125%/);
+  assert.match(ctxChip({ contextEvidence: { pressure: { lastBps: 0 } } }), /0%/);
+});
+test('later unpaired observations do not fabricate a new ratio', () => {
+  const rec = context([count(100000, 200000), { type: 'task_started', model_context_window: 400000 }, count(300000)]);
+  assert.match(ctxChip(rec), /50%/);
+  assert.doesNotMatch(ctxChip(rec), /75%/);
+});
+test('OpenCode descriptor advertises its SQLite usage collection', t => {
+  assert.equal(HOST_REGISTRY.find(h => h.id === 'opencode').capabilities.usage, true);
+  assert.equal(fixture(t, [0.25]).usage.length, 1);
+});
+
+test('cost estimates use each missing portion model and day in both payloads', () => {
+  const rec = parseCodex('', { id: 'days' }).session;
+  Object.assign(rec, { start: T, end: T + 86400000, responses: 3, models: ['a', 'b'], usage: [
+    { day: '2026-09-09', model: 'a', input: 30, output: 0, cacheRead: 0, cacheWrite: 0, responses: 2,
+      costObserved: 0.25, costObservedMessages: 1, costMissingUsage: { input: 10, output: 0, cacheRead: 0, cacheWrite: 0, responses: 1 } },
+    { day: '2026-09-10', model: 'b', input: 20, output: 0, cacheRead: 0, cacheWrite: 0, responses: 1 },
+  ] });
+  const datedDeps = { ...deps, costOf: ({ model, day, input }) => input * (model === 'a' && day === '2026-09-09' ? 2 : 3) };
+  const meta = sessionPayload(rec, [], datedDeps).meta;
+  const agg = aggregate([rec], { days: 2, now: T + 2 * 86400000, cutoff: T - 1, deps: datedDeps });
+  assert.equal(meta.cost, 80.25);
+  assert.equal(agg.byDay['2026-09-09'].cost, 20.25);
+  assert.equal(agg.byModel.b.cost, 60);
+  assert.equal(agg.totals.cost, meta.cost);
+});
+test('oversized omitted session retains explicit aggregate and reader coverage', () => {
+  const rec = parseCodex('', { id: 'oversized' }).session;
+  rec.acquisitionCoverage = { complete: false, truncated: true, reason: 'byte-limit' };
+  const agg = aggregate([rec], { days: 1, now: T, cutoff: T - 86400000, deps });
+  assert.equal(agg.sessions.length, 0);
+  assert.equal(agg.acquisitionCoverage.omittedSessions, 1);
+  assert.equal(sessionPayload(rec, [], deps).meta.acquisitionCoverage.complete, false);
+});

--- a/tests/kit/usage-index-opencode.test.mjs
+++ b/tests/kit/usage-index-opencode.test.mjs
@@ -267,3 +267,24 @@ test('an opencode session with zero assistant responses never reaches the aggreg
   assert.equal(agg.sessions.find((x) => x.id === 'ses_oc6'), undefined);
   rm(sb.dir);
 });
+
+test('oversized SQLite session coverage survives scan and selected-session payloads', async () => {
+  const sb = sandbox({ sessions: [{ id: 'ses_bounded', directory: '/x', title: 'bounded' }] });
+  try {
+    // Many small native rows exercise the production row ceiling without a
+    // resource-exhaustion fixture or a multi-megabyte JavaScript payload.
+    const db = new DatabaseSync(sb.dbFile);
+    db.prepare(`WITH RECURSIVE n(value) AS (
+      VALUES(1) UNION ALL SELECT value + 1 FROM n WHERE value < 100000
+    ) INSERT INTO message (id, session_id, time_created, time_updated, data)
+      SELECT 'm' || value, 'ses_bounded', ?, ?, '{}' FROM n`).run(NOW - DAY, NOW - DAY);
+    db.close();
+    const index = await buildIndex(opts(sb));
+    assert.equal(index.acquisitionCoverage.complete, false);
+    assert.equal(index.sessions.length, 0, 'refused sources are not zero-cost normal sessions');
+    const selected = await readSession('ses_bounded', opts(sb));
+    assert.equal(selected.meta.acquisitionCoverage.truncated, true);
+    assert.equal(selected.meta.acquisitionCoverage.reason, 'session-row-limit');
+    assert.deepEqual(selected.turns, []);
+  } finally { _resetForTest(); rm(sb.dir); }
+});

--- a/tests/kit/usage-opencode.test.mjs
+++ b/tests/kit/usage-opencode.test.mjs
@@ -320,3 +320,46 @@ test('a user message with no text part fingerprints as an attachment-only contro
   assert.equal(rec.promptFPs[0].t, 0);
   rm(d);
 });
+
+test('selected SQLite session is refused before materialization when its byte or row budget is exceeded', () => {
+  const d = tmp();
+  try {
+    const dbFile = buildDb(path.join(d, 'opencode.db'), {
+      sessions: [{ id: 'bounded', directory: '/x', title: 'bounded' }],
+      messages: [assistantMsg('m1', 'bounded', T), assistantMsg('m2', 'bounded', T + 1000)],
+      parts: [{ id: 'p1', sessionId: 'bounded', messageId: 'm1', at: T, data: { type: 'text', text: 'x'.repeat(4096) } }],
+    });
+    for (const withTurns of [false, true]) {
+      const parsed = parseSession({ dbFile, id: 'bounded', withTurns, maxSessionBytes: 1024 });
+      assert.equal(parsed.session.acquisitionCoverage?.complete, false);
+      assert.equal(parsed.session.acquisitionCoverage.truncated, true);
+      assert.equal(parsed.session.acquisitionCoverage.reason, 'session-byte-limit');
+      assert.deepEqual(parsed.session.usage, []);
+      assert.deepEqual(parsed.turns, []);
+    }
+    const rows = parseSession({ dbFile, id: 'bounded', maxSessionRows: 2 });
+    assert.equal(rows.session.acquisitionCoverage.reason, 'session-row-limit');
+    const complete = parseSession({ dbFile, id: 'bounded' });
+    assert.equal(complete.session.acquisitionCoverage.complete, true);
+    assert.equal(complete.session.responses, 2);
+  } finally { rm(d); }
+});
+
+test('SQLite acquisition bounds cover single message and metadata bytes, including UTF-8', () => {
+  const d = tmp();
+  try {
+    const dbFile = buildDb(path.join(d, 'opencode.db'), {
+      sessions: [
+        { id: 'message-large', directory: '/x', title: 'message' },
+        { id: 'metadata-large', directory: '/x', title: 'é'.repeat(600) },
+      ],
+      messages: [{ id: 'm1', sessionId: 'message-large', at: T, data: { role: 'user', text: 'é'.repeat(600) } }],
+    });
+    for (const id of ['message-large', 'metadata-large']) {
+      const parsed = parseSession({ dbFile, id, maxSessionBytes: 1024 });
+      assert.equal(parsed.session.acquisitionCoverage.reason, 'session-byte-limit');
+      assert.ok(parsed.session.acquisitionCoverage.sourceBytes > 1024);
+      assert.deepEqual(parsed.session.usage, []);
+    }
+  } finally { rm(d); }
+});


### PR DESCRIPTION
Usage could report incomplete OpenCode costs as complete totals, combine unrelated context measurements into a percentage, and allocate unbounded input buffers. Router teardown could overwrite post-setup user edits. Codex plugin checks also incorrectly rejected bundled capitalized skill names that Codex itself loads successfully.

This PR addresses those agentic-kit behaviors in eight focused commits:

- Preserve observed and estimated cost portions, paired context evidence, and explicit acquisition coverage; bound JSONL and selected SQLite-session reads.
- Preserve edited/unknown/interrupted router and environment projections during teardown, with exact receipts and atomic restoration.
- Correct Codex diagnostic metadata/pricing/privacy and explicitly document its independent-comparison limits.
- Enforce the actual unflagged SQLite Node runtime range and add minimum-runtime CI coverage.
- Accept Codex-supported skill display names; report memory filenames without inferring backend/writer identity from file presence.
- Clarify usage scope, cache/provenance labels, and locale formatting; record reproducible audit evidence and troubleshooting guidance.

Ruflo's CLI/MCP memory path divergence remains an upstream defect. This PR does not merge, delete, migrate, or globally redirect existing memory stores, and does not patch external plugins/packages. Fresh isolated confirmation is posted at https://github.com/ruvnet/ruflo/issues/3196#issuecomment-5606621769; follow-up integration is tracked in #213, which must remain open after this PR.

Validation:

- `pnpm test`: 3,908 passed, six platform skips, zero failures; subsequent legacy suites passed. Coverage: 92.02% lines / 80.89% branches / 91.58% functions.
- Actual Node 22.13.0: 85 integrated tests passed.
- `pnpm run test:ui`: 491 browser assertions and six suites passed before the final backend status/plugin changes; focused status/plugin regressions pass afterward.
- Typecheck, lint, hard complexity ceiling, Markdown lint, build, and whitespace checks passed. Existing advisory complexity warnings remain.
- Ownership helper: 100% focused line/branch/function coverage.
- All audit synthetic reproductions pass with matching source digests. Separate isolated Ruflo reproduction still demonstrates the upstream split.

Evidence: `docs/audits/211-remediation.md`, `docs/audits/211-remediation-results.json`, and `docs/audits/plugin-memory-status-followup.md`.

Refs #211, #212. Upstream integration follow-up: #213.
