### PR TITLE
fix: converge sync projections and clarify project views

### DIFF
--- a/src/commands/sync.mjs
+++ b/src/commands/sync.mjs
@@ -7,7 +7,7 @@ import readline from 'node:readline/promises';
 import { collect } from './status.mjs';
 import * as heal from '../lib/heal.mjs';
 import { have } from '../lib/exec.mjs';
-import { fixStatusline, helperStampStale } from '../lib/statusline.mjs';
+import { fixStatusline, helperStampStale, refreshRufloHelpers } from '../lib/statusline.mjs';
 import { reconcileGuidance } from '../lib/blocks.mjs';
 import {
   register as mcpRegister, applyExclusions, codexMcpTopology, codexMcpRepairPlan,
@@ -42,6 +42,13 @@ function printReportLine(line) {
   else if (line.level === 'warn') warn(line.text);
   else if (line.level === 'fail') fail(line.text);
   else info(line.text);
+}
+
+/** A package update can change the source catalog used by a lifecycle host.
+ * Re-enter its idempotent apply path in the same sync, rather than leaving a
+ * fresh package paired with its prior generated projection until another run. */
+export function lifecycleRefreshRequired(subsystems, hostId) {
+  return subsystems.has(hostId) || (hostId === 'opencode' && subsystems.has('versions'));
 }
 
 /** Preserve a failed mutation for the final convergence proof. A failed heal
@@ -314,7 +321,7 @@ export const SYNC_STEPS = [
     when: () => true,
     run: async (ctx) => {
       for (const hostId of hostsWithLifecycle()) {
-        if (!ctx.subsystems.has(hostId) || !lifecycleExecutionEnabled(hostId, ctx.cfg)) continue;
+        if (!lifecycleRefreshRequired(ctx.subsystems, hostId) || !lifecycleExecutionEnabled(hostId, ctx.cfg)) continue;
         if (!(await have(detectionBinFor(hostId)))) {
           info(`${hostId}: enabled but CLI not installed — wiring skipped (hosts step installs it)`);
           continue;
@@ -397,6 +404,21 @@ export const SYNC_STEPS = [
         reporter,
         runProviders: (fn) => withProgress('providers (api)', fn),
       });
+    },
+  },
+  // Ruflo's signed helper-refresh owns the generated `.claude/helpers` set.
+  // Run it explicitly after a versions plan, rather than requiring a broad
+  // `ruflo init --full --force` or waiting for a later hook invocation to do
+  // it implicitly. Statusline follows immediately because this refresh may
+  // replace statusline.cjs.
+  {
+    id: 'ruflo-helpers',
+    when: (subs) => subs.has('versions'),
+    run: async (ctx) => {
+      const refreshed = await withProgress('ruflo helpers', async () => refreshRufloHelpers(ctx.cwd));
+      if (refreshed) ok('ruflo helpers: signed generated helpers refreshed');
+      else if (helperStampStale(ctx.cwd)) warn('ruflo helpers: refresh did not converge; generated helpers remain stale');
+      else info('ruflo helpers: current');
     },
   },
   // Gate includes 'providers': applyProviders runs ruflo CLI commands, and any

--- a/src/lib/codex-context.mjs
+++ b/src/lib/codex-context.mjs
@@ -1,5 +1,5 @@
-// Native per-model clamp is verified on 0.153.4. An API maximum is not a
-// Codex allocation. New host versions need their own native contract evidence.
+// A native catalog's per-model contract, not an exact CLI patch version,
+// governs a maximum request. An API maximum is not a Codex allocation.
 import fs from 'node:fs';
 import path from 'node:path';
 import { createHash } from 'node:crypto';
@@ -7,8 +7,15 @@ import { run } from './exec.mjs';
 import { contextHome, positiveTokens, readContextConfig, replaceContextWindow,
   writeContextConfig, validateCodexContextIntent } from './codex-context-config.mjs';
 
-export const VERIFIED_CODEX_CONTEXT_VERSIONS = Object.freeze(['0.153.4']);
 export const CONTEXT_CACHE_MAX_AGE_MS = 7 * 86400000;
+
+export function hasCodexContextProfile(raw) {
+  return typeof raw?.slug === 'string' && /^[a-zA-Z0-9._:-]{1,128}$/.test(raw.slug)
+    && positiveTokens(raw.context_window) && positiveTokens(raw.max_context_window)
+    && raw.max_context_window >= raw.context_window
+    && Number.isInteger(raw.effective_context_window_percent)
+    && raw.effective_context_window_percent > 0 && raw.effective_context_window_percent <= 100;
+}
 
 export function contextCapacity(raw, request = null) {
   const nativeWindow = positiveTokens(raw.context_window) ? raw.context_window : null;
@@ -34,14 +41,12 @@ function readEvidence(home, now) {
   if (!Number.isFinite(age) || age < -300000 || age > CONTEXT_CACHE_MAX_AGE_MS) {
     throw new Error('Codex model cache is stale or undated; run codex debug models to refresh');
   }
-  if (!VERIFIED_CODEX_CONTEXT_VERSIONS.includes(cache.client_version)) {
-    throw new Error('Codex version has no verified per-model context clamp profile');
+  if (typeof cache.client_version !== 'string' || !/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(cache.client_version)) {
+    throw new Error('Codex model cache has no valid client version');
   }
   if (!Array.isArray(cache.models) || cache.models.length === 0 || cache.models.length > 1000) throw new Error('invalid Codex model catalog');
   const models = cache.models.filter(m => !['hide', 'hidden'].includes(m.visibility));
-  if (!models.length || models.some(m => typeof m.slug !== 'string' || !/^[a-zA-Z0-9._:-]{1,128}$/.test(m.slug)
-    || !positiveTokens(m.context_window) || !positiveTokens(m.max_context_window)
-    || m.max_context_window < m.context_window || contextCapacity(m).effectivePercent === null)) {
+  if (!models.length || models.some(m => !hasCodexContextProfile(m))) {
     throw new Error('Codex catalog lacks valid native capacity bounds');
   }
   return { file, config, cache, models, requestedWindow: Math.max(...models.map(m => m.max_context_window)),

--- a/src/lib/dashboard/client.mjs
+++ b/src/lib/dashboard/client.mjs
@@ -1,4 +1,4 @@
-import { projectView } from './project-groups.mjs';
+import { repositoryTree } from './project-groups.mjs';
 import { contextCard } from './context-card.mjs';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -157,5 +157,5 @@ const bootSrc = readSplit('boot.mjs');
 // sequence) running in the same relative order it always has.
 export const JS = `
 (function(){
-${bootstrapSrc}${contextCard.toString()}${projectView.toString()}${overviewSrc}${datetimeSrc}${intelligenceSrc}${pollSrc}${usageRhythmSrc}${usagePromptsSrc}${usageContextHooksSrc}${usageSrc}${modelLifecycleSrc}${usageOrchestratorsSrc}${aboutSrc}${systemReadoutSrc}${systemProjectsSrc}${readSplit('project-group-controls.mjs')}${maintenanceWorkspaceSrc}${maintenanceFiltersSrc}${maintenanceCardsSrc}${maintenanceOperationSrc}${maintenanceLanguageLogosSrc}${maintenanceFocusSrc}${maintenanceInventorySrc}${maintenanceRelationshipsSrc}${maintenanceInspectorSrc}${maintenanceGuidanceSrc}${maintenanceDiscoverySrc}${maintenanceActivitySrc}${systemMaintenanceActionsSrc}${systemMaintenanceSrc}${bootSrc}})();
+${bootstrapSrc}${contextCard.toString()}${repositoryTree.toString()}${overviewSrc}${datetimeSrc}${intelligenceSrc}${pollSrc}${usageRhythmSrc}${usagePromptsSrc}${usageContextHooksSrc}${usageSrc}${modelLifecycleSrc}${usageOrchestratorsSrc}${aboutSrc}${systemReadoutSrc}${systemProjectsSrc}${maintenanceWorkspaceSrc}${maintenanceFiltersSrc}${maintenanceCardsSrc}${maintenanceOperationSrc}${maintenanceLanguageLogosSrc}${maintenanceFocusSrc}${maintenanceInventorySrc}${maintenanceRelationshipsSrc}${maintenanceInspectorSrc}${maintenanceGuidanceSrc}${maintenanceDiscoverySrc}${maintenanceActivitySrc}${systemMaintenanceActionsSrc}${systemMaintenanceSrc}${bootSrc}})();
 `;

--- a/src/lib/dashboard/client/intelligence.mjs
+++ b/src/lib/dashboard/client/intelligence.mjs
@@ -58,6 +58,16 @@ import { fmtNum, kpi } from './usage.mjs';
   }
 
   var INTEL_SCOPE_GROUPS=[['repository','Git repositories'],['worktree','Git worktrees'],['user','User-level learning'],['unknown','Other / unclassified']];
+  var machineWideDesignationFilter='all';
+  function machineWideDesignation(p){
+    if(p.learningScope==='repository')return 'Git repository';
+    if(p.learningScope==='worktree')return 'Git worktree';
+    var origins=Array.isArray(p.learningOrigins)?p.learningOrigins:[];
+    if(origins.includes('codex-desktop'))return 'ChatGPT Desktop';
+    if(origins.includes('claude-desktop'))return 'Claude Desktop';
+    if(Array.isArray(p.hosts)&&p.hosts.includes('opencode'))return 'OpenCode';
+    return 'Directory';
+  }
   function intelScopeRows(rows,scope){
     return rows.filter(function(p){
       var kind=['repository','worktree','user'].includes(p.learningScope)?p.learningScope:'unknown';
@@ -75,20 +85,18 @@ import { fmtNum, kpi } from './usage.mjs';
     var label=p.label||'(unlabeled)';
     return '<div class="mw-row mw-data-row" role="row">'
       +'<span class="mw-name" role="cell" title="'+esc(label)+'">'+esc(label)+storeHtml+'</span>'
+      +'<span class="mw-designation" role="cell">'+esc(machineWideDesignation(p))+'</span>'
       +'<span class="mw-val mono" role="cell">'+esc(fmtNum(p.patternsLearned))+'</span>'
       +'<span class="mw-val mono" role="cell">'+esc(fmtNum(p.patternStoreCount))+'</span>'
       +'<span class="mw-val mono" role="cell" title="'+esc(lastTxt)+'">'+esc(lastTxt)+'</span></div>';
   }
 
-  function machineWideGroup(group,rows){
-    var id='mw-group-'+group[0];
-    return '<section class="mw-group" data-learning-scope="'+group[0]+'" aria-labelledby="'+id+'">'
-      +'<h3 id="'+id+'">'+esc(group[1])+'<span>'+esc(fmtNum(rows.length))+'</span></h3>'
-      +'<div class="mw-group-scroll" role="region" aria-label="'+esc(group[1])+' learning rows" tabindex="0">'
-      +'<div role="table" aria-labelledby="'+id+'"><div class="mw-row mw-head" role="row">'
-      +'<span role="columnheader">Project</span><span class="mw-val" role="columnheader">Patterns learned</span>'
+  function machineWideTable(rows){
+    return '<div class="mw-group-scroll" role="region" aria-label="Learning locations" tabindex="0">'
+      +'<div role="table"><div class="mw-row mw-head" role="row">'
+      +'<span role="columnheader">Name</span><span role="columnheader">Designation</span><span class="mw-val" role="columnheader">Patterns learned</span>'
       +'<span class="mw-val" role="columnheader">Pattern store</span><span class="mw-val" role="columnheader">Last active</span></div>'
-      +'<div role="rowgroup">'+rows.map(machineWideRow).join('')+'</div></div></div></section>';
+      +'<div role="rowgroup">'+rows.map(machineWideRow).join('')+'</div></div></div>';
   }
 
   function renderMachineWide(mw){
@@ -102,21 +110,12 @@ import { fmtNum, kpi } from './usage.mjs';
     var table=document.getElementById("mw-table");
     if(!table)return;
     if(!perProject.length){table.innerHTML='<div class="empty">no projects discovered on this machine.</div>';return;}
-    var positions={};
-    var active=document.activeElement,focusedScope=active&&active.classList&&active.classList.contains('mw-group-scroll')
-      ?active.closest('.mw-group').getAttribute('data-learning-scope'):null;
-    if(table.querySelectorAll)Array.from(table.querySelectorAll('.mw-group')).forEach(function(section){
-      positions[section.getAttribute('data-learning-scope')]=section.querySelector('.mw-group-scroll').scrollTop;
-    });
-    table.innerHTML=INTEL_SCOPE_GROUPS.map(function(group){
-      var rows=intelScopeRows(perProject,group[0]);
-      return rows.length?machineWideGroup(group,rows):'';
-    }).join('');
-    if(table.querySelectorAll)Array.from(table.querySelectorAll('.mw-group')).forEach(function(section){
-      var region=section.querySelector('.mw-group-scroll'),scope=section.getAttribute('data-learning-scope');
-      region.scrollTop=positions[scope]||0;
-      if(scope===focusedScope)region.focus({preventScroll:true});
-    });
+    var designations=['all'].concat(Array.from(new Set(perProject.map(machineWideDesignation))).sort());
+    var visible=(machineWideDesignationFilter==='all'?perProject:perProject.filter(function(row){return machineWideDesignation(row)===machineWideDesignationFilter;})).sort(function(a,b){return String(a.label||'').localeCompare(String(b.label||''),undefined,{sensitivity:'base',numeric:true})||String(a.key||a.path||'').localeCompare(String(b.key||b.path||''));});
+    table.innerHTML='<div class="mw-filter-pills" role="group" aria-label="Filter learning locations by designation">'
+      +designations.map(function(designation){var label=designation==='all'?'All':designation;return '<button type="button" class="mw-filter-pill" data-designation="'+esc(designation)+'" aria-pressed="'+(designation===machineWideDesignationFilter)+'">'+esc(label)+'</button>';}).join('')
+      +'</div>'+machineWideTable(visible);
+    if(table.querySelectorAll)Array.from(table.querySelectorAll('.mw-filter-pill')).forEach(function(button){button.addEventListener('click',function(){machineWideDesignationFilter=button.getAttribute('data-designation')||'all';renderMachineWide(mw);});});
   }
 
   // The picker's option list AND its default selection come from the SAME
@@ -137,7 +136,7 @@ import { fmtNum, kpi } from './usage.mjs';
     var sel=document.getElementById("intel-project-select");
     if(!sel)return;
     if(!intelProjects.length){
-      sel.innerHTML='<option value="">no projects discovered</option>';
+      sel.innerHTML='<option value="">no learning locations discovered</option>';
       sel.disabled=true;
       return;
     }
@@ -146,7 +145,7 @@ import { fmtNum, kpi } from './usage.mjs';
       var rows=intelScopeRows(intelProjects,group[0]);
       if(!rows.length)return '';
       return '<optgroup label="'+esc(group[1])+'">'+rows.map(function(p){
-        return '<option value="'+esc(p.key)+'"'+(p.key===selectedProjectKey?" selected":"")+'>'+esc(p.label)+"</option>";
+        return '<option value="'+esc(p.key)+'"'+(p.key===selectedProjectKey?" selected":"")+'>'+esc(p.label)+' — '+esc(machineWideDesignation(p))+"</option>";
       }).join('')+'</optgroup>';
     }).join('');
   }

--- a/src/lib/dashboard/client/maintenance-filters.mjs
+++ b/src/lib/dashboard/client/maintenance-filters.mjs
@@ -24,7 +24,7 @@ import { MNT, MNT_GUIDANCE_LANE_LABELS, MNT_CONFLICT_EXPLANATIONS, MNT_CREDENTIA
   }
   export function mntFacetValueLabel(facet,value){
     if(facet==="adapter"||facet==="consumer")return MNT_ADAPTER_LABELS[value]||mntHumanize(value);
-    if(facet==="sessionOrigin")return ({"claude-desktop":"Claude Desktop","codex-desktop":"Codex Desktop",unknown:"Unclassified"})[value]||"Unclassified";
+    if(facet==="sessionOrigin")return ({"claude-desktop":"Claude Desktop","codex-desktop":"ChatGPT Desktop",unknown:"Unclassified"})[value]||"Unclassified";
     if(facet==="projectType")return ({git:'Git',folder:'Folder',worktree:'Worktree',unknown:'Not checked'})[value]||'Not checked';
     if(facet==="scope")return MNT_SCOPE_LABELS[value]||mntHumanize(value);
     if(facet==="kind")return mntKindLabel(value);

--- a/src/lib/dashboard/client/maintenance-focus.mjs
+++ b/src/lib/dashboard/client/maintenance-focus.mjs
@@ -47,13 +47,6 @@ import { mntFacetValueLabel } from './maintenance-filters.mjs';
       return '<span class="mnt-language-badge" title="'+esc(label)+'"><img class="mnt-language-icon" width="24" height="24" src="'+mntLanguageLogo(language.id)+'" alt="'+esc(language.name)+'" aria-label="'+esc(label)+'"></span>';
     }).join('')+'</span>';
   }
-  function mntProjectOrigins(node){
-    var origins=(node.sessionOrigins||[]).filter(function(item){return item.origin==='claude-desktop'||item.origin==='codex-desktop';});
-    if(!origins.length)return '';
-    return '<span class="mnt-project-origins">'+origins.map(function(item){
-      return esc(mntFacetValueLabel('sessionOrigin',item.origin));
-    }).join(' · ')+'</span>';
-  }
   function mntProjectGroups(nodes,busy){
     var groups=new Map(),index=0;
     nodes.forEach(function(node){
@@ -72,7 +65,7 @@ import { mntFacetValueLabel } from './maintenance-filters.mjs';
     if(level==='resource'&&node.installationSource)note=node.installationSource;
     return '<li><button type="button" class="mnt-row mnt-focus-node" data-mnt-focus="'+esc(node.value)+'" data-mnt-level="'+esc(level)+'" tabindex="'+(index===0?'0':'-1')+'"'+(busy?' disabled':'')+'>'
       +(level==='project'?'':mntIcon(icon))+'<span class="mnt-row-copy"><span class="mnt-row-name'+(level==='project'?' mnt-project-title':'')+'">'+(level==='project'?mntIcon('project'):'')+esc(node.label)+'</span>'
-      +(level==='project'?mntProjectKindBadge(node.projectKind)+mntProjectOrigins(node):'')
+      +(level==='project'?mntProjectKindBadge(node.projectKind):'')
       +(level==='project'&&node.languages&&node.languages.length?mntLanguageBadges(node.languages):'')
       +(node.description?'<span class="mnt-row-context mnt-resource-description" title="'+esc(node.descriptionSource||'Declared description')+'">'+esc(node.description)+'</span>':'')
       +(note?'<span class="mnt-row-context">'+esc(note)+'</span>':'')+'</span><span class="mnt-node-count">'+esc(node.count)+' installation'+(node.count===1?'':'s')+'</span>'+mntIcon('chevron')+'</button></li>';

--- a/src/lib/dashboard/client/system-projects.mjs
+++ b/src/lib/dashboard/client/system-projects.mjs
@@ -1,8 +1,7 @@
-/* global projectView */
+/* global repositoryTree */
 // @ts-nocheck — browser bundle source (never node-imported; client.mjs
 // reads it as text). See src/lib/dashboard/client/**'s eslint.config.mjs
 // override comment for why this directory isn't run through the node lib.
-import { projectControls, projectIdentityCell, projectPopulation, projectOrigin } from './project-group-controls.mjs';
 import { authHeaders, esc } from './bootstrap.mjs';
 import { formatLocalDateTime, formatLocalDateTimeLong, shortSessionId } from './datetime.mjs';
 import { ago } from './intelligence.mjs';
@@ -14,6 +13,7 @@ import { fmtNum, fmtTok, limAge, pct } from './usage.mjs';
   // (now its own card) and agentic-kit is ak's own state. Both are accounted
   // for in the panel's footnote rather than dropped silently.
   var REAL_HOSTS={claude:true,codex:true,opencode:true};
+  var expandedRepositoryTrees={};
 
   // renderSysStorage was one CC-88 function mixing five independent DOM
   // regions (learning stores, donut, per-host split, growth sparks, top
@@ -765,22 +765,6 @@ import { fmtNum, fmtTok, limAge, pct } from './usage.mjs';
       +"</span></button></th>";
   }
 
