### PR TITLE
fix: prevent recurring Codex MCP and Brain warnings

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   js-yaml@<5.2.2: 5.2.2
   brace-expansion@>=4.0.0 <5.0.9: '>=5.0.9'
+  smol-toml@<=1.7.0: 1.7.2
 
 importers:
 
@@ -702,8 +703,8 @@ packages:
     resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}
     engines: {node: '>=14.16'}
 
-  smol-toml@1.7.0:
-    resolution: {integrity: sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ==}
+  smol-toml@1.7.2:
+    resolution: {integrity: sha512-pXFZ9B2WinEPzxWkMmlYE/oYx2BP+qLrE95wP8tCuK901uLSMGdCb6QSr82z+wnhXkG4+cO+OMLbZB2Cn+97zw==}
     engines: {node: '>= 18'}
 
   string-width@8.2.1:
@@ -1173,7 +1174,7 @@ snapshots:
       markdownlint: 0.41.1
       markdownlint-cli2-formatter-default: 0.0.6(markdownlint-cli2@0.23.2)
       micromatch: 4.0.8
-      smol-toml: 1.7.0
+      smol-toml: 1.7.2
     transitivePeerDependencies:
       - supports-color
 
@@ -1443,7 +1444,7 @@ snapshots:
 
   slash@5.1.0: {}
 
-  smol-toml@1.7.0: {}
+  smol-toml@1.7.2: {}
 
   string-width@8.2.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,3 +11,7 @@ overrides:
   # unbounded intermediate arrays). It reaches us only via eslint ->
   # minimatch. Drop once eslint ships a bumped minimatch.
   'brace-expansion@>=4.0.0 <5.0.9': '>=5.0.9'
+  # smol-toml <=1.7.0 carries GHSA-7w5x-hrqm-74c2 (malformed-input DoS)
+  # through markdownlint-cli2. Retain the compatible patched 1.7 line until
+  # markdownlint-cli2 updates its direct dependency.
+  'smol-toml@<=1.7.0': 1.7.2

--- a/src/lib/brain-hook-contract.mjs
+++ b/src/lib/brain-hook-contract.mjs
@@ -13,11 +13,9 @@ const CONTINUITY = {
 };
 
 export function brainHookContract(version, hooks) {
-  if (version === '4.3.17') return isDeepStrictEqual(hooks, CONTINUITY)
-    ? { qualified: true, contract: '4.3.17-continuity' }
-    : { qualified: false, issue: 'Automatic hook declarations differ from the exact 4.3.17 continuity contract' };
+  if (isDeepStrictEqual(hooks, CONTINUITY)) return { qualified: true, contract: '4.3.17-continuity' };
   if (['4.3.14', '4.3.15', '4.3.16'].includes(version)) return isDeepStrictEqual(hooks, {})
     ? { qualified: true, contract: '4.3.14-4.3.16-retirement' }
     : { qualified: false, issue: 'Selected payload declares automatic hooks outside the audited retirement baseline' };
-  return { qualified: false, issue: `Automatic hook contract is unqualified for plugin version ${version ?? 'unknown'}` };
+  return { qualified: false, issue: `Automatic hook declarations differ from the exact 4.3.17 continuity contract for plugin version ${version ?? 'unknown'}` };
 }