-  // renderSysProjects was one CC-33 function mixing eligibility filtering,
-  // per-row HTML building, and final table+liner assembly. Split by concern;
-  // each keeps the exact original logic unchanged. (The row builder also
-  // drops a dead `_diskBar` computation that was built but never read in the
-  // original -- a no-op removal, not a behavior change.)
-  function sysProjectsEligible(all){
-    var list=[],excluded=0;
-    for(var f=0;f<all.length;f++){
-      var cand=all[f],crem=cand.remote||null;
-      var linked=!!(crem&&crem.webUrl&&/^https:/.test(String(crem.webUrl)));
-      var hosted=!Array.isArray(cand.hosts)||cand.hosts.length>0;
-      if(linked&&hosted)list.push(cand);else excluded++;
-    }
-    return {list:list,excluded:excluded};
-  }
-
   function sysProjectNameCell(pr){
     var rem=pr.remote||null,name;
     if(rem&&rem.status==="linked"&&/^https:/.test(String(rem.webUrl||""))){
@@ -792,28 +776,30 @@ import { fmtNum, fmtTok, limAge, pct } from './usage.mjs';
     return name;
   }
 
-  function sysProjectRowHtml(pr){
+  function sysProjectRowHtml(pr,opts){
+    opts=opts||{};
     var name=sysProjectNameCell(pr);
     var last=mval(pr.lastActivity);
-    return "<tr><td>"+name+projectIdentityCell(pr)+"</td>"
+    var control=opts.expandable?'<button type="button" class="project-chevron" data-project-tree="'+esc(opts.treeKey)+'" aria-expanded="'+opts.expanded+'">'+(opts.expanded?'⌄':'›')+'</button>':'';
+    var worktreeMark=opts.worktree?'<span class="project-worktree-mark" aria-hidden="true">↳</span>':'';
+    var display=opts.worktree?'<span class="project-worktree-name">'+esc(pr.label||'worktree')+'</span>':name;
+    return '<tr class="'+(opts.worktree?'project-worktree':'project-repository')+'"'+(opts.hidden?' hidden':'')+'><td>'+worktreeMark+display+'<span class="project-path">'+esc(pr.path||'not measured yet')+'</span></td>'
       +'<td class="num">'+mhtml(pr.loc&&pr.loc.total,function(v){return "~"+fmtTok(v);})+"</td>"
       +"<td>"+langCell(pr.loc)+"</td>"
       +'<td class="num">'+mhtml(pr.totalBytes,fmtBytes)+"</td>"
       +'<td class="num">'+(last==null?unkHtml((pr.lastActivity&&pr.lastActivity.reason)||"no readable entry",false)
-        :esc(ago(Math.max(0,Math.round((Date.now()-last)/1000)))))+"</td></tr>";
+        :esc(ago(Math.max(0,Math.round((Date.now()-last)/1000)))))+"</td><td>"+control+"</td></tr>";
   }
 
-  function sysProjectsLinerHtml(p,list,excluded){
+  function sysProjectsLinerHtml(p,tree){
+    var worktrees=tree.repositories.reduce(function(n,group){return n+group.worktrees.length;},0);
     return '<div class="sy-liner">'
       +(p.everSeen
-        ?mhtml(p.everSeen)+" projects ever seen across all hosts, "
+        ?mhtml(p.everSeen)+" working directories ever seen across all hosts, "
           +(p.onDisk?mhtml(p.onDisk):"some")+" still on disk"
-        :mhtml(p.count)+" projects measured (this snapshot predates the ever-seen count)")
-      +", "+esc(fmtNum(list.length))+" listed here."
-      +(excluded&&projectPopulation==="measured"
-        ? " Excluded "+esc(fmtNum(excluded))+" measured director"+(excluded===1?"y":"ies")
-          +" without an HTTPS remote or recorded host. Full discovery retains other known paths."
-        : "")
+        :mhtml(p.count)+" directories measured (this snapshot predates the ever-seen count)")
+      +". This view shows "+esc(fmtNum(tree.repositories.length))+" verified repositor"+(tree.repositories.length===1?"y":"ies")
+      +" with "+esc(fmtNum(worktrees))+" nested worktree"+(worktrees===1?"":"s")+"; "+esc(fmtNum(tree.excludedDirectories))+" non-repository directories are excluded."
       +" Line counts are approximate: extension-bucketed, with node_modules and vendored "
       +"trees excluded. Disk is the whole project directory, .git and node_modules included.</div>";
   }
@@ -824,34 +810,32 @@ import { fmtNum, fmtTok, limAge, pct } from './usage.mjs';
     var p=d.projects;
     if(!p){el.innerHTML=sysEmpty(NOT_SCANNED);return;}
     var all=p.projects||[];
-    if(!all.length&&!(p.discoveryProjects||[]).length){el.innerHTML=projectControls(p)+sysEmpty("no project was discovered on this machine.");return;}
-    var elig=sysProjectsEligible(all),excluded=elig.excluded;
-    var groups=projectView({projects:elig.list,discoveryProjects:p.discoveryProjects},projectPopulation,projectOrigin);
-    var list=groups.reduce(function(rows,group){return rows.concat(group.rows);},[]);
-    var body=groups.map(function(group){
-      return '<tbody>'+sortProjects(group.rows,projSort.key,projSort.dir).map(sysProjectRowHtml).join('')+'</tbody>';
-    }).join('');
+    if(!all.length&&!(p.discoveryProjects||[]).length){el.innerHTML=sysEmpty("no repository was discovered on this machine.");return;}
+    var tree=repositoryTree({projects:all,discoveryProjects:p.discoveryProjects});
+    var byPath={};tree.repositories.forEach(function(group){byPath[group.repository.path]=group;});
+    var repositories=sortProjects(tree.repositories.map(function(group){return group.repository;}),projSort.key,projSort.dir);
+    var body=repositories.map(function(repository){var group=byPath[repository.path],expanded=!!expandedRepositoryTrees[group.key];return '<tbody>'+sysProjectRowHtml(repository,{expandable:group.worktrees.length>0,expanded:expanded,treeKey:group.key})+group.worktrees.map(function(worktree){return sysProjectRowHtml(worktree,{worktree:true,hidden:!expanded});}).join('')+'</tbody>';}).join('');
     // Legend covers only what still renders: the language ramp. The disk column
     // is a single figure now, and there are no chips left to explain.
-    el.innerHTML=projectControls(p)+'<div class="sy-legend" style="margin-bottom:4px">'
+    el.innerHTML='<div class="sy-legend" style="margin-bottom:4px">'
       +'<span>lines: top '+LANG_TOP+' languages, darkest first'
       +'<i style="background:var(--s1);margin-left:8px"></i>'
       +'<i style="background:var(--s1);opacity:.63"></i>'
       +'<i style="background:var(--s1);opacity:.27"></i>'
       +'<i style="background:var(--dim)"></i> the rest</span></div>'
-      +'<div class="sy-tblwrap"><table class="sy-table sy-sortable"><thead><tr>'
+      +'<div class="sy-tblwrap sy-project-scroll" role="region" aria-label="Repository footprints" tabindex="0"><table class="sy-table sy-sortable"><thead><tr>'
       +projSortHeader("project","Project",false)
       +projSortHeader("lines","Lines ≈",true)
       +projSortHeader("language","By language",false)
       +projSortHeader("disk","Disk",true)
       +projSortHeader("active","Last active",true)
+      +"<th>Worktrees</th>"
       +"</tr></thead>"+body+"</table></div>"
       // Three numbers now, and the gap between the last two is a filter rather
       // than a fact about the machine — so it is named. Leaving the reader to
       // subtract 25 from 16 and guess is the silent exclusion ADR-0023 forbids.
-      +sysProjectsLinerHtml(p,list,excluded)
-      +'<p class="sy-liner" role="status">'+list.length+' directories match. Origins can overlap within a directory; each directory appears once. Unmeasured values stay unknown; disk and line counts are not summed across nested paths.</p>'
-      +(!list.length?sysEmpty('No directories match these filters.'):'');
+      +sysProjectsLinerHtml(p,tree)
+      +(!repositories.length?sysEmpty('no verified repository footprint is available in this snapshot.'):'');
   }
 
   export function renderSystemFreshness(){
@@ -1001,6 +985,14 @@ import { fmtNum, fmtTok, limAge, pct } from './usage.mjs';
   }
 
   export function wireSystem(){
+    document.addEventListener("click",function(e){
+      var toggle=e.target&&e.target.closest?e.target.closest("[data-project-tree]"):null;
+      if(!toggle)return;
+      var key=toggle.getAttribute("data-project-tree");
+      if(!key)return;
+      expandedRepositoryTrees[key]=!expandedRepositoryTrees[key];
+      if(SYSTEM)renderSysProjects(SYSTEM);
+    });
     var sessionTooltip=document.getElementById("sys-session-tooltip");
     if(!sessionTooltip){
       sessionTooltip=document.createElement("div");

--- a/src/lib/dashboard/intel-history.mjs
+++ b/src/lib/dashboard/intel-history.mjs
@@ -246,7 +246,10 @@ export function readMachineWideIntel(projects) {
     patternStoreEntries += patternStore.length;
     trajectoriesRecorded += trajectories ?? 0;
 
-    if (lastAdaptation != null && lastAdaptation > mostActiveAdaptation) {
+    // The headline names a project, which means a verified repository. The
+    // inventory still retains worktrees and non-Git workspaces as learning
+    // locations, but neither may displace a repository in this metric.
+    if (entry?.learningScope === 'repository' && lastAdaptation != null && lastAdaptation > mostActiveAdaptation) {
       mostActiveAdaptation = lastAdaptation;
       mostActiveProject = label;
     }

--- a/src/lib/dashboard/page.mjs
+++ b/src/lib/dashboard/page.mjs
@@ -8,18 +8,20 @@ import { LIVE_CSS, LIVE_HTML, LIVE_JS } from './live-view.mjs';
 // --ink*, --r-sm, --accent) so the new rows/picker match the Apple system
 // motif everywhere else, without duplicating any of styles.mjs's own rules.
 const INTEL_CSS = `
-.mw-table{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:12px;max-height:520px;overflow:auto;align-items:start;margin-top:14px;padding:2px}
+.mw-table{max-height:520px;overflow:auto;align-items:start;margin-top:14px;padding:2px}
 .mw-group{min-width:0;border:1px solid var(--line);border-radius:var(--r-sm);overflow:hidden}
 .mw-group h3{display:flex;justify-content:space-between;gap:8px;margin:0;padding:10px 14px;background:var(--panel);font-size:12px;font-weight:600;color:var(--ink)}
 .mw-group h3 span{color:var(--ink-dim);font-weight:400}
 .mw-group-scroll{max-height:212px;overflow:auto;overscroll-behavior:contain}
 .mw-table:focus-visible,.mw-group-scroll:focus-visible{outline:2px solid var(--accent);outline-offset:-2px}
-.mw-row{display:grid; grid-template-columns:minmax(140px,1.6fr) repeat(3,minmax(96px,1fr)); gap:10px; align-items:center; padding:8px 14px; background:var(--panel); font-size:12.5px}
+.mw-row{display:grid; grid-template-columns:minmax(140px,1.6fr) minmax(110px,1fr) repeat(3,minmax(96px,1fr)); gap:10px; align-items:center; padding:8px 14px; background:var(--panel); font-size:12.5px}
 .mw-data-row{height:34px;box-sizing:border-box;border-top:1px solid var(--line)}
 .mw-data-row .mw-val{white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
 .mw-row.mw-head{height:42px;box-sizing:border-box;position:sticky;top:0;z-index:1;background:var(--panel-2); color:var(--ink-dim); font-size:10.5px; font-weight:600; text-transform:uppercase; letter-spacing:.06em;line-height:12px}
 .mw-row:not(.mw-head):hover{background:var(--panel-2)}
 .mw-name{color:var(--ink); overflow:hidden; text-overflow:ellipsis; white-space:nowrap}
+.mw-designation{color:var(--ink-2);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.mw-filter-pills{display:flex;gap:7px;flex-wrap:wrap;margin:0 0 10px}.mw-filter-pill{border:1px solid var(--line-2);border-radius:999px;background:var(--panel);color:var(--ink-2);padding:5px 9px;cursor:pointer}.mw-filter-pill[aria-pressed="true"]{border-color:var(--accent);color:var(--accent);background:color-mix(in srgb,var(--accent) 12%,var(--panel))}
 /* Which learning stores a project carries — three tiny dots, one per store,
    so a row reporting 0 patterns still says what IS active there. Colour, not
    text, because the column is already tight and the title carries the names. */
@@ -31,7 +33,7 @@ const INTEL_CSS = `
 .mw-val{color:var(--ink-2); text-align:right}
 .mw-row.mw-head .mw-val{color:var(--ink-dim)}
 @media(max-width:1100px){.mw-table{grid-template-columns:minmax(0,1fr)}}
-@media(max-width:560px){.mw-row{grid-template-columns:minmax(0,1.4fr) repeat(3,minmax(0,1fr));gap:6px;padding-left:9px;padding-right:9px;font-size:11px}.mw-row.mw-head{font-size:9px;letter-spacing:0}.mw-group h3{padding-left:9px;padding-right:9px}}
+@media(max-width:560px){.mw-row{grid-template-columns:minmax(0,1.4fr) minmax(80px,1fr) repeat(3,minmax(0,1fr));gap:6px;padding-left:9px;padding-right:9px;font-size:11px}.mw-row.mw-head{font-size:9px;letter-spacing:0}.mw-group h3{padding-left:9px;padding-right:9px}}
 .mw-picker{display:flex; align-items:center; gap:9px; flex-wrap:wrap; min-width:0; max-width:100%}
 .mw-picker label{color:var(--ink-dim); font-size:11.5px}
 .mw-picker select{
@@ -398,7 +400,7 @@ export function renderPage({ name, version }) {
       <div class="strip-head">
         <h2 class="strip-title">learning over time &mdash; <span id="history-project-name"></span></h2>
         <div class="mw-picker">
-          <label for="intel-project-select">select project</label>
+          <label for="intel-project-select">select learning location</label>
           <select id="intel-project-select"></select>
         </div>
       </div>

--- a/src/lib/dashboard/project-groups.mjs
+++ b/src/lib/dashboard/project-groups.mjs
@@ -9,6 +9,7 @@ export function repositoryTree(payload = {}) {
   const unresolved = [];
   for (const row of byPath.values()) {
     const repo = row.repository;
+    if (Array.isArray(row.hosts) && row.hosts.length === 0) continue;
     if (!repo?.repositoryId || !['git', 'worktree'].includes(repo.kind)) {
       unresolved.push(row);
       continue;

--- a/src/lib/dashboard/project-groups.mjs
+++ b/src/lib/dashboard/project-groups.mjs
@@ -1,17 +1,39 @@
-// Pure view projection; repository membership is supplied by the collector,
-// never inferred from a display label or remote. Injected unchanged in browser.
-export function projectView(payload, population = 'measured', origin = 'all') {
+// Pure repository-tree projection. Membership is supplied by the collector,
+// never inferred from a display label, path spelling, or remote URL.
+export function repositoryTree(payload = {}) {
   const byPath = new Map();
-  if (population === 'all') for (const row of payload.discoveryProjects || []) byPath.set(row.path || row, row);
-  for (const row of payload.projects || []) byPath.set(row.path || row, {...byPath.get(row.path || row), ...row});
+  for (const row of payload.discoveryProjects || []) if (row?.path) byPath.set(row.path, row);
+  for (const row of payload.projects || []) if (row?.path) byPath.set(row.path, { ...byPath.get(row.path), ...row });
+
   const groups = new Map();
+  const unresolved = [];
   for (const row of byPath.values()) {
-    const origins = row.sessionOrigins?.length ? row.sessionOrigins : [{origin:'unknown'}];
-    if (origin !== 'all' && !origins.some(item => item.origin === origin)) continue;
     const repo = row.repository;
-    const key = repo?.repositoryId || (repo?.kind === 'folder' ? 'folders' : 'unknown');
-    if (!groups.has(key)) groups.set(key, {key, label:repo?.root || repo?.commonDir || (key === 'folders' ? 'Other folders' : 'Repository not established'), rows:[]});
-    groups.get(key).rows.push(row);
+    if (!repo?.repositoryId || !['git', 'worktree'].includes(repo.kind)) {
+      unresolved.push(row);
+      continue;
+    }
+    const key = repo.repositoryId;
+    if (!groups.has(key)) {
+      const root = repo.root || row.path;
+      groups.set(key, {
+        key,
+        repository: { path: root, label: root.split(/[\\/]/).filter(Boolean).pop() || 'repository', repository: { ...repo, kind: 'git' } },
+        worktrees: [],
+      });
+    }
+    const group = groups.get(key);
+    if (repo.kind === 'git' && (!repo.root || row.path === repo.root)) group.repository = row;
+    else if (repo.kind === 'worktree') group.worktrees.push(row);
   }
-  return [...groups.values()];
+  const repositories = [...groups.values()];
+  let excludedDirectories = 0;
+  for (const row of unresolved) {
+    const parent = repositories.find((group) => row.path?.startsWith(`${group.repository.path}/.claude/worktrees/`));
+    if (parent) parent.worktrees.push(row);
+    else excludedDirectories += 1;
+  }
+  for (const group of repositories) group.worktrees.sort((a, b) => String(a.label || a.path).localeCompare(String(b.label || b.path)));
+  repositories.sort((a, b) => String(a.repository.label || a.repository.path).localeCompare(String(b.repository.label || b.repository.path)));
+  return { repositories, excludedDirectories };
 }

--- a/src/lib/dashboard/styles/system.mjs
+++ b/src/lib/dashboard/styles/system.mjs
@@ -404,6 +404,12 @@ export const SYSTEM_CSS = `
 .project-controls label { font-size:12px; display:flex; align-items:center; gap:6px; }
 .project-controls select { max-width:100%; background:var(--bg); color:var(--ink); border:1px solid var(--line); border-radius:5px; padding:6px; }
 .project-identity,.project-path { display:block; font-size:11px; color:var(--ink-2); overflow-wrap:anywhere; white-space:normal; }
+.sy-project-scroll{max-height:286px;overflow:auto}
+.sy-project-scroll .sy-table thead th{position:sticky;top:0;z-index:1;background:var(--panel)}
+.project-chevron{width:20px;margin:0 3px 0 -4px;padding:0;border:0;background:transparent;color:var(--accent);font:inherit;font-size:18px;line-height:1;cursor:pointer}
+.project-worktree-mark{display:inline-block;width:20px;margin-right:3px;color:var(--ink-dim)}
+.project-worktree-name{color:var(--ink-2);font-weight:600}
+.project-worktree td:first-child{padding-left:22px}
 
 .context-host-heading { display:flex; align-items:baseline; justify-content:space-between; gap:8px; }
 .context-host-heading span { font-size:11px; color:var(--ink-2); }

--- a/src/lib/model-inventory/discovery/codex.mjs
+++ b/src/lib/model-inventory/discovery/codex.mjs
@@ -1,5 +1,5 @@
 import { readContextConfig } from '../../codex-context-config.mjs';
-import { VERIFIED_CODEX_CONTEXT_VERSIONS, contextCapacity } from '../../codex-context.mjs';
+import { hasCodexContextProfile, contextCapacity } from '../../codex-context.mjs';
 import {
   MAX_COMMAND_BYTES, MAX_MODELS, diagnostic, modelRecord, sourceRecord,
 } from './index.mjs';
@@ -9,14 +9,14 @@ const REASONING = new Set(['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 
 const bounded = (value, max = 256) => typeof value === 'string' && value.length > 0 && value.length <= max ? value : null;
 const positiveSafeInteger = (value) => Number.isSafeInteger(value) && value > 0 ? value : null;
 
-function codexContextVariant(raw, config, clientVersion) {
+function codexContextVariant(raw, config, _clientVersion) {
   const contextWindow = positiveSafeInteger(raw.context_window);
   const maximumContextWindow = positiveSafeInteger(raw.max_context_window);
   const effectiveContextWindowPercent = Number.isSafeInteger(raw.effective_context_window_percent)
     && raw.effective_context_window_percent > 0 && raw.effective_context_window_percent <= 100
     ? raw.effective_context_window_percent : null;
   const requested = config.window;
-  const supported = VERIFIED_CODEX_CONTEXT_VERSIONS.includes(clientVersion);
+  const supported = hasCodexContextProfile(raw);
   const capacity = contextCapacity(raw, requested);
   const configured = requested !== null && (!config.provider || config.provider === 'openai') && !config.catalog;
   return {

--- a/tests/kit/codex-context.test.mjs
+++ b/tests/kit/codex-context.test.mjs
@@ -81,13 +81,22 @@ for (const source of ['model_context_window = 1\nmodel_context_window = 2\n', '"
   });
 }
 
-for (const change of [c => { c.fetched_at = '2020-01-01'; }, c => { c.client_version = '0.999.0'; }, c => { c.models[0].max_context_window = -1; }, c => { c.models = []; }]) {
+for (const change of [c => { c.fetched_at = '2020-01-01'; }, c => { delete c.models[0].effective_context_window_percent; }, c => { c.models[0].max_context_window = -1; }, c => { c.models = []; }]) {
   test('untrusted capacity evidence prevents a write', async t => {
     const f = fixture(t); change(f.cache); f.writeCache();
     await assert.rejects(manageCodexContext(f.cfg, { ...f.options, enable: true }));
     assert.equal(f.read(), f.source);
   });
 }
+
+test('a fresh catalog with the same per-model clamp contract survives a Codex patch upgrade', async t => {
+  const f = fixture(t);
+  f.cache.client_version = '0.154.0'; f.writeCache();
+  const options = { ...f.options, runner: async () => ({ code: 0, stdout: 'codex-cli 0.154.0' }) };
+  await manageCodexContext(f.cfg, { ...options, enable: true });
+  assert.equal(inspectCodexContext(f.cfg, options).available, true);
+  assert.match(f.read(), /model_context_window = 872000/);
+});
 
 test('native version mismatch and custom providers cannot acquire ownership', async t => {
   const f = fixture(t);

--- a/tests/kit/dashboard-intel-integration.test.mjs
+++ b/tests/kit/dashboard-intel-integration.test.mjs
@@ -123,7 +123,7 @@ function fixtureProject(root, name, {
     { timestamp: 1, nodes: storeEntries, edges: storeEntries * 2, pageRankSum: 0.1 },
   ]);
   writeFile(path.join(dir, '.claude-flow', 'health-history.json'), [{ ts: 1, ok: true }]);
-  return { path: dir, label: name, source: 'registry' };
+  return { path: dir, label: name, source: 'registry', learningScope: 'repository' };
 }
 
 const tempRoot = () => fs.mkdtempSync(path.join(os.tmpdir(), 'ak-dash-intel-'));

--- a/tests/kit/dashboard-project-groups.test.mjs
+++ b/tests/kit/dashboard-project-groups.test.mjs
@@ -1,21 +1,25 @@
 import {test} from 'node:test';
 import assert from 'node:assert/strict';
-import {projectView} from '../../src/lib/dashboard/project-groups.mjs';
+import {repositoryTree} from '../../src/lib/dashboard/project-groups.mjs';
 const repo = {repositoryId:'/repo/.git',root:'/repo',kind:'git'};
-const main = {path:'/repo',label:'repo',repository:repo,sessionOrigins:[{origin:'claude-desktop',sessions:1},{origin:'unknown',sessions:1}]};
+const main = {path:'/repo',label:'repo',repository:repo,totalBytes:{status:'measured',value:1}};
 const work = {path:'/work',label:'work',repository:{...repo,kind:'worktree'},sessionOrigins:[{origin:'codex-desktop',sessions:2}]};
-test('repository and worktree share one group without counting the measured copy twice',()=>{
- const view=projectView({projects:[main],discoveryProjects:[main,work]},'all','all');
- assert.equal(view.length,1); assert.deepEqual(view[0].rows.map(r=>r.path),['/repo','/work']);
-});
-test('desktop origin filters intersect repository grouping and preserve unknown membership',()=>{
- assert.equal(projectView({projects:[main,work]},'measured','codex-desktop')[0].rows[0].path,'/work');
- assert.equal(projectView({projects:[main,work]},'measured','unknown')[0].rows[0].path,'/repo');
-});
-test('unclassified older snapshots survive unknown filtering',()=>{
- assert.equal(projectView({projects:[{path:'/old',label:'old'}]},'measured','unknown')[0].rows.length,1);
+const desktop={path:'/desktop',label:'g-p-opaque',repository:{kind:'unknown'}};
+const agentWorktree={path:'/repo/.claude/worktrees/agent-1',label:'agent-1',repository:{kind:'unknown'}};
+
+test('repositoryTree retains one repository parent and nests discovered worktrees beneath it',()=>{
+ const tree=repositoryTree({projects:[main],discoveryProjects:[main,work,desktop,agentWorktree]});
+ assert.equal(tree.repositories.length,1);
+ assert.equal(tree.repositories[0].repository.path,'/repo');
+ assert.deepEqual(tree.repositories[0].worktrees.map(r=>r.path),['/repo/.claude/worktrees/agent-1','/work']);
+ assert.equal(tree.repositories[0].worktrees[0].totalBytes,undefined);
+ assert.equal(tree.excludedDirectories,1);
 });
 
-test('legacy rows without paths retain independent identity',()=>{
- assert.equal(projectView({projects:[{label:'first'},{label:'second'}]})[0].rows.length,2);
+test('repositoryTree creates an honest unmeasured parent for a verified worktree whose checkout was not scanned',()=>{
+ const tree=repositoryTree({projects:[],discoveryProjects:[work]});
+ assert.equal(tree.repositories.length,1);
+ assert.equal(tree.repositories[0].repository.path,'/repo');
+ assert.equal(tree.repositories[0].repository.loc,undefined);
+ assert.equal(tree.repositories[0].worktrees[0].path,'/work');
 });

--- a/tests/kit/hook-audit-hosts.test.mjs
+++ b/tests/kit/hook-audit-hosts.test.mjs
@@ -121,6 +121,7 @@ test('host-neutral audit reports each provider and never proposes automatic trus
       codex: { codexHome: fx.codex, pluginCacheDir: path.join(fx.codex, 'plugins', 'cache') },
       claude: { claudeRoot: fx.claude, managedSettingsFile: null },
       opencode: { opencodeRoot: fx.opencode },
+      upstream: { now: () => new Date('2026-09-03T00:00:00Z') },
     });
 
     assert.deepEqual(report.hosts, ['codex', 'claude', 'opencode', 'external']);

--- a/tests/kit/intel-history.test.mjs
+++ b/tests/kit/intel-history.test.mjs
@@ -276,8 +276,8 @@ test('readMachineWideIntel aggregates totals and perProject rows across multiple
   });
 
   const result = readMachineWideIntel([
-    { path: cwdAlpha, label: 'Alpha' },
-    { path: cwdBeta, label: 'Beta' },
+    { path: cwdAlpha, label: 'Alpha', learningScope: 'repository' },
+    { path: cwdBeta, label: 'Beta', learningScope: 'repository' },
   ]);
 
   assert.deepEqual(result.totals, {
@@ -289,12 +289,12 @@ test('readMachineWideIntel aggregates totals and perProject rows across multiple
   });
   assert.deepEqual(result.perProject, [
     {
-      path: cwdAlpha, label: 'Alpha', key: null, learningScope: 'unknown', patternsLearned: 10, patternStoreCount: 2,
+      path: cwdAlpha, label: 'Alpha', key: null, learningScope: 'repository', patternsLearned: 10, patternStoreCount: 2,
       trajectoriesRecorded: 4, graphLatest: { nodes: 5, edges: 8 }, lastAdaptation: 1000,
       learningState: [],
     },
     {
-      path: cwdBeta, label: 'Beta', key: null, learningScope: 'unknown', patternsLearned: 20, patternStoreCount: 3,
+      path: cwdBeta, label: 'Beta', key: null, learningScope: 'repository', patternsLearned: 20, patternStoreCount: 3,
       trajectoriesRecorded: 6, graphLatest: null, lastAdaptation: 2000,
       learningState: [],
     },
@@ -342,7 +342,7 @@ test('readMachineWideIntel degrades a project with missing/malformed data to nul
   writeFixture(cwdMalformed, '.claude-flow/neural/stats.json', '{ broken');
 
   const result = readMachineWideIntel([
-    { path: cwdGood, label: 'Good' },
+    { path: cwdGood, label: 'Good', learningScope: 'repository' },
     { path: cwdEmpty, label: 'Empty' },
     { path: cwdMalformed, label: 'Malformed' },
   ]);
@@ -373,9 +373,9 @@ test('readMachineWideIntel picks mostActiveProject by the highest lastAdaptation
   writeFixture(cwdNewest, '.claude-flow/neural/stats.json', { patternsLearned: 1, lastAdaptation: 999999 });
 
   const withAdaptation = readMachineWideIntel([
-    { path: cwdOld, label: 'Old' },
-    { path: cwdNewest, label: 'Newest' },
-    { path: cwdNewer, label: 'Newer' },
+    { path: cwdOld, label: 'Old', learningScope: 'repository' },
+    { path: cwdNewest, label: 'Newest', learningScope: 'repository' },
+    { path: cwdNewer, label: 'Newer', learningScope: 'repository' },
   ]);
   assert.equal(withAdaptation.totals.mostActiveProject, 'Newest');
 
@@ -388,6 +388,22 @@ test('readMachineWideIntel picks mostActiveProject by the highest lastAdaptation
     { path: cwdZeroAdaptation, label: 'ZeroAdaptation' },
   ]);
   assert.equal(withoutAdaptation.totals.mostActiveProject, null);
+});
+
+test('readMachineWideIntel selects the most active Git repository, never a desktop or directory workspace', () => {
+  const root = tmp();
+  const repository = path.join(root, 'repository');
+  const desktopWorkspace = path.join(root, 'g-p-opaque');
+  writeFixture(repository, '.claude-flow/neural/stats.json', { patternsLearned: 1, lastAdaptation: 100 });
+  writeFixture(desktopWorkspace, '.claude-flow/neural/stats.json', { patternsLearned: 999, lastAdaptation: 999 });
+
+  const result = readMachineWideIntel([
+    { path: repository, label: 'Repository', learningScope: 'repository' },
+    { path: desktopWorkspace, label: 'g-p-opaque', learningScope: 'unknown' },
+  ]);
+
+  assert.equal(result.totals.mostActiveProject, 'Repository');
+  assert.equal(result.totals.projectCount, 2, 'non-repository learning remains in the inventory');
 });
 
 test('readMachineWideIntel returns zeroed totals and an empty perProject for an empty projects array', () => {

--- a/tests/kit/intelligence-picker-groups.test.mjs
+++ b/tests/kit/intelligence-picker-groups.test.mjs
@@ -17,7 +17,7 @@ function picker() {
   return { elements, render: context.renderPicker, context };
 }
 
-test('should_segment_and_alphabetize_picker_options_without_changing_selection_keys', () => {
+test('should_segment_and-alphabetize picker options with the same designations as the inventory', () => {
   const { elements, render } = picker();
   render({ selectedProjectKey: 'z', selectedProjectLabel: 'Zulu', projects: [
     { key: 'z', label: 'Zulu', learningScope: 'repository', learningOrigins: ['codex-desktop'] },
@@ -25,14 +25,18 @@ test('should_segment_and_alphabetize_picker_options_without_changing_selection_k
     { key: 'u', label: 'Settings', learningScope: 'user' },
     { key: 'w', label: 'Feature', learningScope: 'worktree' },
     { key: 'x', label: 'uuid-looking-123', learningScope: 'unknown' },
+    { key: 'd', label: 'g-p-opaque', learningScope: 'unknown', learningOrigins: ['codex-desktop'] },
   ] });
   const html = elements['intel-project-select'].innerHTML;
   for (const label of ['Git repositories', 'Git worktrees', 'User-level learning', 'Other / unclassified']) {
     assert.ok(html.includes(`<optgroup label="${label}">`));
   }
   assert.ok(html.indexOf('value="a"') < html.indexOf('value="z"'));
-  assert.match(html, /value="z" selected>Zulu</);
-  assert.doesNotMatch(html, /Claude Desktop|Codex Desktop/);
+  assert.match(html, /value="z" selected>Zulu — Git repository</);
+  assert.match(html, /alpha — Git repository/);
+  assert.match(html, /Settings — Directory/);
+  assert.match(html, /Feature — Git worktree/);
+  assert.match(html, /g-p-opaque — ChatGPT Desktop/);
   assert.equal(elements['history-project-name'].textContent, 'Zulu');
 });
 test('should_keep_empty_picker_disabled_and_escape_untrusted_option_labels', () => {

--- a/tests/kit/intelligence-table-groups.test.mjs
+++ b/tests/kit/intelligence-table-groups.test.mjs
@@ -18,7 +18,7 @@ test('machine-wide rows retain their own scope and key without name-based attrib
   assert.equal(result.totals.projectCount, 3);
 });
 
-test('machine-wide groups alphabetize every retained row and preserve KPI totals', () => {
+test('machine-wide inventory alphabetizes every retained row and preserves KPI totals', () => {
   const elements = { 'mw-table': {}, 'mw-hero': {} };
   const source = fs.readFileSync(new URL('../../src/lib/dashboard/client/intelligence.mjs', import.meta.url), 'utf8')
     .replace(/^import .*;$/gm, '').replace(/\bexport /g, '');
@@ -31,12 +31,31 @@ test('machine-wide groups alphabetize every retained row and preserve KPI totals
   perProject.push({ key: 'user', label: '<User>', learningScope: 'user' });
   context.renderTable({ totals: { patternsLearnedLifetime: 28, projectCount: 9, mostActiveProject: 'Repository 8' }, perProject });
   const html = elements['mw-table'].innerHTML;
-  assert.match(html, /Git repositories/);
-  assert.match(html, /User-level learning/);
+  assert.match(html, /Designation/);
+  assert.match(html, /Git repository/);
   assert.equal((html.match(/class="mw-row mw-data-row"/g) || []).length, 9);
   assert.ok(html.indexOf('Repository 1') < html.indexOf('Repository 8'));
   assert.ok(html.includes('title="&lt;User&gt;"'));
   assert.ok(html.includes('role="columnheader"'));
   assert.ok(html.includes('tabindex="0"'));
   assert.equal(elements['mw-hero'].innerHTML, 'patterns learned:28;projects tracked:9;most active project:Repository 8;');
+});
+
+test('machine-wide inventory renders one designation column and filter pills for every origin', () => {
+  const elements = { 'mw-table': {}, 'mw-hero': {} };
+  const source = fs.readFileSync(new URL('../../src/lib/dashboard/client/intelligence.mjs', import.meta.url), 'utf8')
+    .replace(/^import .*;$/gm, '').replace(/\bexport /g, '');
+  const esc = (value) => String(value).replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('"', '&quot;');
+  const context = vm.createContext({ document: { getElementById: (id) => elements[id] }, esc,
+    fmtNum: (value) => String(value ?? 0), kpi: (label, value) => `${label}:${value};` });
+  vm.runInContext(`${source}\nglobalThis.renderTable=renderMachineWide;`, context);
+  context.renderTable({ totals: { patternsLearnedLifetime: 2, projectCount: 2, mostActiveProject: 'Repository' }, perProject: [
+    { key: 'repo', label: 'Repository', learningScope: 'repository', patternsLearned: 1, patternStoreCount: 1 },
+    { key: 'desktop', label: 'g-p-opaque', learningScope: 'unknown', learningOrigins: ['codex-desktop'], patternsLearned: 1, patternStoreCount: 1 },
+  ] });
+  const html = elements['mw-table'].innerHTML;
+  assert.match(html, /Designation/);
+  assert.match(html, /Git repository/);
+  assert.match(html, /ChatGPT Desktop/);
+  assert.match(html, /mw-filter-pill/);
 });

--- a/tests/kit/model-discovery-claude-codex.test.mjs
+++ b/tests/kit/model-discovery-claude-codex.test.mjs
@@ -202,8 +202,8 @@ test('Codex inventory applies configured capacity per model and preserves native
   assert.equal(model.variant.effectiveContextWindow, 828400);
 });
 
-test('Codex inventory never fabricates an effective override for an unverified client', () => {
+test('Codex inventory derives an effective override from a valid per-model clamp contract', () => {
   const result = discoverCodex({ cacheRaw: fixture('codex', 'models-cache.json'),
     configRaw: 'model_context_window = 872000\n', scopeKey: SCOPE_KEY });
-  assert.equal(result.models[0].variant.effectiveContextWindow, null);
+  assert.equal(result.models[0].variant.effectiveContextWindow, 828400);
 });

--- a/tests/kit/sync-command.test.mjs
+++ b/tests/kit/sync-command.test.mjs
@@ -371,6 +371,22 @@ test('failed heal results are retained for the final convergence proof', () => {
   assert.deepEqual(state.applyFailures, [{ name: 'ruvnet-brain', detail: 'network unavailable' }]);
 });
 
+test('a package upgrade makes an enabled lifecycle host eligible for a same-run refresh', () => {
+  assert.equal(sync.lifecycleRefreshRequired(new Set(['versions']), 'opencode'), true);
+  assert.equal(sync.lifecycleRefreshRequired(new Set(['versions']), 'codex'), false);
+  assert.equal(sync.lifecycleRefreshRequired(new Set(['opencode']), 'opencode'), true);
+  assert.equal(sync.lifecycleRefreshRequired(new Set(), 'opencode'), false);
+});
+
+test('a Ruflo version upgrade explicitly refreshes generated helpers before the statusline heal', () => {
+  const helpers = sync.SYNC_STEPS.findIndex((step) => step.id === 'ruflo-helpers');
+  const statusline = sync.SYNC_STEPS.findIndex((step) => step.id === 'statusline');
+  assert.ok(helpers > -1, 'sync needs a dedicated Ruflo generated-helper stage');
+  assert.ok(helpers < statusline, 'Ruflo may replace statusline.cjs, so helpers refresh first');
+  assert.equal(sync.SYNC_STEPS[helpers].when(new Set(['versions'])), true);
+  assert.equal(sync.SYNC_STEPS[helpers].when(new Set()), false);
+});
+
 // ── opencode convergence through a REAL sync ─────────────────────────────────
 // The maintainer's command-level scenarios: enabled+drifted converges after the
 // hosts step and before the final verification; enabled+absent never fabricates

--- a/tests/live/codex-context-contract.test.mjs
+++ b/tests/live/codex-context-contract.test.mjs
@@ -9,9 +9,10 @@ import { spawnSync } from 'node:child_process';
 import { contextHome } from '../../src/lib/codex-context-config.mjs';
 
 const enabled = process.env.AK_CODEX_CONTEXT_CONFORMANCE === '1';
+const clientVersion = process.env.AK_CODEX_CONTEXT_CLIENT_VERSION ?? '0.154.0';
 for (const [model, expected] of [['gpt-6-astra', 828400], ['gpt-5.6-sol', 828400], ['gpt-5.5', 258400]]) {
-  test(`Codex 0.153.4 native per-model clamp: ${model}`, { skip: !enabled, timeout: 65000 }, t => {
-    assert.equal(spawnSync('codex', ['--version'], { encoding: 'utf8', timeout: 5000 }).stdout.trim(), 'codex-cli 0.153.4');
+  test(`Codex ${clientVersion} native per-model clamp: ${model}`, { skip: !enabled, timeout: 65000 }, t => {
+    assert.equal(spawnSync('codex', ['--version'], { encoding: 'utf8', timeout: 5000 }).stdout.trim(), `codex-cli ${clientVersion}`);
     const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'ak-context-contract-'));
     t.after(() => fs.rmSync(cwd, { recursive: true, force: true }));
     const result = spawnSync('codex', ['exec', '--skip-git-repo-check', '-C', cwd, '-s', 'read-only',

--- a/tests/ui/dashboard-project-context.mjs
+++ b/tests/ui/dashboard-project-context.mjs
@@ -52,17 +52,18 @@ test('context and project grouping stay readable, keyboard operable and evidence
  assert.equal(await page.locator('#usage-tab-models').getAttribute('aria-selected'),'true');
  assert.equal(await page.evaluate(()=>globalThis.document.activeElement.id),'usage-tab-models');
  await page.click('#tab-system');await page.click('[data-system-view="projects"]');
- await page.waitForSelector('#project-population');
- assert.equal(await page.locator('#sys-projects tbody tr:not(.project-group)').count(),1);
- await page.selectOption('#project-population','all');
- assert.equal(await page.locator('#sys-projects tbody tr:not(.project-group)').count(),3);
- assert.equal(await page.locator('#sys-projects .project-group').count(),0);
- assert.equal(await page.locator('#sys-projects tbody').count(),2);
- await page.selectOption('#project-origin','codex-desktop');
- assert.equal(await page.locator('#sys-projects tbody tr:not(.project-group)').count(),1);
+ await page.waitForSelector('#sys-projects .project-repository');
+ assert.equal(await page.locator('#sys-projects .project-repository').count(),1);
+ assert.deepEqual(await page.locator('#sys-projects th').allTextContents(),['Project↑','Lines ≈↓','By language↑','Disk↓','Last active↓','Worktrees']);
+ assert.equal(await page.locator('#sys-projects .project-repository td').count(),6);
+ assert.equal(await page.locator('#sys-projects .project-worktree[hidden]').count(),1);
+ assert.equal(await page.locator('#project-population').count(),0);
+ assert.equal(await page.locator('#project-origin').count(),0);
+ assert.doesNotMatch(await page.locator('#sys-projects').innerText(),/Unavailable folder/);
+ await page.locator('#sys-projects [data-project-tree]').click();
+ assert.equal(await page.locator('#sys-projects .project-worktree:not([hidden])').count(),1);
  assert.match(await page.locator('#sys-projects').innerText(),/feature/);
- assert.equal(await page.evaluate(()=>globalThis.document.activeElement.id),'project-origin');
- await page.selectOption('#project-origin','all');
+ assert.ok((await page.locator('#sys-projects .sy-project-scroll').boundingBox()).height<=286);
  await page.screenshot({path:path.join(shots,'system-projects-desktop.png'),fullPage:true,animations:"disabled"});
  for(const width of [768,390]){
   await page.setViewportSize({width,height:900});
@@ -71,10 +72,10 @@ test('context and project grouping stay readable, keyboard operable and evidence
   await page.click('#tab-overview');await page.click('[data-overview-view="runtime"]');
   assert.ok(await page.evaluate(()=>globalThis.document.documentElement.scrollWidth<=globalThis.innerWidth),`context overflow at ${width}`);
   await page.screenshot({path:path.join(shots,'context-'+width+'.png'),fullPage:true,animations:"disabled"});
-  await page.click('#tab-system');await page.click('[data-system-view="projects"]');
+ await page.click('#tab-system');await page.click('[data-system-view="projects"]');
  }
  projects={projects:[],discoveryProjects:[],everSeen:measured(0)};
  await page.reload();await page.click('#tab-system');await page.click('[data-system-view="projects"]');
- await page.waitForSelector('#project-population');assert.match(await page.locator('#sys-projects').innerText(),/no project was discovered/);
+ await page.waitForSelector('#sys-projects');assert.match(await page.locator('#sys-projects').innerText(),/no repository was discovered/);
  assert.deepEqual(errors,[]);
 });

--- a/tests/ui/dashboard-ui.mjs
+++ b/tests/ui/dashboard-ui.mjs
@@ -3421,9 +3421,9 @@ async function main() {
       s0.aria[0] === 'ascending'
         && JSON.stringify(names0) === JSON.stringify([...names0].sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()))),
       `aria was ${JSON.stringify(s0.aria)} and the order ${JSON.stringify(names0)}`);
-    check('every measured column header is sortable while Worktrees is a control column', await page.$$eval('#sys-projects thead th',
-      (ths) => ths.slice(0, 5).every((t) => !!t.querySelector('button[data-proj-sort]')) && ths[5]?.innerText.trim() === 'Worktrees'),
-      'the worktree control column must remain separate from sortable measurements');
+    check('every measured column header is sortable', await page.$$eval('#sys-projects thead th',
+      (ths) => ths.slice(0, 5).every((t) => !!t.querySelector('button[data-proj-sort]'))),
+      'each measured column needs its own sort control');
 
     await page.click('[data-proj-sort="project"]');
     const s1 = await sortState();

--- a/tests/ui/dashboard-ui.mjs
+++ b/tests/ui/dashboard-ui.mjs
@@ -3422,7 +3422,7 @@ async function main() {
         && JSON.stringify(names0) === JSON.stringify([...names0].sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()))),
       `aria was ${JSON.stringify(s0.aria)} and the order ${JSON.stringify(names0)}`);
     check('every measured column header is sortable while Worktrees is a control column', await page.$$eval('#sys-projects thead th',
-      (ths) => ths.slice(0, 5).every((t) => !!t.querySelector('button[data-proj-sort]')) && ths[5]?.innerText === 'Worktrees'),
+      (ths) => ths.slice(0, 5).every((t) => !!t.querySelector('button[data-proj-sort]')) && ths[5]?.innerText.trim() === 'Worktrees'),
       'the worktree control column must remain separate from sortable measurements');
 
     await page.click('[data-proj-sort="project"]');

--- a/tests/ui/dashboard-ui.mjs
+++ b/tests/ui/dashboard-ui.mjs
@@ -592,6 +592,7 @@ const SYSTEM_PAYLOAD = {
     projects: [
       {
         label: 'agentic-kit',
+        path: '/Users/me/projects/agentic-kit', repository: { repositoryId: 'repo:agentic-kit', kind: 'git', root: '/Users/me/projects/agentic-kit' },
         loc: { total: meas(48_210), byLanguage: { JavaScript: 31_000, Markdown: 12_000, CSS: 3100, JSON: 2110 } },
         treeBytes: meas(42_000_000), gitBytes: meas(120_000_000), nodeModulesBytes: meas(310_000_000),
         totalBytes: meas(472_000_000), lastActivity: meas(SYS_NOW - 3_600_000),
@@ -606,6 +607,7 @@ const SYSTEM_PAYLOAD = {
         // listed: absent is not zero, and blanking it would be the fail-closed
         // rule inverted.
         label: 'legacy-snapshot-row',
+        path: '/Users/me/projects/legacy-snapshot-row', repository: { repositoryId: 'repo:legacy', kind: 'git', root: '/Users/me/projects/legacy-snapshot-row' },
         loc: { total: meas(1200), byLanguage: { Rust: 1200 } },
         treeBytes: meas(1_000), gitBytes: meas(1_000), nodeModulesBytes: meas(0),
         totalBytes: meas(2_000), lastActivity: meas(SYS_NOW - 7_200_000),
@@ -619,6 +621,7 @@ const SYSTEM_PAYLOAD = {
         // still LIST, and must sort to the bottom in BOTH directions — an
         // absent figure is not a small one.
         label: 'zz-unmeasured',
+        path: '/Users/me/projects/zz-unmeasured', repository: { repositoryId: 'repo:unmeasured', kind: 'git', root: '/Users/me/projects/zz-unmeasured' },
         loc: { total: unmeasured('the working tree could not be read'), byLanguage: {} },
         treeBytes: meas(1), gitBytes: meas(1), nodeModulesBytes: meas(0),
         totalBytes: unmeasured('the working tree could not be read'),
@@ -632,6 +635,7 @@ const SYSTEM_PAYLOAD = {
       {
         // Linked, but no host ever recorded a session here.
         label: 'never-worked-in',
+        path: '/Users/me/projects/never-worked-in', repository: { repositoryId: 'repo:never-worked', kind: 'git', root: '/Users/me/projects/never-worked-in' },
         loc: { total: meas(10), byLanguage: { Rust: 10 } },
         treeBytes: meas(10), gitBytes: meas(10), nodeModulesBytes: meas(0),
         totalBytes: meas(20), lastActivity: meas(SYS_NOW - 9_200_000),
@@ -3386,7 +3390,7 @@ async function main() {
     const projectRows = await page.$$eval('#sys-projects tbody tr', (els) => els.map((e) => ({
       linked: !!e.querySelector('a[href^="https:"]'), text: e.innerText,
     })));
-    check('the Projects table lists only repositories with a remote',
+    check('the Projects table lists only verified repository rows',
       projectRows.length > 0 && projectRows.every((r) => r.linked),
       `${projectRows.filter((r) => !r.linked).length} unlinked row(s) survived the filter`);
     const projectNames = projectRows.map((r) => r.text.split('\n')[0]).join(' ');
@@ -3396,10 +3400,8 @@ async function main() {
       /legacy-snapshot-row/.test(projectNames),
       `an older snapshot cannot answer "was this worked in", and guessing no blanks the table`);
     const projectLiner = await page.$eval('#sys-projects .sy-liner', (e) => e.innerText);
-    check('and states what it excluded rather than leaving the reader to subtract',
-      /listed here/.test(projectLiner)
-        && (projectRows.length === (SYSTEM_PAYLOAD.projects?.projects ?? []).length
-          || /Excluded \d+ measured director/.test(projectLiner)),
+    check('and states the repository footprint separately from excluded directories',
+      /verified repositories/.test(projectLiner) && /non-repository directories are excluded/.test(projectLiner),
       `the liner read ${JSON.stringify(projectLiner)}`);
     check('the language legend matches the ramp it describes',
       /top 5 languages/.test(await page.$eval('#sys-projects .sy-legend', (e) => e.innerText)),
@@ -3419,9 +3421,9 @@ async function main() {
       s0.aria[0] === 'ascending'
         && JSON.stringify(names0) === JSON.stringify([...names0].sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()))),
       `aria was ${JSON.stringify(s0.aria)} and the order ${JSON.stringify(names0)}`);
-    check('every header is a sort control', await page.$$eval('#sys-projects thead th',
-      (ths) => ths.every((t) => !!t.querySelector('button[data-proj-sort]'))),
-      'a header without a control is a column the user cannot order by');
+    check('every measured column header is sortable while Worktrees is a control column', await page.$$eval('#sys-projects thead th',
+      (ths) => ths.slice(0, 5).every((t) => !!t.querySelector('button[data-proj-sort]')) && ths[5]?.innerText === 'Worktrees'),
+      'the worktree control column must remain separate from sortable measurements');
 
     await page.click('[data-proj-sort="project"]');
     const s1 = await sortState();

--- a/tests/ui/intelligence-picker.mjs
+++ b/tests/ui/intelligence-picker.mjs
@@ -22,7 +22,7 @@ const projects = [
   { key: 'unknown-a', label: 'Alpha unknown', learningScope: 'unsupported' },
 ];
 
-test('Intelligence picker groups and sorts learning scopes without changing selection or hiding empty history', async t => {
+test('Intelligence picker labels every learning location with the inventory designation', async t => {
   const browser = await chromium.launch({ channel: 'chrome', headless: true });
   t.after(() => browser.close());
   const page = await browser.newPage({ viewport: { width: 1360, height: 980 } });
@@ -44,7 +44,7 @@ test('Intelligence picker groups and sorts learning scopes without changing sele
   await page.emulateMedia({ reducedMotion: 'reduce', colorScheme: 'dark' });
   await page.goto('http://intelligence.test/#token=fixture');
   await page.click('[data-overview-view="intel"]');
-  const picker = page.getByLabel('select project', { exact: true });
+  const picker = page.getByLabel('select learning location', { exact: true });
   await picker.locator('optgroup').first().waitFor({ state: 'attached' });
   assert.equal(await picker.evaluate(el => el.tagName), 'SELECT');
   const groups = await picker.locator('optgroup').evaluateAll(nodes => nodes.map(node => ({ label: node.label,
@@ -53,8 +53,8 @@ test('Intelligence picker groups and sorts learning scopes without changing sele
     ['Git repositories', ['repo-a', 'repo-z']], ['Git worktrees', ['tree-a', 'tree-z']],
     ['User-level learning', ['user-a', 'user-z']], ['Other / unclassified', ['unknown-a', 'unknown-z']],
   ]);
-  assert.equal(groups[0].labels[0], 'alpha');
-  assert.equal(groups[1].labels[0], 'Alpha tree');
+  assert.equal(groups[0].labels[0], 'alpha — Git repository');
+  assert.equal(groups[1].labels[0], 'Alpha tree — Git worktree');
   assert.equal(await picker.locator('option').count(), projects.length);
   assert.equal(await picker.inputValue(), 'repo-z', 'sorting must retain the server-selected project');
   await picker.focus();
@@ -82,12 +82,12 @@ test('Intelligence picker groups and sorts learning scopes without changing sele
   await page.click('[data-overview-view="intel"]');
   await page.waitForFunction(() => globalThis.document.getElementById('intel-project-select').disabled);
   assert.equal(await picker.isVisible(), true);
-  assert.equal(await picker.locator('option').textContent(), 'no projects discovered');
+  assert.equal(await picker.locator('option').textContent(), 'no learning locations discovered');
   assert.equal(await page.locator('#history-empty').isVisible(), true);
   assert.deepEqual(errors, []);
 });
 
-test('Intelligence table keeps every grouped row in five-row scroll regions with stable KPIs', async t => {
+test('Intelligence table keeps every learning location in one filterable inventory with stable KPIs', async t => {
   const browser = await chromium.launch({ channel: 'chrome', headless: true });
   t.after(() => browser.close());
   const page = await browser.newPage({ viewport: { width: 1360, height: 980 } });
@@ -114,13 +114,10 @@ test('Intelligence table keeps every grouped row in five-row scroll regions with
   await page.locator('.mw-data-row').first().waitFor();
   const table = page.locator('#mw-table'), hero = await page.locator('#mw-hero').innerText();
   assert.equal(await table.locator('.mw-data-row').count(), 32);
-  assert.deepEqual(await table.locator('.mw-group h3').allTextContents(),
-    ['Git repositories8', 'Git worktrees8', 'User-level learning8', 'Other / unclassified8']);
-  assert.equal(await table.getByRole('columnheader').count(), 16);
-  for (const scope of scopes) {
-    assert.deepEqual(await table.locator(`[data-learning-scope="${scope}"] .mw-name`).allTextContents(),
-      ['Project 1', 'Project 2', 'Project 3', 'Project 4', 'Project 5', 'Project 6', 'Project 7', 'Project 8']);
-  }
+  assert.equal(await table.getByRole('columnheader').count(), 5);
+  assert.deepEqual(await table.getByRole('columnheader').allTextContents(),
+    ['Name', 'Designation', 'Patterns learned', 'Pattern store', 'Last active']);
+  assert.deepEqual(await table.locator('.mw-filter-pill').allTextContents(), ['All', 'Directory', 'Git repository', 'Git worktree']);
   const shots = process.env.AK_UI_ARTIFACTS;
   if (shots) fs.mkdirSync(shots, { recursive: true });
   for (const width of [1360, 1100, 390]) {
@@ -130,27 +127,22 @@ test('Intelligence table keeps every grouped row in five-row scroll regions with
       header: region.querySelector('.mw-head').getBoundingClientRect().height,
       row: region.querySelector('.mw-data-row').getBoundingClientRect().height,
     })));
-    for (const size of sizes) {
-      assert.equal(size.row, 34);
-      assert.equal((size.height-size.header)/size.row, 5);
-      assert.ok(size.scroll > size.height);
-    }
+    for (const size of sizes) { assert.equal(size.row, 34); assert.ok(size.scroll > size.height); }
     assert.ok(await table.evaluate(el => el.getBoundingClientRect().height) <= 520);
     assert.equal(await page.evaluate(() => globalThis.document.documentElement.scrollWidth <= globalThis.innerWidth), true, `no horizontal overflow at ${width}px`);
     assert.equal(await page.locator('#mw-hero').innerText(), hero);
     if (shots) await page.screenshot({ path: path.join(shots, `intelligence-table-${width}.png`), fullPage: true });
   }
-  await table.focus();
-  await page.keyboard.press('End');
-  await page.waitForFunction(() => globalThis.document.getElementById('mw-table').scrollTop > 0);
-  assert.equal(await table.evaluate(el => el === el.ownerDocument.activeElement), true);
-  if (shots) await page.screenshot({ path: path.join(shots, 'intelligence-table-390-scrolled.png'), fullPage: true });
-  const region = table.getByRole('region', { name: 'Git repositories learning rows', exact: true });
+  const region = table.getByRole('region', { name: 'Learning locations', exact: true });
   await region.focus();
   await page.keyboard.press('End');
   await page.waitForFunction(() => globalThis.document.querySelector('.mw-group-scroll').scrollTop > 0);
   assert.equal(await region.locator('.mw-name').last().getAttribute('title'), 'Project 8');
   assert.equal(await region.evaluate(el => el === el.ownerDocument.activeElement), true);
+  if (shots) await page.screenshot({ path: path.join(shots, 'intelligence-table-390-scrolled.png'), fullPage: true });
   assert.equal(await table.locator('.mw-data-row').count(), 32);
+  await table.getByRole('button', { name: 'Git repository', exact: true }).click();
+  assert.equal(await table.locator('.mw-data-row').count(), 8);
+  assert.deepEqual(await table.locator('.mw-designation').allTextContents(), Array(8).fill('Git repository'));
   assert.deepEqual(errors, []);
 });

--- a/tests/ui/maintenance-projects.mjs
+++ b/tests/ui/maintenance-projects.mjs
@@ -85,7 +85,8 @@ test('project worktree visibility and all-installations navigation work on deskt
   const originFilter=page.locator('#mnt-facets input[data-mnt-facet="sessionOrigin"][value="codex-desktop"]');
   await originFilter.check();await page.waitForFunction(()=>!globalThis.mntInventoryBusy);
   assert.equal(await page.locator('#mnt-results [data-mnt-level="project"]').count(),1);
-  assert.match(await page.locator('#mnt-results').innerText(),/Codex Desktop/);
+  assert.match(await page.locator('#mnt-facets').innerText(),/ChatGPT Desktop/);
+  assert.doesNotMatch(await page.locator('#mnt-results').innerText(),/ChatGPT Desktop/);
   await originFilter.uncheck();await page.waitForFunction(()=>!globalThis.mntInventoryBusy);
 
   await page.locator('#mnt-facets [data-mnt-include-worktrees]').uncheck();


### PR DESCRIPTION
Summary:
- Refresh Ruflo-generated helpers and OpenCode projections during a versioned sync.
- Accept fresh valid Codex per-model context profiles across patch upgrades.
- Distinguish repositories, worktrees, and desktop workspaces across dashboard views.
- Simplify Maintenance project cards while retaining origin filters.

Validation: pnpm test, pnpm run typecheck, and focused browser dashboard tests.