--- a/src/lib/mcp.mjs
+++ b/src/lib/mcp.mjs
@@ -183,8 +183,8 @@ function mcpTableName(table) {
 /** Read the bounded base-table sections behind Codex MCP registrations. This
  * is deliberately not a general TOML parser: only a base
  * `[mcp_servers.<name>]` table with single-line string command/args facts is
- * observed. Any extra field or child table makes the entry ineligible for
- * automatic repair, while status can still report a suspicious topology. */
+ * observed. Extra fields or child tables preserve ownership, except for the
+ * exact kit-managed browser environment on the retired Ruflo transport. */
 function codexMcpSections(file, scope) {
   let source;
   let regularFile = false;
@@ -210,12 +210,25 @@ function codexMcpSections(file, scope) {
       && meaningful.some((line) => /^command\s*=/.test(line))
       && meaningful.some((line) => /^args\s*=/.test(line));
     const childPrefixes = [`mcp_servers.${name}.`, `mcp_servers."${name}".`];
-    const hasChildren = headers.some((candidate) =>
+    const childTables = headers.filter((candidate) =>
       childPrefixes.some((prefix) => candidate[1].trim().startsWith(prefix)));
+    const hasChildren = childTables.length > 0;
+    const managedBrowserChild = childTables.length === 1
+      && childTables[0][1].trim() === `mcp_servers.${name}.env`
+      && (() => {
+        const childIndex = headers.indexOf(childTables[0]);
+        const childBody = source.slice(childTables[0].index + childTables[0][0].length,
+          headers[childIndex + 1]?.index ?? source.length);
+        const childFields = childBody.split(/\r?\n/).map((line) => line.trim())
+          .filter((line) => line && !line.startsWith('#'));
+        const configured = tomlString(/^\s*AGENT_BROWSER_CONFIG\s*=\s*("(?:[^"\\]|\\.)*")\s*$/m.exec(childBody)?.[1]);
+        return childFields.length === 1
+          && configured === managedAgentBrowserEnv().AGENT_BROWSER_CONFIG;
+      })();
     let repairKind = null;
     if (exactFields && !hasChildren && name === 'codex' && command === 'codex'
       && sameArgs(args, ['mcp-server'])) repairKind = 'recursive-codex';
-    if (exactFields && !hasChildren && name === 'claude-flow' && command === 'ruflo'
+    if (exactFields && (!hasChildren || managedBrowserChild) && name === 'claude-flow' && command === 'ruflo'
       && sameArgs(args, ['mcp', 'start'])) repairKind = 'legacy-ruflo';
     return [{
       name, scope, file, command, args, enabled, repairKind, regularFile,

--- a/tests/kit/brain-hook-contract.test.mjs
+++ b/tests/kit/brain-hook-contract.test.mjs
@@ -9,12 +9,11 @@ const fixture = () => ({
     command: 'node "${CLAUDE_PLUGIN_ROOT}/scripts/hook-shim.mjs" continuation-gate || true', timeout: 10 }] }],
 });
 
-test('Brain continuity is qualified only for the exact reviewed release', () => {
-  assert.equal(brainHookContract('4.3.17', fixture()).qualified, true);
-  assert.equal(brainHookContract('4.3.16', {}).qualified, true);
-  for (const version of ['4.3.16', '4.3.18', '4.3.17-beta.1', null]) {
-    assert.equal(brainHookContract(version, fixture()).qualified, false);
+test('Brain continuity is qualified by the exact reviewed hook contract', () => {
+  for (const version of ['4.3.17', '4.3.18', '4.3.19', '4.3.17-beta.1', null]) {
+    assert.equal(brainHookContract(version, fixture()).qualified, true);
   }
+  assert.equal(brainHookContract('4.3.16', {}).qualified, true);
   assert.equal(brainHookContract('4.3.17', {}).qualified, false);
 });
 

--- a/tests/kit/codex-mcp.test.mjs
+++ b/tests/kit/codex-mcp.test.mjs
@@ -6,6 +6,7 @@ import path from 'node:path';
 import {
   codexMcpStatus, codexMcpTopology, codexMcpRepairPlan, repairCodexMcpTopology,
 } from '../../src/lib/mcp.mjs';
+import { agentBrowserConfigPath } from '../../src/lib/paths.mjs';
 
 // A tmp dir with a .git marker → repoRoot() resolves to it, so codexMcpStatus reads
 // the .mcp.json we write here (not the real repo's).
@@ -117,7 +118,7 @@ test('Codex MCP topology detects recursive self-registration, duplicate Ruflo, a
   } finally { rm(dir); rm(home); }
 });
 
-test('Codex should detect an environment-bearing Ruflo duplicate without allowing automatic removal', () => {
+test('Codex should preserve a duplicate with a user-owned Ruflo environment', () => {
   const dir = tmpProject();
   const home = fs.mkdtempSync(path.join(os.tmpdir(), 'kit-codexmcp-home-'));
   try {
@@ -125,7 +126,7 @@ test('Codex should detect an environment-bearing Ruflo duplicate without allowin
     const file = path.join(home, '.codex', 'config.toml');
     const source = [
       '[mcp_servers.claude-flow]', 'command = "ruflo"', 'args = ["mcp", "start"]',
-      '[mcp_servers.claude-flow.env]', 'AGENT_BROWSER_CONFIG = "/owned/browser.json"',
+      '[mcp_servers.claude-flow.env]', 'USER_OWNED_SETTING = "preserve"',
       '[mcp_servers.ruflo]', 'command = "ak"', 'args = ["x", "ruflo-mcp"]', '',
     ].join('\n');
     fs.writeFileSync(file, source);
@@ -133,6 +134,25 @@ test('Codex should detect an environment-bearing Ruflo duplicate without allowin
     assert.equal(topology.duplicateRuflo, true);
     assert.deepEqual(codexMcpRepairPlan(topology), []);
     assert.equal(fs.readFileSync(file, 'utf8'), source);
+  } finally { rm(dir); rm(home); }
+});
+
+test('Codex should repair a legacy duplicate with only the managed browser environment', () => {
+  const dir = tmpProject();
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'kit-codexmcp-home-'));
+  try {
+    fs.mkdirSync(path.join(home, '.codex'), { recursive: true });
+    const file = path.join(home, '.codex', 'config.toml');
+    fs.writeFileSync(file, [
+      '[mcp_servers.claude-flow]', 'command = "ruflo"', 'args = ["mcp", "start"]',
+      '[mcp_servers.claude-flow.env]', `AGENT_BROWSER_CONFIG = "${agentBrowserConfigPath()}"`,
+      '[mcp_servers.ruflo]', 'command = "ak"', 'args = ["x", "ruflo-mcp"]', '',
+    ].join('\n'));
+
+    const plan = codexMcpRepairPlan(codexMcpTopology({ cwd: dir, home }));
+    assert.deepEqual(plan.map(({ name, repairKind }) => ({ name, repairKind })), [
+      { name: 'claude-flow', repairKind: 'legacy-ruflo' },
+    ]);
   } finally { rm(dir); rm(home); }
 });
 

--- a/tests/kit/codex-mcp.test.mjs
+++ b/tests/kit/codex-mcp.test.mjs
@@ -145,7 +145,7 @@ test('Codex should repair a legacy duplicate with only the managed browser envir
     const file = path.join(home, '.codex', 'config.toml');
     fs.writeFileSync(file, [
       '[mcp_servers.claude-flow]', 'command = "ruflo"', 'args = ["mcp", "start"]',
-      '[mcp_servers.claude-flow.env]', `AGENT_BROWSER_CONFIG = "${agentBrowserConfigPath()}"`,
+      '[mcp_servers.claude-flow.env]', `AGENT_BROWSER_CONFIG = ${JSON.stringify(agentBrowserConfigPath())}`,
       '[mcp_servers.ruflo]', 'command = "ak"', 'args = ["x", "ruflo-mcp"]', '',
     ].join('\n'));
 

--- a/tests/kit/ruvnet-brain-plugin.test.mjs
+++ b/tests/kit/ruvnet-brain-plugin.test.mjs
@@ -56,6 +56,38 @@ test('Brain continuity requires the selected shim without claiming runtime execu
   }
 });
 
+test('Brain should qualify the 4.3.18 continuity contract', (t) => {
+  const f = fixture(t);
+  f.registry([{ ...f.record, version: '4.3.18' }]);
+  f.write(path.join(f.payload, '.claude-plugin/plugin.json'), { name: 'ruvnet-brain', version: '4.3.18' });
+  const entry = (matcher, action, timeout) => [{ matcher, hooks: [{ type: 'command',
+    command: `node "\${CLAUDE_PLUGIN_ROOT}/scripts/hook-shim.mjs" ${action} || true`, timeout }] }];
+  f.write(path.join(f.payload, 'hooks/hooks.json'), { hooks: {
+    SessionStart: entry('startup|resume|clear|compact|fork', 'session-start', 5),
+    Stop: entry('*', 'continuation-gate', 10),
+  } });
+  f.write(path.join(f.payload, 'scripts/hook-shim.mjs'), 'not executed');
+
+  const result = f.inspect();
+  assert.deepEqual(result.issues, []);
+  assert.equal(result.hookContract, '4.3.17-continuity');
+});
+
+test('Brain should qualify a future release with the exact continuity contract', (t) => {
+  const f = fixture(t);
+  f.registry([{ ...f.record, version: '4.3.19' }]);
+  f.write(path.join(f.payload, '.claude-plugin/plugin.json'), { name: 'ruvnet-brain', version: '4.3.19' });
+  const entry = (matcher, action, timeout) => [{ matcher, hooks: [{ type: 'command',
+    command: `node "\${CLAUDE_PLUGIN_ROOT}/scripts/hook-shim.mjs" ${action} || true`, timeout }] }];
+  f.write(path.join(f.payload, 'hooks/hooks.json'), { hooks: {
+    SessionStart: entry('startup|resume|clear|compact|fork', 'session-start', 5),
+    Stop: entry('*', 'continuation-gate', 10),
+  } });
+  f.write(path.join(f.payload, 'scripts/hook-shim.mjs'), 'not executed');
+
+  assert.deepEqual(f.inspect().issues, []);
+});
+
 test('Brain should disclose both missing commands and retired hooks in a disabled old payload', (t) => {
   const f = fixture(t);
   fs.unlinkSync(path.join(f.payload, 'commands/rvbc.md'));


### PR DESCRIPTION
## Summary
- qualify RuvNet Brain continuity from the exact hook contract rather than a point-version allowlist
- recognize and safely repair the legacy Codex Ruflo transport when its only child setting is the kit-managed browser environment
- add regression coverage for the 4.3.18 and future continuity contracts, managed-child repair, and user-owned-child preservation

## Verification
- pnpm test
- pnpm run typecheck
- pnpm run lint (existing warnings only)
- pnpm run build

Live machine verification removed the legacy claude-flow entry, preserving the workspace-aware ruflo and Agentic QE registrations.